### PR TITLE
[WebProfilerBundle] Added response status code and text to request profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -109,6 +109,10 @@
 
     {% include '@WebProfiler/Profiler/bag.html.twig' with { 'bag': collector.requestserver } only %}
 
+    <h2>Response Status</h2>
+
+    <p><strong>{{ collector.statusCode }}</strong> {{ collector.statusText }}</p>
+
     <h2>Response Headers</h2>
 
     {% include '@WebProfiler/Profiler/bag.html.twig' with { 'bag': collector.responseheaders } only %}

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -455,6 +455,18 @@ class Response
     }
 
     /**
+     * Retrieves the status text for the current web response.
+     *
+     * @return string Status text
+     *
+     * @api
+     */
+    public function getStatusText()
+    {
+        return $this->statusText;
+    }
+
+    /**
      * Sets the response charset.
      *
      * @param string $charset Character set

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -84,6 +84,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             'content'            => $content,
             'content_type'       => $response->headers->get('Content-Type') ? $response->headers->get('Content-Type') : 'text/html',
             'status_code'        => $response->getStatusCode(),
+            'status_text'        => $response->getStatusText(),
             'request_query'      => $request->query->all(),
             'request_request'    => $request->request->all(),
             'request_headers'    => $request->headers->all(),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I notice the response status code and text were missing from the response info in the profiler, so I added them.
