### PR TITLE
[Validation] Fixed IdentityTranslator to pass correct Locale to MessageSelector

### DIFF
--- a/src/Symfony/Component/Translation/IdentityTranslator.php
+++ b/src/Symfony/Component/Translation/IdentityTranslator.php
@@ -21,6 +21,7 @@ namespace Symfony\Component\Translation;
 class IdentityTranslator implements TranslatorInterface
 {
     private $selector;
+    private $locale;
 
     /**
      * Constructor.
@@ -41,6 +42,7 @@ class IdentityTranslator implements TranslatorInterface
      */
     public function setLocale($locale)
     {
+        $this->locale = $locale;
     }
 
     /**
@@ -50,6 +52,7 @@ class IdentityTranslator implements TranslatorInterface
      */
     public function getLocale()
     {
+        return $this->locale ?: \Locale::getDefault();
     }
 
     /**
@@ -69,6 +72,6 @@ class IdentityTranslator implements TranslatorInterface
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
     {
-        return strtr($this->selector->choose((string) $id, (int) $number, $locale), $parameters);
+        return strtr($this->selector->choose((string) $id, (int) $number, $locale ?: $this->getLocale()), $parameters);
     }
 }

--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -29,19 +29,43 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getTransChoiceTests
      */
-    public function testTransChoice($expected, $id, $number, $parameters)
+    public function testTransChoiceWithExplicitLocale($expected, $id, $number, $parameters)
     {
+        $translator = new IdentityTranslator(new MessageSelector());
+        $translator->setLocale('en');
+
+        $this->assertEquals($expected, $translator->transChoice($id, $number, $parameters));
+    }
+
+    /**
+     * @dataProvider getTransChoiceTests
+     */
+    public function testTransChoiceWithDefaultLocale($expected, $id, $number, $parameters)
+    {
+        \Locale::setDefault('en');
+
         $translator = new IdentityTranslator(new MessageSelector());
 
         $this->assertEquals($expected, $translator->transChoice($id, $number, $parameters));
     }
 
-    // noop
     public function testGetSetLocale()
     {
         $translator = new IdentityTranslator(new MessageSelector());
         $translator->setLocale('en');
-        $translator->getLocale();
+
+        $this->assertEquals('en', $translator->getLocale());
+    }
+
+    public function testGetLocaleReturnsDefaultLocaleIfNotSet()
+    {
+        $translator = new IdentityTranslator(new MessageSelector());
+
+        \Locale::setDefault('en');
+        $this->assertEquals('en', $translator->getLocale());
+
+        \Locale::setDefault('pt_BR');
+        $this->assertEquals('pt_BR', $translator->getLocale());
     }
 
     public function getTransTests()
@@ -55,7 +79,12 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
     public function getTransChoiceTests()
     {
         return array(
-            array('There is 10 apples', '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', 10, array('%count%' => 10)),
+            array('There is no apple', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 0, array('%count%' => 0)),
+            array('There is one apple', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 1, array('%count%' => 1)),
+            array('There are 10 apples', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 10, array('%count%' => 10)),
+            array('There are 0 apples', 'There is 1 apple|There are %count% apples', 0, array('%count%' => 0)),
+            array('There is 1 apple', 'There is 1 apple|There are %count% apples', 1, array('%count%' => 1)),
+            array('There are 10 apples', 'There is 1 apple|There are %count% apples', 10, array('%count%' => 10)),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR fixes the following case:

``` php
\Locale::setDefault('en');
$translator = new IdentityTranslator(new MessageSelector());

echo $translator->transChoice('There is one apple|There are %count% apples', 10, array('%count' => 10));
```

Result before PR:

```
There are 1 apples
```

Result after PR:

```
There is one apple
```

The reason for the current behavior is that the locale `null` is passed to `MessageSelector`, but `MessageSelector` is not programmed to accept `null` values.
