### PR TITLE
[HttpFoundation] NativeSessionStorage regenerate

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -220,6 +220,8 @@ class NativeSessionStorage implements SessionStorageInterface
                 session_start();
             }
         }
+        
+        $this->loadSession();
 
         return $ret;
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -219,9 +219,9 @@ class NativeSessionStorage implements SessionStorageInterface
             } else {
                 session_start();
             }
+            
+            $this->loadSession();
         }
-        
-        $this->loadSession();
 
         return $ret;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8460 |
| License | MIT |
| Doc PR |  |

Since session_start is called by the regenerate function, then the 'started' flag of NativeSessionStorage have to be set to true. Otherwise, the variable $_SESSION is initiated and the exception "Failed to start the session: already started by PHP ($_SESSION is set)." is thrown.

This can be reproduced by clearing the session data (cookies) before authenticating with a method that does not require csrf (eg. using the confirmation link of FOSUserBundle).
