### PR TITLE
use "translator" alias not "translator.default"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -24,7 +24,7 @@
         <service id="validator" class="%validator.class%">
             <argument type="service" id="validator.mapping.class_metadata_factory" />
             <argument type="service" id="validator.validator_factory" />
-            <argument type="service" id="translator.default" />
+            <argument type="service" id="translator" />
             <argument>%validator.translation_domain%</argument>
             <argument type="collection" />
         </service>


### PR DESCRIPTION
Validator is the only instance which references to the "translator.default" service. It should reference to the "translator" service so the validator can use a custom validator if the user overwrites the "translator" alias.
