### PR TITLE
[Config] Fix FileResource test

### DIFF
--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -20,7 +20,7 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->file = sys_get_temp_dir().'/tmp.xml';
+        $this->file = realpath(sys_get_temp_dir()).'/tmp.xml';
         touch($this->file);
         $this->resource = new FileResource($this->file);
     }


### PR DESCRIPTION
I had the following test failing on OS X before:

```
There was 1 failure:

1) Symfony\Component\Config\Tests\Resource\FileResourceTest::testSerializeUnserialize
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-/var/folders/ph/1jns4kxj653gqg7try5m2k780000gn/T/tmp.xml
+/private/var/folders/ph/1jns4kxj653gqg7try5m2k780000gn/T/tmp.xml

symfony/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php:56
```
