### PR TITLE
[2.2][Locale] Fixed: StubLocale::setDefault() throws no exception when "en" is passed

### DIFF
--- a/src/Symfony/Component/Locale/Stub/StubLocale.php
+++ b/src/Symfony/Component/Locale/Stub/StubLocale.php
@@ -466,7 +466,9 @@ class StubLocale
      */
     public static function setDefault($locale)
     {
-        throw new MethodNotImplementedException(__METHOD__);
+        if ('en' !== $locale) {
+            throw new MethodNotImplementedException(__METHOD__);
+        }
     }
 
     public static function getDataDirectory()

--- a/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
@@ -252,4 +252,9 @@ class StubLocaleTest extends LocaleTestCase
     {
         StubLocale::setDefault('pt_BR');
     }
+
+    public function testSetDefaultAcceptsEn()
+    {
+        StubLocale::setDefault('en');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is necessary to fix `IntlTestHelper::requireIntl()` when ICU is not installed and the Icu component 1.0.0 is used instead. In that case, `IntlTestHelper::requireIntl()` calls `\Locale::setDefault('en')` and fails. Consequently, the Form component test cases are partially red when running without ICU installed.

This PR fixes that.
