### PR TITLE
[Form] Fixed FormValidator::findClickedButton() not to be called exponentially

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -23,6 +23,11 @@ use Symfony\Component\Validator\ConstraintValidator;
 class FormValidator extends ConstraintValidator
 {
     /**
+     * @var \SplObjectStorage
+     */
+    private static $clickedButtons;
+
+    /**
      * @var ServerParams
      */
     private $serverParams;
@@ -45,6 +50,16 @@ class FormValidator extends ConstraintValidator
     {
         if (!$form instanceof FormInterface) {
             return;
+        }
+
+        if (null === static::$clickedButtons) {
+            static::$clickedButtons = new \SplObjectStorage();
+        }
+
+        // If the form was previously validated, remove it from the cache in
+        // case the clicked button has changed
+        if (static::$clickedButtons->contains($form)) {
+            static::$clickedButtons->detach($form);
         }
 
         /* @var FormInterface $form */
@@ -172,7 +187,17 @@ class FormValidator extends ConstraintValidator
      */
     private static function getValidationGroups(FormInterface $form)
     {
-        $button = self::findClickedButton($form->getRoot());
+        $root = $form->getRoot();
+
+        // Determine the clicked button of the complete form tree
+        if (!static::$clickedButtons->contains($root)) {
+            // Only call findClickedButton() once to prevent an exponential
+            // runtime
+            // https://github.com/symfony/symfony/issues/8317
+            static::$clickedButtons->attach($root, self::findClickedButton($root));
+        }
+
+        $button = static::$clickedButtons->offsetGet($root);
 
         if (null !== $button) {
             $groups = $button->getConfig()->getOption('validation_groups');

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Constraints;
+
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Test\FormPerformanceTestCase;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class FormValidatorPerformanceTest extends FormPerformanceTestCase
+{
+    protected function getExtensions()
+    {
+        return array(
+            new ValidatorExtension(Validation::createValidator()),
+        );
+    }
+
+    /**
+     * findClickedButton() used to have an exponential number of calls
+     *
+     * @group benchmark
+     */
+    public function testValidationPerformance()
+    {
+        $this->setMaxRunningTime(1);
+
+        $builder = $this->factory->createBuilder('form');
+
+        for ($i = 0; $i < 100; ++$i) {
+            $builder->add($i, 'form');
+
+            $builder->get($i)
+                ->add('a')
+                ->add('b')
+                ->add('c');
+        }
+
+        $form = $builder->getForm();
+
+        $form->submit(null);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8317 |
| License | MIT |
| Doc PR | - |
