### PR TITLE
[WIP] [Validator] Allow to set "validatedBy" as option

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -54,6 +54,12 @@ abstract class Constraint
     public $groups = array(self::DEFAULT_GROUP);
 
     /**
+     * The class that validates this constraint
+     * @var string
+     */
+    protected $validatedBy;
+
+    /**
      * Initializes the constraint with options.
      *
      * You should pass an associative array. The keys should be the names of
@@ -191,8 +197,8 @@ abstract class Constraint
      * Returns the name of the class that validates this constraint
      *
      * By default, this is the fully qualified name of the constraint class
-     * suffixed with "Validator". You can override this method to change that
-     * behaviour.
+     * suffixed with "Validator". You can pass the "validatedBy" option or
+     * override this method to change that behaviour.
      *
      * @return string
      *
@@ -200,7 +206,7 @@ abstract class Constraint
      */
     public function validatedBy()
     {
-        return get_class($this).'Validator';
+        return $this->validatedBy !== null ? $this->validatedBy : get_class($this).'Validator';
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests;
 
 use Symfony\Component\Validator\Tests\Fixtures\ClassConstraint;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintAValidator;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintC;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithValue;
@@ -114,6 +115,15 @@ class ConstraintTest extends \PHPUnit_Framework_TestCase
     public function testRequiredOptionsPassed()
     {
         new ConstraintC(array('option1' => 'default'));
+    }
+
+    public function testSetValidatedByPropertyAsOption()
+    {
+        $validatorClass = get_class(new ConstraintAValidator());
+
+        $constraint = new ConstraintB(array('validatedBy' => $validatorClass));
+
+        $this->assertEquals($validatorClass, $constraint->validatedBy());
     }
 
     public function testGroupsAreConvertedToArray()


### PR DESCRIPTION
This change makes the constraints more flexible by allowing to set the class (that validates the constraints) as option

Why? If i want to reuse an existing constraint e.g. Date but with my own validator i have to create a new class that extends the Date constraint class - just to override the "validatedBy" method!

With this change:
new Date(array('validatedBy' => "Yet\Another\DateValidator"));

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

todo if this pr will be accepted:
- [ ] submit changes to the documentation
