### PR TITLE
[WIP] [DependencyInjection] added support for expressions in the service container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.4.0
+-----
+
+ * added support for expressions in service definitions
+
 2.2.0
 -----
 

--- a/src/Symfony/Component/DependencyInjection/Expression.php
+++ b/src/Symfony/Component/DependencyInjection/Expression.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Expression
+{
+    private $id;
+    private $path;
+
+    /**
+     * Constructor.
+     *
+     * @param string $id   A service identifier
+     * @param string $path A PropertyAccess path
+     */
+    public function __construct($id, $path)
+    {
+        $this->id = $id;
+        $this->path = $path;
+    }
+
+    /**
+     * Gets the service identifier of the expression.
+     *
+     * @return string The service identifier
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Gets the property path.
+     *
+     * @return string The property path
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Expression;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Yaml\Parser as YamlParser;
@@ -312,6 +313,11 @@ class YamlFileLoader extends FileLoader
         if (is_array($value)) {
             $value = array_map(array($this, 'resolveServices'), $value);
         } elseif (is_string($value) &&  0 === strpos($value, '@')) {
+            // is it an expression?
+            if (false !== $pos = strpos($value, '::')) {
+                return new Expression(substr($value, 1, $pos - 1), substr($value, $pos + 2));
+            }
+
             if (0 === strpos($value, '@@')) {
                 $value = substr($value, 1);
                 $invalidBehavior = null;

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -140,6 +140,7 @@
     <xsd:attribute name="key" type="xsd:string" />
     <xsd:attribute name="index" type="xsd:integer" />
     <xsd:attribute name="on-invalid" type="xsd:string" />
+    <xsd:attribute name="path" type="xsd:string" />
     <xsd:attribute name="strict" type="boolean" />
   </xsd:complexType>
 
@@ -164,6 +165,7 @@
     <xsd:restriction base="xsd:string">
       <xsd:enumeration value="collection" />
       <xsd:enumeration value="service" />
+      <xsd:enumeration value="expression" />
       <xsd:enumeration value="string" />
       <xsd:enumeration value="constant" />
     </xsd:restriction>

--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -77,6 +77,9 @@ class SimpleXMLElement extends \SimpleXMLElement
 
                     $arguments[$key] = new Reference((string) $arg['id'], $invalidBehavior, $strict);
                     break;
+                case 'expression':
+                    $arguments[$key] = new Expression((string) $arg['id'], (string) $arg['path']);
+                    break;
                 case 'collection':
                     $arguments[$key] = $arg->getArgumentsAsPhp($name, false);
                     break;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7352 |
| License | MIT |
| Doc PR | not yet |

This PR introduces a way to inject expression in the definition of a service.

Here is a small usage example:

``` php
use Symfony\Component\DependencyInjection\ContainerBuilder;
use Symfony\Component\DependencyInjection\Expression;

class Foo
{
    private $value;

    public function __construct($value)
    {
        $this->value = $value;
    }

    public function getBarValue()
    {
        return $this->value;
    }
}

class Bar
{
    public function getValue()
    {
        return 'bar';
    }
}

$c = new ContainerBuilder();
$c->register('bar', 'Bar');
$c->register('foo', 'Foo')->addArgument(new Expression('bar', 'value'));

echo $c->get('foo')->getBarValue()."\n";
```

Here is the XML version:

``` xml
    <services>
        <service id="foo" class="Foo">
            <argument type="expression" id="bar" path="value" />
        </service>
        <service id="bar" class="Bar" />
    </services>
```

And the YAML version:

``` yml
services:
    bar:
        class: Bar

    foo:
        class: Foo
        arguments: [@bar::value]
```

The `Expression` constructor takes a service id and a property path (as defined by the Symfony PropertyAccess component). Using the Symfony PropertyAccess component gives you a lot of flexibility in the way you get data from your objects.

Expressions are not limited to service arguments, you can use them everywhere (like in a method call, a configurator, ...).

Todo
- [ ] update documentation
- [ ] update all loaders and dumpers
- [ ] add tests

Open questions:
- Do we allow some cusomtization of the property access object (like support for __call?)
