### PR TITLE
[Console] Fixed exception rendering

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\DialogHelper;
@@ -827,7 +828,7 @@ class Application
             $output->writeln("");
             $output->writeln("");
             foreach ($messages as $message) {
-                $output->writeln('<error>'.$message.'</error>');
+                $output->writeln('<error>'.OutputFormatter::escape($message).'</error>');
             }
             $output->writeln("");
             $output->writeln("");

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -23,7 +23,7 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * The pattern to phrase the format.
      */
-    const FORMAT_PATTERN = '#(\\\\?)<(/?)([a-z][a-z0-9_=;-]+)?>((?: [^<\\\\]+ | (?!<(?:/?[a-z]|/>)). | .(?<=\\\\<) )*)#isx';
+    const FORMAT_PATTERN = '#(\\\\?)<(/?)([a-z][a-z0-9_=;-]*)?>((?: [^<\\\\]+ | (?!<(?:/?[a-z]|/>)). | .(?<=\\\\<) )*)#isx';
 
     private $decorated;
     private $styles = array();

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -163,6 +163,8 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Replaces style of the output.
      *
+     * All escaped tags and tags that reference unknown styles are kept as is.
+     *
      * @param array $match
      *
      * @return string The replaced style

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -429,6 +429,9 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester->run(array('command' => 'foo3:bar'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3.txt', $this->normalizeLineBreaks($tester->getDisplay()), '->renderException() renders a pretty exceptions with previous exceptions');
 
+        $tester->run(array('command' => 'foo3:bar'), array('decorated' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3decorated.txt', $tester->getDisplay(true), '->renderException() renders a pretty exceptions with previous exceptions');
+
         $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
         $application->setAutoExit(false);
         $application->expects($this->any())

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo3Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo3Command.php
@@ -20,7 +20,7 @@ class Foo3Command extends Command
             try {
                 throw new \Exception("First exception <p>this is html</p>");
             } catch (\Exception $e) {
-                throw new \Exception("Second exception <comment>comment<comment>", 0, $e);
+                throw new \Exception("Second exception <comment>comment</comment>", 0, $e);
             }
         } catch (\Exception $e) {
             throw new \Exception("Third exception <fg=blue;bg=red>comment</>", 0, $e);

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo3Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo3Command.php
@@ -17,9 +17,13 @@ class Foo3Command extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            throw new \Exception("First exception");
+            try {
+                throw new \Exception("First exception <p>this is html</p>");
+            } catch (\Exception $e) {
+                throw new \Exception("Second exception <comment>comment<comment>", 0, $e);
+            }
         } catch (\Exception $e) {
-            throw new \Exception("Second exception", 0, $e);
+            throw new \Exception("Third exception <fg=blue;bg=red>comment</>", 0, $e);
         }
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3.txt
@@ -1,17 +1,25 @@
 
 
-                    
-  [Exception]       
-  Second exception  
-                    
+                                              
+  [Exception]                                 
+  Third exception <fg=blue;bg=red>comment</>  
+                                              
 
 
 
 
-                   
-  [Exception]      
-  First exception  
-                   
+                                              
+  [Exception]                                 
+  Second exception <comment>comment<comment>  
+                                              
+
+
+
+
+                                       
+  [Exception]                          
+  First exception <p>this is html</p>  
+                                       
 
 
 foo3:bar

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3.txt
@@ -1,17 +1,17 @@
 
 
-                                              
-  [Exception]                                 
-  Third exception <fg=blue;bg=red>comment</>  
-                                              
+                           
+  [Exception]              
+  Third exception comment  
+                           
 
 
 
 
-                                              
-  [Exception]                                 
-  Second exception <comment>comment<comment>  
-                                              
+                            
+  [Exception]               
+  Second exception comment  
+                            
 
 
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
@@ -1,24 +1,24 @@
 
 
-[37;41m                                              [0m
-[37;41m  [Exception]                                 [0m
-[37;41m  Third exception <fg=blue;bg=red>comment</>  [0m
-[37;41m                                              [0m
+[37;41m                           [0m
+[37;41m  [Exception]              [0m
+[37;41m  Third exception [0m[34;41mcomment[0m[37;41m  [0m
+[37;41m                           [0m
 
 
 
 
-[37;41m                                              [0m
-[37;41m  [Exception]                                 [0m
-[37;41m  Second exception <comment>comment<comment>  [0m
-[37;41m                                              [0m
+[37;41m                            [0m
+[37;41m  [Exception]               [0m
+[37;41m  Second exception [0m[33mcomment[0m[37;41m  [0m
+[37;41m                            [0m
 
 
 
 
 [37;41m                                       [0m
 [37;41m  [Exception]                          [0m
-[37;41m  First exception <p>this is html</p>  [0m
+[37;41m  First exception [0m[37;41m<p>this is html[0m[37;41m</p>  [0m
 [37;41m                                       [0m
 
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
@@ -1,0 +1,27 @@
+
+
+[37;41m                                              [0m
+[37;41m  [Exception]                                 [0m
+[37;41m  Third exception <fg=blue;bg=red>comment</>  [0m
+[37;41m                                              [0m
+
+
+
+
+[37;41m                                              [0m
+[37;41m  [Exception]                                 [0m
+[37;41m  Second exception <comment>comment<comment>  [0m
+[37;41m                                              [0m
+
+
+
+
+[37;41m                                       [0m
+[37;41m  [Exception]                          [0m
+[37;41m  First exception <p>this is html</p>  [0m
+[37;41m                                       [0m
+
+
+[32mfoo3:bar[0m
+
+

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -113,7 +113,10 @@ class FormatterStyleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($style, $formatter->getStyle('test'));
         $this->assertNotEquals($style, $formatter->getStyle('info'));
 
-        $this->assertEquals("\033[34;47msome custom msg\033[0m", $formatter->format('<test>some custom msg</test>'));
+        $style = new OutputFormatterStyle('blue', 'white');
+        $formatter->setStyle('b', $style);
+
+        $this->assertEquals("\033[34;47msome \033[0m\033[34;47mcustom\033[0m\033[34;47m msg\033[0m", $formatter->format('<test>some <b>custom</b> msg</test>'));
     }
 
     public function testRedefineStyle()
@@ -137,7 +140,7 @@ class FormatterStyleTest extends \PHPUnit_Framework_TestCase
     public function testNonStyleTag()
     {
         $formatter = new OutputFormatter(true);
-        $this->assertEquals("\033[32msome \033[0m\033[32m<tag> styled\033[0m", $formatter->format('<info>some <tag> styled</info>'));
+        $this->assertEquals("\033[32msome \033[0m\033[32m<tag> styled \033[0m\033[32m<p>single-char tag\033[0m\033[32m</p>\033[0m", $formatter->format('<info>some <tag> styled <p>single-char tag</p></info>'));
     }
 
     public function testNotDecoratedFormatter()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9045 |
| License | MIT |
| Doc PR | n/a |

When an exception message contains styles, the output is not the expected one. This PR addresses this issue.
