### PR TITLE
Fix: Arguments including space and quote are not correctly escaped (win)

### DIFF
--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -46,14 +46,23 @@ class ProcessUtils
             }
 
             $escapedArgument = '';
+            $quote = FALSE;
             foreach (preg_split('/([%"])/i', $argument, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE) as $part) {
                 if ('"' === $part) {
                     $escapedArgument .= '\\"';
                 } elseif ('%' === $part) {
                     $escapedArgument .= '^%';
                 } else {
-                    $escapedArgument .= escapeshellarg($part);
+                    $part = escapeshellarg($part);
+                    if ($part[0] === '"' && $part[strlen($part) - 1] === '"') {
+                        $part = substr($part, 1, -1);
+                        $quote = TRUE;
+                    }
+                    $escapedArgument .= $part;
                 }
+            }
+            if ($quote) {
+                $escapedArgument = '"' . $escapedArgument . '"';
             }
 
             return $escapedArgument;

--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -46,7 +46,7 @@ class ProcessUtils
             }
 
             $escapedArgument = '';
-            $quote = FALSE;
+            $quote =  false;
             foreach (preg_split('/([%"])/i', $argument, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE) as $part) {
                 if ('"' === $part) {
                     $escapedArgument .= '\\"';
@@ -56,7 +56,7 @@ class ProcessUtils
                     $part = escapeshellarg($part);
                     if ($part[0] === '"' && $part[strlen($part) - 1] === '"') {
                         $part = substr($part, 1, -1);
-                        $quote = TRUE;
+                        $quote = true;
                     }
                     $escapedArgument .= $part;
                 }


### PR DESCRIPTION
Bad
`"bin" "command" \""bin"\"" "\""another command"\"`

Better
`"bin" "command" "\"bin\" \"another command\""`

Note: _This is just proposition, I am not sure if this change covers all the options._
