### PR TITLE
Fix PropertyPathMapper reference handling

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -90,8 +90,9 @@ class PropertyPathMapper implements DataMapperInterface
 
                 // If the data is identical to the value in $data, we are
                 // dealing with a reference
-                if (!is_object($data) || !$config->getByReference() || $form->getData() !== $this->propertyAccessor->getValue($data, $propertyPath)) {
-                    $this->propertyAccessor->setValue($data, $propertyPath, $form->getData());
+                $formData = $form->getData();
+                if (null !== $formData && (!is_object($formData) || !$config->getByReference() || $formData !== $this->propertyAccessor->getValue($data, $propertyPath))) {
+                    $this->propertyAccessor->setValue($data, $propertyPath, $formData);
                 }
             }
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -318,6 +318,9 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->propertyAccessor->expects($this->never())
             ->method('setValue');
+        $this->propertyAccessor->expects($this->any())
+            ->method('getValue')
+            ->will($this->returnValue(new \stdClass));
 
         $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
         $config->setByReference(true);
@@ -360,6 +363,26 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $config->setPropertyPath($propertyPath);
         $config->setData($engine);
         $config->setDisabled(true);
+        $form = $this->getForm($config);
+
+        $this->mapper->mapFormsToData(array($form), $car);
+    }
+
+    public function testMapFormsToDataScalarsNotByReference()
+    {
+        $car = new \stdClass;
+        $propertyPath = $this->getPropertyPath('brand');
+
+        $this->propertyAccessor->expects($this->atLeastOnce())
+            ->method('setValue');
+        $this->propertyAccessor->expects($this->any())
+            ->method('getValue')
+            ->will($this->returnValue('FooCar'));
+
+        $config = new FormConfigBuilder('name', null, $this->dispatcher);
+        $config->setByReference(true);
+        $config->setPropertyPath($propertyPath);
+        $config->setData('FooCar');
         $form = $this->getForm($config);
 
         $this->mapper->mapFormsToData(array($form), $car);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Actually I am not entirely sure, if this should get treated as "BC-break". 

Scalar values were treated by-reference before as well. This means for scalar values, when the value before and after are the same, the setter was never called. 
