### PR TITLE
removed deps checks in unit tests

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -18,10 +18,6 @@ class ContainerAwareEventManagerTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-
         $this->container = new Container();
         $this->evm = new ContainerAwareEventManager($this->container);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -18,17 +18,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Doctrine\DBAL\Platforms\MySqlPlatform')) {
-            $this->markTestSkipped('Doctrine DBAL is not available.');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     public function testCollectConnections()
     {
         $c = $this->createCollector(array());

--- a/src/Symfony/Bridge/Doctrine/Tests/DataFixtures/ContainerAwareLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataFixtures/ContainerAwareLoaderTest.php
@@ -16,17 +16,6 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\ContainerAwareFixture;
 
 class ContainerAwareLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-
-        if (!class_exists('Doctrine\Common\DataFixtures\Loader')) {
-            $this->markTestSkipped('Doctrine Data Fixtures is not available.');
-        }
-    }
-
     public function testShouldSetContainerOnContainerAwareFixture()
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class RegisterEventListenersAndSubscribersPassTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-    }
-
     public function testProcessEventListenersWithPriorities()
     {
         $container = $this->createBuilder();

--- a/src/Symfony/Bridge/Doctrine/Tests/DoctrineOrmTestCase.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DoctrineOrmTestCase.php
@@ -17,21 +17,6 @@ use Doctrine\ORM\EntityManager;
 
 abstract class DoctrineOrmTestCase extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Doctrine\Common\Version')) {
-            $this->markTestSkipped('Doctrine Common is not available.');
-        }
-
-        if (!class_exists('Doctrine\DBAL\Platforms\MySqlPlatform')) {
-            $this->markTestSkipped('Doctrine DBAL is not available.');
-        }
-
-        if (!class_exists('Doctrine\ORM\EntityManager')) {
-            $this->markTestSkipped('Doctrine ORM is not available.');
-        }
-    }
-
     /**
      * @return EntityManager
      */

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/EntityChoiceListTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/EntityChoiceListTest.php
@@ -35,10 +35,6 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Form\Form')) {
-            $this->markTestSkipped('The "Form" component is not available');
-        }
-
         parent::setUp();
 
         $this->em = $this->createTestEntityManager();

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -50,22 +50,6 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Form\Form')) {
-            $this->markTestSkipped('The "Form" component is not available');
-        }
-
-        if (!class_exists('Doctrine\DBAL\Platforms\MySqlPlatform')) {
-            $this->markTestSkipped('Doctrine DBAL is not available.');
-        }
-
-        if (!class_exists('Doctrine\Common\Version')) {
-            $this->markTestSkipped('Doctrine Common is not available.');
-        }
-
-        if (!class_exists('Doctrine\ORM\EntityManager')) {
-            $this->markTestSkipped('Doctrine ORM is not available.');
-        }
-
         $this->em = DoctrineOrmTestCase::createTestEntityManager();
 
         parent::setUp();

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -44,22 +44,6 @@ class EntityTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Form\Form')) {
-            $this->markTestSkipped('The "Form" component is not available');
-        }
-
-        if (!class_exists('Doctrine\DBAL\Platforms\MySqlPlatform')) {
-            $this->markTestSkipped('Doctrine DBAL is not available.');
-        }
-
-        if (!class_exists('Doctrine\Common\Version')) {
-            $this->markTestSkipped('Doctrine Common is not available.');
-        }
-
-        if (!class_exists('Doctrine\ORM\EntityManager')) {
-            $this->markTestSkipped('Doctrine ORM is not available.');
-        }
-
         $this->em = DoctrineOrmTestCase::createTestEntityManager();
         $this->emRegistry = $this->createRegistryMock('default', $this->em);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/HttpFoundation/DbalSessionHandlerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/HttpFoundation/DbalSessionHandlerTest.php
@@ -20,13 +20,6 @@ use Symfony\Bridge\Doctrine\HttpFoundation\DbalSessionHandler;
  */
 class DbalSessionHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testConstruct()
     {
         $this->connection = $this->getMock('Doctrine\DBAL\Driver\Connection');

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -18,15 +18,6 @@ use Doctrine\ORM\Tools\SchemaTool;
 
 class EntityUserProviderTest extends DoctrineOrmTestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Security\Core\SecurityContext')) {
-            $this->markTestSkipped('The "Security" component is not available');
-        }
-
-        parent::setUp();
-    }
-
     public function testRefreshUserGetsUserByPrimaryKey()
     {
         $em = $this->createTestEntityManager();

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -26,19 +26,6 @@ use Doctrine\ORM\Tools\SchemaTool;
 
 class UniqueValidatorTest extends DoctrineOrmTestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (!class_exists('Symfony\Component\Security\Core\SecurityContext')) {
-            $this->markTestSkipped('The "Security" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Validator\Constraint')) {
-            $this->markTestSkipped('The "Validator" component is not available');
-        }
-    }
-
     protected function createRegistryMock($entityManagerName, $em)
     {
         $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ConsoleHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Monolog\\Logger')) {
-            $this->markTestSkipped('Monolog is not available.');
-        }
-    }
-
     public function testConstructor()
     {
         $handler = new ConsoleHandler(null, false);

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class WebProcessorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Monolog\\Logger')) {
-            $this->markTestSkipped('Monolog is not available.');
-        }
-    }
-
     public function testUsesRequestServerData()
     {
         $server = array(

--- a/src/Symfony/Bridge/Propel1/Tests/DataCollector/PropelDataCollectorTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/DataCollector/PropelDataCollectorTest.php
@@ -18,13 +18,6 @@ use Symfony\Bridge\Propel1\Tests\Propel1TestCase;
 
 class PropelDataCollectorTest extends Propel1TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testCollectWithoutData()
     {
         $c = $this->createCollector(array());

--- a/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/ModelChoiceListTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/ModelChoiceListTest.php
@@ -21,17 +21,6 @@ class ModelChoiceListTest extends Propel1TestCase
 {
     const ITEM_CLASS = '\Symfony\Bridge\Propel1\Tests\Fixtures\Item';
 
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Form\Form')) {
-            $this->markTestSkipped('The "Form" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\PropertyAccess\PropertyAccessor')) {
-            $this->markTestSkipped('The "PropertyAccessor" component is not available');
-        }
-    }
-
     public function testEmptyChoicesReturnsEmpty()
     {
         $choiceList = new ModelChoiceList(

--- a/src/Symfony/Bridge/Propel1/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
@@ -21,12 +21,6 @@ class CollectionToArrayTransformerTest extends Propel1TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Form\Form')) {
-            $this->markTestSkipped('The "Form" component is not available');
-        }
-
-        parent::setUp();
-
         $this->transformer = new CollectionToArrayTransformer();
     }
 

--- a/src/Symfony/Bridge/Propel1/Tests/Propel1TestCase.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Propel1TestCase.php
@@ -13,10 +13,4 @@ namespace Symfony\Bridge\Propel1\Tests;
 
 abstract class Propel1TestCase extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('\Propel')) {
-            $this->markTestSkipped('Propel is not available.');
-        }
-    }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubFilesystemLoader.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubFilesystemLoader.php
@@ -11,20 +11,13 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension\Fixtures;
 
-// Preventing autoloader throwing E_FATAL when Twig is now available
-if (!class_exists('Twig_Environment')) {
-    class StubFilesystemLoader
+class StubFilesystemLoader extends \Twig_Loader_Filesystem
+{
+    protected function findTemplate($name)
     {
-    }
-} else {
-    class StubFilesystemLoader extends \Twig_Loader_Filesystem
-    {
-        protected function findTemplate($name)
-        {
-            // strip away bundle name
-            $parts = explode(':', $name);
+        // strip away bundle name
+        $parts = explode(':', $name);
 
-            return parent::findTemplate(end($parts));
-        }
+        return parent::findTemplate(end($parts));
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -30,22 +30,6 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Locale\Locale')) {
-            $this->markTestSkipped('The "Locale" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Form\Form')) {
-            $this->markTestSkipped('The "Form" component is not available');
-        }
-
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-
         parent::setUp();
 
         $rendererEngine = new TwigRendererEngine(array(

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -29,22 +29,6 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Locale\Locale')) {
-            $this->markTestSkipped('The "Locale" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Form\Form')) {
-            $this->markTestSkipped('The "Form" component is not available');
-        }
-
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-
         parent::setUp();
 
         $rendererEngine = new TwigRendererEngine(array(

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -18,19 +18,6 @@ use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 
 class HttpKernelExtensionTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-    }
-
     /**
      * @expectedException \Twig_Error_Runtime
      */

--- a/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
@@ -16,15 +16,6 @@ use Symfony\Bridge\Twig\Tests\TestCase;
 
 class RoutingExtensionTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (!class_exists('Symfony\Component\Routing\Route')) {
-            $this->markTestSkipped('The "Routing" component is not available');
-        }
-    }
-
     /**
      * @dataProvider getEscapingTemplates
      */

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -17,15 +17,6 @@ use Symfony\Bridge\Twig\Tests\TestCase;
 
 class StopwatchExtensionTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (!class_exists('Symfony\Component\Stopwatch\Stopwatch')) {
-            $this->markTestSkipped('The "Stopwatch" component is not available');
-        }
-    }
-
     /**
      * @expectedException \Twig_Error_Syntax
      */

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -19,19 +19,6 @@ use Symfony\Bridge\Twig\Tests\TestCase;
 
 class TranslationExtensionTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (!class_exists('Symfony\Component\Translation\Translator')) {
-            $this->markTestSkipped('The "Translation" component is not available');
-        }
-
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-    }
-
     public function testEscaping()
     {
         $output = $this->getTemplate('{% trans %}Percent: %value%%% (%msg%){% endtrans %}')->render(array('value' => 12, 'msg' => 'approx.'));

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -16,15 +16,6 @@ use Symfony\Bridge\Twig\Node\FormThemeNode;
 
 class FormThemeTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
-            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
-        }
-    }
-
     public function testConstructor()
     {
         $form = new \Twig_Node_Expression_Name('form', 0);

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -16,15 +16,6 @@ use Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode;
 
 class SearchAndRenderBlockNodeTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
-            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
-        }
-    }
-
     public function testCompileWidget()
     {
         $arguments = new \Twig_Node(array(

--- a/src/Symfony/Bridge/Twig/Tests/TestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/TestCase.php
@@ -13,10 +13,4 @@ namespace Symfony\Bridge\Twig\Tests;
 
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-    }
 }

--- a/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
@@ -17,15 +17,6 @@ use Symfony\Bridge\Twig\Node\FormThemeNode;
 
 class FormThemeTokenParserTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
-            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
-        }
-    }
-
     /**
      * @dataProvider getTestsForFormTheme
      */

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -18,13 +18,6 @@ use Symfony\Bridge\Twig\Tests\TestCase;
 
 class TwigExtractorTest extends TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Translation\Translator')) {
-            $this->markTestSkipped('The "Translation" component is not available');
-        }
-    }
-
     /**
      * @dataProvider getExtractData
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -234,10 +234,6 @@ abstract class FrameworkExtensionTest extends TestCase
 
     public function testAnnotations()
     {
-        if (!class_exists('Doctrine\\Common\\Version')) {
-            $this->markTestSkipped('Doctrine is not available.');
-        }
-
         $container = $this->createContainerFromFile('full');
 
         $this->assertEquals($container->getParameter('kernel.cache_dir').'/annotations', $container->getDefinition('annotations.file_cache_reader')->getArgument(1));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
@@ -23,15 +23,6 @@ class WebTestCase extends BaseWebTestCase
         self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
-    protected function setUp()
-    {
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-
-        parent::setUp();
-    }
-
     protected function deleteTmpDir($testCase)
     {
         if (!file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$testCase)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -29,19 +29,6 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
      */
     protected $engine;
 
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper')) {
-            $this->markTestSkipped('The "FrameworkBundle" is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Templating\PhpEngine')) {
-            $this->markTestSkipped('The "Templating" component is not available');
-        }
-
-        parent::setUp();
-    }
-
     protected function getExtensions()
     {
         // should be moved to the Form component once absolute file paths are supported

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -29,19 +29,6 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
      */
     protected $engine;
 
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper')) {
-            $this->markTestSkipped('The "FrameworkBundle" is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Templating\PhpEngine')) {
-            $this->markTestSkipped('The "Templating" component is not available');
-        }
-
-        parent::setUp();
-    }
-
     protected function getExtensions()
     {
         // should be moved to the Form component once absolute file paths are supported

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
@@ -23,15 +23,6 @@ class WebTestCase extends BaseWebTestCase
         self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
-    protected function setUp()
-    {
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-
-        parent::setUp();
-    }
-
     protected function deleteTmpDir($testCase)
     {
         if (!file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$testCase)) {

--- a/src/Symfony/Bundle/TwigBundle/Tests/TestCase.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TestCase.php
@@ -13,10 +13,4 @@ namespace Symfony\Bundle\TwigBundle\Tests;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-    }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/TestCase.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/TestCase.php
@@ -13,10 +13,4 @@ namespace Symfony\Bundle\WebProfilerBundle\Tests;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Twig_Environment')) {
-            $this->markTestSkipped('Twig is not available.');
-        }
-    }
 }

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -238,14 +238,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testClick()
     {
-        if (!class_exists('Symfony\Component\DomCrawler\Crawler')) {
-            $this->markTestSkipped('The "DomCrawler" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\CssSelector\CssSelector')) {
-            $this->markTestSkipped('The "CssSelector" component is not available');
-        }
-
         $client = new TestClient();
         $client->setNextResponse(new Response('<html><a href="/foo">foo</a></html>'));
         $crawler = $client->request('GET', 'http://www.example.com/foo/foobar');
@@ -257,14 +249,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testClickForm()
     {
-        if (!class_exists('Symfony\Component\DomCrawler\Crawler')) {
-            $this->markTestSkipped('The "DomCrawler" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\CssSelector\CssSelector')) {
-            $this->markTestSkipped('The "CssSelector" component is not available');
-        }
-
         $client = new TestClient();
         $client->setNextResponse(new Response('<html><form action="/foo"><input type="submit" /></form></html>'));
         $crawler = $client->request('GET', 'http://www.example.com/foo/foobar');
@@ -276,14 +260,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmit()
     {
-        if (!class_exists('Symfony\Component\DomCrawler\Crawler')) {
-            $this->markTestSkipped('The "DomCrawler" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\CssSelector\CssSelector')) {
-            $this->markTestSkipped('The "CssSelector" component is not available');
-        }
-
         $client = new TestClient();
         $client->setNextResponse(new Response('<html><form action="/foo"><input type="submit" /></form></html>'));
         $crawler = $client->request('GET', 'http://www.example.com/foo/foobar');
@@ -295,14 +271,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmitPreserveAuth()
     {
-        if (!class_exists('Symfony\Component\DomCrawler\Crawler')) {
-            $this->markTestSkipped('The "DomCrawler" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\CssSelector\CssSelector')) {
-            $this->markTestSkipped('The "CssSelector" component is not available');
-        }
-
         $client = new TestClient(array('PHP_AUTH_USER' => 'foo', 'PHP_AUTH_PW' => 'bar'));
         $client->setNextResponse(new Response('<html><form action="/foo"><input type="submit" /></form></html>'));
         $crawler = $client->request('GET', 'http://www.example.com/foo/foobar');
@@ -475,10 +443,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testInsulatedRequests()
     {
-        if (!class_exists('Symfony\Component\Process\Process')) {
-            $this->markTestSkipped('The "Process" component is not available');
-        }
-
         $client = new TestClient();
         $client->insulate();
         $client->setNextScript("new Symfony\Component\BrowserKit\Response('foobar')");

--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -120,10 +120,6 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateMapFinderSupport()
     {
-        if (!class_exists('Symfony\\Component\\Finder\\Finder')) {
-            $this->markTestSkipped('Finder component is not available');
-        }
-
         $finder = new \Symfony\Component\Finder\Finder();
         $finder->files()->in(__DIR__.'/Fixtures/beta/NamespaceCollision');
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -731,10 +731,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function testRunWithDispatcher()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $application = new Application();
         $application->setAutoExit(false);
         $application->setDispatcher($this->getDispatcher());
@@ -754,10 +750,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
      */
     public function testRunWithExceptionAndDispatcher()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $application = new Application();
         $application->setDispatcher($this->getDispatcher());
         $application->setAutoExit(false);
@@ -773,10 +765,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function testRunDispatchesAllEventsWithException()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $application = new Application();
         $application->setDispatcher($this->getDispatcher());
         $application->setAutoExit(false);

--- a/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testDebug()
     {
         $handler = new ExceptionHandler(false);

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -485,10 +485,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddObjectResource()
     {
-        if (!class_exists('Symfony\Component\Config\Resource\FileResource')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $container = new ContainerBuilder();
 
         $container->setResourceTracking(false);
@@ -515,10 +511,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddClassResource()
     {
-        if (!class_exists('Symfony\Component\Config\Resource\FileResource')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $container = new ContainerBuilder();
 
         $container->setResourceTracking(false);
@@ -545,10 +537,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCompilesClassDefinitionsOfLazyServices()
     {
-        if (!class_exists('Symfony\Component\Config\Resource\FileResource')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $container = new ContainerBuilder();
 
         $this->assertEmpty($container->getResources(), 'No resources get registered without resource tracking');
@@ -575,10 +563,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testResources()
     {
-        if (!class_exists('Symfony\Component\Config\Resource\FileResource')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $container = new ContainerBuilder();
         $container->addResource($a = new FileResource(__DIR__.'/Fixtures/xml/services1.xml'));
         $container->addResource($b = new FileResource(__DIR__.'/Fixtures/xml/services2.xml'));
@@ -669,10 +653,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionWhenAddServiceOnAFrozenContainer()
     {
-        if (!class_exists('Symfony\Component\Config\Resource\FileResource')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $container = new ContainerBuilder();
         $container->compile();
         $container->set('a', new \stdClass());
@@ -680,10 +660,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testNoExceptionWhenSetSyntheticServiceOnAFrozenContainer()
     {
-        if (!class_exists('Symfony\Component\Config\Resource\FileResource')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $container = new ContainerBuilder();
         $def = new Definition('stdClass');
         $def->setSynthetic(true);

--- a/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
@@ -18,13 +18,6 @@ class CrossCheckTest extends \PHPUnit_Framework_TestCase
 {
     protected static $fixturesPath;
 
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public static function setUpBeforeClass()
     {
         self::$fixturesPath = __DIR__.'/Fixtures/';

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -18,13 +18,6 @@ class YamlDumperTest extends \PHPUnit_Framework_TestCase
 {
     protected static $fixturesPath;
 
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
-            $this->markTestSkipped('The "Yaml" component is not available');
-        }
-    }
-
     public static function setUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/ClosureLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/ClosureLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 
 class ClosureLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     /**
      * @covers Symfony\Component\DependencyInjection\Loader\ClosureLoader::supports
      */

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
@@ -29,10 +29,6 @@ class IniFileLoaderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $this->container = new ContainerBuilder();
         $this->loader    = new IniFileLoader($this->container, new FileLocator(self::$fixturesPath.'/ini'));
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -18,13 +18,6 @@ use Symfony\Component\Config\FileLocator;
 
 class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     /**
      * @covers Symfony\Component\DependencyInjection\Loader\PhpFileLoader::supports
      */

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -27,13 +27,6 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
     protected static $fixturesPath;
 
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public static function setUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
@@ -126,10 +119,6 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadImports()
     {
-        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
-            $this->markTestSkipped('The "Yaml" component is not available');
-        }
-
         $container = new ContainerBuilder();
         $resolver = new LoaderResolver(array(
             new IniFileLoader($container, new FileLocator(self::$fixturesPath.'/xml')),

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -25,17 +25,6 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
     protected static $fixturesPath;
 
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
-            $this->markTestSkipped('The "Yaml" component is not available');
-        }
-    }
-
     public static function setUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -371,10 +371,6 @@ EOF
      */
     public function testFilter()
     {
-        if (!class_exists('Symfony\Component\CssSelector\CssSelector')) {
-            $this->markTestSkipped('The "CssSelector" component is not available');
-        }
-
         $crawler = $this->createTestCrawler();
         $this->assertNotSame($crawler, $crawler->filter('li'), '->filter() returns a new instance of a crawler');
         $this->assertInstanceOf('Symfony\\Component\\DomCrawler\\Crawler', $crawler, '->filter() returns a new instance of a crawler');

--- a/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
@@ -19,13 +19,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-    }
-
     public function testAddAListenerService()
     {
         $event = new Event();

--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -25,10 +25,6 @@ abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
             ->getFormFactory();

--- a/src/Symfony/Component/Form/Tests/AbstractFormTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractFormTest.php
@@ -34,10 +34,6 @@ abstract class AbstractFormTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         // We need an actual dispatcher to use the deprecated
         // bindRequest() method
         $this->dispatcher = new EventDispatcher();

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -517,10 +517,6 @@ class CompoundFormTest extends AbstractFormTest
      */
     public function testSubmitPostOrPutRequest($method)
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $path = tempnam(sys_get_temp_dir(), 'sf2');
         touch($path);
 
@@ -569,10 +565,6 @@ class CompoundFormTest extends AbstractFormTest
      */
     public function testSubmitPostOrPutRequestWithEmptyRootFormName($method)
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $path = tempnam(sys_get_temp_dir(), 'sf2');
         touch($path);
 
@@ -620,10 +612,6 @@ class CompoundFormTest extends AbstractFormTest
      */
     public function testSubmitPostOrPutRequestWithSingleChildForm($method)
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $path = tempnam(sys_get_temp_dir(), 'sf2');
         touch($path);
 
@@ -660,10 +648,6 @@ class CompoundFormTest extends AbstractFormTest
      */
     public function testSubmitPostOrPutRequestWithSingleChildFormUploadedFile($method)
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $path = tempnam(sys_get_temp_dir(), 'sf2');
         touch($path);
 
@@ -689,10 +673,6 @@ class CompoundFormTest extends AbstractFormTest
 
     public function testSubmitGetRequest()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $values = array(
             'author' => array(
                 'firstName' => 'Bernhard',
@@ -721,10 +701,6 @@ class CompoundFormTest extends AbstractFormTest
 
     public function testSubmitGetRequestWithEmptyRootFormName()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $values = array(
             'firstName' => 'Bernhard',
             'lastName' => 'Schussek',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -34,14 +34,6 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\Event')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\PropertyAccess\PropertyAccess')) {
-            $this->markTestSkipped('The "PropertyAccess" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->propertyAccessor = $this->getMock('Symfony\Component\PropertyAccess\PropertyAccessorInterface');
         $this->mapper = new PropertyPathMapper($this->propertyAccessor);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixRadioInputListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixRadioInputListenerTest.php
@@ -21,10 +21,6 @@ class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         parent::setUp();
 
         $this->choiceList = new SimpleChoiceList(array('' => 'Empty', 0 => 'A', 1 => 'B'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener;
 
 class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-    }
-
     public function testFixHttpUrl()
     {
         $data = "www.symfony.com";

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
@@ -22,10 +22,6 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->form = $this->getForm('axes');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -23,10 +23,6 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->form = $this->getBuilder()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Form\Extension\Core\EventListener\TrimListener;
 
 class TrimListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-    }
-
     public function testTrim()
     {
         $data = " Foo! ";

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/SessionCsrfProviderTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/SessionCsrfProviderTest.php
@@ -20,10 +20,6 @@ class SessionCsrfProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Session\Session')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $this->session = $this->getMock(
             'Symfony\Component\HttpFoundation\Session\Session',
             array(),

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -23,10 +23,6 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->csrfProvider = $this->getMock('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface');

--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/EventListener/BindRequestListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/EventListener/BindRequestListenerTest.php
@@ -86,10 +86,6 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSubmitRequest($method)
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $values = array('author' => $this->values);
         $files = array('author' => $this->filesNested);
         $request = new Request(array(), $values, array(), array(), $files, array(
@@ -115,10 +111,6 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSubmitRequestWithEmptyName($method)
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $request = new Request(array(), $this->values, array(), array(), $this->filesPlain, array(
             'REQUEST_METHOD' => $method,
         ));
@@ -142,10 +134,6 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSubmitEmptyRequestToCompoundForm($method)
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $request = new Request(array(), array(), array(), array(), array(), array(
             'REQUEST_METHOD' => $method,
         ));
@@ -169,10 +157,6 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSubmitEmptyRequestToSimpleForm($method)
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $request = new Request(array(), array(), array(), array(), array(), array(
             'REQUEST_METHOD' => $method,
         ));
@@ -192,10 +176,6 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmitGetRequest()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $values = array('author' => $this->values);
         $request = new Request($values, array(), array(), array(), array(), array(
             'REQUEST_METHOD' => 'GET',
@@ -217,10 +197,6 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmitGetRequestWithEmptyName()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $request = new Request($this->values, array(), array(), array(), array(), array(
             'REQUEST_METHOD' => 'GET',
         ));
@@ -241,10 +217,6 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmitEmptyGetRequestToCompoundForm()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $request = new Request(array(), array(), array(), array(), array(), array(
             'REQUEST_METHOD' => 'GET',
         ));
@@ -264,10 +236,6 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmitEmptyGetRequestToSimpleForm()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $request = new Request(array(), array(), array(), array(), array(), array(
             'REQUEST_METHOD' => 'GET',
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -49,10 +49,6 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\Event')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->serverParams = $this->getMock(

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -54,10 +54,6 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\Event')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TypeTestCase.php
@@ -20,10 +20,6 @@ abstract class TypeTestCase extends BaseTypeTestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Validator\Constraint')) {
-            $this->markTestSkipped('The "Validator" component is not available');
-        }
-
         $this->validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
         $metadataFactory = $this->getMock('Symfony\Component\Validator\MetadataFactoryInterface');
         $this->validator->expects($this->once())->method('getMetadataFactory')->will($this->returnValue($metadataFactory));

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -60,10 +60,6 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\Event')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->mapper = new ViolationMapper();
         $this->message = 'Message';

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -23,10 +23,6 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->builder = new FormBuilder('name', null, $this->dispatcher, $this->factory);

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -53,10 +53,6 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->resolvedTypeFactory = $this->getMock('Symfony\Component\Form\ResolvedFormTypeFactoryInterface');
         $this->guesser1 = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
         $this->guesser2 = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -39,14 +39,6 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\OptionsResolver\OptionsResolver')) {
-            $this->markTestSkipped('The "OptionsResolver" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->dataMapper = $this->getMock('Symfony\Component\Form\DataMapperInterface');

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -21,18 +21,6 @@ class BundleTest extends \PHPUnit_Framework_TestCase
 {
     public function testRegisterCommands()
     {
-        if (!class_exists('Symfony\Component\Console\Application')) {
-            $this->markTestSkipped('The "Console" component is not available');
-        }
-
-        if (!interface_exists('Symfony\Component\DependencyInjection\ContainerAwareInterface')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Finder\Finder')) {
-            $this->markTestSkipped('The "Finder" component is not available');
-        }
-
         $cmd = new FooCommand();
         $app = $this->getMock('Symfony\Component\Console\Application');
         $app->expects($this->once())->method('add')->with($this->equalTo($cmd));

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\TestClient;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\BrowserKit\Client')) {
-            $this->markTestSkipped('The "BrowserKit" component is not available');
-        }
-    }
-
     public function testDoRequest()
     {
         $client = new Client(new TestHttpKernel());
@@ -50,14 +43,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testGetScript()
     {
-        if (!class_exists('Symfony\Component\Process\Process')) {
-            $this->markTestSkipped('The "Process" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\ClassLoader\ClassLoader')) {
-            $this->markTestSkipped('The "ClassLoader" component is not available');
-        }
-
         $client = new TestClient(new TestHttpKernel());
         $client->insulate();
         $client->request('GET', '/');

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testGetController()
     {
         $logger = new Logger();

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -19,13 +19,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testCollect()
     {
         $kernel = new KernelForTest('test', true);

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ExceptionDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ExceptionDataCollectorTest.php
@@ -18,13 +18,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExceptionDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testCollect()
     {
         $e = new \Exception('foo',500);

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -18,13 +18,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LoggerDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     /**
      * @dataProvider getCollectTestData
      */

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/MemoryDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/MemoryDataCollectorTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MemoryDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testCollect()
     {
         $collector = new MemoryDataCollector();

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     /**
      * @dataProvider provider
      */

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TimeDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testCollect()
     {
         $c = new TimeDataCollector;

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -22,17 +22,6 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
 class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testAddRemoveListener()
     {
         $dispatcher = new EventDispatcher();

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -19,21 +19,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     /**
      * @dataProvider getProviderTypes
      */

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/MergeExtensionConfigurationPassTest.php
@@ -15,17 +15,6 @@ use Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfiguration
 
 class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Config\FileLocator')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testAutoloadMainExtension()
     {
         $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/EsiListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/EsiListenerTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class EsiListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-    }
-
     public function testFilterDoesNothingForSubRequests()
     {
         $dispatcher = new EventDispatcher();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -26,17 +26,6 @@ use Symfony\Component\HttpKernel\Tests\Logger;
  */
 class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testConstruct()
     {
         $logger = new TestLogger();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
@@ -19,13 +19,6 @@ use Symfony\Component\HttpKernel\UriSigner;
 
 class FragmentListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-    }
-
     public function testOnlyTriggeredOnFragmentRoute()
     {
         $request = Request::create('http://example.com/foo?_path=foo%3Dbar%26_controller%3Dfoo');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -18,13 +18,6 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-    }
-
     public function testDefaultLocaleWithoutSession()
     {
         $listener = new LocaleListener('fr');
@@ -50,10 +43,6 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testLocaleSetForRoutingContext()
     {
-        if (!class_exists('Symfony\Component\Routing\Router')) {
-            $this->markTestSkipped('The "Routing" component is not available');
-        }
-
         // the request context is updated
         $context = $this->getMock('Symfony\Component\Routing\RequestContext');
         $context->expects($this->once())->method('setParameter')->with('_locale', 'es');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
@@ -27,10 +27,6 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
         $this->dispatcher = new EventDispatcher();
         $listener = new ResponseListener('UTF-8');
         $this->dispatcher->addListener(KernelEvents::RESPONSE, array($listener, 'onKernelResponse'));

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -19,17 +19,6 @@ use Symfony\Component\Routing\RequestContext;
 
 class RouterListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Routing\Router')) {
-            $this->markTestSkipped('The "Routing" component is not available');
-        }
-    }
-
     /**
      * @dataProvider getPortData
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -18,13 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testRenderFallbackToInlineStrategyIfNoRequest()
     {
         $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true));

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
@@ -18,13 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class HIncludeFragmentRendererTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     /**
      * @expectedException \LogicException
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -21,17 +21,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testRender()
     {
         $strategy = new InlineFragmentRenderer($this->getKernel($this->returnValue(new Response('foo'))));

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EsiTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testHasSurrogateEsiCapability()
     {
         $esi = new Esi();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -19,19 +19,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class HttpCacheTest extends HttpCacheTestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testTerminateDelegatesTerminationOnlyForTerminableInterface()
     {
-        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-
         $storeMock = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\HttpCache\\StoreInterface')
             ->disableOriginalConstructor()
             ->getMock();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -31,10 +31,6 @@ class HttpCacheTestCase extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $this->kernel = null;
 
         $this->cache = null;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -23,10 +23,6 @@ class StoreTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $this->request = Request::create('/');
         $this->response = new Response('hello world', 200, array());
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -23,17 +23,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class HttpKernelTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     /**
      * @expectedException RuntimeException
      */

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\FooBarBundle;
 
 class KernelTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
-            $this->markTestSkipped('The "DependencyInjection" component is not available');
-        }
-    }
-
     public function testConstructor()
     {
         $env = 'test_env';

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -19,13 +19,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProfilerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testCollect()
     {
         if (!class_exists('SQLite3') && (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers()))) {

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -207,10 +207,6 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateForRouteWithInvalidOptionalParameterNonStrictWithLogger()
     {
-        if (!interface_exists('Psr\Log\LoggerInterface')) {
-            $this->markTestSkipped('The "psr/log" package is not available');
-        }
-
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', array('foo' => '1'), array('foo' => 'd+')));
         $logger = $this->getMock('Psr\Log\LoggerInterface');
         $logger->expects($this->once())

--- a/src/Symfony/Component/Routing/Tests/Loader/AbstractAnnotationLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AbstractAnnotationLoaderTest.php
@@ -13,13 +13,6 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 abstract class AbstractAnnotationLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Doctrine\\Common\\Version')) {
-            $this->markTestSkipped('Doctrine is not available.');
-        }
-    }
-
     public function getReader()
     {
         return $this->getMockBuilder('Doctrine\Common\Annotations\Reader')

--- a/src/Symfony/Component/Routing/Tests/Loader/ClosureLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ClosureLoaderTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\Routing\RouteCollection;
 
 class ClosureLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\FileLocator')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testSupports()
     {
         $loader = new ClosureLoader();

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Routing\Loader\PhpFileLoader;
 
 class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\FileLocator')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testSupports()
     {
         $loader = new PhpFileLoader($this->getMock('Symfony\Component\Config\FileLocator'));

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\Routing\Tests\Fixtures\CustomXmlFileLoader;
 
 class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\FileLocator')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testSupports()
     {
         $loader = new XmlFileLoader($this->getMock('Symfony\Component\Config\FileLocator'));

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -17,17 +17,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\FileLocator')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
-            $this->markTestSkipped('The "Yaml" component is not available');
-        }
-    }
-
     public function testSupports()
     {
         $loader = new YamlFileLoader($this->getMock('Symfony\Component\Config\FileLocator'));

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -103,10 +103,6 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAddCollectionWithResources()
     {
-        if (!class_exists('Symfony\Component\Config\Resource\FileResource')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $collection = new RouteCollection();
         $collection->addResource($foo = new FileResource(__DIR__.'/Fixtures/foo.xml'));
         $collection1 = new RouteCollection();
@@ -178,10 +174,6 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testResource()
     {
-        if (!class_exists('Symfony\Component\Config\Resource\FileResource')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $collection = new RouteCollection();
         $collection->addResource($foo = new FileResource(__DIR__.'/Fixtures/foo.xml'));
         $collection->addResource($bar = new FileResource(__DIR__.'/Fixtures/bar.xml'));

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderBenchmarkTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderBenchmarkTest.php
@@ -32,10 +32,6 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Doctrine\DBAL\DriverManager')) {
-            $this->markTestSkipped('The "Doctrine DBAL" library is not available');
-        }
-
         try {
             $this->con = DriverManager::getConnection(array(
                 'driver' => 'pdo_mysql',

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderTest.php
@@ -141,9 +141,6 @@ class AclProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Doctrine\DBAL\DriverManager')) {
-            $this->markTestSkipped('The Doctrine2 DBAL is required for this test');
-        }
         if (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers())) {
             self::markTestSkipped('This test requires SQLite support in your environment');
         }

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/MutableAclProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/MutableAclProviderTest.php
@@ -429,9 +429,6 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Doctrine\DBAL\DriverManager')) {
-            $this->markTestSkipped('The Doctrine2 DBAL is required for this test');
-        }
         if (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers())) {
             self::markTestSkipped('This test requires SQLite support in your environment');
         }

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/AclTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/AclTest.php
@@ -511,11 +511,4 @@ class AclTest extends \PHPUnit_Framework_TestCase
     {
         return new Acl(1, new ObjectIdentity(1, 'foo'), new PermissionGrantingStrategy(), array(), true);
     }
-
-    protected function setUp()
-    {
-        if (!class_exists('Doctrine\DBAL\DriverManager')) {
-            $this->markTestSkipped('The Doctrine2 DBAL is required for this test');
-        }
-    }
 }

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/DoctrineAclCacheTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/DoctrineAclCacheTest.php
@@ -98,11 +98,4 @@ class DoctrineAclCacheTest extends \PHPUnit_Framework_TestCase
 
         return new DoctrineAclCache($cacheDriver, $this->getPermissionGrantingStrategy(), $prefix);
     }
-
-    protected function setUp()
-    {
-        if (!class_exists('Doctrine\DBAL\DriverManager')) {
-            $this->markTestSkipped('The Doctrine2 DBAL is required for this test');
-        }
-    }
 }

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/ObjectIdentityTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/ObjectIdentityTest.php
@@ -85,13 +85,6 @@ namespace Symfony\Component\Security\Tests\Acl\Domain
                 array(new ObjectIdentity('1', 'bla'), new ObjectIdentity('1', 'blub'), false),
             );
         }
-
-        protected function setUp()
-        {
-            if (!class_exists('Doctrine\DBAL\DriverManager')) {
-                $this->markTestSkipped('The Doctrine2 DBAL is required for this test');
-            }
-        }
     }
 
     class TestDomainObject

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/PermissionGrantingStrategyTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/PermissionGrantingStrategyTest.php
@@ -182,11 +182,4 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
 
         return new Acl($id++, new ObjectIdentity(1, 'Foo'), $strategy, array(), true);
     }
-
-    protected function setUp()
-    {
-        if (!class_exists('Doctrine\DBAL\DriverManager')) {
-            $this->markTestSkipped('The Doctrine2 DBAL is required for this test');
-        }
-    }
 }

--- a/src/Symfony/Component/Security/Tests/Core/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Validator/Constraints/UserPasswordValidatorTest.php
@@ -23,10 +23,6 @@ class UserPasswordValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (false === class_exists('Symfony\Component\Validator\Validator')) {
-            $this->markTestSkipped('The Validator component is required for this test.');
-        }
-
         $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
     }
 

--- a/src/Symfony/Component/Security/Tests/Http/AccessMapTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/AccessMapTest.php
@@ -15,13 +15,6 @@ use Symfony\Component\Security\Http\AccessMap;
 
 class AccessMapTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testReturnsFirstMatchedPattern()
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');

--- a/src/Symfony/Component/Security/Tests/Http/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -31,18 +31,6 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!interface_exists('Psr\Log\LoggerInterface')) {
-            $this->markTestSkipped('The "LoggerInterface" is not available');
-        }
-
         $this->httpKernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
         $this->httpUtils = $this->getMock('Symfony\Component\Security\Http\HttpUtils');
         $this->logger = $this->getMock('Psr\Log\LoggerInterface');

--- a/src/Symfony/Component/Security/Tests/Http/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -23,10 +23,6 @@ class DefaultAuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCas
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $this->httpUtils = $this->getMock('Symfony\Component\Security\Http\HttpUtils');
         $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $this->request->headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');

--- a/src/Symfony/Component/Security/Tests/Http/EntryPoint/BasicAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/EntryPoint/BasicAuthenticationEntryPointTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class BasicAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testStart()
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');

--- a/src/Symfony/Component/Security/Tests/Http/EntryPoint/DigestAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/EntryPoint/DigestAuthenticationEntryPointTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\Security\Core\Exception\NonceExpiredException;
 
 class DigestAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testStart()
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');

--- a/src/Symfony/Component/Security/Tests/Http/EntryPoint/FormAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/EntryPoint/FormAuthenticationEntryPointTest.php
@@ -16,17 +16,6 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class FormAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     public function testStart()
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);

--- a/src/Symfony/Component/Security/Tests/Http/EntryPoint/RetryAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/EntryPoint/RetryAuthenticationEntryPointTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RetryAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     /**
      * @dataProvider dataForStart
      */

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/AbstractPreAuthenticatedListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/AbstractPreAuthenticatedListenerTest.php
@@ -18,21 +18,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     public function testHandleWithValidValues()
     {
         $userCredentials = array('TheUser', 'TheCredentials');

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/AccessListenerTest.php
@@ -15,21 +15,6 @@ use Symfony\Component\Security\Http\Firewall\AccessListener;
 
 class AccessListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
      */

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/AnonymousAuthenticationListenerTest.php
@@ -15,13 +15,6 @@ use Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener;
 
 class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-    }
-
     public function testHandleWithContextHavingAToken()
     {
         $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/BasicAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/BasicAuthenticationListenerTest.php
@@ -20,21 +20,6 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager
 
 class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     public function testHandleWithValidUsernameAndPasswordServerParameters()
     {
         $request = new Request(array(), array(), array(), array(), array(), array(

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/ChannelListenerTest.php
@@ -17,21 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ChannelListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     public function testHandleWithNotSecuredRequestAndHttpChannel()
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/ContextListenerTest.php
@@ -26,18 +26,6 @@ class ContextListenerTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-
         $this->securityContext = new SecurityContext(
             $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface'),
             $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/LogoutListenerTest.php
@@ -17,25 +17,6 @@ use Symfony\Component\Security\Http\Firewall\LogoutListener;
 
 class LogoutListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Form\Form')) {
-            $this->markTestSkipped('The "Form" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     public function testHandleUnmatchedPath()
     {
         list($listener, $context, $httpUtils, $options) = $this->getListener();

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/RememberMeListenerTest.php
@@ -17,21 +17,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     public function testOnCoreSecurityDoesNotTryToPopulateNonEmptySecurityContext()
     {
         list($listener, $context, $service,,) = $this->getListener();

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/SwitchUserListenerTest.php
@@ -29,14 +29,6 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-
         $this->securityContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
         $this->userProvider = $this->getMock('Symfony\Component\Security\Core\User\UserProviderInterface');
         $this->userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/X509AuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/X509AuthenticationListenerTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Security\Http\Firewall\X509AuthenticationListener;
 
 class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     /**
      * @dataProvider dataProviderGetPreAuthenticatedData
      */

--- a/src/Symfony/Component/Security/Tests/Http/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/FirewallMapTest.php
@@ -16,17 +16,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class FirewallMapTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testGetListeners()
     {
         $map = new FirewallMap();

--- a/src/Symfony/Component/Security/Tests/Http/FirewallTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/FirewallTest.php
@@ -17,21 +17,6 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class FirewallTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
-        }
-    }
-
     public function testOnKernelRequestRegistersExceptionListener()
     {
         $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');

--- a/src/Symfony/Component/Security/Tests/Http/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/HttpUtilsTest.php
@@ -19,17 +19,6 @@ use Symfony\Component\Security\Http\HttpUtils;
 
 class HttpUtilsTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Routing\Router')) {
-            $this->markTestSkipped('The "Routing" component is not available');
-        }
-    }
-
     public function testCreateRedirectResponseWithPath()
     {
         $utils = new HttpUtils($this->getUrlGenerator());

--- a/src/Symfony/Component/Security/Tests/Http/Logout/CookieClearingLogoutHandlerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Logout/CookieClearingLogoutHandlerTest.php
@@ -18,13 +18,6 @@ use Symfony\Component\Security\Http\Logout\CookieClearingLogoutHandler;
 
 class CookieClearingLogoutHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testLogout()
     {
         $request = new Request();

--- a/src/Symfony/Component/Security/Tests/Http/Logout/DefaultLogoutSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Logout/DefaultLogoutSuccessHandlerTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler;
 
 class DefaultLogoutSuccessHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testLogout()
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');

--- a/src/Symfony/Component/Security/Tests/Http/Logout/SessionLogoutHandlerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Logout/SessionLogoutHandlerTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Security\Http\Logout\SessionLogoutHandler;
 
 class SessionLogoutHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testLogout()
     {
         $handler = new SessionLogoutHandler();

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/AbstractRememberMeServicesTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testGetRememberMeParameter()
     {
         $service = $this->getService(null, array('remember_me_parameter' => 'foo'));

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -26,13 +26,6 @@ use Symfony\Component\Security\Core\Util\SecureRandom;
 
 class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testAutoLoginReturnsNullWhenNoCookie()
     {
         $service = $this->getService(null, array('name' => 'foo'));

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/ResponseListenerTest.php
@@ -19,13 +19,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class ResponseListenerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testRememberMeCookieIsSentWithResponse()
     {
         $cookie = new Cookie('rememberme');

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -23,13 +23,6 @@ use Symfony\Component\Security\Http\RememberMe\TokenBasedRememberMeServices;
 
 class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testAutoLoginReturnsNullWhenNoCookie()
     {
         $service = $this->getService(null, array('name' => 'foo'));

--- a/src/Symfony/Component/Security/Tests/Http/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Session/SessionAuthenticationStrategyTest.php
@@ -15,13 +15,6 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 
 class SessionAuthenticationStrategyTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-    }
-
     public function testSessionIsNotChanged()
     {
         $request = $this->getRequest();

--- a/src/Symfony/Component/Translation/Tests/Dumper/YamlFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/YamlFileDumperTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Translation\Dumper\YamlFileDumper;
 
 class YamlFileDumperTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
-            $this->markTestSkipped('The "Yaml" component is not available');
-        }
-    }
-
     public function testDump()
     {
         $catalogue = new MessageCatalogue('en');

--- a/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class CsvFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testLoad()
     {
         $loader = new CsvFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/IcuDatFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IcuDatFileLoaderTest.php
@@ -18,10 +18,6 @@ class IcuDatFileLoaderTest extends LocalizedTestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('This test requires intl extension to work.');
         }

--- a/src/Symfony/Component/Translation/Tests/Loader/IcuResFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IcuResFileLoaderTest.php
@@ -18,10 +18,6 @@ class IcuResFileLoaderTest extends LocalizedTestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('This test requires intl extension to work.');
         }

--- a/src/Symfony/Component/Translation/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IniFileLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class IniFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testLoad()
     {
         $loader = new IniFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/MoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/MoFileLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class MoFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testLoad()
     {
         $loader = new MoFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PhpFileLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testLoad()
     {
         $loader = new PhpFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class PoFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testLoad()
     {
         $loader = new PoFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/QtFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/QtFileLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class QtFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testLoad()
     {
         $loader = new QtFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -16,13 +16,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-    }
-
     public function testLoad()
     {
         $loader = new XliffFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/YamlFileLoaderTest.php
@@ -16,17 +16,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
-            $this->markTestSkipped('The "Yaml" component is not available');
-        }
-    }
-
     public function testLoad()
     {
         $loader = new YamlFileLoader();

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -82,10 +82,6 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testAddCatalogue()
     {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $r = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
 
@@ -108,10 +104,6 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testAddFallbackCatalogue()
     {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $r = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
 
@@ -155,10 +147,6 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAddResource()
     {
-        if (!class_exists('Symfony\Component\Config\Loader\Loader')) {
-            $this->markTestSkipped('The "Config" component is not available');
-        }
-
         $catalogue = new MessageCatalogue('en');
         $r = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -24,10 +24,6 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\UploadedFile')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new FileValidator();
         $this->validator->initialize($this->context);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -51,10 +51,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidImage()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $this->context->expects($this->never())
             ->method('addViolation');
 
@@ -63,10 +59,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidSize()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $this->context->expects($this->never())
             ->method('addViolation');
 
@@ -82,10 +74,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testWidthTooSmall()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'minWidth' => 3,
             'minWidthMessage' => 'myMessage',
@@ -103,10 +91,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testWidthTooBig()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'maxWidth' => 1,
             'maxWidthMessage' => 'myMessage',
@@ -124,10 +108,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testHeightTooSmall()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'minHeight' => 3,
             'minHeightMessage' => 'myMessage',
@@ -145,10 +125,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testHeightTooBig()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'maxHeight' => 1,
             'maxHeightMessage' => 'myMessage',
@@ -169,10 +145,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMinWidth()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'minWidth' => '1abc',
         ));
@@ -185,10 +157,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMaxWidth()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'maxWidth' => '1abc',
         ));
@@ -201,10 +169,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMinHeight()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'minHeight' => '1abc',
         ));
@@ -217,10 +181,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMaxHeight()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'maxHeight' => '1abc',
         ));
@@ -230,10 +190,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testRatioTooSmall()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'minRatio' => 2,
             'minRatioMessage' => 'myMessage',
@@ -251,10 +207,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testRatioTooBig()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'maxRatio' => 0.5,
             'maxRatioMessage' => 'myMessage',
@@ -275,10 +227,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMinRatio()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'minRatio' => '1abc',
         ));
@@ -291,10 +239,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMaxRatio()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'maxRatio' => '1abc',
         ));
@@ -304,10 +248,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSquareNotAllowed()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'allowSquare' => false,
             'allowSquareMessage' => 'myMessage',
@@ -325,10 +265,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testLandscapeNotAllowed()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'allowLandscape' => false,
             'allowLandscapeMessage' => 'myMessage',
@@ -346,10 +282,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testPortraitNotAllowed()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\File\File')) {
-            $this->markTestSkipped('The "HttpFoundation" component is not available');
-        }
-
         $constraint = new Image(array(
             'allowPortrait' => false,
             'allowPortraitMessage' => 'myMessage',

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -23,13 +23,6 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 
 class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Doctrine\Common\Annotations\AnnotationReader')) {
-            $this->markTestSkipped('The "Doctrine Common" library is not available');
-        }
-    }
-
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
         $reader = new AnnotationReader();

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -23,13 +23,6 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
-            $this->markTestSkipped('The "Yaml" component is not available');
-        }
-    }
-
     public function testLoadClassMetadataReturnsFalseIfEmpty()
     {
         $loader = new YamlFileLoader(__DIR__.'/empty-mapping.yml');

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -75,10 +75,6 @@ class ValidatorBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testEnableAnnotationMapping()
     {
-        if (!class_exists('Doctrine\Common\Annotations\AnnotationReader')) {
-            $this->markTestSkipped('Annotations is required for this test');
-        }
-
         $this->assertSame($this->builder, $this->builder->enableAnnotationMapping());
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

As Composer is now widely used in the PHP world, having to run composer install before running the test suite is expected. This also has the nice benefit of removing a bunch of code, making things easier to maintain (there is only one place to declare a dev dependency), and probably more.

see fabpot/Silex#626 where we did the same a while ago for Silex.
