### PR TITLE
[Console] Ignore posix_istatty warnings

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -177,7 +177,7 @@ class Application
 
         if (function_exists('posix_isatty') && $this->getHelperSet()->has('dialog')) {
             $inputStream = $this->getHelperSet()->get('dialog')->getInputStream();
-            if (!posix_isatty($inputStream)) {
+            if (!@posix_isatty($inputStream)) {
                 $input->setInteractive(false);
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

When input stream is `php://memory` or `php://temp` function `posix_isatty` throws following warning

> posix_isatty(): could not use stream of type 'MEMORY' in .... 
