### PR TITLE
[Form] Abstract FormRenderer::humanize into FormUtil

### DIFF
--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Exception\BadMethodCallException;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\Form\Util\FormUtil;
 
 /**
  * Renders a form into HTML using a rendering engine.
@@ -299,6 +300,6 @@ class FormRenderer implements FormRendererInterface
      */
     public function humanize($text)
     {
-        return ucfirst(trim(strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $text))));
+        return FormUtil::humanize($text);
     }
 }

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -39,4 +39,20 @@ class FormUtil
         // not considered to be empty, ever.
         return null === $data || '' === $data;
     }
+
+    /**
+     * Makes a technical name human readable.
+     *
+     * Sequences of underscores are replaced by single spaces. The first letter
+     * of the resulting string is capitalized, while all other letters are
+     * turned to lowercase.
+     *
+     * @param string $text The text to humanize.
+     *
+     * @return string The humanized text.
+     */
+    public static function humanize($text)
+    {
+        return ucfirst(trim(strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $text))));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I came across the need to humanize a form field name the same way that is used when displaying a label and found that without creating an instance of FormRenderer there was no way to achieve this without duplicating code.

Looking through the codebase I found the FormUtil class and the FormRender::humanize function. To me the humanize function is more of a utility function than functionally dedicated to a specific Renderer class, however I assume it wasn't put in the FormRendererInterface for nothing.

I've abstracted the logic from FormRenderer::humanize and created a function in FormUtil for it. I've left in FormRenderer::humanize for backwards-compatibility.

I don't necessarily expect this PR to be accepted, as I'm not aware on the reasons for the humanize function being part of the interface. Hopefully someone can shed some light on this?
