### PR TITLE
use absolute urls for fragment uri's

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -91,7 +91,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
                 throw new \LogicException('You must use a proper URI when using the Hinclude rendering strategy or set a URL signer.');
             }
 
-            $uri = $this->signer->sign($this->generateFragmentUri($uri, $request));
+            $uri = $this->signer->sign($this->generateFragmentUri($uri, $request, true));
         }
 
         // We need to replace ampersands in the URI with the encoded form in order to return valid html/xml content.


### PR DESCRIPTION
When using render_hinclude, a uri is generated that has a hash added to it.
The FragmentListener then checks the hash to make sure it is signed and valid.
The check however uses the http scheme and host so the uri needs to start as
an absolute uri to match the resulting check. Otherwise all render_hinclude calls
result in an AccessDeniedHttpException.
