### PR TITLE
[Form] enforce correct timezone

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
@@ -58,7 +58,7 @@ class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }
 
-        if ($this->outputTimezone !== $this->inputTimezone) {
+        if ($this->outputTimezone !== $dateTime->getTimezone()->getName()) {
             try {
                 $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));
             } catch (\Exception $e) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -65,6 +65,7 @@ class DateTimeToRfc3339TransformerTest extends DateTimeTestCase
             // format without seconds, as appears in some browsers
             array('UTC', 'UTC', '2010-02-03 04:05:00 UTC', '2010-02-03T04:05Z'),
             array('America/New_York', 'Asia/Hong_Kong', '2010-02-03 04:05:00 America/New_York', '2010-02-03T17:05+08:00'),
+            array('Europe/Amsterdam', 'Europe/Amsterdam', '2013-08-21 10:30:00 Europe/Amsterdam', '2013-08-21T08:30:00Z')
         ));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | not sure if this is a BC break... |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I'm using the Form component to handle JSON requests which come from AJAX requests. The JSON is formed by the Angular toJson method

A typical request would be:

```
{
  name: "Some name"
  start: "2013-08-21T05:00:00.000Z"
  end: "2013-08-21T15:00:00.000Z"
}
```

Note that in this case, what I entered in my input boxes are 7:00 for start and 17:00 for end times. As you can see, Angular (or Chrome, I'm not sure), converts this to the "Z" timezone. Since I cannot enforce the correct timezone client side, the timezone will differ from the one configured in the DateTimeType, however, instead of resulting in either an error or a conversion to the correct timezone, I get a datetime object in the wrong timezone, eventually resulting in wrong values in the database.

By checking the required output timezone against the actual timezone of the input datetime object, rather than the expected timezone supplied, this problem is solved.
