### PR TITLE
[Security] Added 'host' option to firewall configuration

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.4.0
+-----
+
+ * Added 'host' option to firewall configuration
+
 2.3.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -199,6 +199,7 @@ class MainConfiguration implements ConfigurationInterface
 
         $firewallNodeBuilder
             ->scalarNode('pattern')->end()
+            ->scalarNode('host')->end()
             ->booleanNode('security')->defaultTrue()->end()
             ->scalarNode('request_matcher')->end()
             ->scalarNode('access_denied_url')->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -243,8 +243,10 @@ class SecurityExtension extends Extension
         $matcher = null;
         if (isset($firewall['request_matcher'])) {
             $matcher = new Reference($firewall['request_matcher']);
-        } elseif (isset($firewall['pattern'])) {
-            $matcher = $this->createRequestMatcher($container, $firewall['pattern']);
+        } elseif (isset($firewall['pattern']) || isset($firewall['host'])) {
+            $pattern = isset($firewall['pattern']) ? $firewall['pattern'] : null;
+            $host = isset($firewall['host']) ? $firewall['host'] : null;
+            $matcher = $this->createRequestMatcher($container, $pattern, $host);
         }
 
         // Security disabled?

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -71,6 +71,12 @@ $container->loadFromExtension('security', array(
             'x509' => true,
             'logout' => true,
         ),
+        'host' => array(
+            'pattern' => '/test',
+            'host' => 'foo\\.example\\.org',
+            'anonymous' => true,
+            'http_basic' => true,
+        ),
     ),
 
     'access_control' => array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -57,6 +57,11 @@
             <logout />
         </firewall>
 
+        <firewall name="host" pattern="/test" host="foo\.example\.org">
+            <anonymous />
+            <http-basic />
+        </firewall>
+
         <role id="ROLE_ADMIN">ROLE_USER</role>
         <role id="ROLE_SUPER_ADMIN">ROLE_USER,ROLE_ADMIN,ROLE_ALLOWED_TO_SWITCH</role>
         <role id="ROLE_REMOTE">ROLE_USER,ROLE_ADMIN</role>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -53,6 +53,11 @@ security:
             switch_user: true
             x509: true
             logout: true
+        host:
+            pattern: /test
+            host: foo\.example\.org
+            anonymous: true
+            http_basic: true
 
     role_hierarchy:
         ROLE_ADMIN:       ROLE_USER

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -85,7 +85,39 @@ abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
                 'security.access_listener',
                 'security.authentication.switchuser_listener.secure',
             ),
+            array(
+                'security.channel_listener',
+                'security.context_listener.0',
+                'security.authentication.listener.basic.host',
+                'security.authentication.listener.anonymous.host',
+                'security.access_listener',
+            ),
         ), $listeners);
+    }
+
+    public function testFirewallRequestMatchers()
+    {
+        $container = $this->getContainer('container1');
+
+        $arguments = $container->getDefinition('security.firewall.map')->getArguments();
+        $matchers = array();
+
+        foreach ($arguments[1] as $reference) {
+            if ($reference instanceof Reference) {
+                $definition = $container->getDefinition((string) $reference);
+                $matchers[] = $definition->getArguments();
+            }
+        }
+
+        $this->assertEquals(array(
+            array(
+                '/login',
+            ),
+            array(
+                '/test',
+                'foo\\.example\\.org',
+            ),
+        ), $matchers);
     }
 
     public function testAccess()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7103 |
| License | MIT |
| Doc PR |  |

I'm not particularly fond of all the `isset()` checks, and would rather set default values for the `pattern` and `host` options (to `null`). However I'm not sure if that would have any other impact.
