### PR TITLE
[FrameworkBundle][Security] Replaced void return type with null for consistency

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -49,7 +49,7 @@ class GlobalVariables
     /**
      * Returns the current user.
      *
-     * @return mixed|null
+     * @return mixed
      *
      * @see TokenInterface::getUser()
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -26,6 +26,9 @@ class GlobalVariables
 {
     protected $container;
 
+    /**
+     * @param ContainerInterface $container The DI container
+     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
@@ -46,7 +49,7 @@ class GlobalVariables
     /**
      * Returns the current user.
      *
-     * @return mixed|void
+     * @return mixed|null
      *
      * @see TokenInterface::getUser()
      */

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -80,8 +80,6 @@ interface UserInterface
      *
      * This is important if, at any given point, sensitive information like
      * the plain-text password is stored on this object.
-     *
-     * @return null
      */
     public function eraseCredentials();
 }

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -81,7 +81,7 @@ interface UserInterface
      * This is important if, at any given point, sensitive information like
      * the plain-text password is stored on this object.
      *
-     * @return void
+     * @return null
      */
     public function eraseCredentials();
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

We're using `null` everywhere else.
