### PR TITLE
[Process][2.3] Fix process merge in 2.3

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -303,18 +303,6 @@ class Process
         }
         $this->updateStatus(false);
 
-        while ($this->processPipes->hasOpenHandles()) {
-            usleep(100);
-            foreach ($this->processPipes->readAndCloseHandles(true) as $type => $data) {
-                if (3 == $type) {
-                    $this->fallbackExitcode = (int) $data;
-                } else {
-                    call_user_func($this->callback, $type === self::STDOUT ? self::OUT : self::ERR, $data);
-                }
-            }
-        }
-        $this->close();
-
         if ($this->processInformation['signaled']) {
             if ($this->isSigchildEnabled()) {
                 throw new RuntimeException('The process has been signaled.');
@@ -1062,12 +1050,23 @@ class Process
      */
     private function close()
     {
-        $this->processPipes->close();
         $exitcode = -1;
 
         if (is_resource($this->process)) {
             $exitcode = proc_close($this->process);
         }
+
+        while ($this->processPipes->hasOpenHandles()) {
+            usleep(100);
+            foreach ($this->processPipes->readAndCloseHandles(true) as $type => $data) {
+                if (3 == $type) {
+                    $this->fallbackExitcode = (int) $data;
+                } else {
+                    call_user_func($this->callback, $type === self::STDOUT ? self::OUT : self::ERR, $data);
+                }
+            }
+        }
+        $this->processPipes->close();
 
         $this->exitcode = $this->exitcode !== null ? $this->exitcode : -1;
         $this->exitcode = -1 != $exitcode ? $exitcode : $this->exitcode;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Handles should be read and closed after `proc_close` is called. (this follows merge of #8983)
