### PR TITLE
[HttpFoundation] Request->getRequestFormat should only rely on the request attributes

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1218,7 +1218,7 @@ class Request
     public function getRequestFormat($default = 'html')
     {
         if (null === $this->format) {
-            $this->format = $this->get('_format', $default);
+            $this->format = $this->attributes->get('_format', $default);
         }
 
         return $this->format;

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1188,6 +1188,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $this->assertNull($request->setRequestFormat('foo'));
         $this->assertEquals('foo', $request->getRequestFormat(null));
+
+	    $request = new Request(array('_format' => 'foo'));
+	    $this->assertEquals('html', $request->getRequestFormat());
     }
 
     public function testHasSession()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | possibly |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8966 |
| License | MIT |
| Doc PR |  |

Added test case and fix for #8966. Is this functionality relied on somewhere?
