### PR TITLE
[DomCrawler] Added missing docblocks and removed redundant type in a return annotation

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -84,8 +84,6 @@ class Crawler extends \SplObjectStorage
      *
      * @param string      $content A string to parse as HTML/XML
      * @param null|string $type    The content type of the string
-     *
-     * @return null|void
      */
     public function addContent($content, $type = null)
     {
@@ -710,6 +708,11 @@ class Crawler extends \SplObjectStorage
         return sprintf("concat(%s)", implode($parts, ', '));
     }
 
+    /**
+     * @param integer $position
+     *
+     * @return \DOMElement|null
+     */
     private function getNode($position)
     {
         foreach ($this as $i => $node) {
@@ -723,6 +726,12 @@ class Crawler extends \SplObjectStorage
         // @codeCoverageIgnoreEnd
     }
 
+    /**
+     * @param \DOMElement $node
+     * @param string      $siblingDir
+     *
+     * @return array
+     */
     private function sibling($node, $siblingDir = 'nextSibling')
     {
         $nodes = array();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
