### PR TITLE
[Process] fix for Process:isSuccessful()

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -489,7 +489,7 @@ class Process
      */
     public function isSuccessful()
     {
-        return 0 == $this->getExitCode();
+        return 0 === $this->getExitCode();
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -277,6 +277,18 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($process->isSuccessful());
     }
 
+    public function testIsSuccessfulOnlyAfterTerminated()
+    {
+        $process = $this->getProcess('sleep 1');
+        $process->start();
+        while ($process->isRunning()) {
+            $this->assertFalse($process->isSuccessful());
+            usleep(300000);
+        }
+
+        $this->assertTrue($process->isSuccessful());
+    }
+
     public function testIsNotSuccessful()
     {
         $process = $this->getProcess('php -r "sleep(4);"');

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -83,6 +83,14 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
     /**
      * @expectedException \Symfony\Component\Process\Exception\RuntimeException
      */
+    public function testIsSuccessfulOnlyAfterTerminated()
+    {
+        parent::testIsSuccessfulOnlyAfterTerminated();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
+     */
     public function testIsNotSuccessful()
     {
         parent::testIsNotSuccessful();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [] |

This is a rebase of https://github.com/symfony/symfony/pull/8801

If you call isSuccessful() on a running process you would get true because of 0 == null. I think that is not the expected behavior and that is not what phpdoc @return block said so.
