### PR TITLE
[DependencyInjection] optimized circular reference checker

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -28,6 +28,7 @@ class CheckCircularReferencesPass implements CompilerPassInterface
 {
     private $currentId;
     private $currentPath;
+    private $checkedNodes;
 
     /**
      * Checks the ContainerBuilder object for circular references.
@@ -38,6 +39,7 @@ class CheckCircularReferencesPass implements CompilerPassInterface
     {
         $graph = $container->getCompiler()->getServiceReferenceGraph();
 
+        $this->checkedNodes = array();
         foreach ($graph->getNodes() as $id => $node) {
             $this->currentId = $id;
             $this->currentPath = array($id);
@@ -58,15 +60,20 @@ class CheckCircularReferencesPass implements CompilerPassInterface
         foreach ($edges as $edge) {
             $node      = $edge->getDestNode();
             $id        = $node->getId();
-            $searchKey = array_search($id, $this->currentPath);
-            $this->currentPath[] = $id;
 
-            if (false !== $searchKey) {
-                throw new ServiceCircularReferenceException($id, array_slice($this->currentPath, $searchKey));
+            if (empty($this->checkedNodes[$id])) {
+                $searchKey = array_search($id, $this->currentPath);
+                $this->currentPath[] = $id;
+
+                if (false !== $searchKey) {
+                    throw new ServiceCircularReferenceException($id, array_slice($this->currentPath, $searchKey));
+                }
+
+                $this->checkOutEdges($node->getOutEdges());
+
+                $this->checkedNodes[$id] = true;
+                array_pop($this->currentPath);
             }
-
-            $this->checkOutEdges($node->getOutEdges());
-            array_pop($this->currentPath);
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | no] |
| Tests pass? | [yes] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [] |

It is an addtion to my previous PR https://github.com/symfony/symfony/pull/7699

There is no need to check again previously checked sub-trees.

In our tightly coupled services graph, this circular reference check runs avg 1,5ms, before that: 100ms
