### PR TITLE
[Routing] unify RequestContext as fluent class

### DIFF
--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Holds information about the current request.
  *
+ * This class implements a fluent interface.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
  *
@@ -67,6 +69,8 @@ class RequestContext
      * Updates the RequestContext information based on a HttpFoundation Request.
      *
      * @param Request $request A Request instance
+     *
+     * @return RequestContext The current instance, implementing a fluent interface
      */
     public function fromRequest(Request $request)
     {
@@ -78,6 +82,8 @@ class RequestContext
         $this->setHttpPort($request->isSecure() ? $this->httpPort : $request->getPort());
         $this->setHttpsPort($request->isSecure() ? $request->getPort() : $this->httpsPort);
         $this->setQueryString($request->server->get('QUERY_STRING', ''));
+
+        return $this;
     }
 
     /**
@@ -95,11 +101,15 @@ class RequestContext
      *
      * @param string $baseUrl The base URL
      *
+     * @return RequestContext The current instance, implementing a fluent interface
+     *
      * @api
      */
     public function setBaseUrl($baseUrl)
     {
         $this->baseUrl = $baseUrl;
+
+        return $this;
     }
 
     /**
@@ -116,10 +126,14 @@ class RequestContext
      * Sets the path info.
      *
      * @param string $pathInfo The path info
+     *
+     * @return RequestContext The current instance, implementing a fluent interface
      */
     public function setPathInfo($pathInfo)
     {
         $this->pathInfo = $pathInfo;
+
+        return $this;
     }
 
     /**
@@ -139,11 +153,15 @@ class RequestContext
      *
      * @param string $method The HTTP method
      *
+     * @return RequestContext The current instance, implementing a fluent interface
+     *
      * @api
      */
     public function setMethod($method)
     {
         $this->method = strtoupper($method);
+
+        return $this;
     }
 
     /**
@@ -163,11 +181,15 @@ class RequestContext
      *
      * @param string $host The HTTP host
      *
+     * @return RequestContext The current instance, implementing a fluent interface
+     *
      * @api
      */
     public function setHost($host)
     {
         $this->host = strtolower($host);
+
+        return $this;
     }
 
     /**
@@ -185,11 +207,15 @@ class RequestContext
      *
      * @param string $scheme The HTTP scheme
      *
+     * @return RequestContext The current instance, implementing a fluent interface
+     *
      * @api
      */
     public function setScheme($scheme)
     {
         $this->scheme = strtolower($scheme);
+
+        return $this;
     }
 
     /**
@@ -207,11 +233,15 @@ class RequestContext
      *
      * @param int $httpPort The HTTP port
      *
+     * @return RequestContext The current instance, implementing a fluent interface
+     *
      * @api
      */
     public function setHttpPort($httpPort)
     {
         $this->httpPort = (int) $httpPort;
+
+        return $this;
     }
 
     /**
@@ -229,11 +259,15 @@ class RequestContext
      *
      * @param int $httpsPort The HTTPS port
      *
+     * @return RequestContext The current instance, implementing a fluent interface
+     *
      * @api
      */
     public function setHttpsPort($httpsPort)
     {
         $this->httpsPort = (int) $httpsPort;
+
+        return $this;
     }
 
     /**
@@ -251,12 +285,16 @@ class RequestContext
      *
      * @param string $queryString The query string (after "?")
      *
+     * @return RequestContext The current instance, implementing a fluent interface
+     *
      * @api
      */
     public function setQueryString($queryString)
     {
         // string cast to be fault-tolerant, accepting null
         $this->queryString = (string) $queryString;
+
+        return $this;
     }
 
     /**
@@ -313,10 +351,14 @@ class RequestContext
      * @param string $name      A parameter name
      * @param mixed  $parameter The parameter value
      *
+     * @return RequestContext The current instance, implementing a fluent interface
+     *
      * @api
      */
     public function setParameter($name, $parameter)
     {
         $this->parameters[$name] = $parameter;
+
+        return $this;
     }
 }

--- a/src/Symfony/Component/Routing/Tests/RequestContextTest.php
+++ b/src/Symfony/Component/Routing/Tests/RequestContextTest.php
@@ -140,4 +140,20 @@ class RequestContextTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(123, $requestContext->getHttpPort());
         $this->assertSame(456, $requestContext->getHttpsPort());
     }
+
+    public function testFluentInterface()
+    {
+        $requestContext = new RequestContext();
+
+        $this->assertSame($requestContext, $requestContext->setBaseUrl('/app.php'));
+        $this->assertSame($requestContext, $requestContext->setPathInfo('/index'));
+        $this->assertSame($requestContext, $requestContext->setMethod('POST'));
+        $this->assertSame($requestContext, $requestContext->setScheme('https'));
+        $this->assertSame($requestContext, $requestContext->setHost('example.com'));
+        $this->assertSame($requestContext, $requestContext->setQueryString('foo=bar'));
+        $this->assertSame($requestContext, $requestContext->setHttpPort(80));
+        $this->assertSame($requestContext, $requestContext->setHttpsPort(443));
+        $this->assertSame($requestContext, $requestContext->setParameters(array()));
+        $this->assertSame($requestContext, $requestContext->setParameter('foo', 'bar'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | partly |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
- [x] <del>some methods were tagged with `@api` which makes no sense since the class is already tagged as stable. this automatically includes all methods. also our bc promise is only about `@api` on classes</del>
- [x] setParameters the only fluent method! I made them all fluent which makes sense for this class
