### PR TITLE
[Validator] Added hasser support for entity method validation

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/GetterMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GetterMetadata.php
@@ -27,13 +27,16 @@ class GetterMetadata extends MemberMetadata
     {
         $getMethod = 'get'.ucfirst($property);
         $isMethod = 'is'.ucfirst($property);
+        $hasMethod = 'has'.ucfirst($property);
 
         if (method_exists($class, $getMethod)) {
             $method = $getMethod;
         } elseif (method_exists($class, $isMethod)) {
             $method = $isMethod;
+        } elseif (method_exists($class, $hasMethod)) {
+            $method = $hasMethod;
         } else {
-            throw new ValidatorException(sprintf('Neither method %s nor %s exists in class %s', $getMethod, $isMethod, $class));
+            throw new ValidatorException(sprintf('Neither of these methods exist in class %s: %s, %s, %s', $class, $getMethod, $isMethod, $hasMethod));
         }
 
         parent::__construct($class, $method, $property);

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -70,10 +70,10 @@ class AnnotationLoader implements LoaderInterface
 
                         $metadata->addConstraint($constraint);
                     } elseif ($constraint instanceof Constraint) {
-                        if (preg_match('/^(get|is)(.+)$/i', $method->name, $matches)) {
+                        if (preg_match('/^(get|is|has)(.+)$/i', $method->name, $matches)) {
                             $metadata->addGetterConstraint(lcfirst($matches[2]), $constraint);
                         } else {
-                            throw new MappingException(sprintf('The constraint on "%s::%s" cannot be added. Constraints can only be added on methods beginning with "get" or "is".', $className, $method->name));
+                            throw new MappingException(sprintf('The constraint on "%s::%s" cannot be added. Constraints can only be added on methods beginning with "get", "is" or "has".', $className, $method->name));
                         }
                     }
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Entity.php
@@ -56,6 +56,22 @@ class Entity extends EntityParent implements EntityInterface
         return $this->lastName;
     }
 
+    /**
+     * @Assert\True
+     */
+    public function isValid()
+    {
+        return 'valid';
+    }
+
+    /**
+     * @Assert\True
+     */
+    public function hasPermissions()
+    {
+        return 'permissions';
+    }
+
     public function getData()
     {
         return 'Overridden data';

--- a/src/Symfony/Component/Validator/Tests/Mapping/GetterMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/GetterMetadataTest.php
@@ -43,4 +43,20 @@ class GetterMetadataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Overridden data', $metadata->getPropertyValue($entity));
     }
+
+    public function testGetPropertyValueFromIsser()
+    {
+        $entity = new Entity();
+        $metadata = new GetterMetadata(self::CLASSNAME, 'valid');
+
+        $this->assertEquals('valid', $metadata->getPropertyValue($entity));
+    }
+
+    public function testGetPropertyValueFromHasser()
+    {
+        $entity = new Entity();
+        $metadata = new GetterMetadata(self::CLASSNAME, 'permissions');
+
+        $this->assertEquals('permissions', $metadata->getPropertyValue($entity));
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\True;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
@@ -67,6 +68,8 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
             'choices' => array('A', 'B'),
         )));
         $expected->addGetterConstraint('lastName', new NotNull());
+        $expected->addGetterConstraint('valid', new True());
+        $expected->addGetterConstraint('permissions', new True());
 
         // load reflection class so that the comparison passes
         $expected->getReflectionClass();
@@ -134,6 +137,8 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
             'choices' => array('A', 'B'),
         )));
         $expected->addGetterConstraint('lastName', new NotNull());
+        $expected->addGetterConstraint('valid', new True());
+        $expected->addGetterConstraint('permissions', new True());
 
         // load reflection class so that the comparison passes
         $expected->getReflectionClass();

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\True;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
@@ -69,6 +70,8 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
             'choices' => array('A', 'B'),
         )));
         $expected->addGetterConstraint('lastName', new NotNull());
+        $expected->addGetterConstraint('valid', new True());
+        $expected->addGetterConstraint('permissions', new True());
 
         $this->assertEquals($expected, $metadata);
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\True;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
@@ -86,6 +87,8 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
             'choices' => array('A', 'B'),
         )));
         $expected->addGetterConstraint('lastName', new NotNull());
+        $expected->addGetterConstraint('valid', new True());
+        $expected->addGetterConstraint('permissions', new True());
 
         $this->assertEquals($expected, $metadata);
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
@@ -102,6 +102,12 @@
     <getter property="lastName">
       <constraint name="NotNull" />
     </getter>
+    <getter property="valid">
+      <constraint name="True" />
+    </getter>
+    <getter property="permissions">
+      <constraint name="True" />
+    </getter>
   </class>
 
   <class name="Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity">

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
@@ -53,6 +53,10 @@ Symfony\Component\Validator\Tests\Fixtures\Entity:
   getters:
     lastName:
       - NotNull: ~
+    valid:
+      - "True": ~
+    permissions:
+      - "True": ~
 
 Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity:
   group_sequence_provider: true


### PR DESCRIPTION
Hasser support was added in addition to existing getter and isser support for more consistency between components

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | symfony/symfony-docs#3418 |
