### PR TITLE
[DependencyInjection] added a simple way to replace a service by keeping a reference to the old one

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.5.0
+-----
+
+* added DecoratorServicePass and a way to override a service definition (Definition::setDecoratedService())
+
 2.4.0
 -----
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Alias;
+
+/**
+ * Overwrites a service but keeps the overridden one.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class DecoratorServicePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$decorated = $definition->getDecoratedService()) {
+                continue;
+            }
+
+            list ($decorated, $renamedId) = $decorated;
+            if (!$renamedId) {
+                $renamedId = $id.'.inner';
+            }
+
+            // we create a new alias/service for the service we are replacing
+            // to be able to reference it in the new one
+            if ($container->hasAlias($decorated)) {
+                $alias = $container->getAlias($decorated);
+                $public = $alias->isPublic();
+                $container->setAlias($renamedId, new Alias((string) $alias, false));
+            } else {
+                $definition = $container->getDefinition($decorated);
+                $public = $definition->isPublic();
+                $definition->setPublic(false);
+                $container->setDefinition($renamedId, $definition);
+            }
+
+            $container->setAlias($decorated, new Alias($id, $public));
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -50,6 +50,7 @@ class PassConfig
 
         $this->optimizationPasses = array(
             new ResolveDefinitionTemplatesPass(),
+            new DecoratorServicePass(),
             new ResolveParameterPlaceHoldersPass(),
             new CheckDefinitionValidityPass(),
             new ResolveReferencesToAliasesPass(),

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -38,6 +38,7 @@ class Definition
     private $abstract;
     private $synchronized;
     private $lazy;
+    private $decoratedService;
 
     protected $arguments;
 
@@ -62,6 +63,31 @@ class Definition
         $this->lazy = false;
         $this->abstract = false;
         $this->properties = array();
+    }
+
+    /**
+     * Sets the service that this service is decorating.
+     *
+     * @param string $id        The decorated service id
+     * @param string $renamedId The new decorated service id
+     */
+    public function setDecoratedService($id, $renamedId = null)
+    {
+        if ($renamedId && $id == $renamedId) {
+            throw new \LogicException(sprintf('The decorated service parent name for "%s" must be different than the service name itself.', $id));
+        }
+
+        $this->decoratedService = array($id, $renamedId);
+    }
+
+    /**
+     * Gets the service that decorates this service.
+     *
+     * @return array An array composed of the decorated service id and the new id for it
+     */
+    public function getDecoratedService()
+    {
+        return $this->decoratedService;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5920 |
| License | MIT |
| Doc PR | not yet |

TODO:
- [ ] add a cookbook entry for this new feature
- [ ] add support in all loaders/dumpers
- [ ] add unit tests
- [x] see if there are use cases in Symfony that would benefit from this new feature
- [x] find the best name for this feature

When overriding an existing definition, the old service is lost:

``` php
$c->set('foo', 'stdClass');

// this is going to remove the old definition with the new one
// old definition is lost
$c->set('foo', 'stdClass');
```

Most of the time, that's exactly what you want to do, but sometimes, you might want to decorate the old one instead. In this case, the old service should be kept around to be able to reference it in the new one. This PR implements this new feature:

``` php
$c->set('foo', 'stdClass');

// I want to replace foo with a new one, but I need a reference of the old one (foo1.parent here)
$c->set('foo1', 'stdClass')->addArgument('foo1.parent')->setDecoratedService('foo');
```

Here is what's going on here: the `setDecoratedService()` method tells the container that the `foo1` service should replace the `foo` service. By convention, the old `foo` service is going to be renamed `foo1.parent`, so I can inject it into my new service.

You can change the parent service name if you want to:

``` php
$c->set('foo1', 'stdClass')->addArgument('foo1.wooz')->setDecoratedService('foo', 'foo1.wooz');
```

Also, several service can decorate a single one and everything should work fine:

``` php
$c->set('foo', 'stdClass');

$c->set('foo1', 'stdClass')->addArgument('foo1.parent')->setDecoratedService('foo');
$c->set('foo2', 'stdClass')->addArgument('foo2.parent')->setDecoratedService('foo');
```

Note that this is different from the existing `parent` definition attribute, where a service inherit/extends another one (as the two services co-exist independently).

In XML, that would work like this:

``` xml
<service id="foo1" class="stdClass" decorate="foo">
    <argument type="service" id="foo1.parent" />
</service>
```
