### PR TITLE
Use isset() instead of array_key_exists() in DIC

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -240,8 +240,8 @@ class Container implements IntrospectableContainerInterface
     {
         $id = strtolower($id);
 
-        return array_key_exists($id, $this->services)
-            || array_key_exists($id, $this->aliases)
+        return isset($this->services[$id])
+            || isset($this->aliases[$id])
             || method_exists($this, 'get'.strtr($id, array('_' => '', '.' => '_')).'Service')
         ;
     }
@@ -275,7 +275,7 @@ class Container implements IntrospectableContainerInterface
         }
 
         // re-use shared service instance if it exists
-        if (array_key_exists($id, $this->services)) {
+        if (isset($this->services[$id])) {
             return $this->services[$id];
         }
 
@@ -339,7 +339,7 @@ class Container implements IntrospectableContainerInterface
      */
     public function initialized($id)
     {
-        return array_key_exists(strtolower($id), $this->services);
+        return isset($this->services[strtolower($id)]);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -268,16 +268,21 @@ class Container implements IntrospectableContainerInterface
      */
     public function get($id, $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE)
     {
-        $id = strtolower($id);
-
-        // resolve aliases
-        if (isset($this->aliases[$id])) {
-            $id = $this->aliases[$id];
-        }
-
-        // re-use shared service instance if it exists
-        if (isset($this->services[$id]) || array_key_exists($id, $this->services)) {
-            return $this->services[$id];
+        // Attempt to retrieve the service by checking first aliases then
+        // available services. Service IDs are case insensitive, however since
+        // this method can be called thousands of times during a request, avoid
+        // calling strotolower() unless necessary.
+        foreach (array(FALSE, TRUE) as $strtolower) {
+            if ($strtolower) {
+              $id = strtolower($id);
+            }
+            if (isset($this->aliases[$id])) {
+              $id = $this->aliases[$id];
+            }
+            // Re-use shared service instance if it exists.
+            if (isset($this->services[$id]) || array_key_exists($id, $this->services)) {
+                return $this->services[$id];
+            }
         }
 
         if (isset($this->loading[$id])) {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -274,10 +274,10 @@ class Container implements IntrospectableContainerInterface
         // calling strotolower() unless necessary.
         foreach (array(FALSE, TRUE) as $strtolower) {
             if ($strtolower) {
-              $id = strtolower($id);
+                $id = strtolower($id);
             }
             if (isset($this->aliases[$id])) {
-              $id = $this->aliases[$id];
+                $id = $this->aliases[$id];
             }
             // Re-use shared service instance if it exists.
             if (isset($this->services[$id]) || array_key_exists($id, $this->services)) {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -272,7 +272,7 @@ class Container implements IntrospectableContainerInterface
         // available services. Service IDs are case insensitive, however since
         // this method can be called thousands of times during a request, avoid
         // calling strotolower() unless necessary.
-        foreach (array(FALSE, TRUE) as $strtolower) {
+        foreach (array(false, true) as $strtolower) {
             if ($strtolower) {
                 $id = strtolower($id);
             }

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -241,6 +241,7 @@ class Container implements IntrospectableContainerInterface
         $id = strtolower($id);
 
         return isset($this->services[$id])
+            || array_key_exists($id, $this->services)
             || isset($this->aliases[$id])
             || method_exists($this, 'get'.strtr($id, array('_' => '', '.' => '_')).'Service')
         ;
@@ -275,7 +276,7 @@ class Container implements IntrospectableContainerInterface
         }
 
         // re-use shared service instance if it exists
-        if (isset($this->services[$id])) {
+        if (isset($this->services[$id]) || array_key_exists($id, $this->services)) {
             return $this->services[$id];
         }
 
@@ -339,7 +340,8 @@ class Container implements IntrospectableContainerInterface
      */
     public function initialized($id)
     {
-        return isset($this->services[strtolower($id)]);
+        $id = strtolower($id);
+        return isset($this->services[$id]) || array_key_exists($id, $this->services);
     }
 
     /**


### PR DESCRIPTION
It doesn't look like the array_key_exists() in Container::get() and Container::has() is necessary. Changing this to isset() removed over 1,000 calls on a default Drupal 8 install - attaching before/after xhprof screenshots with this change.

![screen shot 2013-09-01 at 1 13 41 pm](https://f.cloud.github.com/assets/116285/1063965/d826057c-1300-11e3-96c3-2c94b89fe83a.png)

![screen shot 2013-09-01 at 1 13 49 pm](https://f.cloud.github.com/assets/116285/1063961/99a0f7b2-1300-11e3-9bd2-b0bf22d4245e.png)
