### PR TITLE
Prepend Child Bundle paths before the parent

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -79,13 +79,11 @@ class TwigExtension extends Extension
                 $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
             }
 
-            if ($reflection->hasMethod('getParent')) {
-                $bundleInstance = $reflection->newInstance();
+            $bundleInstance = $reflection->newInstance();
 
-                if (null !== $parentBundle = $bundleInstance->getParent()) {
-                    if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
-                        $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);
-                    }
+            if (null !== $parentBundle = $bundleInstance->getParent()) {
+                if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
+                    $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);
                 }
             }
         }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -156,7 +156,7 @@ class TwigExtension extends Extension
             $reflection = new \ReflectionClass($class);
 
             $bundleInstance = $reflection->newInstance();
-            if (null === $parentBundle = $bundleInstance->getParent()) {
+            if (null === $bundleInstance->getParent()) {
                 $parentBundles[$bundle] = $reflection;
             } else {
                 $childBundles[$bundle] = $reflection;

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -83,11 +83,11 @@ class TwigExtension extends Extension
                 $bundleInstance = $reflection->newInstance();
 
                 if (null !== $parentBundle = $bundleInstance->getParent()) {
-                    if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
+                    if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
                         $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);
                     }
 
-                    if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
+                    if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
                         $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);
                     }
                 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -80,7 +80,6 @@ class TwigExtension extends Extension
             }
 
             $bundleInstance = $reflection->newInstance();
-
             if (null !== $parentBundle = $bundleInstance->getParent()) {
                 if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
                     $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -86,10 +86,6 @@ class TwigExtension extends Extension
                     if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
                         $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);
                     }
-
-                    if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
-                        $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);
-                    }
                 }
             }
         }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -71,21 +71,24 @@ class TwigExtension extends Extension
         // register bundles as Twig namespaces
         $bundles = $this->getBundlesByChildPriority($container);
         foreach ($bundles as $bundle => $bundleReflection) {
-            if (null !== $parentBundle = $bundleReflection->newInstance()->getParent()) {
-                if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
-                    $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
-                }
+            /** @var \Symfony\Component\HttpKernel\Bundle\BundleInterface $bundleInstance */
+            $bundleInstance = $bundleReflection->newInstance();
 
-                if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$parentBundle.'/views')) {
+            if (null !== $parentBundle = $bundleInstance->getParent()) {
+                if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
                     $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);
                 }
 
-                if (is_dir($dir = dirname($bundleReflection->getFilename()).'/Resources/views')) {
+                if (is_dir($dir = $bundleInstance->getPath().'/Resources/views')) {
                     $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $parentBundle);
                 }
             }
 
-            if (is_dir($dir = dirname($bundleReflection->getFilename()).'/Resources/views')) {
+            if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
+                $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
+            }
+
+            if (is_dir($dir = $bundleInstance->getPath().'/Resources/views')) {
                 $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
             }
         }


### PR DESCRIPTION
This fixes #9085

Say you have AcmeDemoBundle and AppDemoBundle. AcmeDemoBundle is the parent of AppDemoBundle.

If you load templates using @AcmeDemoBundle/ControllerDir/template.html.twig it means that you cannot override the template in AppDemoBundle. The patch below prepends the AppDemoBundle Resources directory to the AcmeDemo namespace.

The namespace directories would not result in:

```
[AcmeDemo] => Array(
    [0] => [absolute-dir-here]/src/App/DemoBundle/Resources/views
    [1] => [absolute-dir-here]/app/Resources/AcmeDemoBundle/views
    [2] => [absolute-dir-here]/src/Acme/DemoBundle/Resources/views
)
```
