### PR TITLE
[Config] Created and switched to new FileNotFoundException

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileNotFoundException.php
+++ b/src/Symfony/Component/Config/Exception/FileNotFoundException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Exception;
+
+use Symfony\Component\Filesystem\Exception\ExceptionInterface;
+
+/**
+ * Exception class for when a file could not be found.
+ * Implements the ExceptionInterface of the FileSystem Component
+ *
+ * @author Christian Gärtner <christiangaertner.film@googlemail.com>
+ */
+class FileNotFoundException extends \InvalidArgumentException implements ExceptionInterface
+{
+    /**
+     * @param string     $resource       The resource that could not be imported
+     * @param string     $sourceResource The original resource importing the new resource
+     * @param integer    $code           The error code
+     * @param \Exception $previous       A previous exception
+     */
+    public function __construct($file, $currentPath = null, $paths = null, $code = null, $previous = null)
+    {
+        if ($currentPath === null) {
+            $message = sprintf('The file "%s" does not exist.', $file);
+        } else {
+            $message = sprintf('The file "%s" does not exist (in: %s%s).', $file, null !== $currentPath ? $currentPath.', ' : '', implode(', ', $paths));
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Config;
 
+use Symfony\Component\Config\Exception\FileNotFoundException;
+
 /**
  * FileLocator uses an array of pre-defined paths to find files.
  *
@@ -45,7 +47,7 @@ class FileLocator implements FileLocatorInterface
     {
         if ($this->isAbsolutePath($name)) {
             if (!file_exists($name)) {
-                throw new \InvalidArgumentException(sprintf('The file "%s" does not exist.', $name));
+                throw new FileNotFoundException($name);
             }
 
             return $name;
@@ -69,7 +71,7 @@ class FileLocator implements FileLocatorInterface
         }
 
         if (!$filepaths) {
-            throw new \InvalidArgumentException(sprintf('The file "%s" does not exist (in: %s%s).', $name, null !== $currentPath ? $currentPath.', ' : '', implode(', ', $this->paths)));
+            throw new FileNotFoundException($name, $currentPath, $this->paths);
         }
 
         return array_values(array_unique($filepaths));

--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -41,7 +41,7 @@ class FileLocator implements FileLocatorInterface
      *
      * @return string|array The full path to the file|An array of file paths
      *
-     * @throws \InvalidArgumentException When file is not found
+     * @throws \Symfony\Component\Config\Exception\FileNotFoundException When file is not found
      */
     public function locate($name, $currentPath = null, $first = true)
     {

--- a/src/Symfony/Component/Config/FileLocatorInterface.php
+++ b/src/Symfony/Component/Config/FileLocatorInterface.php
@@ -25,7 +25,7 @@ interface FileLocatorInterface
      *
      * @return string|array The full path to the file|An array of file paths
      *
-     * @throws \Symfony\Component\Filesystem\Exception\IOException When file is not found
+     * @throws \Symfony\Component\Config\Exception\FileNotFoundException When file is not found
      */
     public function locate($name, $currentPath = null, $first = true);
 }

--- a/src/Symfony/Component/Config/FileLocatorInterface.php
+++ b/src/Symfony/Component/Config/FileLocatorInterface.php
@@ -25,7 +25,7 @@ interface FileLocatorInterface
      *
      * @return string|array The full path to the file|An array of file paths
      *
-     * @throws \InvalidArgumentException When file is not found
+     * @throws \Symfony\Component\Filesystem\Exception\IOException When file is not found
      */
     public function locate($name, $currentPath = null, $first = true);
 }


### PR DESCRIPTION
The `InvalidArgumentException` is technically wrong. Because the argument itself doesn' t has to be invalid. The file couldn' t be found on the system. I think this is a little better to throw the new `FileNotFoundException`.

The new Exception class is extending `InvalidArgumentException` this way it doesn' t break BC. I haven' t modified the tests at all, this should proof this.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes (kinda... a little maybe) |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none (The exception "throwing" isn' t mentioned in the docs.) |
