### PR TITLE
[Form] Created FormErrorBag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_errors.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_errors.html.php
@@ -1,4 +1,4 @@
-<?php if ($errors): ?>
+<?php if (count($errors)): ?>
     <ul>
         <?php foreach ($errors as $error): ?>
             <li><?php echo $error->getMessage() ?></li>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,12 @@ CHANGELOG
 2.5.0
 ------
 
+ * [BC BREAK] changed getErrors() to return a FormErrorBag, which is countable,
+   traversable and can be converted to a string. This breaks BC if the return
+   value is used in array function like is_array().
+ * deprecated getErrorsAsString() in favor of converting getErrors() to a
+   string
+
  * added an option for multiple files upload
 
 2.4.0

--- a/src/Symfony/Component/Form/FormErrorBag.php
+++ b/src/Symfony/Component/Form/FormErrorBag.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form;
+
+use Symfony\Component\Form\Exception\InvalidArgumentException;
+
+/**
+ * A bag of Form Errors.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ *
+ * @since v2.5
+ */
+class FormErrorBag implements \RecursiveIterator, \Countable, \ArrayAccess
+{
+    /**
+     * @var array An array of FormError and FormErrorBag instances
+     */
+    protected $errors = array();
+
+    private $formName;
+
+    public function setFormName($name)
+    {
+        $this->formName = $name;
+    }
+
+    /**
+     * Adds a new form error.
+     *
+     * @param FormError $error
+     */
+    public function addError(FormError $error)
+    {
+        $this->errors[] = $error;
+    }
+
+    /**
+     * Adds a new form error collection.
+     *
+     * @param string       $formName
+     * @param FormErrorBag $collection
+     */
+    public function addCollection($formName, $collection)
+    {
+        $collection->setFormName($formName);
+
+        $this->errors[$formName] = $collection;
+    }
+
+    public function current()
+    {
+        $current = current($this->errors);
+
+        if (!$current instanceof FormError) {
+            $this->next();
+
+            if ($this->valid()) {
+                $current = $this->current();
+            }
+        }
+
+        return $current;
+    }
+
+    public function key()
+    {
+        return isset($this->formName) ? $this->formName : key($this->errors);
+    }
+
+    public function next()
+    {
+        return next($this->errors);
+    }
+
+    public function rewind()
+    {
+        reset($this->errors);
+    }
+
+    public function valid()
+    {
+        return false === key($this->errors);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasChildren()
+    {
+        return current($this->errors) instanceof FormErrorBag;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getChildren()
+    {
+        return current($this->errors);
+    }
+
+    public function count()
+    {
+        $count = 0;
+
+        foreach ($this->errors as $error) {
+            if ($error instanceof FormError) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Counts all errors, including errors from children.
+     *
+     * @return int
+     */
+    public function countAll()
+    {
+        $count = 0;
+
+        foreach ($this->errors as $error) {
+            if ($error instanceof FormErrorBag) {
+                $count += $error->countAll();
+            } else {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    public function get($offset)
+    {
+        return $this->errors[$offset];
+    }
+
+    public function set($offset, $value)
+    {
+        $this->errors[$offset] = $value;
+    }
+
+    public function has($offset)
+    {
+        return isset($this->errors[$offset]);
+    }
+
+    public function all()
+    {
+        return $this->errors;
+    }
+
+    public function clear()
+    {
+        $this->replace();
+    }
+
+    public function remove($offset)
+    {
+        unset($this->errors[$offset]);
+    }
+
+    public function replace(array $errors = array())
+    {
+        $this->errors = $errors;
+    }
+
+    public function isEmpty()
+    {
+        return empty($this->errors);
+    }
+
+    public function keys()
+    {
+        return array_keys($this->errors);
+    }
+
+    public function __toString()
+    {
+        $level = func_num_args() > 0 ? func_get_arg(0) : 0;
+        $errors = '';
+
+        foreach ($this->errors as $key => $error) {
+            if ($error instanceof self) {
+                $errors .= str_repeat(' ', $level).$key.":\n";
+                if ($err = $error->__toString($level + 4)) {
+                    $errors .= $err;
+                } else {
+                    $errors .= str_repeat(' ', $level + 4)."No errors\n";
+                }
+            } else {
+                $errors .= str_repeat(' ', $level).'ERROR: '.$error->getMessage()."\n";
+            }
+        }
+
+        return $errors;
+    }
+
+    public function offsetExists($offset)
+    {
+        return $this->has($offset) && $this->errors[$offset] instanceof FormError;
+    }
+
+    public function offsetGet($offset)
+    {
+        $error = $this->get($offset);
+
+        if ($error instanceof FormError) {
+            return $error;
+        }
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        return $this->set($offset);
+    }
+
+    public function offsetUnset($offset)
+    {
+        return $this->remove($offset);
+    }
+}

--- a/src/Symfony/Component/Form/FormErrorBag.php
+++ b/src/Symfony/Component/Form/FormErrorBag.php
@@ -89,7 +89,7 @@ class FormErrorBag implements \RecursiveIterator, \Countable, \ArrayAccess
 
     public function valid()
     {
-        return false === key($this->errors);
+        return null !== key($this->errors);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormErrorBag.php
+++ b/src/Symfony/Component/Form/FormErrorBag.php
@@ -89,6 +89,14 @@ class FormErrorBag implements \RecursiveIterator, \Countable, \ArrayAccess
 
     public function valid()
     {
+        while (current($this->errors) instanceof FormErrorBag) {
+            $this->next();
+
+            if (!$this->valid()) {
+                return false;
+            }
+        }
+
         return null !== key($this->errors);
     }
 

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -94,7 +94,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns all errors.
      *
-     * @return FormError[] An array of FormError instances that occurred during validation
+     * @return FormErrorBag
      */
     public function getErrors();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorBag;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Validator\ConstraintViolation;
 
@@ -127,7 +128,11 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->mapper->mapViolation($violation, $parent);
 
         $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
-        $this->assertEquals(array($this->getFormError()), $child->getErrors(), $child->getName().' should have an error, but has none');
+
+        $childErrors = new FormErrorBag();
+        $childErrors->addError($this->getFormError());
+        $childErrors->addCollection($grandChild->getName(), new FormErrorBag());
+        $this->assertEquals($childErrors, $child->getErrors(), $child->getName().' should have an error, but has none');
         $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName().' should not have an error, but has one');
     }
 
@@ -154,7 +159,10 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
         $this->assertCount(0, $child->getErrors(), $child->getName().' should not have an error, but has one');
         $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName().' should not have an error, but has one');
-        $this->assertEquals(array($this->getFormError()), $grandGrandChild->getErrors(), $grandGrandChild->getName().' should have an error, but has none');
+
+        $grandGrandChildErrors = new FormErrorBag();
+        $grandGrandChildErrors->addError($this->getFormError());
+        $this->assertEquals($grandGrandChildErrors, $grandGrandChild->getErrors(), $grandGrandChild->getName().' should have an error, but has none');
     }
 
     public function testAbortMappingIfNotSynchronized()
@@ -744,18 +752,27 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->mapViolation($violation, $parent);
 
+        $expectedErrors = new FormErrorBag();
+        $expectedErrors->addError($this->getFormError());
+
         if (self::LEVEL_0 === $target) {
-            $this->assertEquals(array($this->getFormError()), $parent->getErrors(), $parent->getName().' should have an error, but has none');
+            $childErrors = new FormErrorBag();
+            $childErrors->addCollection($grandChildName, new FormErrorBag());
+            $expectedErrors->addCollection($childName, $childErrors);
+
+            $this->assertEquals($expectedErrors, $parent->getErrors(), $parent->getName().' should have an error, but has none');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
         } elseif (self::LEVEL_1 === $target) {
+            $expectedErrors->addCollection($grandChildName, new FormErrorBag());
+
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $child->getErrors(), $childName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $child->getErrors(), $childName.' should have an error, but has none');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
         } else {
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChildName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $grandChild->getErrors(), $grandChildName.' should have an error, but has none');
         }
     }
 
@@ -1216,18 +1233,27 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
             $this->assertCount(0, $distraction->getErrors(), 'distraction should not have an error, but has one');
         }
 
+        $expectedErrors = new FormErrorBag();
+        $expectedErrors->addError($this->getFormError());
+
         if (self::LEVEL_0 === $target) {
-            $this->assertEquals(array($this->getFormError()), $parent->getErrors(), $parent->getName().' should have an error, but has none');
+            $childErrors = new FormErrorBag();
+            $childErrors->addCollection($grandChildName, new FormErrorBag());
+            $expectedErrors->addCollection($childName, $childErrors);
+
+            $this->assertEquals($expectedErrors, $parent->getErrors(), $parent->getName().' should have an error, but has none');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
         } elseif (self::LEVEL_1 === $target) {
+            $expectedErrors->addCollection($grandChildName, new FormErrorBag());
+
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $child->getErrors(), $childName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $child->getErrors(), $childName.' should have an error, but has none');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
         } else {
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChildName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $grandChild->getErrors(), $grandChildName.' should have an error, but has none');
         }
     }
 
@@ -1397,18 +1423,27 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->mapViolation($violation, $parent);
 
+        $expectedErrors = new FormErrorBag();
+        $expectedErrors->addError($this->getFormError());
+
         if (self::LEVEL_0 === $target) {
+            $childErrors = new FormErrorBag();
+            $childErrors->addCollection($grandChildName, new FormErrorBag());
+            $expectedErrors->addCollection($childName, $childErrors);
+
             $this->assertCount(0, $errorChild->getErrors(), $errorName.' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $parent->getErrors(), $parent->getName().' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $parent->getErrors(), $parent->getName().' should have an error, but has none');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
         } elseif (self::LEVEL_1 === $target) {
+            $expectedErrors->addCollection($grandChildName, new FormErrorBag());
+
             $this->assertCount(0, $errorChild->getErrors(), $errorName.' should not have an error, but has one');
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $child->getErrors(), $childName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $child->getErrors(), $childName.' should have an error, but has none');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
         } elseif (self::LEVEL_1B === $target) {
-            $this->assertEquals(array($this->getFormError()), $errorChild->getErrors(), $errorName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $errorChild->getErrors(), $errorName.' should have an error, but has none');
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
@@ -1416,7 +1451,7 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
             $this->assertCount(0, $errorChild->getErrors(), $errorName.' should not have an error, but has one');
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChildName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $grandChild->getErrors(), $grandChildName.' should have an error, but has none');
         }
     }
 
@@ -1460,18 +1495,27 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->mapViolation($violation, $parent);
 
+        $expectedErrors = new FormErrorBag();
+        $expectedErrors->addError($this->getFormError());
+
         if (self::LEVEL_0 === $target) {
-            $this->assertEquals(array($this->getFormError()), $parent->getErrors(), $parent->getName().' should have an error, but has none');
+            $childErrors = new FormErrorBag();
+            $childErrors->addCollection($grandChildName, new FormErrorBag());
+            $expectedErrors->addCollection($childName, $childErrors);
+
+            $this->assertEquals($expectedErrors, $parent->getErrors(), $parent->getName().' should have an error, but has none');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
         } elseif (self::LEVEL_1 === $target) {
+            $expectedErrors->addCollection($grandChildName, new FormErrorBag());
+
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $child->getErrors(), $childName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $child->getErrors(), $childName.' should have an error, but has none');
             $this->assertCount(0, $grandChild->getErrors(), $grandChildName.' should not have an error, but has one');
         } else {
             $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
             $this->assertCount(0, $child->getErrors(), $childName.' should not have an error, but has one');
-            $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChildName.' should have an error, but has none');
+            $this->assertEquals($expectedErrors, $grandChild->getErrors(), $grandChildName.' should have an error, but has none');
         }
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormErrorBagTest.php
+++ b/src/Symfony/Component/Form/Tests/FormErrorBagTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorBag;
+
+class FormErrorBagTest extends \Symfony\Component\Form\Tests\FormPerformanceTestCase
+{
+    public function testIterateErrors()
+    {
+        $collection = new FormErrorBag(true);
+        $collection->addCollection('date', new FormErrorBag());
+        $collection->addCollection('checkbox', new FormErrorBag());
+        $collection->addError(new FormError('This value should not be blank.'));
+
+        $this->assertCount(1, $collection);
+        foreach ($collection as $error) {
+            $this->assertInstanceof('Symfony\Component\Form\FormError', $error);
+            $this->assertEquals('This value should not be blank.', $error->getMessage());
+        }
+    }
+
+    public function testRecursivelyIterateErrors()
+    {
+        $collection = new FormErrorBag();
+        $collection->addError(new FormError('This value should not be blank.'));
+
+        $childrenCollection = new FormErrorBag();
+        $childrenCollection->addError(new FormError('This value is not a valid email.'));
+        $childrenCollection->addError(new FormError('This value is not a valid date.'));
+        $collection->addCollection('user', $childrenCollection);
+
+        $iterator = new \RecursiveIteratorIterator($collection);
+        $messages = array(
+            '', // because we use next() in the loop
+            'This value should not be blank.',
+            'This value is not a valid email.',
+            'This value is not a valid date.',
+        );
+        foreach ($iterator as $error) {
+            $this->assertInstanceof('Symfony\Component\Form\FormError', $error);
+            $this->assertEquals(next($messages), $error->getMessage());
+        }
+    }
+
+    public function testCountingErrors()
+    {
+        $collection = new FormErrorBag();
+        $collection->addError(new FormError('This value should not be blank.'));
+        $collection->addError(new FormError('This value should not be blank.'));
+
+        $childrenCollection = new FormErrorBag();
+        $childrenCollection->addError(new FormError('This value is not a valid email.'));
+        $childrenCollection->addError(new FormError('This value is not a valid date.'));
+        $collection->addCollection('user', $childrenCollection);
+
+        $this->assertCount(2, $collection);
+    }
+
+    public function testCoutingAllErrors()
+    {
+        $collection = new FormErrorBag();
+        $collection->addError(new FormError('This value should not be blank.'));
+
+        $childrenCollection = new FormErrorBag();
+        $childrenCollection->addError(new FormError('This value is not a valid email.'));
+        $childrenCollection->addError(new FormError('This value is not a valid date.'));
+        $collection->addCollection('user', $childrenCollection);
+
+        $this->assertEquals(3, $collection->countAll());
+    }
+
+    public function testFormNameAsKeys()
+    {
+        $collection = new FormErrorBag();
+        $collection->addError(new FormError('This value should not be blank.'));
+
+        $childrenCollection = new FormErrorBag();
+        $childrenCollection->addError(new FormError('This value is not a valid email.'));
+        $childrenCollection->addError(new FormError('This value is not a valid date.'));
+        $collection->addCollection('user', $childrenCollection);
+
+        $iterator = new \RecursiveIteratorIterator($collection);
+        $keys = array(
+            '', // use of next() in loop
+            '0',
+            'user',
+            'user',
+        );
+        foreach ($iterator as $name => $error) {
+            $this->assertEquals(next($keys), $name);
+        }
+    }
+
+    public function testToString()
+    {
+        $collection = new FormErrorBag();
+        $collection->addError(new FormError('This value should not be blank.'));
+
+        $childrenCollection = new FormErrorBag();
+        $childrenCollection->addError(new FormError('This value is not a valid email.'));
+        $childrenCollection->addError(new FormError('This value is not a valid date.'));
+        $collection->addCollection('user', $childrenCollection);
+
+        $collection->addCollection('date', new FormErrorBag());
+
+        $this->assertEquals("ERROR: This value should not be blank.\nuser:\n    ERROR: This value is not a valid email.\n    ERROR: This value is not a valid date.\ndate:\n    No errors\n", (string) $collection);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/FormErrorBagTest.php
+++ b/src/Symfony/Component/Form/Tests/FormErrorBagTest.php
@@ -51,6 +51,8 @@ class FormErrorBagTest extends \Symfony\Component\Form\Tests\FormPerformanceTest
             $this->assertInstanceof('Symfony\Component\Form\FormError', $error);
             $this->assertEquals(next($messages), $error->getMessage());
         }
+
+        $this->assertFalse(next($messages), 'got all errors');
     }
 
     public function testCountingErrors()

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -664,7 +664,7 @@ class SimpleFormTest extends AbstractFormTest
         $this->form->addError(new FormError('Error!'));
         $this->form->submit('foobar');
 
-        $this->assertSame(array(), $this->form->getErrors());
+        $this->assertCount(0, $this->form->getErrors());
     }
 
     public function testCreateView()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #7205 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/issues/3397 |

The only BC break in this PR is checking it with is_array. Iterating
over the array works just the same as previously:
- Normally iterating over the `RecursiveIterator` results in only
  iterating over the errors of the current form.
- Iterating using `RecursiveIteratorIterator` results in iterating over
  all errors recursively.
### Todo
- [x] Adding `__toString()` support and deprecating `Form::getErrorsAsString()`.
- [x] Use this class in `Form:getErrors()`
- [x] Fixing tests
- [x] Use field name as key
