### PR TITLE
[HttpKernel] fixes RequestDataCollector bug, visible on Drupal8

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -50,9 +50,9 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
 
         $attributes = array();
         foreach ($request->attributes->all() as $key => $value) {
-            if ('_route' == $key && is_object($value)) {
+            if ('_route' === $key && is_object($value)) {
                 $attributes['_route'] = $this->varToString($value->getPath());
-            } elseif ('_route_params' == $key) {
+            } elseif ('_route_params' === $key) {
                 foreach ($value as $key => $v) {
                     $attributes['_route_params'][$key] = $this->varToString($v);
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

In Drupal8 `$request->attributes->all()` returns an array with a 0 key whose value is the `Drupal\user\Entity\User`

``` php
array(
 0 => Drupal\user\Entity\User,
 ...
)
```

`('_route' == $key && is_object($value))` is therefore true which provokes an exception:

``` php
FatalErrorException: Error: Call to undefined method Drupal\user\Entity\User::getPath() in [...]/RequestDataCollector.php line 54
```

This patch corrects this with a simple replacement of == by ===
