### PR TITLE
[Bridge][Doctrine][Validator] allow UniqueEntity constraint to be set on external class

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIdentModel.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIdentModel.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+
+class SingleIdentModel
+{
+    protected $id;
+
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -28,6 +28,7 @@ class UniqueEntity extends Constraint
     public $fields = array();
     public $errorPath = null;
     public $ignoreNull = true;
+    public $externalClass = null;
 
     public function getRequiredOptions()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Use case for this feature would be if you want to validate data on a DTO before actually mapping it to the Entity itself.
