### PR TITLE
[FrameworkBundle] added support for double-quoted strings in the extractor (closes #8797)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
@@ -1,2 +1,3 @@
 This template is used for translation message extraction tests
-<?php echo $view['translator']->trans('new key') ?>
+<?php echo $view['translator']->trans('single-quoted key') ?>
+<?php echo $view['translator']->trans("double-quoted key") ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/PhpExtractorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/PhpExtractorTest.php
@@ -28,8 +28,9 @@ class PhpExtractorTest extends TestCase
         $extractor->extract(__DIR__.'/../Fixtures/Resources/views/', $catalogue);
 
         // Assert
-        $this->assertCount(1, $catalogue->all('messages'), '->extract() should find 1 translation');
-        $this->assertTrue($catalogue->has('new key'), '->extract() should find at leat "new key" message');
-        $this->assertEquals('prefixnew key', $catalogue->get('new key'), '->extract() should apply "prefix" as prefix');
+        $this->assertCount(2, $catalogue->all('messages'), '->extract() should find 1 translation');
+        $this->assertTrue($catalogue->has('single-quoted key'), '->extract() should find the "single-quoted key" message');
+        $this->assertTrue($catalogue->has('double-quoted key'), '->extract() should find the "double-quoted key" message');
+        $this->assertEquals('prefixsingle-quoted key', $catalogue->get('single-quoted key'), '->extract() should apply "prefix" as prefix');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
@@ -111,7 +111,7 @@ class PhpExtractor implements ExtractorInterface
                     }
                 }
 
-                $message = trim($message, '\'');
+                $message = trim($message, '\'"');
 
                 if ($message) {
                     $catalog->set($message, $this->prefix.$message);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8797 |
| License | MIT |
| Doc PR | n/a |
