### PR TITLE
[MonologBridge] Allow SwiftMailerHandler to listen to kernel.terminate.event

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Handler;
+
+use Monolog\Handler\SwiftMailerHandler as BaseSwiftMailerHandler;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+
+/**
+ * Extended SwiftMailerHandler that flushes mail queue if necessary
+ *
+ * @author Philipp Kräutli <pkraeutli@astina.ch>
+ */
+class SwiftMailerHandler extends BaseSwiftMailerHandler
+{
+    protected $transport;
+
+    protected $instantFlush = false;
+
+    /**
+     * @param \Swift_Transport $transport
+     */
+    public function setTransport(\Swift_Transport $transport)
+    {
+        $this->transport = $transport;
+    }
+
+    /**
+     * After the kernel has been terminated we will always flush messages
+     *
+     * @param PostResponseEvent $event
+     */
+    public function onKernelTerminate(PostResponseEvent $event)
+    {
+        $this->instantFlush = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function send($content, array $records)
+    {
+        parent::send($content, $records);
+
+        if ($this->instantFlush) {
+            $this->flushMemorySpool();
+        }
+    }
+
+    /**
+     * Flushes the mail queue if a memory spool is used
+     */
+    private function flushMemorySpool()
+    {
+        $transport = $this->mailer->getTransport();
+        if (!$transport instanceof \Swift_Transport_SpoolTransport) {
+            return;
+        }
+
+        $spool = $transport->getSpool();
+        if (!$spool instanceof \Swift_MemorySpool) {
+            return;
+        }
+
+        if (null == $this->transport) {
+            throw new \Exception('No transport available to flush mail queue');
+        }
+
+        $spool->flushQueue($this->transport);
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
@@ -60,17 +60,17 @@ class SwiftMailerHandler extends BaseSwiftMailerHandler
      */
     private function flushMemorySpool()
     {
-        $transport = $this->mailer->getTransport();
-        if (!$transport instanceof \Swift_Transport_SpoolTransport) {
+        $mailerTransport = $this->mailer->getTransport();
+        if (!$mailerTransport instanceof \Swift_Transport_SpoolTransport) {
             return;
         }
 
-        $spool = $transport->getSpool();
+        $spool = $mailerTransport->getSpool();
         if (!$spool instanceof \Swift_MemorySpool) {
             return;
         }
 
-        if (null == $this->transport) {
+        if (null === $this->transport) {
             throw new \Exception('No transport available to flush mail queue');
         }
 


### PR DESCRIPTION
This PR accompanies symfony/MonologBundle#51. Both are intended to fix symfony/symfony-standard#425.

MonologBundle configures SwiftMailerHandler as a Monolog handler and injects the proper transport service. 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 425 |
| License | MIT |
| Doc PR | 2905 |
