### PR TITLE
clearToken exception is thrown at wrong place.

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -105,7 +105,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
         $token = $this->securityContext->getToken();
         if ($token instanceof PreAuthenticatedToken && $this->providerKey === $token->getProviderKey()) {
             $this->securityContext->setToken(null);
-            
+
             if (null !== $this->logger) {
                 $this->logger->info(sprintf("Cleared security context due to exception: %s", $exception->getMessage()));
             }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -100,7 +100,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
      * 
      * @param AuthenticationException $exception
      */
-    protected function clearToken(AuthenticationException $exception)
+    private function clearToken(AuthenticationException $exception)
     {
         $token = $this->securityContext->getToken();
         if ($token instanceof PreAuthenticatedToken && $this->providerKey === $token->getProviderKey()) {

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -105,10 +105,10 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
         $token = $this->securityContext->getToken();
         if ($token instanceof PreAuthenticatedToken && $this->providerKey === $token->getProviderKey()) {
             $this->securityContext->setToken(null);
-        }
-        
-        if (null !== $this->logger) {
-            $this->logger->info(sprintf("Cleared security context due to exception: %s", $exception->getMessage()));
+            
+            if (null !== $this->logger) {
+                $this->logger->info(sprintf("Cleared security context due to exception: %s", $exception->getMessage()));
+            }
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -92,6 +92,10 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             }
         } catch (AuthenticationException $failed) {
             $this->clearToken();
+            
+            if (null !== $this->logger) {
+                $this->logger->info(sprintf("Cleared security context due to exception: %s", $failed->getMessage()));
+            }
         }
     }
 
@@ -103,10 +107,6 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
         $token = $this->securityContext->getToken();
         if ($token instanceof PreAuthenticatedToken && $this->providerKey === $token->getProviderKey()) {
             $this->securityContext->setToken(null);
-
-            if (null !== $this->logger) {
-                $this->logger->info(sprintf("Cleared security context due to exception: %s", $failed->getMessage()));
-            }
         }
     }
 


### PR DESCRIPTION
The PR https://github.com/symfony/symfony/pull/8528 has added a problem when logger is enabled.

The log message for clearToken exception throw actually a fatal error because $failed doesn't exist in clearToken method. I have moved the log message to the handle method.
