### PR TITLE
[Form][2.2] Fixed Form::submit() to react to dynamic form modifications

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -44,11 +44,9 @@ class PropertyPathMapper implements DataMapperInterface
      */
     public function mapDataToForms($data, array $forms)
     {
-        if (null === $data || array() === $data) {
-            return;
-        }
+        $empty = null === $data || array() === $data;
 
-        if (!is_array($data) && !is_object($data)) {
+        if (!$empty && !is_array($data) && !is_object($data)) {
             throw new UnexpectedTypeException($data, 'object, array or empty');
         }
 
@@ -56,12 +54,14 @@ class PropertyPathMapper implements DataMapperInterface
         $iterator = new \RecursiveIteratorIterator($iterator);
 
         foreach ($iterator as $form) {
-            /* @var FormInterface $form */
+            /* @var \Symfony\Component\Form\FormInterface $form */
             $propertyPath = $form->getPropertyPath();
             $config = $form->getConfig();
 
-            if (null !== $propertyPath && $config->getMapped()) {
+            if (!$empty && null !== $propertyPath && $config->getMapped()) {
                 $form->setData($this->propertyAccessor->getValue($data, $propertyPath));
+            } else {
+                $form->setData($form->getConfig()->getData());
             }
         }
     }
@@ -83,7 +83,7 @@ class PropertyPathMapper implements DataMapperInterface
         $iterator = new \RecursiveIteratorIterator($iterator);
 
         foreach ($iterator as $form) {
-            /* @var FormInterface $form */
+            /* @var \Symfony\Component\Form\FormInterface $form */
             $propertyPath = $form->getPropertyPath();
             $config = $form->getConfig();
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -552,8 +552,6 @@ class Form implements \IteratorAggregate, FormInterface
                 $submittedData = array();
             }
 
-            reset($this->children);
-
             for (reset($this->children); false !== current($this->children); next($this->children)) {
                 $child = current($this->children);
                 $name = key($this->children);

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -552,7 +552,12 @@ class Form implements \IteratorAggregate, FormInterface
                 $submittedData = array();
             }
 
-            foreach ($this->children as $name => $child) {
+            reset($this->children);
+
+            for (reset($this->children); false !== current($this->children); next($this->children)) {
+                $child = current($this->children);
+                $name = key($this->children);
+
                 $child->bind(isset($submittedData[$name]) ? $submittedData[$name] : null);
                 unset($submittedData[$name]);
             }
@@ -829,7 +834,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * {@inheritdoc}
      */
-    public function all()
+    public function &all()
     {
         return $this->children;
     }

--- a/src/Symfony/Component/Form/Tests/AbstractFormTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractFormTest.php
@@ -81,6 +81,9 @@ abstract class AbstractFormTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->any())
             ->method('getName')
             ->will($this->returnValue($name));
+        $form->expects($this->any())
+            ->method('getConfig')
+            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormConfigInterface')));
 
         return $form;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -165,8 +165,9 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($form->getData());
     }
 
-    public function testMapDataToFormsIgnoresEmptyData()
+    public function testMapDataToFormsSetsDefaultDataIfPassedDataIsNull()
     {
+        $default = new \stdClass();
         $propertyPath = $this->getPropertyPath('engine');
 
         $this->propertyAccessor->expects($this->never())
@@ -175,11 +176,43 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
         $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
-        $form = $this->getForm($config);
+        $config->setData($default);
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->setConstructorArgs(array($config))
+            ->setMethods(array('setData'))
+            ->getMock();
+
+        $form->expects($this->once())
+            ->method('setData')
+            ->with($default);
 
         $this->mapper->mapDataToForms(null, array($form));
+    }
 
-        $this->assertNull($form->getData());
+    public function testMapDataToFormsSetsDefaultDataIfPassedDataIsEmptyArray()
+    {
+        $default = new \stdClass();
+        $propertyPath = $this->getPropertyPath('engine');
+
+        $this->propertyAccessor->expects($this->never())
+            ->method('getValue');
+
+        $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
+        $config->setByReference(true);
+        $config->setPropertyPath($propertyPath);
+        $config->setData($default);
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->setConstructorArgs(array($config))
+            ->setMethods(array('setData'))
+            ->getMock();
+
+        $form->expects($this->once())
+            ->method('setData')
+            ->with($default);
+
+        $this->mapper->mapDataToForms(array(), array($form));
     }
 
     public function testMapDataToFormsSkipsVirtualForms()

--- a/src/Symfony/Component/Form/Tests/Util/VirtualFormAwareIteratorTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/VirtualFormAwareIteratorTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Util;
+
+use Symfony\Component\Form\Util\VirtualFormAwareIterator;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class VirtualFormAwareIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSupportDynamicModification()
+    {
+        $form = $this->getMockForm('form');
+        $formToBeAdded = $this->getMockForm('added');
+        $formToBeRemoved = $this->getMockForm('removed');
+
+        $forms = array('form' => $form, 'removed' => $formToBeRemoved);
+        $iterator = new VirtualFormAwareIterator($forms);
+
+        $iterator->rewind();
+        $this->assertTrue($iterator->valid());
+        $this->assertSame('form', $iterator->key());
+        $this->assertSame($form, $iterator->current());
+
+        // dynamic modification
+        unset($forms['removed']);
+        $forms['added'] = $formToBeAdded;
+
+        // continue iteration
+        $iterator->next();
+        $this->assertTrue($iterator->valid());
+        $this->assertSame('added', $iterator->key());
+        $this->assertSame($formToBeAdded, $iterator->current());
+
+        // end of array
+        $iterator->next();
+        $this->assertFalse($iterator->valid());
+    }
+
+    public function testSupportDynamicModificationInRecursiveCall()
+    {
+        $virtualForm = $this->getMockForm('virtual');
+        $form = $this->getMockForm('form');
+        $formToBeAdded = $this->getMockForm('added');
+        $formToBeRemoved = $this->getMockForm('removed');
+
+        $virtualForm->getConfig()->expects($this->any())
+            ->method('getVirtual')
+            ->will($this->returnValue(true));
+
+        $virtualForm->add($form);
+        $virtualForm->add($formToBeRemoved);
+
+        $forms = array('virtual' => $virtualForm);
+        $iterator = new VirtualFormAwareIterator($forms);
+
+        $iterator->rewind();
+        $this->assertTrue($iterator->valid());
+        $this->assertSame('virtual', $iterator->key());
+        $this->assertSame($virtualForm, $iterator->current());
+        $this->assertTrue($iterator->hasChildren());
+
+        // enter nested iterator
+        $nestedIterator = $iterator->getChildren();
+        $this->assertSame('form', $nestedIterator->key());
+        $this->assertSame($form, $nestedIterator->current());
+        $this->assertFalse($nestedIterator->hasChildren());
+
+        // dynamic modification
+        $virtualForm->remove('removed');
+        $virtualForm->add($formToBeAdded);
+
+        // continue iteration - nested iterator discovers change in the form
+        $nestedIterator->next();
+        $this->assertTrue($nestedIterator->valid());
+        $this->assertSame('added', $nestedIterator->key());
+        $this->assertSame($formToBeAdded, $nestedIterator->current());
+
+        // end of array
+        $nestedIterator->next();
+        $this->assertFalse($nestedIterator->valid());
+    }
+
+    /**
+     * @param  string $name
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockForm($name = 'name')
+    {
+        $config = $this->getMock('Symfony\Component\Form\FormConfigInterface');
+
+        $config->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue($name));
+        $config->expects($this->any())
+            ->method('getCompound')
+            ->will($this->returnValue(true));
+        $config->expects($this->any())
+            ->method('getDataMapper')
+            ->will($this->returnValue($this->getMock('Symfony\Component\Form\DataMapperInterface')));
+        $config->expects($this->any())
+            ->method('getEventDispatcher')
+            ->will($this->returnValue($this->getMock('Symfony\Component\EventDispatcher\EventDispatcher')));
+
+        return $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->setConstructorArgs(array($config))
+            ->disableArgumentCloning()
+            ->setMethods(array('getViewData'))
+            ->getMock();
+    }
+}

--- a/src/Symfony/Component/Form/Util/ReferencingArrayIterator.php
+++ b/src/Symfony/Component/Form/Util/ReferencingArrayIterator.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Util;
+
+/**
+ * Iterator that traverses an array.
+ *
+ * Contrary to {@link \ArrayIterator}, this iterator recognizes changes in the
+ * original array during iteration.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class ReferencingArrayIterator implements \Iterator
+{
+    /**
+     * @var array
+     */
+    private $array;
+
+    /**
+     * Creates a new iterator.
+     *
+     * @param array $array An array
+     */
+    public function __construct(array &$array)
+    {
+        $this->array = &$array;
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function current()
+    {
+        return current($this->array);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function next()
+    {
+        next($this->array);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function key()
+    {
+        return key($this->array);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function valid()
+    {
+        return null !== key($this->array);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function rewind()
+    {
+        reset($this->array);
+    }
+}

--- a/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
+++ b/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
@@ -14,71 +14,16 @@ namespace Symfony\Component\Form\Util;
 /**
  * Iterator that traverses an array of forms.
  *
- * Contrary to \ArrayIterator, this iterator recognizes changes in the original
- * array during iteration.
+ * Contrary to {@link \ArrayIterator}, this iterator recognizes changes in the
+ * original array during iteration.
  *
  * You can wrap the iterator into a {@link \RecursiveIterator} in order to
  * enter any virtual child form and iterate the children of that virtual form.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class VirtualFormAwareIterator implements \RecursiveIterator
+class VirtualFormAwareIterator extends ReferencingArrayIterator implements \RecursiveIterator
 {
-    /**
-     * @var \Symfony\Component\Form\FormInterface[]
-     */
-    private $forms;
-
-    /**
-     * Creates a new iterator.
-     *
-     * @param \Symfony\Component\Form\FormInterface[] $forms An array of forms
-     */
-    public function __construct(array &$forms)
-    {
-        $this->forms = &$forms;
-    }
-
-    /**
-     *{@inheritdoc}
-     */
-    public function current()
-    {
-        return current($this->forms);
-    }
-
-    /**
-     *{@inheritdoc}
-     */
-    public function next()
-    {
-        next($this->forms);
-    }
-
-    /**
-     *{@inheritdoc}
-     */
-    public function key()
-    {
-        return key($this->forms);
-    }
-
-    /**
-     *{@inheritdoc}
-     */
-    public function valid()
-    {
-        return null !== key($this->forms);
-    }
-
-    /**
-     *{@inheritdoc}
-     */
-    public function rewind()
-    {
-        reset($this->forms);
-    }
-
     /**
      *{@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
+++ b/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
@@ -12,22 +12,86 @@
 namespace Symfony\Component\Form\Util;
 
 /**
- * Iterator that traverses fields of a field group
+ * Iterator that traverses an array of forms.
  *
- * If the iterator encounters a virtual field group, it enters the field
- * group and traverses its children as well.
+ * Contrary to \ArrayIterator, this iterator recognizes changes in the original
+ * array during iteration.
+ *
+ * You can wrap the iterator into a {@link \RecursiveIterator} in order to
+ * enter any virtual child form and iterate the children of that virtual form.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class VirtualFormAwareIterator extends \ArrayIterator implements \RecursiveIterator
+class VirtualFormAwareIterator implements \RecursiveIterator
 {
+    /**
+     * @var \Symfony\Component\Form\FormInterface[]
+     */
+    private $forms;
+
+    /**
+     * Creates a new iterator.
+     *
+     * @param \Symfony\Component\Form\FormInterface[] $forms An array of forms
+     */
+    public function __construct(array &$forms)
+    {
+        $this->forms = &$forms;
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function current()
+    {
+        return current($this->forms);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function next()
+    {
+        next($this->forms);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function key()
+    {
+        return key($this->forms);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function valid()
+    {
+        return null !== key($this->forms);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
+    public function rewind()
+    {
+        reset($this->forms);
+    }
+
+    /**
+     *{@inheritdoc}
+     */
     public function getChildren()
     {
         return new self($this->current()->all());
     }
 
+    /**
+     *{@inheritdoc}
+     */
     public function hasChildren()
     {
-        return $this->current()->getConfig()->getVirtual();
+        return (bool) $this->current()->getConfig()->getVirtual();
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

ref #3767, #3768, #4548, #8748
cc @Burgov

This PR ensures that fields that are added during the submission process of a form are submitted as well. For example:

``` php
$builder = $this->createFormBuilder()
    ->add('country', 'choice', ...)
    ->getForm();

$builder->get('country')->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
    $form = $event->getForm()->getParent();
    $country = $event->getForm()->getData();

    $form->add('province', 'choice', /* ... something with $country ... */);
});
```

Currently, the field "province" will not be submitted, because the submission loop uses `foreach`, which ignores changes in the underyling array.

Additionally, this PR ensures that `setData()` is called on _every_ element of a form (except those inheriting their parent data) when `setData()` is called on the root element (i.e., during initialization). Currently, when some of the intermediate nodes (e.g. embedded forms) are submitted with an empty value, `setData()` won't be called on the nodes below (i.e. the fields of the embedded form) until `get*Data()` is called on them. If `getData()` is _not_ called before `createView()`, any effects of `*_DATA` event listeners attached to those fields will not be visible in the view.
