### PR TITLE
Fixed docblock in UserInterface::getSalt()

### DIFF
--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -64,7 +64,7 @@ interface UserInterface
      *
      * This can return null if the password was not encoded using a salt.
      *
-     * @return string The salt
+     * @return string|null The salt
      */
     public function getSalt();
 


### PR DESCRIPTION
This method can return null, too.
See the line above:

> "This can return null if the password was not encoded using a salt."
