### PR TITLE
Fixed typo

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -28,7 +28,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
     /**
      * Should not be used by application code. Use
-     * {@link PropertyAccess::getPropertyAccessor()} instead.
+     * {@link PropertyAccess::createPropertyAccessor()} instead.
      */
     public function __construct($magicCall = false)
     {


### PR DESCRIPTION
The `PropertyAccess::getPropertyAccessor()` is deprecated.
