### PR TITLE
[HttpFoundation] Fixing broken http auth digest in some circumstances.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -64,11 +64,17 @@ class ServerBag extends ParameterBag
                 $authorizationHeader = $this->parameters['REDIRECT_HTTP_AUTHORIZATION'];
             }
 
-            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
-            if ((null !== $authorizationHeader) && (0 === stripos($authorizationHeader, 'basic'))) {
-                $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
-                if (count($exploded) == 2) {
-                    list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;
+            if ((null !== $authorizationHeader)) {
+                if ((0 === stripos($authorizationHeader, 'basic'))) {
+                    // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
+                    $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
+                    if (count($exploded) == 2) {
+                        list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;
+                    }
+                } elseif (empty($this->parameters['PHP_AUTH_DIGEST']) && (0 === stripos($authorizationHeader, 'digest'))) {
+                    // In some circumstances PHP_AUTH_DIGEST needs to be set
+                    $headers['PHP_AUTH_DIGEST'] = $authorizationHeader;
+                    $this->parameters['PHP_AUTH_DIGEST'] = $authorizationHeader;
                 }
             }
         }
@@ -76,6 +82,8 @@ class ServerBag extends ParameterBag
         // PHP_AUTH_USER/PHP_AUTH_PW
         if (isset($headers['PHP_AUTH_USER'])) {
             $headers['AUTHORIZATION'] = 'Basic '.base64_encode($headers['PHP_AUTH_USER'].':'.$headers['PHP_AUTH_PW']);
+        } elseif (isset($headers['PHP_AUTH_DIGEST'])) {
+            $headers['AUTHORIZATION'] = $headers['PHP_AUTH_DIGEST'];
         }
 
         return $headers;

--- a/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
@@ -89,6 +89,28 @@ class ServerBagTest extends \PHPUnit_Framework_TestCase
         ), $bag->getHeaders());
     }
 
+    public function testHttpDigestAuthWithPhpCgi()
+    {
+        $digest = 'Digest username="foo", realm="acme", nonce="'.md5('secret').'", uri="/protected, qop="auth"';
+        $bag = new ServerBag(array('HTTP_AUTHORIZATION' => $digest));
+
+        $this->assertEquals(array(
+            'AUTHORIZATION' => $digest,
+            'PHP_AUTH_DIGEST' => $digest,
+        ), $bag->getHeaders());
+    }
+
+    public function testHttpDigestAuthWithPhpCgiRedirect()
+    {
+        $digest = 'Digest username="foo", realm="acme", nonce="'.md5('secret').'", uri="/protected, qop="auth"';
+        $bag = new ServerBag(array('REDIRECT_HTTP_AUTHORIZATION' => $digest));
+
+        $this->assertEquals(array(
+            'AUTHORIZATION' => $digest,
+            'PHP_AUTH_DIGEST' => $digest,
+        ), $bag->getHeaders());
+    }
+
     public function testOAuthBearerAuth()
     {
         $headerContent = 'Bearer L-yLEOr9zhmUYRkzN1jwwxwQ-PBNiKDc8dgfB4hTfvo';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | can be refered in issue #1813 |
| License | MIT |
| Doc PR | n/a |

With some apache + php-fpm setup we need to set `PHP_AUTH_DIGEST` value if not already setted in GLOBAL vars.

Added some unit tests too.
