### PR TITLE
[Console] Improved xml generated when listing commands

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -93,7 +93,15 @@ class XmlDescriptor extends Descriptor
     public function getApplicationDocument(Application $application, $namespace = null)
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
-        $dom->appendChild($rootXml = $dom->createElement('symfony'));
+        $dom->appendChild($rootXml = $dom->createElement('application'));
+
+        if ($application->getName() !== 'UNKNOWN') {
+            $rootXml->setAttribute('name', $application->getName());
+            if ($application->getVersion() !== 'UNKNOWN') {
+                $rootXml->setAttribute('version', $application->getVersion());
+            }
+        }
+
         $rootXml->appendChild($commandsXML = $dom->createElement('commands'));
 
         $description = new ApplicationDescription($application, $namespace);

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<symfony>
+<application>
   <commands>
     <command id="help" name="help">
       <usage>help [--xml] [--format="..."] [--raw] [command_name]</usage>
@@ -105,4 +105,4 @@
       <command>list</command>
     </namespace>
   </namespaces>
-</symfony>
+</application>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<symfony>
+<application name="My Symfony application" version="v1.0">
   <commands>
     <command id="help" name="help">
       <usage>help [--xml] [--format="..."] [--raw] [command_name]</usage>
@@ -182,4 +182,4 @@
       <command>descriptor:command2</command>
     </namespace>
   </namespaces>
-</symfony>
+</application>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_asxml1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_asxml1.txt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<symfony>
+<application>
   <commands>
     <command id="help" name="help">
   <usage>help [--xml] [--format="..."] [--raw] [command_name]</usage>
@@ -141,4 +141,4 @@
       <command>foo:bar</command>
     </namespace>
   </namespaces>
-</symfony>
+</application>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_asxml2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_asxml2.txt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<symfony>
+<application>
   <commands namespace="foo">
     <command id="foo:bar" name="foo:bar">
   <usage>foo:bar</usage>
@@ -34,4 +34,4 @@
     </options>
 </command>
   </commands>
-</symfony>
+</application>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I marked this PR as a BC break, as it breaks the xml schema generated by the command **app/console list --xml**

It replaces the first node (currently _symfony_) by a more generic node name ( _application_ ) and adds the application name and application version if specified in the _Symfony\Component\Console\Application_ constructor.

Before (using composer console that uses symfony console component):

```
<?xml version="1.0" encoding="UTF-8"?>
<symfony>
    ...
</symfony>
```

After (using composer console that uses symfony console component):

```
<?xml version="1.0" encoding="UTF-8"?>
<application name="Composer" version="x.x.x">
    ...
</application>
```
