### PR TITLE
[SecurityBundle] Fix typo in the check_path validator

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -283,7 +283,7 @@ class MainConfiguration implements ConfigurationInterface
                             continue;
                         }
 
-                        if (false !== strpos('/', $firewall[$k]['check_path']) && !preg_match('#'.$firewall['pattern'].'#', $firewall[$k]['check_path'])) {
+                        if (false !== strpos($firewall[$k]['check_path'], '/') && !preg_match('#'.$firewall['pattern'].'#', $firewall[$k]['check_path'])) {
                             throw new \LogicException(sprintf('The check_path "%s" for login method "%s" is not matched by the firewall pattern "%s".', $firewall[$k]['check_path'], $k, $firewall['pattern']));
                         }
                     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/invalid_check_path.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/invalid_check_path.php
@@ -1,0 +1,16 @@
+<?php
+
+$container->loadFromExtension('security', array(
+    'providers' => array(
+        'default' => array('id' => 'foo'),
+    ),
+
+    'firewalls' => array(
+        'some_firewall' => array(
+            'pattern' => '/secured_area/.*',
+            'form_login' => array(
+                'check_path' => '/some_area/login_check',
+            )
+        )
+    )
+));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/invalid_check_path.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/invalid_check_path.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/security"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <config>
+        <provider name="default" id="foo" />
+
+        <firewall name="some_firewall" pattern="/secured_area/.*">
+            <form-login check-path="/some_area/login_check" />
+        </firewall>
+    </config>
+
+</srv:container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/invalid_check_path.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/invalid_check_path.yml
@@ -1,0 +1,9 @@
+security:
+    providers:
+        default: { id: foo }
+
+    firewalls:
+        some_firewall:
+            pattern: /secured_area/.*
+            form_login:
+                check_path: /some_area/login_check

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -184,6 +184,15 @@ abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', (string) $container->getAlias('security.acl.provider'));
     }
 
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage not matched by the firewall pattern
+     */
+    public function testInvalidCheckPath()
+    {
+        $container = $this->getContainer('invalid_check_path');
+    }
+
     protected function getContainer($file)
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #3005, #2954 |
| License | MIT |

Actually, validator of `check_path` value is broken by #3005. It doesn't throw any exception even if `check_path` is an URI. 

I've faced with wrong tests class hierarchy: `SecurityExtensionTest` is abstract test and I have to create the same test configuration for every format: PHP, XML, YAML. It looks like we test `Dependency Injection` and `Yaml` components. Issue with `check_path` does not depend on format, but such class hierarchy leaves me no choice. And I can't put test case into `ConfigurationTest`, because it doesn't know anything about security factories.

It looks like it's better to create new class for `SecurityExtension` tests.
