### PR TITLE
[Security] Fixed problem with losing ROLE_PREVIOUS_ADMIN role.

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\SwitchUserRole;
 
 /**
  * UserProviderInterface retrieves users for UsernamePasswordToken tokens.
@@ -92,7 +93,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
             throw $e;
         }
 
-        $authenticatedToken = new UsernamePasswordToken($user, $token->getCredentials(), $this->providerKey, $user->getRoles());
+        $authenticatedToken = new UsernamePasswordToken($user, $token->getCredentials(), $this->providerKey, $this->getRoles($user, $token));
         $authenticatedToken->setAttributes($token->getAttributes());
 
         return $authenticatedToken;
@@ -104,6 +105,29 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
     public function supports(TokenInterface $token)
     {
         return $token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey();
+    }
+
+    /**
+     * Retrives roles from user and appends SwitchUserRole if original token contained one.
+     *
+     * @param \Symfony\Component\Security\Core\User\UserInterface                  $user
+     * @param \Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token
+     *
+     * @return \Symfony\Component\Security\Core\Role\SwitchUserRole
+     */
+    protected function getRoles(UserInterface $user, TokenInterface $token)
+    {
+        $roles = $user->getRoles();
+
+        foreach ($token->getRoles() as $role) {
+            if ($role instanceof SwitchUserRole) {
+                $roles[] = $role;
+
+                break;
+            }
+        }
+
+        return $roles;
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -108,14 +108,14 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
     }
 
     /**
-     * Retrives roles from user and appends SwitchUserRole if original token contained one.
+     * Retrieves roles from user and appends SwitchUserRole if original token contained one.
      *
-     * @param \Symfony\Component\Security\Core\User\UserInterface                  $user
-     * @param \Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token
+     * @param UserInterface  $user  The user
+     * @param TokenInterface $token The token
      *
-     * @return \Symfony\Component\Security\Core\Role\SwitchUserRole
+     * @return Role[] The user roles
      */
-    protected function getRoles(UserInterface $user, TokenInterface $token)
+    private function getRoles(UserInterface $user, TokenInterface $token)
     {
         $roles = $user->getRoles();
 


### PR DESCRIPTION
<table>
  <tr>
    <td><b>Q</b></td>
    <td><b>A</b></td>
  </tr>
  <tr>
    <td>Bug fix?</td>
    <td>yes</td>
  </tr>
  <tr>
    <td>New feature</td>
    <td>no</td>
  </tr>
  <tr>
    <td>BC breaks?</td>
    <td>no</td>
  </tr>
  <tr>
    <td>Deprecations?</td>
    <td>no</td>
  </tr>
  <tr>
    <td>Tests pass?</td>
    <td>yes</td>
  </tr>
  <tr>
    <td>Fixed tickets</td>
    <td>#3085, #8974</td>
  </tr>
  <tr>
    <td>License</td>
    <td>MIT</td>
  </tr>
  <tr>
    <td>Doc PR</td>
    <td>n/a</td>
  </tr>
</table>


Problem occurs while user is impersonated. Authentication process generates new token and doeas not preserve role `ROLE_PREVIOUS_ADMIN`. Ex. when parameter `security.always_authenticate_before_granting` is enabled.
