### PR TITLE
[Translation] Fixed regression: When only one rule is passed to transChoice(), this rule should be used

### DIFF
--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Translation;
  * MessageSelector.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
@@ -73,7 +74,14 @@ class MessageSelector
         }
 
         $position = PluralizationRules::get($number, $locale);
+
         if (!isset($standardRules[$position])) {
+            // when there's exactly one rule given, and that rule is a standard
+            // rule, use this rule
+            if (1 === count($parts) && isset($standardRules[0])) {
+                return $standardRules[0];
+            }
+
             throw new \InvalidArgumentException(sprintf('Unable to choose a translation for "%s" with locale "%s". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %%count%% apples").', $message, $locale));
         }
 

--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -79,9 +79,9 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
     public function getTransChoiceTests()
     {
         return array(
-            array('There is no apple', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 0, array('%count%' => 0)),
-            array('There is one apple', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 1, array('%count%' => 1)),
-            array('There are 10 apples', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 10, array('%count%' => 10)),
+            array('There are no apples', '{0} There are no apples|{1} There is one apple|]1,Inf] There are %count% apples', 0, array('%count%' => 0)),
+            array('There is one apple', '{0} There are no apples|{1} There is one apple|]1,Inf] There are %count% apples', 1, array('%count%' => 1)),
+            array('There are 10 apples', '{0} There are no apples|{1} There is one apple|]1,Inf] There are %count% apples', 10, array('%count%' => 10)),
             array('There are 0 apples', 'There is 1 apple|There are %count% apples', 0, array('%count%' => 0)),
             array('There is 1 apple', 'There is 1 apple|There are %count% apples', 1, array('%count%' => 1)),
             array('There are 10 apples', 'There is 1 apple|There are %count% apples', 10, array('%count%' => 10)),

--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -85,6 +85,8 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
             array('There are 0 apples', 'There is 1 apple|There are %count% apples', 0, array('%count%' => 0)),
             array('There is 1 apple', 'There is 1 apple|There are %count% apples', 1, array('%count%' => 1)),
             array('There are 10 apples', 'There is 1 apple|There are %count% apples', 10, array('%count%' => 10)),
+            // custom validation messages may be coded with a fixed value
+            array('There are 2 apples', 'There are 2 apples', 2, array('%count%' => 2)),
         );
     }
 }

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -46,25 +46,25 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
     public function getNonMatchingMessages()
     {
         return array(
-            array('{0} There is no apple|{1} There is one apple', 2),
+            array('{0} There are no apples|{1} There is one apple', 2),
             array('{1} There is one apple|]1,Inf] There are %count% apples', 0),
             array('{1} There is one apple|]2,Inf] There are %count% apples', 2),
-            array('{0} There is no apple|There is one apple', 2),
+            array('{0} There are no apples|There is one apple', 2),
         );
     }
 
     public function getChooseTests()
     {
         return array(
-            array('There is no apple', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 0),
-            array('There is no apple', '{0}     There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 0),
-            array('There is no apple', '{0}There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 0),
+            array('There are no apples', '{0} There are no apples|{1} There is one apple|]1,Inf] There are %count% apples', 0),
+            array('There are no apples', '{0}     There are no apples|{1} There is one apple|]1,Inf] There are %count% apples', 0),
+            array('There are no apples', '{0}There are no apples|{1} There is one apple|]1,Inf] There are %count% apples', 0),
 
-            array('There is one apple', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 1),
+            array('There is one apple', '{0} There are no apples|{1} There is one apple|]1,Inf] There are %count% apples', 1),
 
-            array('There are %count% apples', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 10),
-            array('There are %count% apples', '{0} There is no apple|{1} There is one apple|]1,Inf]There are %count% apples', 10),
-            array('There are %count% apples', '{0} There is no apple|{1} There is one apple|]1,Inf]     There are %count% apples', 10),
+            array('There are %count% apples', '{0} There are no apples|{1} There is one apple|]1,Inf] There are %count% apples', 10),
+            array('There are %count% apples', '{0} There are no apples|{1} There is one apple|]1,Inf]There are %count% apples', 10),
+            array('There are %count% apples', '{0} There are no apples|{1} There is one apple|]1,Inf]     There are %count% apples', 10),
 
             array('There are %count% apples', 'There is one apple|There are %count% apples', 0),
             array('There is one apple', 'There is one apple|There are %count% apples', 1),
@@ -74,12 +74,12 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There is one apple', 'one: There is one apple|more: There are %count% apples', 1),
             array('There are %count% apples', 'one: There is one apple|more: There are %count% apples', 10),
 
-            array('There is no apple', '{0} There is no apple|one: There is one apple|more: There are %count% apples', 0),
-            array('There is one apple', '{0} There is no apple|one: There is one apple|more: There are %count% apples', 1),
-            array('There are %count% apples', '{0} There is no apple|one: There is one apple|more: There are %count% apples', 10),
+            array('There are no apples', '{0} There are no apples|one: There is one apple|more: There are %count% apples', 0),
+            array('There is one apple', '{0} There are no apples|one: There is one apple|more: There are %count% apples', 1),
+            array('There are %count% apples', '{0} There are no apples|one: There is one apple|more: There are %count% apples', 10),
 
             array('', '{0}|{1} There is one apple|]1,Inf] There are %count% apples', 0),
-            array('', '{0} There is no apple|{1}|]1,Inf] There are %count% apples', 1),
+            array('', '{0} There are no apples|{1}|]1,Inf] There are %count% apples', 1),
 
             // Indexed only tests which are Gettext PoFile* compatible strings.
             array('There are %count% apples', 'There is one apple|There are %count% apples', 0),
@@ -87,12 +87,12 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are %count% apples', 'There is one apple|There are %count% apples', 2),
 
             // Tests for float numbers
-            array('There is almost one apple', '{0} There is no apple|]0,1[ There is almost one apple|{1} There is one apple|[1,Inf] There is more than one apple', 0.7),
-            array('There is one apple', '{0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 1),
-            array('There is more than one apple', '{0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 1.7),
-            array('There is no apple', '{0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
-            array('There is no apple', '{0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0.0),
-            array('There is no apple', '{0.0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
+            array('There is almost one apple', '{0} There are no apples|]0,1[ There is almost one apple|{1} There is one apple|[1,Inf] There is more than one apple', 0.7),
+            array('There is one apple', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 1),
+            array('There is more than one apple', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 1.7),
+            array('There are no apples', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
+            array('There are no apples', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0.0),
+            array('There are no apples', '{0.0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
         );
     }
 }

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -25,43 +25,61 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $selector->choose($id, $number, 'en'));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testChooseWhenNoEnoughChoices()
+    public function testReturnMessageIfExactlyOneStandardRuleIsGiven()
     {
         $selector = new MessageSelector();
 
-        $selector->choose('foo', 10, 'en');
+        $this->assertEquals('There are two apples', $selector->choose('There are two apples', 2, 'en'));
+    }
+
+    /**
+     * @dataProvider getNonMatchingMessages
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowExceptionIfMatchingMessageCannotBeFound($id, $number)
+    {
+        $selector = new MessageSelector();
+
+        $selector->choose($id, $number, 'en');
+    }
+
+    public function getNonMatchingMessages()
+    {
+        return array(
+            array('{0} There is no apple|{1} There is one apple', 2),
+            array('{1} There is one apple|]1,Inf] There are %count% apples', 0),
+            array('{1} There is one apple|]2,Inf] There are %count% apples', 2),
+            array('{0} There is no apple|There is one apple', 2),
+        );
     }
 
     public function getChooseTests()
     {
         return array(
-            array('There is no apples', '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', 0),
-            array('There is no apples', '{0}     There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', 0),
-            array('There is no apples', '{0}There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', 0),
+            array('There is no apple', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 0),
+            array('There is no apple', '{0}     There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 0),
+            array('There is no apple', '{0}There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 0),
 
-            array('There is one apple', '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', 1),
+            array('There is one apple', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 1),
 
-            array('There is %count% apples', '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', 10),
-            array('There is %count% apples', '{0} There is no apples|{1} There is one apple|]1,Inf]There is %count% apples', 10),
-            array('There is %count% apples', '{0} There is no apples|{1} There is one apple|]1,Inf]     There is %count% apples', 10),
+            array('There are %count% apples', '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples', 10),
+            array('There are %count% apples', '{0} There is no apple|{1} There is one apple|]1,Inf]There are %count% apples', 10),
+            array('There are %count% apples', '{0} There is no apple|{1} There is one apple|]1,Inf]     There are %count% apples', 10),
 
-            array('There is %count% apples', 'There is one apple|There is %count% apples', 0),
-            array('There is one apple', 'There is one apple|There is %count% apples', 1),
-            array('There is %count% apples', 'There is one apple|There is %count% apples', 10),
+            array('There are %count% apples', 'There is one apple|There are %count% apples', 0),
+            array('There is one apple', 'There is one apple|There are %count% apples', 1),
+            array('There are %count% apples', 'There is one apple|There are %count% apples', 10),
 
-            array('There is %count% apples', 'one: There is one apple|more: There is %count% apples', 0),
-            array('There is one apple', 'one: There is one apple|more: There is %count% apples', 1),
-            array('There is %count% apples', 'one: There is one apple|more: There is %count% apples', 10),
+            array('There are %count% apples', 'one: There is one apple|more: There are %count% apples', 0),
+            array('There is one apple', 'one: There is one apple|more: There are %count% apples', 1),
+            array('There are %count% apples', 'one: There is one apple|more: There are %count% apples', 10),
 
-            array('There is no apples', '{0} There is no apples|one: There is one apple|more: There is %count% apples', 0),
-            array('There is one apple', '{0} There is no apples|one: There is one apple|more: There is %count% apples', 1),
-            array('There is %count% apples', '{0} There is no apples|one: There is one apple|more: There is %count% apples', 10),
+            array('There is no apple', '{0} There is no apple|one: There is one apple|more: There are %count% apples', 0),
+            array('There is one apple', '{0} There is no apple|one: There is one apple|more: There are %count% apples', 1),
+            array('There are %count% apples', '{0} There is no apple|one: There is one apple|more: There are %count% apples', 10),
 
-            array('', '{0}|{1} There is one apple|]1,Inf] There is %count% apples', 0),
-            array('', '{0} There is no apples|{1}|]1,Inf] There is %count% apples', 1),
+            array('', '{0}|{1} There is one apple|]1,Inf] There are %count% apples', 0),
+            array('', '{0} There is no apple|{1}|]1,Inf] There are %count% apples', 1),
 
             // Indexed only tests which are Gettext PoFile* compatible strings.
             array('There are %count% apples', 'There is one apple|There are %count% apples', 0),
@@ -69,12 +87,12 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are %count% apples', 'There is one apple|There are %count% apples', 2),
 
             // Tests for float numbers
-            array('There is almost one apple', '{0} There is no apples|]0,1[ There is almost one apple|{1} There is one apple|[1,Inf] There is more than one apple', 0.7),
-            array('There is one apple', '{0} There is no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 1),
-            array('There is more than one apple', '{0} There is no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 1.7),
-            array('There is no apples', '{0} There is no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
-            array('There is no apples', '{0} There is no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0.0),
-            array('There is no apples', '{0.0} There is no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
+            array('There is almost one apple', '{0} There is no apple|]0,1[ There is almost one apple|{1} There is one apple|[1,Inf] There is more than one apple', 0.7),
+            array('There is one apple', '{0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 1),
+            array('There is more than one apple', '{0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 1.7),
+            array('There is no apple', '{0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
+            array('There is no apple', '{0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0.0),
+            array('There is no apple', '{0.0} There is no apple|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
         );
     }
 }

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -277,16 +277,15 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('10 things', $translator->transChoice('some_message2', 10, array('%count%' => 10)));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testTransChoiceFallbackWithNoTranslation()
     {
         $translator = new Translator('ru', new MessageSelector());
         $translator->setFallbackLocale('en');
         $translator->addLoader('array', new ArrayLoader());
 
-        $this->assertEquals('10 things', $translator->transChoice('some_message2', 10, array('%count%' => 10)));
+        // consistent behavior with Translator::trans(), which returns the string
+        // unchanged if it can't be found
+        $this->assertEquals('some_message2', $translator->transChoice('some_message2', 10, array('%count%' => 10)));
     }
 }
 

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -237,9 +237,9 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     public function getTransChoiceTests()
     {
         return array(
-            array('Il y a 0 pomme', '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', '[0,1] Il y a %count% pomme|]1,Inf] Il y a %count% pommes', 0, array('%count%' => 0), 'fr', ''),
-            array('Il y a 1 pomme', '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', '[0,1] Il y a %count% pomme|]1,Inf] Il y a %count% pommes', 1, array('%count%' => 1), 'fr', ''),
-            array('Il y a 10 pommes', '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples', '[0,1] Il y a %count% pomme|]1,Inf] Il y a %count% pommes', 10, array('%count%' => 10), 'fr', ''),
+            array('Il y a 0 pomme', '{0} There are no appless|{1} There is one apple|]1,Inf] There is %count% apples', '[0,1] Il y a %count% pomme|]1,Inf] Il y a %count% pommes', 0, array('%count%' => 0), 'fr', ''),
+            array('Il y a 1 pomme', '{0} There are no appless|{1} There is one apple|]1,Inf] There is %count% apples', '[0,1] Il y a %count% pomme|]1,Inf] Il y a %count% pommes', 1, array('%count%' => 1), 'fr', ''),
+            array('Il y a 10 pommes', '{0} There are no appless|{1} There is one apple|]1,Inf] There is %count% apples', '[0,1] Il y a %count% pomme|]1,Inf] Il y a %count% pommes', 10, array('%count%' => 10), 'fr', ''),
 
             array('Il y a 0 pomme', 'There is one apple|There is %count% apples', 'Il y a %count% pomme|Il y a %count% pommes', 0, array('%count%' => 0), 'fr', ''),
             array('Il y a 1 pomme', 'There is one apple|There is %count% apples', 'Il y a %count% pomme|Il y a %count% pommes', 1, array('%count%' => 1), 'fr', ''),
@@ -249,11 +249,11 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
             array('Il y a 1 pomme', 'one: There is one apple|more: There is %count% apples', 'one: Il y a %count% pomme|more: Il y a %count% pommes', 1, array('%count%' => 1), 'fr', ''),
             array('Il y a 10 pommes', 'one: There is one apple|more: There is %count% apples', 'one: Il y a %count% pomme|more: Il y a %count% pommes', 10, array('%count%' => 10), 'fr', ''),
 
-            array('Il n\'y a aucune pomme', '{0} There is no apple|one: There is one apple|more: There is %count% apples', '{0} Il n\'y a aucune pomme|one: Il y a %count% pomme|more: Il y a %count% pommes', 0, array('%count%' => 0), 'fr', ''),
-            array('Il y a 1 pomme', '{0} There is no apple|one: There is one apple|more: There is %count% apples', '{0} Il n\'y a aucune pomme|one: Il y a %count% pomme|more: Il y a %count% pommes', 1, array('%count%' => 1), 'fr', ''),
-            array('Il y a 10 pommes', '{0} There is no apple|one: There is one apple|more: There is %count% apples', '{0} Il n\'y a aucune pomme|one: Il y a %count% pomme|more: Il y a %count% pommes', 10, array('%count%' => 10), 'fr', ''),
+            array('Il n\'y a aucune pomme', '{0} There are no apples|one: There is one apple|more: There is %count% apples', '{0} Il n\'y a aucune pomme|one: Il y a %count% pomme|more: Il y a %count% pommes', 0, array('%count%' => 0), 'fr', ''),
+            array('Il y a 1 pomme', '{0} There are no apples|one: There is one apple|more: There is %count% apples', '{0} Il n\'y a aucune pomme|one: Il y a %count% pomme|more: Il y a %count% pommes', 1, array('%count%' => 1), 'fr', ''),
+            array('Il y a 10 pommes', '{0} There are no apples|one: There is one apple|more: There is %count% apples', '{0} Il n\'y a aucune pomme|one: Il y a %count% pomme|more: Il y a %count% pommes', 10, array('%count%' => 10), 'fr', ''),
 
-            array('Il y a 0 pomme', new String('{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples'), '[0,1] Il y a %count% pomme|]1,Inf] Il y a %count% pommes', 0, array('%count%' => 0), 'fr', ''),
+            array('Il y a 0 pomme', new String('{0} There are no appless|{1} There is one apple|]1,Inf] There is %count% apples'), '[0,1] Il y a %count% pomme|]1,Inf] Il y a %count% pommes', 0, array('%count%' => 0), 'fr', ''),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

There was one regression introduced by #8789, namely when exactly one message is passed to `transChoice()`. Before, the following code was perfectly valid:

``` php
$translator = new IdentityTranslator(new MessageSelector());

echo $translator->transChoice('There are two apples', 2, array('%count%' => 2));
```

This didn't fail, because internally, the locale `null` was passed to `MessageSelector`, which always returned the index `0` in that case.

Now, the user's locale is passed, and if the selector returns anything but `0`, an exception is thrown.

I removed this exception for the case that exactly one standard message (without explicit interval) is passed. In that case, this message is returned (just like from `trans()`). If the message key contains more than one message, or if the message has explicit intervals, the exception will still be thrown. See the tests for clarification.

A use case for why no exception should be thrown is validation:

``` php
/**
 * @Assert\Length(min=2, minMessage="Please enter at least two characters")
 */
```
