### PR TITLE
[Console] Escape exception message during the rendering of an exception

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\DialogHelper;
@@ -827,7 +828,7 @@ class Application
             $output->writeln("");
             $output->writeln("");
             foreach ($messages as $message) {
-                $output->writeln('<error>'.$message.'</error>');
+                $output->writeln('<error>'.OutputFormatter::escape($message).'</error>');
             }
             $output->writeln("");
             $output->writeln("");

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -429,6 +429,9 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester->run(array('command' => 'foo3:bar'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3.txt', $this->normalizeLineBreaks($tester->getDisplay()), '->renderException() renders a pretty exceptions with previous exceptions');
 
+        $tester->run(array('command' => 'foo3:bar'), array('decorated' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3decorated.txt', $tester->getDisplay(true), '->renderException() renders a pretty exceptions with previous exceptions');
+
         $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
         $application->setAutoExit(false);
         $application->expects($this->any())

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo3Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo3Command.php
@@ -17,9 +17,13 @@ class Foo3Command extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            throw new \Exception("First exception");
+            try {
+                throw new \Exception("First exception <p>this is html</p>");
+            } catch (\Exception $e) {
+                throw new \Exception("Second exception <comment>comment<comment>", 0, $e);
+            }
         } catch (\Exception $e) {
-            throw new \Exception("Second exception", 0, $e);
+            throw new \Exception("Third exception <fg=blue;bg=red>comment</>", 0, $e);
         }
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3.txt
@@ -1,17 +1,25 @@
 
 
-                    
-  [Exception]       
-  Second exception  
-                    
+                                              
+  [Exception]                                 
+  Third exception <fg=blue;bg=red>comment</>  
+                                              
 
 
 
 
-                   
-  [Exception]      
-  First exception  
-                   
+                                              
+  [Exception]                                 
+  Second exception <comment>comment<comment>  
+                                              
+
+
+
+
+                                       
+  [Exception]                          
+  First exception <p>this is html</p>  
+                                       
 
 
 foo3:bar

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
@@ -1,0 +1,27 @@
+
+
+[37;41m                                              [0m
+[37;41m  [Exception]                                 [0m
+[37;41m  Third exception <fg=blue;bg=red>comment</>  [0m
+[37;41m                                              [0m
+
+
+
+
+[37;41m                                              [0m
+[37;41m  [Exception]                                 [0m
+[37;41m  Second exception <comment>comment<comment>  [0m
+[37;41m                                              [0m
+
+
+
+
+[37;41m                                       [0m
+[37;41m  [Exception]                          [0m
+[37;41m  First exception <p>this is html</p>  [0m
+[37;41m                                       [0m
+
+
+[32mfoo3:bar[0m
+
+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

reopen #8853 against 2.2 branch

When the exception message contains some HTML, this display is
broken.

I don't know enought about the differents Output classes.
Maybe we have to check the current Output class before
escaping. But for the moment, we allways format the message
with error tags, so I guess the escape is not an issue.
