### PR TITLE
[Security] Keep other query string parameters when switching users

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -92,7 +92,9 @@ class SwitchUserListener implements ListenerInterface
             }
         }
 
-        $request->server->set('QUERY_STRING', '');
+        $request->query->remove($this->usernameParameter);
+        $request->server->set('QUERY_STRING', http_build_query($request->query->all()));
+
         $response = new RedirectResponse($request->getUri(), 302);
 
         $event->setResponse($response);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| Doc PR | n/a |

When switching users, the whole query string gets dropped when redirecting after the switch.
I think only the switch user parameter should be dropped from the query string.
