### PR TITLE
fixed misleading doc block

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -719,9 +719,9 @@ class Request
     /**
      * Returns the client IP addresses.
      *
-     * The most trusted IP address is first, and the less trusted one last.
-     * The "real" client IP address is the last one, but this is also the
-     * less trusted one.
+     * The least trusted IP address is first, and the most trusted one last.
+     * The "real" client IP address is the first one, but this is also the
+     * least trusted one.
      *
      * Use this method carefully; you should use getClientIp() instead.
      *


### PR DESCRIPTION
This doc block does not match what's happening in the code.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
