### PR TITLE
[Config] Making tests pass on mac os x

### DIFF
--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -53,6 +53,6 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
     {
         $unserialized = unserialize(serialize($this->resource));
 
-        $this->assertSame($this->file, $this->resource->getResource());
+        $this->assertSame(realpath($this->file), $this->resource->getResource());
     }
 }


### PR DESCRIPTION
without this change tests would fail under mac os x (at least in 10.8.2).

I think this change also removes inconstancy in the test (the `realpath()` is added in the other tests as well!).

| Q | A |
| --- | --- |
| Bug fix? | yes (fixes the test) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Cheers,

Christian
