### PR TITLE
[DependencyInjection] added tags validation when compiling a container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -74,6 +74,17 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
                    $id
                 ));
             }
+
+            // tag attribute values must be scalars
+            foreach ($definition->getTags() as $name => $tags) {
+                foreach ($tags as $attributes) {
+                    foreach ($attributes as $attribute => $value) {
+                        if (!is_scalar($value)) {
+                            throw new RuntimeException(sprintf('A "tags" attribute must be of a scalar-type for service "%s", tag "%s", attribute "%s".', $id, $name, $attribute));
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -225,7 +225,7 @@ class YamlFileLoader extends FileLoader
 
                 foreach ($tag as $attribute => $value) {
                     if (!is_scalar($value)) {
-                        throw new InvalidArgumentException(sprintf('A "tags" attribute must be of a scalar-type for service "%s", tag "%s" in %s.', $id, $name, $file));
+                        throw new InvalidArgumentException(sprintf('A "tags" attribute must be of a scalar-type for service "%s", tag "%s", attribute "%s" in %s.', $id, $name, $attribute, $file));
                     }
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class CheckDefinitionValidityPassTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      */
     public function testProcessDetectsSyntheticNonPublicDefinitions()
     {
@@ -29,7 +29,7 @@ class CheckDefinitionValidityPassTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      */
     public function testProcessDetectsSyntheticPrototypeDefinitions()
     {
@@ -40,7 +40,7 @@ class CheckDefinitionValidityPassTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      */
     public function testProcessDetectsNonSyntheticNonAbstractDefinitionWithoutClass()
     {
@@ -57,6 +57,17 @@ class CheckDefinitionValidityPassTest extends \PHPUnit_Framework_TestCase
         $container->register('b', 'class')->setSynthetic(true)->setPublic(true);
         $container->register('c', 'class')->setAbstract(true);
         $container->register('d', 'class')->setSynthetic(true);
+
+        $this->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     */
+    public function testInvalidTags()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a', 'class')->addTag('foo', array('bar' => array('baz' => 'baz')));
 
         $this->process($container);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/badtag3.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/badtag3.yml
@@ -3,4 +3,4 @@ services:
         class:    FooClass
         tags:
           # tag-attribute is not a scalar
-          - { name: foo, foo: { foo: foo, bar: bar } }
+          - { name: foo, bar: { foo: foo, bar: bar } }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -198,7 +198,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
             $this->fail('->load() should throw an exception when a tag-attribute is not a scalar');
         } catch (\Exception $e) {
             $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException', $e, '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
-            $this->assertStringStartsWith('A "tags" attribute must be of a scalar-type for service ', $e->getMessage(), '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
+            $this->assertStringStartsWith('A "tags" attribute must be of a scalar-type for service "foo_service", tag "foo", attribute "bar"', $e->getMessage(), '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes & no |
| New feature? | yes & no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7543 |
| License | MIT |
| Doc PR | n/a |

When using YAML or XML, the tags validadity are checked during loading, but when using PHP, that's not possible.
So, the added step in the compilation phase does that nicely.
