### PR TITLE
[MonologBridge] add LoggerProxy

### DIFF
--- a/src/Symfony/Bridge/Monolog/LoggerProxy.php
+++ b/src/Symfony/Bridge/Monolog/LoggerProxy.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Symfony\Bridge\Monolog;
+
+use Psr\Log\LoggerInterface;
+
+class LoggerProxy implements LoggerInterface
+{
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function emergency($message, array $context = array())
+    {
+        $this->logger->emergency($message, $context);
+    }
+
+    public function alert($message, array $context = array())
+    {
+        $this->logger->alert($message, $context);
+    }
+
+    public function critical($message, array $context = array())
+    {
+        $this->logger->critical($message, $context);
+    }
+
+    public function error($message, array $context = array())
+    {
+        $this->logger->error($message, $context);
+    }
+
+    public function warning($message, array $context = array())
+    {
+        $this->logger->warning($message, $context);
+    }
+
+    public function notice($message, array $context = array())
+    {
+        $this->logger->notice($message, $context);
+    }
+
+    public function info($message, array $context = array())
+    {
+        $this->logger->info($message, $context);
+    }
+
+    public function debug($message, array $context = array())
+    {
+        $this->logger->debug($message, $context);
+    }
+
+    public function log($level, $message, array $context = array())
+    {
+        $this->logger->log($level, $message, $context);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This allows easy setup for setter injected logger writing to different channels. http://symfony.com/doc/current/reference/dic_tags.html#dic-tags-monolog

Example service:

``` yaml
services:
    my_logger.my_channel:
        class: Symfony\Bridge\Monolog\LoggerProxy
        arguments:
            - '@logger'
        tags:
            - { name: 'monolog.logger', channel: 'my_channel' }
```

I'm not exactly sure, whether this is the best way of solving it, but I don't want to clutter constructors just because of this limitation :-)
