### PR TITLE
[Security] Delete unnecessary "use" statements

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
@@ -11,13 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Provider;
 
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Security\Core\User\UserCheckerInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
-use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;


### PR DESCRIPTION
 Delete unnecessary "use" statements in SimpleAuthenticationProvider
