### PR TITLE
Exclude little words of 'ee' to 'oo' plural transformation

### DIFF
--- a/src/Symfony/Component/PropertyAccess/StringUtil.php
+++ b/src/Symfony/Component/PropertyAccess/StringUtil.php
@@ -188,7 +188,7 @@ class StringUtil
         }
 
         // Convert teeth to tooth, feet to foot
-        if (false !== ($pos = strpos($plural, 'ee'))) {
+        if (false !== ($pos = strpos($plural, 'ee')) && strlen($plural) > 3) {
             return substr_replace($plural, 'oo', $pos, 2);
         }
 


### PR DESCRIPTION
The plural form of 'bee' and 'fee' are not 'foo' and 'boo'. In general words smaller than 3 letters doesn't change to a 'oo' form.
