### PR TITLE
fixed request format when forwarding a request

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ControllerTest extends TestCase
+{
+    public function testForward()
+    {
+        $request = Request::create('/');
+        $request->setLocale('fr');
+        $request->setRequestFormat('xml');
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+            return new Response($request->getRequestFormat().'--'.$request->getLocale());
+        }));
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->at(0))->method('get')->will($this->returnValue($request));
+        $container->expects($this->at(1))->method('get')->will($this->returnValue($kernel));
+
+        $controller = new Controller();
+        $controller->setContainer($container);
+
+        $response = $controller->forward('a_controller');
+        $this->assertEquals('xml--fr', $response->getContent());
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -406,6 +406,10 @@ class Request
         $dup->method = null;
         $dup->format = null;
 
+        if (!$dup->get('_format')) {
+            $dup->setRequestFormat($this->getRequestFormat());
+        }
+
         return $dup;
     }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -55,7 +55,6 @@ class ExceptionListener implements EventSubscriberInterface
             '_controller' => $this->controller,
             'exception'   => FlattenException::create($exception),
             'logger'      => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
-            '_format'     => $request->getRequestFormat(),
             // keep for BC -- as $format can be an argument of the controller callable
             // see src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
             // @deprecated in 2.4, to be removed in 3.0

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -111,6 +111,25 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
             array($event, $event2)
         );
     }
+
+    public function testSubRequestFormat()
+    {
+        $listener = new ExceptionListener('foo', $this->getMock('Psr\Log\LoggerInterface'));
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+            return new Response($request->getRequestFormat());
+        }));
+
+        $request = Request::create('/');
+        $request->setRequestFormat('xml');
+
+        $event = new GetResponseForExceptionEvent($kernel, $request, 'foo', new \Exception('foo'));
+        $listener->onKernelException($event);
+
+        $response = $event->getResponse();
+        $this->assertEquals('xml', $response->getContent());
+    }
 }
 
 class TestLogger extends Logger implements DebugLoggerInterface


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6932 |
| License | MIT |
| Doc PR | n/a |

When calling forward() in a controller, the format is not the same as for the master request.
