### PR TITLE
[BrowserKit] Fixed the handling of parameters when redirecting

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -435,10 +435,17 @@ abstract class Client
             $content = $request->getContent();
         }
 
+        if ('get' === strtolower($method)) {
+            // Don't forward parameters for GET request as it should reach the redirection URI
+            $parameters = array();
+        } else {
+            $parameters = $request->getParameters();
+        }
+
         $server = $request->getServer();
         unset($server['HTTP_IF_NONE_MATCH'], $server['HTTP_IF_MODIFIED_SINCE']);
 
-        return $this->request($method, $this->redirect, $request->getParameters(), $files, $server, $content);
+        return $this->request($method, $this->redirect, $parameters, $files, $server, $content);
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -329,9 +329,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client = new TestClient();
         $client->setNextResponse(new Response('', 302, array('Location' => 'http://www.example.com/redirected')));
-        $client->request('POST', 'http://www.example.com/foo/foobar');
+        $client->request('POST', 'http://www.example.com/foo/foobar', array('name' => 'bar'));
 
         $this->assertEquals('get', $client->getRequest()->getMethod(), '->followRedirect() uses a get for 302');
+        $this->assertEquals(array(), $client->getRequest()->getParameters(), '->followRedirect() does not submit parameters when changing the method');
     }
 
     public function testFollowRedirectWithCookies()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This fixes the handling of request parameters after 2d34e78aafa0e170845a23d0e163b3a15569fa8e to avoid sending POST parameters as GET parameters in the next request.

In case of a 307 redirect on a GET request, I'm not sure of the expected behavior. Should we re-add the GET parameters in the URI ? I would make things inconsistent between `$client->request('GET', 'http://www.example.com/?foo=bar')` and `$client->request('GET', 'http://www.example.com/', array('foo' => 'bar')`
