### PR TITLE
Include untrusted host in the exception message

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1101,7 +1101,7 @@ class Request
         // as the host can come from the user (HTTP_HOST and depending on the configuration, SERVER_NAME too can come from the user)
         // check that it does not contain forbidden characters (see RFC 952 and RFC 2181)
         if ($host && !preg_match('/^\[?(?:[a-zA-Z0-9-:\]_]+\.?)+$/', $host)) {
-            throw new \UnexpectedValueException('Invalid Host');
+            throw new \UnexpectedValueException('Invalid Host "'.$host.'"');
         }
 
         if (count(self::$trustedHostPatterns) > 0) {
@@ -1119,7 +1119,7 @@ class Request
                 }
             }
 
-            throw new \UnexpectedValueException('Untrusted Host');
+            throw new \UnexpectedValueException('Untrusted Host "'.$host.'"');
         }
 
         return $host;

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1520,7 +1520,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             $request->getHost();
             $this->fail('Request::getHost() should throw an exception when host is not trusted.');
         } catch (\UnexpectedValueException $e) {
-            $this->assertEquals('Untrusted Host', $e->getMessage());
+            $this->assertEquals('Untrusted Host "evil.com"', $e->getMessage());
         }
 
         // trusted hosts


### PR DESCRIPTION
`Invalid *` error message without the actual value that triggered them are really unhelpful to debug issues.
