### PR TITLE
[HttpFoundation] Request->getPort() should prefer HTTP_HOST over SERVER_PORT

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -912,6 +912,14 @@ class Request
             }
         }
 
+        if ($host = $this->headers->get('HOST')) {
+            if (preg_match('/:(\d+)$/', $host, $matches)) {
+                return intval($matches[1]);
+            }
+
+            return 'https' === $this->getScheme() ? 443 : 80;
+        }
+
         return $this->server->get('SERVER_PORT');
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1566,6 +1566,18 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         // trusted hosts
         $request->headers->set('host', 'trusted.com');
         $this->assertEquals('trusted.com', $request->getHost());
+        $this->assertEquals(80, $request->getPort());
+
+        $request->server->set('HTTPS', true);
+        $request->headers->set('host', 'trusted.com');
+        $this->assertEquals('trusted.com', $request->getHost());
+        $this->assertEquals(443, $request->getPort());
+        $request->server->set('HTTPS', false);
+
+        $request->headers->set('host', 'trusted.com:8000');
+        $this->assertEquals('trusted.com', $request->getHost());
+        $this->assertEquals(8000, $request->getPort());
+
         $request->headers->set('host', 'subdomain.trusted.com');
         $this->assertEquals('subdomain.trusted.com', $request->getHost());
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/3420 |
| License | MIT |
| Doc PR | none |
## What is this?

_Note to reviewer: This follows on from a previous pull request: https://github.com/symfony/symfony/pull/8184
Since the introduction of `Request->setTrustedHosts()` — the implementation of this fix has been simplified._

This fixes the semantics of the `Request#getPort()` method to prefer the HTTP_HOST header over SERVER_PORT.

This is relevant in situations where the web server is running on a different port to the public facing website. e.g. load balancers, proxies, port forwarding.
## Consistency

This change makes Symfony more consistent with other popular web frameworks.

Preferring HTTP_HOST over SERVER_NAME and SERVER_PORT is the strategy used by Ruby's Rack and Python's Django.

Python has a PEP that describes how to reconstruct URLs:
http://www.python.org/dev/peps/pep-0333/#url-reconstruction

https://github.com/rack/rack/blob/b6290a184cead2ffd731647d0836c5ebd3c21e7a/lib/rack/request.rb#L92
