### PR TITLE
fixed locale management in sub-requests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FragmentController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FragmentController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\DependencyInjection\ContainerAware;
 
@@ -29,7 +30,9 @@ class FragmentController extends ContainerAware
 
         $html2 = $actions->render($actions->controller('TestBundle:Fragment:customformat', array('_format' => 'html')));
 
-        return new Response($html1.'--'.$html2);
+        $html3 = $actions->render($actions->controller('TestBundle:Fragment:customlocale', array('_locale' => 'es')));
+
+        return new Response($html1.'--'.$html2.'--'.$html3);
     }
 
     public function inlinedAction($options, $_format)
@@ -40,6 +43,11 @@ class FragmentController extends ContainerAware
     public function customFormatAction($_format)
     {
         return new Response($_format);
+    }
+
+    public function customLocaleAction(Request $request)
+    {
+        return new Response($request->getLocale());
     }
 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FragmentController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FragmentController.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerAware;
 
 class FragmentController extends ContainerAware
 {
-    public function indexAction()
+    public function indexAction(Request $request)
     {
         $actions = $this->container->get('templating')->get('actions');
 
@@ -32,7 +32,10 @@ class FragmentController extends ContainerAware
 
         $html3 = $actions->render($actions->controller('TestBundle:Fragment:customlocale', array('_locale' => 'es')));
 
-        return new Response($html1.'--'.$html2.'--'.$html3);
+        $request->setLocale('fr');
+        $html4 = $actions->render($actions->controller('TestBundle:Fragment:forwardlocale'));
+
+        return new Response($html1.'--'.$html2.'--'.$html3.'--'.$html4);
     }
 
     public function inlinedAction($options, $_format)
@@ -46,6 +49,11 @@ class FragmentController extends ContainerAware
     }
 
     public function customLocaleAction(Request $request)
+    {
+        return new Response($request->getLocale());
+    }
+
+    public function forwardLocaleAction(Request $request)
     {
         return new Response($request->getLocale());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
@@ -28,7 +28,7 @@ class FragmentTest extends WebTestCase
 
         $client->request('GET', '/fragment_home');
 
-        $this->assertEquals('bar txt--html', $client->getResponse()->getContent());
+        $this->assertEquals('bar txt--html--es', $client->getResponse()->getContent());
     }
 
     public function getConfigs()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
@@ -28,7 +28,7 @@ class FragmentTest extends WebTestCase
 
         $client->request('GET', '/fragment_home');
 
-        $this->assertEquals('bar txt--html--es', $client->getResponse()->getContent());
+        $this->assertEquals('bar txt--html--es--fr', $client->getResponse()->getContent());
     }
 
     public function getConfigs()

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -55,9 +55,11 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
             $attributes = $reference->attributes;
             $reference->attributes = array();
 
-            // The request format might have been overriden by the user
-            if (isset($attributes['_format'])) {
-                $reference->attributes['_format'] = $attributes['_format'];
+            // The request format and locale might have been overriden by the user
+            foreach (array('_format', '_locale') as $key) {
+                if (isset($attributes[$key])) {
+                    $reference->attributes[$key] = $attributes[$key];
+                }
             }
 
             $uri = $this->generateFragmentUri($uri, $request);

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -46,10 +46,14 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
      */
     protected function generateFragmentUri(ControllerReference $reference, Request $request)
     {
+        // We need to forward the current _format and _locale values as we don't have
+        // a proper routing pattern to do the job for us.
+        // This makes things inconsistent if you switch from rendering a controller
+        // to rendering a route if the route pattern does not contain the special
+        // _format and _locale placeholders.
         if (!isset($reference->attributes['_format'])) {
             $reference->attributes['_format'] = $request->getRequestFormat();
         }
-
         if (!isset($reference->attributes['_locale'])) {
             $reference->attributes['_locale'] = $request->getLocale();
         }

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -50,6 +50,10 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
             $reference->attributes['_format'] = $request->getRequestFormat();
         }
 
+        if (!isset($reference->attributes['_locale'])) {
+            $reference->attributes['_locale'] = $request->getLocale();
+        }
+
         $reference->attributes['_controller'] = $reference->controller;
 
         $reference->query['_path'] = http_build_query($reference->attributes, '', '&');

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -42,12 +42,13 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy());
 
         $request = Request::create('/');
+        $request->setLocale('fr');
         $request->headers->set('Surrogate-Capability', 'ESI/1.0');
 
         $this->assertEquals('<esi:include src="/" />', $strategy->render('/', $request)->getContent());
         $this->assertEquals("<esi:comment text=\"This is a comment\" />\n<esi:include src=\"/\" />", $strategy->render('/', $request, array('comment' => 'This is a comment'))->getContent());
         $this->assertEquals('<esi:include src="/" alt="foo" />', $strategy->render('/', $request, array('alt' => 'foo'))->getContent());
-        $this->assertEquals('<esi:include src="http://localhost/_fragment?_path=_format%3Dhtml%26_controller%3Dmain_controller" alt="http://localhost/_fragment?_path=_format%3Dhtml%26_controller%3Dalt_controller" />', $strategy->render(new ControllerReference('main_controller', array(), array()), $request, array('alt' => new ControllerReference('alt_controller', array(), array())))->getContent());
+        $this->assertEquals('<esi:include src="http://localhost/_fragment?_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" alt="http://localhost/_fragment?_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dalt_controller" />', $strategy->render(new ControllerReference('main_controller', array(), array()), $request, array('alt' => new ControllerReference('alt_controller', array(), array())))->getContent());
     }
 
     private function getInlineStrategy($called = false)

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
@@ -38,7 +38,7 @@ class HIncludeFragmentRendererTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new HIncludeFragmentRenderer(null, new UriSigner('foo'));
 
-        $this->assertEquals('<hx:include src="http://localhost/_fragment?_path=_format%3Dhtml%26_controller%3Dmain_controller&amp;_hash=VI25qJj8J0qveB3bGKPhsJtexKg%3D"></hx:include>', $strategy->render(new ControllerReference('main_controller', array(), array()), Request::create('/'))->getContent());
+        $this->assertEquals('<hx:include src="http://localhost/_fragment?_path=_format%3Dhtml%26_locale%3Den%26_controller%3Dmain_controller&amp;_hash=g4b3vtCnhkZBFKrciEFwG7fucVo%3D"></hx:include>', $strategy->render(new ControllerReference('main_controller', array(), array()), Request::create('/'))->getContent());
     }
 
     public function testRenderWithUri()

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -51,6 +51,8 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
 
         $subRequest = Request::create('/_fragment?_path=_format%3Dhtml%26_controller%3Dmain_controller');
         $subRequest->attributes->replace(array('object' => $object, '_format' => 'html', '_controller' => 'main_controller'));
+        $subRequest = Request::create('/_fragment?_path=_format%3Dhtml%26_locale%3Den%26_controller%3Dmain_controller');
+        $subRequest->attributes->replace(array('object' => $object, '_format' => 'html', '_controller' => 'main_controller', '_locale' => 'en'));
 
         $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
         $kernel

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
@@ -28,11 +28,11 @@ class RoutableFragmentRendererTest extends \PHPUnit_Framework_TestCase
     public function getGenerateFragmentUriData()
     {
         return array(
-            array('http://localhost/_fragment?_path=_format%3Dhtml%26_controller%3Dcontroller', new ControllerReference('controller', array(), array())),
-            array('http://localhost/_fragment?_path=_format%3Dxml%26_controller%3Dcontroller', new ControllerReference('controller', array('_format' => 'xml'), array())),
-            array('http://localhost/_fragment?_path=foo%3Dfoo%26_format%3Djson%26_controller%3Dcontroller', new ControllerReference('controller', array('foo' => 'foo', '_format' => 'json'), array())),
-            array('http://localhost/_fragment?bar=bar&_path=foo%3Dfoo%26_format%3Dhtml%26_controller%3Dcontroller', new ControllerReference('controller', array('foo' => 'foo'), array('bar' => 'bar'))),
-            array('http://localhost/_fragment?foo=foo&_path=_format%3Dhtml%26_controller%3Dcontroller', new ControllerReference('controller', array(), array('foo' => 'foo'))),
+            array('http://localhost/_fragment?_path=_format%3Dhtml%26_locale%3Den%26_controller%3Dcontroller', new ControllerReference('controller', array(), array())),
+            array('http://localhost/_fragment?_path=_format%3Dxml%26_locale%3Den%26_controller%3Dcontroller', new ControllerReference('controller', array('_format' => 'xml'), array())),
+            array('http://localhost/_fragment?_path=foo%3Dfoo%26_format%3Djson%26_locale%3Den%26_controller%3Dcontroller', new ControllerReference('controller', array('foo' => 'foo', '_format' => 'json'), array())),
+            array('http://localhost/_fragment?bar=bar&_path=foo%3Dfoo%26_format%3Dhtml%26_locale%3Den%26_controller%3Dcontroller', new ControllerReference('controller', array('foo' => 'foo'), array('bar' => 'bar'))),
+            array('http://localhost/_fragment?foo=foo&_path=_format%3Dhtml%26_locale%3Den%26_controller%3Dcontroller', new ControllerReference('controller', array(), array('foo' => 'foo'))),
         );
     }
 
@@ -40,9 +40,10 @@ class RoutableFragmentRendererTest extends \PHPUnit_Framework_TestCase
     {
         $request = Request::create('/');
         $request->attributes->set('_format', 'json');
+        $request->setLocale('fr');
         $controller = new ControllerReference('controller', array(), array());
 
-        $this->assertEquals('http://localhost/_fragment?_path=_format%3Djson%26_controller%3Dcontroller', $this->getRenderer()->doGenerateFragmentUri($controller, $request));
+        $this->assertEquals('http://localhost/_fragment?_path=_format%3Djson%26_locale%3Dfr%26_controller%3Dcontroller', $this->getRenderer()->doGenerateFragmentUri($controller, $request));
     }
 
     private function getRenderer()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6932, #5532, #8604 |
| License | MIT |
| Doc PR | n/a |

Same fix as #8821 but for `_locale`, and a rebase of #8604.
