### PR TITLE
[HttpKernel] RouterListener doesn´t update the context if request is modified

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -35,7 +35,6 @@ class RouterListener implements EventSubscriberInterface
     private $matcher;
     private $context;
     private $logger;
-    private $request;
 
     /**
      * Constructor.
@@ -73,10 +72,9 @@ class RouterListener implements EventSubscriberInterface
      */
     public function setRequest(Request $request = null)
     {
-        if (null !== $request && $this->request !== $request) {
+        if (null !== $request) {
             $this->context->fromRequest($request);
         }
-        $this->request = $request;
     }
 
     public function onKernelRequest(GetResponseEvent $event)

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -131,4 +131,20 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('GET', $context->getMethod());
     }
+
+    public function testContextGetsUpdatedWhenRequestChangesValue()
+    {
+        $request = Request::create('http://localhost/', 'post');
+        $context = new RequestContext();
+
+        $requestMatcher = $this->getMock('Symfony\Component\Routing\Matcher\RequestMatcherInterface');
+
+        $listener = new RouterListener($requestMatcher, $context);
+        $listener->setRequest($request);
+
+        $request->setMethod('GET');
+        $listener->setRequest($request);
+
+        $this->assertEquals('GET', $context->getMethod());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8474 |
| License | MIT |
| Doc PR |  |

This Pull request reverts the patch ea633f5 as discussed in the ticket #8474, and adds a test to prevent regressions.
