### PR TITLE
[HttpKernel] Fix request _format duplication for HttpKernel's ExceptionListener

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -34,6 +34,9 @@ UPGRADE FROM 2.x to 3.0
      * `Symfony\Bridge\Monolog\Logger`
      * `Symfony\Component\HttpKernel\Log\NullLogger`
 
+ * The `Symfony\Component\HttpKernel\EventListener\ExceptionListener` now
+   passes the Request format as the `_format` argument instead of `format`.
+
 ### Routing
 
  * Some route settings have been renamed:

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -39,22 +39,20 @@ class ExceptionController
      * @param Request              $request   The request
      * @param FlattenException     $exception A FlattenException instance
      * @param DebugLoggerInterface $logger    A DebugLoggerInterface instance
-     * @param string               $format    The format to use for rendering (html, xml, ...)
+     * @param string               $_format   The format to use for rendering (html, xml, ...)
      *
      * @return Response
      *
      * @throws \InvalidArgumentException When the exception template does not exist
      */
-    public function showAction(Request $request, FlattenException $exception, DebugLoggerInterface $logger = null, $format = 'html')
+    public function showAction(Request $request, FlattenException $exception, DebugLoggerInterface $logger = null, $_format = 'html')
     {
-        $request->setRequestFormat($format);
-
         $currentContent = $this->getAndCleanOutputBuffering($request->headers->get('X-Php-Ob-Level', -1));
 
         $code = $exception->getStatusCode();
 
         return new Response($this->twig->render(
-            $this->findTemplate($request, $format, $code, $this->debug),
+            $this->findTemplate($request, $_format, $code, $this->debug),
             array(
                 'status_code'    => $code,
                 'status_text'    => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -55,6 +55,10 @@ class ExceptionListener implements EventSubscriberInterface
             '_controller' => $this->controller,
             'exception'   => FlattenException::create($exception),
             'logger'      => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
+            '_format'     => $request->getRequestFormat(),
+            // keep for BC -- as $format can be an argument of the controller callable
+            // see src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+            // @deprecated in 2.4, to be removed in 3.0
             'format'      => $request->getRequestFormat(),
         );
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8777, #8778 |
| License | MIT |

This is a better fix for #8777.
