### PR TITLE
[PropelBridge] PropelTypeGuesser can now recognize columns by their phpName

### DIFF
--- a/src/Symfony/Bridge/Propel1/Form/PropelTypeGuesser.php
+++ b/src/Symfony/Bridge/Propel1/Form/PropelTypeGuesser.php
@@ -169,5 +169,9 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
         if ($table && $table->hasColumn($property)) {
             return $this->cache[$class.'::'.$property] = $table->getColumn($property);
         }
+
+        if ($table && $table->hasColumnByInsensitiveCase($property)) {
+            return $this->cache[$class.'::'.$property] = $table->getColumnByInsensitiveCase($property);
+        }
     }
 }

--- a/src/Symfony/Bridge/Propel1/Tests/Fixtures/ItemQuery.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Fixtures/ItemQuery.php
@@ -22,6 +22,11 @@ class ItemQuery
         'updated_at'    => \PropelColumnTypes::TIMESTAMP,
     );
 
+    private $caseInsensitiveMap = array(
+        'isactive'      => 'is_active',
+        'updatedat'     => 'updated_at',
+    );
+
     public function getTableMap()
     {
         // Allows to define methods in this class
@@ -52,6 +57,30 @@ class ItemQuery
     {
         if ($this->hasColumn($column)) {
             return new Column($column, $this->map[$column]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Method from the TableMap API
+     */
+    public function hasColumnByInsensitiveCase($column)
+    {
+        $column = strtolower($column);
+
+        return in_array($column, array_keys($this->caseInsensitiveMap));
+    }
+
+    /**
+     * Method from the TableMap API
+     */
+    public function getColumnByInsensitiveCase($column)
+    {
+        $column = strtolower($column);
+
+        if (isset($this->caseInsensitiveMap[$column])) {
+            return $this->getColumn($this->caseInsensitiveMap[$column]);
         }
 
         return null;

--- a/src/Symfony/Bridge/Propel1/Tests/Form/PropelTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/PropelTypeGuesserTest.php
@@ -114,6 +114,8 @@ class PropelTypeGuesserTest extends Propel1TestCase
             array('value',      'text',     Guess::MEDIUM_CONFIDENCE),
             array('price',      'number',   Guess::MEDIUM_CONFIDENCE),
             array('updated_at', 'datetime', Guess::HIGH_CONFIDENCE),
+            array('isActive',   'checkbox', Guess::HIGH_CONFIDENCE),
+            array('updatedAt',  'datetime', Guess::HIGH_CONFIDENCE),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Until now, the `PropelTypeGuesser` could only find columns by their name.
Example: `created_at` was recognized but `createdAt` wasn't.

This PR adds the ability to match column's phpNames (in a case-insensitive way).
