### PR TITLE
[Translation][Translator] added getLoaders() method

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -222,6 +222,16 @@ class Translator implements TranslatorInterface
         return strtr($this->selector->choose($catalogue->get($id, $domain), (int) $number, $locale), $parameters);
     }
 
+    /**
+     * Gets the loaders.
+     *
+     * @return array LoaderInterface[]
+     */
+    protected function getLoaders()
+    {
+        return $this->loaders;
+    }
+    
     protected function loadCatalogue($locale)
     {
         try {


### PR DESCRIPTION
Except extend the Translator with a useless hack it is not possible to get the list of loaders.

It would be well to allow access to $loaders (protected) property or to a getLoaders()

| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [no] |
| License | MIT |
| Doc PR | [?] |
