### PR TITLE
[Process][2.2] Fix Process component on windows

### DIFF
--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -1,0 +1,254 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process;
+
+use Symfony\Component\Process\Exception\RuntimeException;
+
+/**
+ * ProcessPipes manages descriptors and pipes for the use of proc_open.
+ */
+class ProcessPipes
+{
+    /** @var array */
+    public $pipes = array();
+    /** @var array */
+    private $fileHandles = array();
+    /** @var array */
+    private $readBytes = array();
+    /** @var Boolean */
+    private $useFiles;
+
+    public function __construct($useFiles = false)
+    {
+        $this->useFiles = (Boolean) $useFiles;
+
+        // Fix for PHP bug #51800: reading from STDOUT pipe hangs forever on Windows if the output is too big.
+        // Workaround for this problem is to use temporary files instead of pipes on Windows platform.
+        //
+        // Please note that this work around prevents hanging but
+        // another issue occurs : In some race conditions, some data may be
+        // lost or corrupted.
+        //
+        // @see https://bugs.php.net/bug.php?id=51800
+        if ($this->useFiles) {
+            $this->fileHandles = array(
+                Process::STDOUT => tmpfile(),
+                Process::STDERR => tmpfile(),
+            );
+            if (false === $this->fileHandles[Process::STDOUT]) {
+                throw new RuntimeException('A temporary file could not be opened to write the process output to, verify that your TEMP environment variable is writable');
+            }
+            if (false === $this->fileHandles[Process::STDERR]) {
+                throw new RuntimeException('A temporary file could not be opened to write the process output to, verify that your TEMP environment variable is writable');
+            }
+            $this->readBytes = array(
+                Process::STDOUT => 0,
+                Process::STDERR => 0,
+            );
+        }
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    /**
+     * Sets non-blocking mode on pipes.
+     */
+    public function unblock()
+    {
+        foreach ($this->pipes as $pipe) {
+            stream_set_blocking($pipe, 0);
+        }
+    }
+
+    /**
+     * Closes file handles and pipes.
+     */
+    public function close()
+    {
+        foreach ($this->pipes as $offset => $pipe) {
+            fclose($pipe);
+        }
+
+        foreach ($this->fileHandles as $offset => $handle) {
+            fclose($handle);
+        }
+        $this->fileHandles = $this->pipes = array();
+    }
+
+    /**
+     * Returns an array of descriptors for the use of proc_open.
+     *
+     * @return array
+     */
+    public function getDescriptors()
+    {
+        if ($this->useFiles) {
+            return array(
+                array('pipe', 'r'),
+                $this->fileHandles[Process::STDOUT],
+                $this->fileHandles[Process::STDERR],
+            );
+        }
+
+        return array(
+            array('pipe', 'r'), // stdin
+            array('pipe', 'w'), // stdout
+            array('pipe', 'w'), // stderr
+        );
+    }
+
+    /**
+     * Reads data in file handles and pipes.
+     *
+     * @param Boolean $blocking Whether to use blocking calls or not.
+     *
+     * @return array An array of read data indexed by their fd.
+     */
+    public function read($blocking)
+    {
+        return array_replace($this->readStreams($blocking), $this->readFileHandles());
+    }
+
+    /**
+     * Writes stdin data.
+     *
+     * @param Boolean $blocking Whether to use blocking calls or not.
+     * @param string  $stdin    The data to write.
+     */
+    public function write($blocking, $stdin)
+    {
+        if (null === $stdin) {
+            fclose($this->pipes[0]);
+            unset($this->pipes[0]);
+
+            return;
+        }
+
+        $writePipes = array($this->pipes[0]);
+        unset($this->pipes[0]);
+        $stdinLen = strlen($stdin);
+        $stdinOffset = 0;
+
+        while ($writePipes) {
+            $r = null;
+            $w = $writePipes;
+            $e = null;
+
+            if (false === $n = @stream_select($r, $w, $e, 0, $blocking ? ceil(Process::TIMEOUT_PRECISION * 1E6) : 0)) {
+                // if a system call has been interrupted, forget about it, let's try again
+                if ($this->hasSystemCallBeenInterrupted()) {
+                    continue;
+                }
+                break;
+            }
+
+            // nothing has changed, let's wait until the process is ready
+            if (0 === $n) {
+                continue;
+            }
+
+            if ($w) {
+                $written = fwrite($writePipes[0], (binary) substr($stdin, $stdinOffset), 8192);
+                if (false !== $written) {
+                    $stdinOffset += $written;
+                }
+                if ($stdinOffset >= $stdinLen) {
+                    fclose($writePipes[0]);
+                    $writePipes = null;
+                }
+            }
+        }
+    }
+
+    /**
+     * Reads data in file handles.
+     *
+     * @return array An array of read data indexed by their fd.
+     */
+    private function readFileHandles()
+    {
+        $read = array();
+
+        foreach ($this->fileHandles as $type => $fileHandle) {
+            fseek($fileHandle, $this->readBytes[$type]);
+            $data = '';
+            while (!feof($fileHandle)) {
+                $data .= fread($fileHandle, 8192);
+            }
+            if (0 < $length = strlen($data)) {
+                $this->readBytes[$type] += $length;
+                $read[$type] = $data;
+            }
+        }
+
+        return $read;
+    }
+
+    /**
+     * Reads data in file pipes streams.
+     *
+     * @param Boolean $blocking Whether to use blocking calls or not.
+     *
+     * @return array An array of read data indexed by their fd.
+     */
+    private function readStreams($blocking)
+    {
+        $read = array();
+
+        $r = $this->pipes;
+        $w = null;
+        $e = null;
+
+        // let's have a look if something changed in streams
+        if (false === $n = @stream_select($r, $w, $e, 0, $blocking ? ceil(Process::TIMEOUT_PRECISION * 1E6) : 0)) {
+            // if a system call has been interrupted, forget about it, let's try again
+            // otherwise, an error occured, let's reset pipes
+            if (!$this->hasSystemCallBeenInterrupted()) {
+                $this->pipes = array();
+            }
+
+            return $read;
+        }
+
+        // nothing has changed
+        if (0 === $n) {
+            return $read;
+        }
+
+        foreach ($r as $pipe) {
+            $type = array_search($pipe, $this->pipes);
+            $data = fread($pipe, 8192);
+
+            if (strlen($data) > 0) {
+                $read[$type] = $data;
+            }
+        }
+
+        return $read;
+    }
+
+    /**
+     * Returns true if a system call has been interrupted.
+     *
+     * @return Boolean
+     */
+    private function hasSystemCallBeenInterrupted()
+    {
+        $lastError = error_get_last();
+
+        // stream_select returns false when the `select` system call is interrupted by an incoming signal
+        return isset($lastError['message']) && false !== stripos($lastError['message'], 'interrupted system call');
+    }
+}

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -123,6 +123,12 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     public function chainedCommandsOutputProvider()
     {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            return array(
+                array("2 \r\n2\r\n", '&&', '2')
+            );
+        }
+
         return array(
             array("1\n1\n", ';', '1'),
             array("2\n2\n", '&&', '2'),
@@ -135,10 +141,6 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
      */
     public function testChainedCommandsOutput($expected, $operator, $input)
     {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Does it work on windows ?');
-        }
-
         $process = $this->getProcess(sprintf('echo %s %s echo %s', $input, $operator, $input));
         $process->run();
         $this->assertEquals($expected, $process->getOutput());

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -74,17 +74,16 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     {
         $data = '';
 
-        $process = $this->getProcess('echo "foo";sleep 1;echo "foo"');
+        $process = $this->getProcess('echo foo && php -r "sleep(1);" && echo foo');
         $process->start(function ($type, $buffer) use (&$data) {
             $data .= $buffer;
         });
 
-        $start = microtime(true);
         while ($process->isRunning()) {
             usleep(10000);
         }
 
-        $this->assertEquals("foo\nfoo\n", $data);
+        $this->assertEquals(2, preg_match_all('/foo/', $data, $matches));
     }
 
     /**
@@ -178,7 +177,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testGetOutput()
     {
-        $p = new Process(sprintf('php -r %s', escapeshellarg('$n=0;while ($n<3) {echo \' foo \';$n++;}')));
+        $p = new Process(sprintf('php -r %s', escapeshellarg('$n=0;while ($n<3) {echo \' foo \';$n++; usleep(500); }')));
 
         $p->run();
         $this->assertEquals(3, preg_match_all('/foo/', $p->getOutput(), $matches));
@@ -300,7 +299,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testIsSuccessfulOnlyAfterTerminated()
     {
-        $process = $this->getProcess('sleep 1');
+        $process = $this->getProcess('php -r "sleep(1);"');
         $process->start();
         while ($process->isRunning()) {
             $this->assertFalse($process->isSuccessful());
@@ -402,7 +401,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function testRunProcessWithTimeout()
     {
         $timeout = 0.5;
-        $process = $this->getProcess('sleep 3');
+        $process = $this->getProcess('php -r "sleep(3);"');
         $process->setTimeout($timeout);
         $start = microtime(true);
         try {
@@ -420,7 +419,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     {
         $timeout = 0.5;
         $precision = 100000;
-        $process = $this->getProcess('sleep 3');
+        $process = $this->getProcess('php -r "sleep(3);"');
         $process->setTimeout($timeout);
         $start = microtime(true);
 

--- a/src/Symfony/Component/Process/Tests/ProcessTestHelper.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTestHelper.php
@@ -8,9 +8,9 @@ define('ERR_WRITE_FAILED', 4);
 $read = array(STDIN);
 $write = array(STDOUT, STDERR);
 
-stream_set_blocking(STDIN, false);
-stream_set_blocking(STDOUT, false);
-stream_set_blocking(STDERR, false);
+stream_set_blocking(STDIN, 0);
+stream_set_blocking(STDOUT, 0);
+stream_set_blocking(STDERR, 0);
 
 $out = $err = '';
 while ($read || $write) {
@@ -26,7 +26,7 @@ while ($read || $write) {
     }
 
     if (in_array(STDOUT, $w) && strlen($out) > 0) {
-         $written = fwrite(STDOUT, (binary) $out, 1024);
+         $written = fwrite(STDOUT, (binary) $out, 32768);
          if (false === $written) {
              die(ERR_WRITE_FAILED);
          }
@@ -37,7 +37,7 @@ while ($read || $write) {
     }
 
     if (in_array(STDERR, $w) && strlen($err) > 0) {
-         $written = fwrite(STDERR, (binary) $err, 1024);
+         $written = fwrite(STDERR, (binary) $err, 32768);
          if (false === $written) {
              die(ERR_WRITE_FAILED);
          }
@@ -48,7 +48,7 @@ while ($read || $write) {
     }
 
     if ($r) {
-        $str = fread(STDIN, 1024);
+        $str = fread(STDIN, 32768);
         if (false !== $str) {
             $out .= $str;
             $err .= $str;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8836, #8799, #7078 |
| License | MIT |

This PR fixes Process on windows (almost, see note below).
- Some unit tests were not Windows compatible
- Use a file handle for STDERR as well as STDOUT to avoid blocking
- Decouple pipes and descriptors from Process

As this move some a part of Process in a sub class, I hope merging this in 2.3 and master would not be a PITA. I'm here to make some adjustments after theses merge if needed.

**Important note** : 

We are using file handles instead of streams for `proc_open` pipes as described in the code (see [PHP bug #51800](https://bugs.php.net/bug.php?id=51800)). Unfortunately, this workaround may produce corrupted output/error output in some race conditions. That's why `AbstractProcessTest::testProcessPipes` randomly fails when using file handles (on unix and windows). 
