### PR TITLE
Parallelized travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ php:
   - 5.5
 
 before_script:
+    - sudo apt-get install parallel
     - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
     - sh -c 'if [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
+
+script:
+    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || exit 1
+    - echo "Running tests requiring tty"; phpunit --group tty

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -95,6 +95,9 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FooBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
     }
 
+    /**
+     * @group tty
+     */
     public function testAskHiddenResponse()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Yet another approach to running all tests in parallel (see #7708 and #8312).

This one uses [GNU Parallel](http://www.gnu.org/software/parallel/) which by default [will run one job per available CPU](http://www.gnu.org/software/parallel/man.html#jobs_n).

Comparison of random builds (recent build times on my travis account):

| PHP version | [master](https://travis-ci.org/jakzal/symfony/builds/11300678) | [parallel](https://travis-ci.org/jakzal/symfony/builds/11300689) |
| --- | --- | --- |
| 5.3.3 | 6 min 11 sec | 3 min 45 sec |
| 5.3 | 7 min 26 sec | 4 min 10 sec |
| 5.4 | 6 min 31 sec | 3 min 31 sec |
| 5.5 | 6 min 37 sec | 3 min 45 sec |

On my laptop it takes 1.5min to run a whole suite parallelised (compared to over 4min when run as usual).
