### PR TITLE
[Console] Improved searching commands

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -494,51 +494,31 @@ class Application
     public function findNamespace($namespace)
     {
         $allNamespaces = $this->getNamespaces();
-        $found = '';
-        foreach (explode(':', $namespace) as $i => $part) {
-            // select sub-namespaces matching the current namespace we found
-            $namespaces = array();
-            foreach ($allNamespaces as $n) {
-                if ('' === $found || 0 === strpos($n, $found)) {
-                    $namespaces[$n] = explode(':', $n);
-                }
-            }
+        $expr = preg_replace_callback('{([^:]+|)}', function ($matches) { return preg_quote($matches[1]).'[^:]*'; }, $namespace);
+        $namespaces = preg_grep('{^'.$expr.'}', $allNamespaces);
 
-            $abbrevs = static::getAbbreviations(array_unique(array_values(array_filter(array_map(function ($p) use ($i) { return isset($p[$i]) ? $p[$i] : ''; }, $namespaces)))));
+        if (empty($namespaces)) {
+            $message = sprintf('There are no commands defined in the "%s" namespace.', $namespace);
 
-            if (!isset($abbrevs[$part])) {
-                $message = sprintf('There are no commands defined in the "%s" namespace.', $namespace);
-
-                if (1 <= $i) {
-                    $part = $found.':'.$part;
+            if ($alternatives = $this->findAlternatives($namespace, $allNamespaces, array())) {
+                if (1 == count($alternatives)) {
+                    $message .= "\n\nDid you mean this?\n    ";
+                } else {
+                    $message .= "\n\nDid you mean one of these?\n    ";
                 }
 
-                if ($alternatives = $this->findAlternativeNamespace($part, $abbrevs)) {
-                    if (1 == count($alternatives)) {
-                        $message .= "\n\nDid you mean this?\n    ";
-                    } else {
-                        $message .= "\n\nDid you mean one of these?\n    ";
-                    }
-
-                    $message .= implode("\n    ", $alternatives);
-                }
-
-                throw new \InvalidArgumentException($message);
+                $message .= implode("\n    ", $alternatives);
             }
 
-            // there are multiple matches, but $part is an exact match of one of them so we select it
-            if (in_array($part, $abbrevs[$part])) {
-                $abbrevs[$part] = array($part);
-            }
-
-            if (count($abbrevs[$part]) > 1) {
-                throw new \InvalidArgumentException(sprintf('The namespace "%s" is ambiguous (%s).', $namespace, $this->getAbbreviationSuggestions($abbrevs[$part])));
-            }
-
-            $found .= $found ? ':' . $abbrevs[$part][0] : $abbrevs[$part][0];
+            throw new \InvalidArgumentException($message);
         }
 
-        return $found;
+        $exact = in_array($namespace, $namespaces, true);
+        if (1 < count($namespaces) && !$exact) {
+            throw new \InvalidArgumentException(sprintf('The namespace "%s" is ambiguous (%s).', $namespace, $this->getAbbreviationSuggestions($namespaces)));
+        }
+
+        return $exact ? $namespace : reset($namespaces);
     }
 
     /**
@@ -557,58 +537,19 @@ class Application
      */
     public function find($name)
     {
-        // namespace
-        $namespace = '';
-        $searchName = $name;
-        if (false !== $pos = strrpos($name, ':')) {
-            $namespace = $this->findNamespace(substr($name, 0, $pos));
-            $searchName = $namespace.substr($name, $pos);
-        }
+        $allCommands = array_keys($this->commands);
+        $expr = preg_replace_callback('{([^:]+|)}', function ($matches) { return preg_quote($matches[1]).'[^:]*'; }, $name);
+        $commands = preg_grep('{^'.$expr.'}', $allCommands);
 
-        // name
-        $commands = array();
-        foreach ($this->commands as $command) {
-            $extractedNamespace = $this->extractNamespace($command->getName());
-            if ($extractedNamespace === $namespace
-               || !empty($namespace) && 0 === strpos($extractedNamespace, $namespace)
-            ) {
-                $commands[] = $command->getName();
+        if (empty($commands) || count(preg_grep('{^'.$expr.'$}', $commands)) < 1) {
+            if (false !== $pos = strrpos($name, ':')) {
+                // check if a namespace exists and contains commands
+                $this->findNamespace(substr($name, 0, $pos));
             }
-        }
 
-        $abbrevs = static::getAbbreviations(array_unique($commands));
-        if (isset($abbrevs[$searchName]) && 1 == count($abbrevs[$searchName])) {
-            return $this->get($abbrevs[$searchName][0]);
-        }
-
-        if (isset($abbrevs[$searchName]) && in_array($searchName, $abbrevs[$searchName])) {
-            return $this->get($searchName);
-        }
-
-        if (isset($abbrevs[$searchName]) && count($abbrevs[$searchName]) > 1) {
-            $suggestions = $this->getAbbreviationSuggestions($abbrevs[$searchName]);
-
-            throw new \InvalidArgumentException(sprintf('Command "%s" is ambiguous (%s).', $name, $suggestions));
-        }
-
-        // aliases
-        $aliases = array();
-        foreach ($this->commands as $command) {
-            foreach ($command->getAliases() as $alias) {
-                $extractedNamespace = $this->extractNamespace($alias);
-                if ($extractedNamespace === $namespace
-                   || !empty($namespace) && 0 === strpos($extractedNamespace, $namespace)
-                ) {
-                    $aliases[] = $alias;
-                }
-            }
-        }
-
-        $aliases = static::getAbbreviations(array_unique($aliases));
-        if (!isset($aliases[$searchName])) {
             $message = sprintf('Command "%s" is not defined.', $name);
 
-            if ($alternatives = $this->findAlternativeCommands($searchName, $abbrevs)) {
+            if ($alternatives = $this->findAlternatives($name, $allCommands, array())) {
                 if (1 == count($alternatives)) {
                     $message .= "\n\nDid you mean this?\n    ";
                 } else {
@@ -620,11 +561,14 @@ class Application
             throw new \InvalidArgumentException($message);
         }
 
-        if (count($aliases[$searchName]) > 1) {
-            throw new \InvalidArgumentException(sprintf('Command "%s" is ambiguous (%s).', $name, $this->getAbbreviationSuggestions($aliases[$searchName])));
+        $exact = in_array($name, $commands, true);
+        if (count($commands) > 1 && !$exact) {
+            $suggestions = $this->getAbbreviationSuggestions(array_values($commands));
+
+            throw new \InvalidArgumentException(sprintf('Command "%s" is ambiguous (%s).', $name, $suggestions));
         }
 
-        return $this->get($aliases[$searchName][0]);
+        return $this->get($exact ? $name : reset($commands));
     }
 
     /**
@@ -1093,72 +1037,50 @@ class Application
     }
 
     /**
-     * Finds alternative commands of $name
-     *
-     * @param string $name    The full name of the command
-     * @param array  $abbrevs The abbreviations
-     *
-     * @return array A sorted array of similar commands
-     */
-    private function findAlternativeCommands($name, $abbrevs)
-    {
-        $callback = function($item) {
-            return $item->getName();
-        };
-
-        return $this->findAlternatives($name, $this->commands, $abbrevs, $callback);
-    }
-
-    /**
-     * Finds alternative namespace of $name
-     *
-     * @param string $name    The full name of the namespace
-     * @param array  $abbrevs The abbreviations
-     *
-     * @return array A sorted array of similar namespace
-     */
-    private function findAlternativeNamespace($name, $abbrevs)
-    {
-        return $this->findAlternatives($name, $this->getNamespaces(), $abbrevs);
-    }
-
-    /**
-     * Finds alternative of $name among $collection,
-     * if nothing is found in $collection, try in $abbrevs
+     * Finds alternative of $name among $collection
      *
      * @param string               $name       The string
      * @param array|Traversable    $collection The collection
-     * @param array                $abbrevs    The abbreviations
-     * @param Closure|string|array $callback   The callable to transform collection item before comparison
      *
      * @return array A sorted array of similar string
      */
-    private function findAlternatives($name, $collection, $abbrevs, $callback = null)
+    private function findAlternatives($name, $collection)
     {
+        $threshold = 1e3;
         $alternatives = array();
 
+        $collectionParts = array();
         foreach ($collection as $item) {
-            if (null !== $callback) {
-                $item = call_user_func($callback, $item);
-            }
-
-            $lev = levenshtein($name, $item);
-            if ($lev <= strlen($name) / 3 || false !== strpos($item, $name)) {
-                $alternatives[$item] = $lev;
-            }
+            $collectionParts[$item] = explode(':', $item);
         }
 
-        if (!$alternatives) {
-            foreach ($abbrevs as $key => $values) {
-                $lev = levenshtein($name, $key);
-                if ($lev <= strlen($name) / 3 || false !== strpos($key, $name)) {
-                    foreach ($values as $value) {
-                        $alternatives[$value] = $lev;
-                    }
+        foreach (explode(':', $name) as $i => $subname) {
+            foreach ($collectionParts as $collectionName => $parts) {
+                $exists = isset($alternatives[$collectionName]);
+                if (!isset($parts[$i]) && $exists) {
+                    $alternatives[$collectionName] += $threshold;
+                    continue;
+                } elseif (!isset($parts[$i])) {
+                    continue;
+                }
+
+                $lev = levenshtein($subname, $parts[$i]);
+                if ($lev <= strlen($subname) / 3 || false !== strpos($parts[$i], $subname)) {
+                    $alternatives[$collectionName] = $exists ? $alternatives[$collectionName] + $lev : $lev;
+                } elseif ($exists) {
+                    $alternatives[$collectionName] += $threshold;
                 }
             }
         }
 
+        foreach ($collection as $item) {
+            $lev = levenshtein($name, $item);
+            if ($lev <= strlen($name) / 3 || false !== strpos($item, $name)) {
+                $alternatives[$item] = isset($alternatives[$item]) ? $alternatives[$item] - $lev : $lev;
+            }
+        }
+
+        $alternatives = array_filter($alternatives, function ($lev) use ($threshold) { return $lev < 2*$threshold; });
         asort($alternatives);
 
         return array_keys($alternatives);

--- a/src/Symfony/Component/Console/Tests/Fixtures/FoobarCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/FoobarCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FoobarCommand extends Command
+{
+    public $input;
+    public $output;
+
+    protected function configure()
+    {
+        $this
+            ->setName('foobar:foo')
+            ->setDescription('The foobar:foo command')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+        $this->output = $output;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I was very annoyed when I typed the command `app/console a:d` and I saw this exception `The namespace "a" is ambiguous (assets, assetic)`. However, the shortcut `a:d` is unambiguous (`assets:install` vs `assetic:dump`).
