### PR TITLE
[Validator] The default option name can now be omitted when defining constraints as annotations

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -87,8 +87,9 @@ abstract class Constraint
         $invalidOptions = array();
         $missingOptions = array_flip((array) $this->getRequiredOptions());
 
-        if (is_array($options) && count($options) == 1 && isset($options['value'])) {
-            $options = $options['value'];
+        if (is_array($options) && count($options) >= 1 && isset($options['value']) && !property_exists($this, 'value')) {
+            $options[$this->getDefaultOption()] = $options['value'];
+            unset($options['value']);
         }
 
         if (is_array($options) && count($options) > 0 && is_string(key($options))) {

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Tests\Fixtures\ClassConstraint;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintC;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithValue;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithValueAsDefault;
 
 class ConstraintTest extends \PHPUnit_Framework_TestCase
 {
@@ -69,6 +71,30 @@ class ConstraintTest extends \PHPUnit_Framework_TestCase
         $constraint = new ConstraintA(array('value' => 'foo'));
 
         $this->assertEquals('foo', $constraint->property2);
+    }
+
+    public function testSetDefaultPropertyDoctrineStylePlusOtherProperty()
+    {
+        $constraint = new ConstraintA(array('value' => 'foo', 'property1' => 'bar'));
+
+        $this->assertEquals('foo', $constraint->property2);
+        $this->assertEquals('bar', $constraint->property1);
+    }
+
+    public function testSetDefaultPropertyDoctrineStyleWhenDefaultPropertyIsNamedValue()
+    {
+        $constraint = new ConstraintWithValueAsDefault(array('value' => 'foo'));
+
+        $this->assertEquals('foo', $constraint->value);
+        $this->assertNull($constraint->property);
+    }
+
+    public function testDontSetDefaultPropertyIfValuePropertyExists()
+    {
+        $constraint = new ConstraintWithValue(array('value' => 'foo'));
+
+        $this->assertEquals('foo', $constraint->value);
+        $this->assertNull($constraint->property);
     }
 
     public function testSetUndefinedDefaultProperty()

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValue.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValue.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+
+/** @Annotation */
+class ConstraintWithValue extends Constraint
+{
+    public $property;
+    public $value;
+
+    public function getDefaultOption()
+    {
+        return 'property';
+    }
+
+    public function getTargets()
+    {
+        return array(self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValueAsDefault.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValueAsDefault.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+
+/** @Annotation */
+class ConstraintWithValueAsDefault extends Constraint
+{
+    public $property;
+    public $value;
+
+    public function getDefaultOption()
+    {
+        return 'value';
+    }
+
+    public function getTargets()
+    {
+        return array(self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When a constraint has a default option, but other options should be set as well, the name of the default option had to be set explicitly when defining the constraint as annotation:

``` php
/** @GreaterThan(value=2, message="Should be greater than 2") */
private $value;
```

After this PR, it is possible to omit the name of the default option:

``` php
/** @GreaterThan(2, message="Should be greater than 2") */
private $value;
```
