### PR TITLE
[Yaml] Fixed filename in the ParseException message

### DIFF
--- a/src/Symfony/Component/Yaml/Exception/ParseException.php
+++ b/src/Symfony/Component/Yaml/Exception/ParseException.php
@@ -32,9 +32,9 @@ class ParseException extends RuntimeException
      * @param integer   $parsedLine The line where the error occurred
      * @param integer   $snippet    The snippet of code near the problem
      * @param string    $parsedFile The file name where the error occurred
-     * @param Exception $previous   The previous exception
+     * @param \Exception $previous   The previous exception
      */
-    public function __construct($message, $parsedLine = -1, $snippet = null, $parsedFile = null, Exception $previous = null)
+    public function __construct($message, $parsedLine = -1, $snippet = null, $parsedFile = null, \Exception $previous = null)
     {
         $this->parsedFile = $parsedFile;
         $this->parsedLine = $parsedLine;
@@ -125,7 +125,7 @@ class ParseException extends RuntimeException
         }
 
         if (null !== $this->parsedFile) {
-            $this->message .= sprintf(' in %s', json_encode($this->parsedFile));
+            $this->message .= sprintf(' in "%s"', $this->parsedFile);
         }
 
         if ($this->parsedLine >= 0) {

--- a/src/Symfony/Component/Yaml/Tests/ParseExceptionTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParseExceptionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Tests;
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+class ParseExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetMessage()
+    {
+        $exception = new ParseException(
+            'Error message', 42, 'foo: bar', '/var/www/app/config.yml'
+        );
+
+        $this->assertEquals(
+            'Error message in "/var/www/app/config.yml" at line 42 (near "foo: bar")',
+            $exception->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | sort of |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | — |
| License | MIT |
| Doc PR | — |

Yaml component throws an exception with corrupt filename because of `json_encode`:

```
[Symfony\Component\Yaml\Exception\ParseException]
A YAML file cannot contain tabs as indentation in "\/var\/www\/app\/config.yml" at line 42 (near "  foo: bar").
```
