### PR TITLE
[Routing] RedirectableUrlMatcher redirect from slash to non-slash urls

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
@@ -29,14 +29,20 @@ abstract class RedirectableUrlMatcher extends UrlMatcher implements Redirectable
         try {
             $parameters = parent::match($pathinfo);
         } catch (ResourceNotFoundException $e) {
-            if ('/' === substr($pathinfo, -1) || !in_array($this->context->getMethod(), array('HEAD', 'GET'))) {
+            if (!in_array($this->context->getMethod(), array('HEAD', 'GET'))) {
                 throw $e;
             }
 
-            try {
-                parent::match($pathinfo.'/');
+            if ('/' === substr($pathinfo, -1)) {
+                $routeForRedirect = substr($pathinfo, 0, -1);
+            } else {
+                $routeForRedirect = $pathinfo . '/';
+            }
 
-                return $this->redirect($pathinfo.'/', null);
+            try {
+                parent::match($routeForRedirect);
+
+                return $this->redirect($routeForRedirect, null);
             } catch (ResourceNotFoundException $e2) {
                 throw $e;
             }

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -55,4 +55,28 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         ;
         $matcher->match('/foo');
     }
+
+    public function testRedirectWhenSlash()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo'));
+
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext()));
+        $matcher->expects($this->once())->method('redirect');
+        $matcher->match('/foo/');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
+    public function testRedirectWhenSlashForNonSafeMethod()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo'));
+
+        $context = new RequestContext();
+        $context->setMethod('POST');
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, $context));
+        $matcher->match('/foo/');
+    }
 }


### PR DESCRIPTION
In our project we use this behavior to redirect slash urls to non slash urls. /foo/ -> /foo

I thought it may be of interest for Symfony to have this ability. 
I do not know the initial idea to redirect non-slash to slash urls and why not the other way around.
