### PR TITLE
[HttpFoundation] remove unnecessary code in Response::prepare()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -296,11 +296,7 @@ class Response
 
         if ($request->isMethod('HEAD')) {
             // cf. RFC2616 14.13
-            $length = $headers->get('Content-Length');
             $this->setContent(null);
-            if ($length) {
-                $headers->set('Content-Length', $length);
-            }
         }
 
         // Fix protocol


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The code piece just doesn't make sense. Maybe the idea was to get `Content-Length` from `Request`?
