### PR TITLE
[Process][2.2] Close unix pipes before calling `proc_close` to avoid a deadlock

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -310,8 +310,13 @@ class Process
         }
         $this->updateStatus(false);
 
+        // Unix pipes must be closed before calling proc_close to void deadlock
+        // see manual http://php.net/manual/en/function.proc-close.php
+        $this->processPipes->closeUnixPipes();
         $exitcode = proc_close($this->process);
 
+        // Windows only : when using file handles, some activity may occur after
+        // calling proc_close
         while($this->processPipes->hasOpenHandles()) {
             usleep(100);
             foreach ($this->processPipes->readAndCloseHandles(true) as $type => $data) {

--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -77,14 +77,24 @@ class ProcessPipes
      */
     public function close()
     {
-        foreach ($this->pipes as $offset => $pipe) {
-            fclose($pipe);
-        }
-
+        $this->closeUnixPipes();
         foreach ($this->fileHandles as $offset => $handle) {
             fclose($handle);
         }
-        $this->fileHandles = $this->pipes = array();
+        $this->fileHandles = array();
+    }
+
+    /**
+     * Closes unix pipes.
+     *
+     * Nothing happens in case file handles are used.
+     */
+    public function closeUnixPipes()
+    {
+        foreach ($this->pipes as $pipe) {
+            fclose($pipe);
+        }
+        $this->pipes = array();
     }
 
     /**


### PR DESCRIPTION
| Q             | A |
| --- | --- |
| Bug fix?       | potentially |
| New feature?   | no |
| BC breaks?     | no |
| Deprecations? | no |
| Tests pass?   | yes |
| Fixed tickets |  |
| License       | MIT |

see http://php.net/manual/en/function.proc-close.php
