### PR TITLE
[2.3][Locale] Fixed: StubLocale::setDefault() throws no exception when "en" is passed

### DIFF
--- a/src/Symfony/Component/Intl/Locale/Locale.php
+++ b/src/Symfony/Component/Intl/Locale/Locale.php
@@ -312,6 +312,8 @@ class Locale
      */
     public static function setDefault($locale)
     {
-        throw new MethodNotImplementedException(__METHOD__);
+        if ('en' !== $locale) {
+            throw new MethodNotImplementedException(__METHOD__);
+        }
     }
 }

--- a/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
@@ -150,6 +150,11 @@ class LocaleTest extends AbstractLocaleTest
         $this->call('setDefault', 'pt_BR');
     }
 
+    public function testSetDefaultAcceptsEn()
+    {
+        $this->call('setDefault', 'en');
+    }
+
     protected function call($methodName)
     {
         $args = array_slice(func_get_args(), 1);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Same as #8846 for 2.3+.
