### PR TITLE
[BrowserKit] bugix: CookieJar returns cookies with domain "domain.com" f...

### DIFF
--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -195,8 +195,8 @@ class CookieJar
         $cookies = array();
         foreach ($this->cookieJar as $domain => $pathCookies) {
             if ($domain) {
-                $domain = ltrim($domain, '.');
-                if ($domain != substr($parts['host'], -strlen($domain))) {
+                $domain = '.'.ltrim($domain, '.');
+                if ($domain != substr('.'.$parts['host'], -strlen($domain))) {
                     continue;
                 }
             }

--- a/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
@@ -195,4 +195,13 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar1'), $cookieJar->allValues('http://foo.example.com/'));
         $this->assertEquals(array('foo' => 'bar2'), $cookieJar->allValues('http://bar.example.com/'));
     }
+
+    public function testCookieWithWildcardDomain()
+    {
+        $cookieJar = new CookieJar();
+        $cookieJar->set(new Cookie('foo', 'bar', null, '/', '.example.com'));
+
+        $this->assertEquals(array('foo' => 'bar'), $cookieJar->allValues('http://www.example.com'));
+        $this->assertEmpty($cookieJar->allValues('http://wwwexample.com'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Fixes this bug:

``` php
$cookieJar = new CookieJar();
$cookieJar->set(new Cookie('foo', 'bar', null, '/', '.example.com'));

print_r($cookieJar->allValues('http://wwwexample.com'));
// expected result: array()
// actual result: array('foo' => 'bar')
```
