### PR TITLE
[FrameworkBundle] made sure that the debug event dispatcher is used everywhere

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
@@ -18,11 +18,11 @@ class RegisterKernelListenersPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('event_dispatcher')) {
+        if (!$container->hasDefinition('event_dispatcher') && !$container->hasAlias('event_dispatcher')) {
             return;
         }
 
-        $definition = $container->getDefinition('event_dispatcher');
+        $definition = $container->findDefinition('event_dispatcher');
 
         foreach ($container->findTaggedServiceIds('kernel.event_listener') as $id => $events) {
             foreach ($events as $event) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -51,12 +51,14 @@ class FrameworkExtension extends Extension
         if ($container->getParameter('kernel.debug')) {
             $loader->load('debug.xml');
 
-            // only HttpKernel needs the debug event dispatcher
             $definition = $container->findDefinition('http_kernel');
-            $arguments = $definition->getArguments();
-            $arguments[0] = new Reference('debug.event_dispatcher');
-            $arguments[2] = new Reference('debug.controller_resolver');
-            $definition->setArguments($arguments);
+            $definition->replaceArgument(2, new Reference('debug.controller_resolver'));
+
+            // replace the regular event_dispatcher service with the debug one
+            $definition = $container->findDefinition('event_dispatcher');
+            $definition->setPublic(false);
+            $container->setDefinition('debug.event_dispatcher.parent', $definition);
+            $container->setAlias('event_dispatcher', 'debug.event_dispatcher');
         }
 
         $configuration = $this->getConfiguration($configs, $container);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -17,7 +17,7 @@
 
         <service id="debug.event_dispatcher" class="%debug.event_dispatcher.class%">
             <tag name="monolog.logger" channel="event" />
-            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher.parent" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" on-invalid="null" />
             <call method="setProfiler"><argument type="service" id="profiler" on-invalid="null" /></call>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RegisterKernelListenersPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RegisterKernelListenersPassTest.php
@@ -78,6 +78,10 @@ class RegisterKernelListenersPassTest extends \PHPUnit_Framework_TestCase
             ->method('getDefinition')
             ->will($this->returnValue($definition));
 
+        $builder->expects($this->atLeastOnce())
+            ->method('findDefinition')
+            ->will($this->returnValue($definition));
+
         $registerListenersPass = new RegisterKernelListenersPass();
         $registerListenersPass->process($builder);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6686, #7673 |
| License | MIT |
| Doc PR | n/a |
