### PR TITLE
[Yaml] Fix comment containing a colon on a scalar line being parsed as a hash.

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -111,7 +111,7 @@ class Parser
                         $data[] = $this->parseValue($values['value'], $exceptionOnInvalidType, $objectSupport);
                     }
                 }
-            } elseif (preg_match('#^(?P<key>'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\[\{].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $this->currentLine, $values)) {
+            } elseif (preg_match('#^(?P<key>'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\[\{].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $this->currentLine, $values) && false === strpos($values['key'],' #')) {
                 if ($context && 'sequence' == $context) {
                     throw new ParseException('You cannot define a mapping item when in a sequence');
                 }

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
@@ -49,3 +49,17 @@ yaml: |
     foo: bar # a comment
 php: |
     array('foo' => 'bar')
+---
+test: Comment containing a colon on a hash line
+brief: >
+    Comment containing a colon on a scalar line
+yaml: 'foo # comment: this is also part of the comment'
+php: |
+    'foo'
+---
+test: 'Hash key containing a #'
+brief: >
+    'Hash key containing a #'
+yaml: 'foo#bar: baz'
+php: |
+    array('foo#bar' => 'baz')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Note: I only ran the Yaml Component tests.

This PR fixes a bug in YAML parsing where a comment containing a colon followed by a space, like this:

```
foo # warning: this is a scalar with a comment, not a hash
```

was parsed as a hash, resulting in:

```
array( 'foo # warning' => 'this is a scalar with a comment, not a hash' )
```

instead of:

```
'foo'
```
