### PR TITLE
[Locale] added some more stubs for the number formatter

### DIFF
--- a/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
@@ -493,10 +493,8 @@ class StubNumberFormatter
      * @return Boolean|string                               The parsed value of false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.parse.php
-     *
-     * @throws MethodArgumentNotImplementedException        When $position different than null, behavior not implemented
      */
-    public function parse($value, $type = self::TYPE_DOUBLE, &$position = null)
+    public function parse($value, $type = self::TYPE_DOUBLE, &$position = 0)
     {
         if ($type == self::TYPE_DEFAULT || $type == self::TYPE_CURRENCY) {
             trigger_error(__METHOD__.'(): Unsupported format type '.$type, \E_USER_WARNING);
@@ -504,25 +502,22 @@ class StubNumberFormatter
             return false;
         }
 
-        // We don't calculate the position when parsing the value
-        if (null !== $position) {
-            throw new MethodArgumentNotImplementedException(__METHOD__, 'position');
-        }
-
-        preg_match('/^([^0-9\-]{0,})(.*)/', $value, $matches);
+        preg_match('/^([^0-9\-\.]{0,})(.*)/', $value, $matches);
 
         // Any string before the numeric value causes error in the parsing
         if (isset($matches[1]) && !empty($matches[1])) {
             StubIntl::setError(StubIntl::U_PARSE_ERROR, 'Number parsing failed');
             $this->errorCode = StubIntl::getErrorCode();
             $this->errorMessage = StubIntl::getErrorMessage();
+            $position = 0;
 
             return false;
         }
 
-        // Remove everything that is not number or dot (.)
-        $value = preg_replace('/[^0-9\.\-]/', '', $value);
+        preg_match('/^[0-9\-\.\,]*/', $value, $matches);
+        $value = preg_replace('/[^0-9\.\-]/', '', $matches[0]);
         $value = $this->convertValueDataType($value, $type);
+        $position = strlen($matches[0]);
 
         // behave like the intl extension
         $this->resetError();

--- a/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
@@ -221,6 +221,16 @@ class StubNumberFormatter
         'negative' => -9223372036854775808
     );
 
+    private static $enSymbols = array(
+        self::DECIMAL => array('.', ',', ';', '%', '0', '#', '-', '+', '¤', '¤¤', '.', 'E', '‰', '*', '∞', 'NaN', '@', ','),
+        self::CURRENCY => array('.', ',', ';', '%', '0', '#', '-', '+', '¤', '¤¤', '.', 'E', '‰', '*', '∞', 'NaN', '@', ','),
+    );
+
+    private static $enTextAttributes = array(
+        self::DECIMAL => array('', '', '-', '', '*', '', ''),
+        self::CURRENCY => array('¤', '', '(¤', ')', '*', ''),
+    );
+
     /**
      * Constructor
      *
@@ -435,12 +445,10 @@ class StubNumberFormatter
      * @return Boolean|string        The symbol value or false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.getsymbol.php
-     *
-     * @throws MethodNotImplementedException
      */
     public function getSymbol($attr)
     {
-        throw new MethodNotImplementedException(__METHOD__);
+        return array_key_exists($this->style, self::$enSymbols) && array_key_exists($attr, self::$enSymbols[$this->style]) ? self::$enSymbols[$this->style][$attr] : false;
     }
 
     /**
@@ -451,12 +459,10 @@ class StubNumberFormatter
      * @return Boolean|string        The attribute value or false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.gettextattribute.php
-     *
-     * @throws MethodNotImplementedException
      */
     public function getTextAttribute($attr)
     {
-        throw new MethodNotImplementedException(__METHOD__);
+        return array_key_exists($this->style, self::$enTextAttributes) && array_key_exists($attr, self::$enTextAttributes[$this->style]) ? self::$enTextAttributes[$this->style][$attr] : false;
     }
 
     /**

--- a/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
@@ -751,11 +751,13 @@ class StubNumberFormatterTest extends LocaleTestCase
     /**
      * @dataProvider parseProvider
      */
-    public function testParseStub($value, $expected, $message = '')
+    public function testParseStub($value, $expected, $message, $expectedPosition)
     {
         $formatter = $this->getStubFormatterWithDecimalStyle();
-        $parsedValue = $formatter->parse($value, StubNumberFormatter::TYPE_DOUBLE);
+        $position = 0;
+        $parsedValue = $formatter->parse($value, StubNumberFormatter::TYPE_DOUBLE, $position);
         $this->assertSame($expected, $parsedValue, $message);
+        $this->assertSame($expectedPosition, $position, $message);
 
         if ($expected === false) {
             $errorCode = StubIntl::U_PARSE_ERROR;
@@ -776,14 +778,16 @@ class StubNumberFormatterTest extends LocaleTestCase
     /**
      * @dataProvider parseProvider
      */
-    public function testParseIntl($value, $expected, $message = '')
+    public function testParseIntl($value, $expected, $message, $expectedPosition)
     {
         $this->skipIfIntlExtensionIsNotLoaded();
         $this->skipIfICUVersionIsTooOld();
 
         $formatter = $this->getIntlFormatterWithDecimalStyle();
-        $parsedValue = $formatter->parse($value, \NumberFormatter::TYPE_DOUBLE);
+        $position = 0;
+        $parsedValue = $formatter->parse($value, \NumberFormatter::TYPE_DOUBLE, $position);
         $this->assertSame($expected, $parsedValue, $message);
+        $this->assertSame($expectedPosition, $position, $message);
 
         if ($expected === false) {
             $errorCode = StubIntl::U_PARSE_ERROR;
@@ -804,8 +808,8 @@ class StubNumberFormatterTest extends LocaleTestCase
     public function parseProvider()
     {
         return array(
-            array('prefix1', false, '->parse() does not parse a number with a string prefix.'),
-            array('1suffix', (float) 1, '->parse() parses a number with a string suffix.'),
+            array('prefix1', false, '->parse() does not parse a number with a string prefix.', 0),
+            array('1.4suffix', (float) 1.4, '->parse() parses a number with a string suffix.', 3),
         );
     }
 
@@ -854,6 +858,7 @@ class StubNumberFormatterTest extends LocaleTestCase
         return array(
             array('1', 1),
             array('1.1', 1),
+            array('.1', 0),
             array('2,147,483,647', 2147483647),
             array('-2,147,483,648', -2147483647 - 1),
             array('2,147,483,648', false, '->parse() TYPE_INT32 returns false when the number is greater than the integer positive range.'),
@@ -1118,10 +1123,10 @@ class StubNumberFormatterTest extends LocaleTestCase
 
     public function testParseWithNullPositionValueStub()
     {
-        $position = null;
+        $position = 0;
         $formatter = $this->getStubFormatterWithDecimalStyle();
         $formatter->parse('123', StubNumberFormatter::TYPE_INT32, $position);
-        $this->assertNull($position);
+        $this->assertEquals(3, $position);
     }
 
     public function testParseWithNullPositionValueIntl()
@@ -1133,14 +1138,12 @@ class StubNumberFormatterTest extends LocaleTestCase
         $this->assertEquals(3, $position);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Locale\Exception\MethodArgumentNotImplementedException
-     */
     public function testParseWithNotNullPositionValueStub()
     {
         $position = 1;
         $formatter = $this->getStubFormatterWithDecimalStyle();
         $formatter->parse('123', StubNumberFormatter::TYPE_INT32, $position);
+        $this->assertEquals(3, $position);
     }
 
     public function testParseWithNotNullPositionValueIntl()

--- a/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
@@ -707,22 +707,36 @@ class StubNumberFormatterTest extends LocaleTestCase
         $formatter->getPattern();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Locale\Exception\MethodNotImplementedException
-     */
     public function testGetSymbol()
     {
-        $formatter = $this->getStubFormatterWithDecimalStyle();
-        $formatter->getSymbol(null);
+        $this->skipIfIntlExtensionIsNotLoaded();
+
+        $intlDecimalFormatter = new \NumberFormatter('en', \NumberFormatter::DECIMAL);
+        $intlCurrencyFormatter = new \NumberFormatter('en', \NumberFormatter::CURRENCY);
+
+        $stubDecimalFormatter = $this->getStubFormatterWithDecimalStyle();
+        $stubCurrencyFormatter = $this->getStubFormatterWithCurrencyStyle();
+
+        for ($i = 0; $i <= 17; $i++) {
+            $this->assertSame($stubDecimalFormatter->getSymbol($i), $intlDecimalFormatter->getSymbol($i), $i);
+            $this->assertSame($stubCurrencyFormatter->getSymbol($i), $intlCurrencyFormatter->getSymbol($i), $i);
+        }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Locale\Exception\MethodNotImplementedException
-     */
     public function testGetTextAttribute()
     {
-        $formatter = $this->getStubFormatterWithDecimalStyle();
-        $formatter->getTextAttribute(null);
+        $this->skipIfIntlExtensionIsNotLoaded();
+
+        $intlDecimalFormatter = new \NumberFormatter('en', \NumberFormatter::DECIMAL);
+        $intlCurrencyFormatter = new \NumberFormatter('en', \NumberFormatter::CURRENCY);
+
+        $stubDecimalFormatter = $this->getStubFormatterWithDecimalStyle();
+        $stubCurrencyFormatter = $this->getStubFormatterWithCurrencyStyle();
+
+        for ($i = 0; $i <= 5; $i++) {
+            $this->assertSame($stubDecimalFormatter->getTextAttribute($i), $intlDecimalFormatter->getTextAttribute($i), $i);
+            $this->assertSame($stubCurrencyFormatter->getTextAttribute($i), $intlCurrencyFormatter->getTextAttribute($i), 'fooo '.$i);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8588, #6045 |
| License | MIT |
| Doc PR | n/a |

I've used this snippet of code to populate the default values for the en locale:

``` php
for ($style = 0; $style <= 8; $style++) {
    $f = new \NumberFormatter('en', $style);
    echo 'array(';
    for ($i = 0; $i <= 17; $i++) {
        echo "'".$f->getSymbol($i)."', ";
    }

    echo "),\n";
}
```
