### PR TITLE
[DependencyInjection] add ability to dump objects

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1214,8 +1214,10 @@ EOF;
 
                 return $code;
             }
-        } elseif (is_object($value) || is_resource($value)) {
-            throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
+        } elseif (is_object($value) && !method_exists(get_class($value), '__set_state')) {
+            throw new RuntimeException('Unable to dump a service container if a parameter is an object without __set_state magic method.');
+        } elseif (is_resource($value)) {
+            throw new RuntimeException('Unable to dump a service container if a parameter is a resource.');
         } else {
             return var_export($value, true);
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -313,8 +313,15 @@ class XmlDumper extends Dumper
                 return 'false';
             case $value instanceof Parameter:
                 return '%'.$value.'%';
-            case is_object($value) || is_resource($value):
-                throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
+            case is_object($value):
+                if (method_exists(get_class($value), '__set_state')) {
+                    return var_export($value, true);
+                } else {
+                    throw new RuntimeException('Unable to dump a service container if a parameter is an object without __set_state magic method.');
+                }
+                break;
+            case is_resource($value):
+                throw new RuntimeException('Unable to dump a service container if a parameter is a resource.');
             default:
                 return (string) $value;
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -24,6 +24,8 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
+
+        require_once self::$fixturesPath.'/includes/classes.php';
     }
 
     public function testDump()
@@ -116,7 +118,7 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
             $this->fail('->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Exception\RuntimeException', $e, '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
-            $this->assertEquals('Unable to dump a service container if a parameter is an object or a resource.', $e->getMessage(), '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+            $this->assertEquals('Unable to dump a service container if a parameter is an object without __set_state magic method.', $e->getMessage(), '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -21,6 +21,8 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
+
+        require_once self::$fixturesPath.'/includes/classes.php';
     }
 
     public function testDump()
@@ -60,7 +62,7 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
             $this->fail('->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\RuntimeException', $e, '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
-            $this->assertEquals('Unable to dump a service container if a parameter is an object or a resource.', $e->getMessage(), '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+            $this->assertEquals('Unable to dump a service container if a parameter is an object without __set_state magic method.', $e->getMessage(), '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container8.php
@@ -9,6 +9,7 @@ $container = new ContainerBuilder(new ParameterBag(array(
     'bar'    => 'foo is %%foo bar',
     'escape' => '@escapeme',
     'values' => array(true, false, null, 0, 1000.3, 'true', 'false', 'null'),
+    'object' => new BarClass()
 )));
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
@@ -18,6 +18,10 @@ class BarClass
     {
         return $this->baz;
     }
+
+    public static function __set_state($an_array)
+    {
+    }
 }
 
 class BazClass

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -48,6 +48,9 @@ class ProjectServiceContainer extends Container
                 6 => 'false',
                 7 => 'null',
             ),
+            'object' => BarClass::__set_state(array(
+   'baz' => NULL,
+)),
         );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -17,6 +17,9 @@
       <parameter type="string">true</parameter>
       <parameter type="string">false</parameter>
       <parameter type="string">null</parameter>
-    </parameter>
+	</parameter>
+	<parameter key="object">BarClass::__set_state(array(
+   'baz' =&gt; NULL,
+))</parameter>
   </parameters>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
@@ -4,4 +4,5 @@ parameters:
     bar: 'foo is %%foo bar'
     escape: '@@escapeme'
     values: [true, false, null, 0, 1000.3, 'true', 'false', 'null']
+    object: null
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It allows us to use objects in parameters, also pass var_export-able object parameters to services.

It could be useful in many ways, i would like to use it to store annotation objects in parameters (anyway i would have to instantiate reflectionclass)
