### PR TITLE
[Process] Fixed PHPDoc Blocks

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -268,8 +268,8 @@ class Process
      *
      * @return Process The new process
      *
-     * @throws \RuntimeException When process can't be launch or is stopped
-     * @throws \RuntimeException When process is already running
+     * @throws RuntimeException When process can't be launch or is stopped
+     * @throws RuntimeException When process is already running
      *
      * @see start()
      */
@@ -296,8 +296,8 @@ class Process
      *
      * @return integer The exitcode of the process
      *
-     * @throws \RuntimeException When process timed out
-     * @throws \RuntimeException When process stopped after receiving signal
+     * @throws RuntimeException When process timed out
+     * @throws RuntimeException When process stopped after receiving signal
      */
     public function wait($callback = null)
     {


### PR DESCRIPTION
These `RunTimeExceptions` are NOT the native ones, therefor the should not be `\` in front of them.

| Q | A |
| --- | --- |
| Fixed tickets | none |
| License | MIT |
