### PR TITLE
[HttpKernel] Fix request _format duplication for HttpKernel's ExceptionListener

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -55,7 +55,7 @@ class ExceptionListener implements EventSubscriberInterface
             '_controller' => $this->controller,
             'exception'   => FlattenException::create($exception),
             'logger'      => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
-            'format'      => $request->getRequestFormat(),
+            '_format'     => $request->getRequestFormat(),
         );
 
         $request = $request->duplicate(null, null, $attributes);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8777 |
| License | MIT |

Simple fix to store the `_format` properly in a duplicated request created by the `ExceptionListener`.  See #8777.

This bug is also present in `2.3` and `master`
