### PR TITLE
[Form] form_debug.xml should be loaded only if form config is enabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -30,6 +30,8 @@ use Symfony\Component\Config\FileLocator;
  */
 class FrameworkExtension extends Extension
 {
+    private $formConfigEnabled = false;
+
     /**
      * Responds to the app.config configuration parameter.
      *
@@ -90,6 +92,7 @@ class FrameworkExtension extends Extension
         }
 
         if ($this->isConfigEnabled($container, $config['form'])) {
+            $this->formConfigEnabled = true;
             $this->registerFormConfiguration($config, $container, $loader);
             $config['validation']['enabled'] = true;
         }
@@ -218,7 +221,10 @@ class FrameworkExtension extends Extension
             return;
         }
 
-        $loader->load('form_debug.xml');
+        if (true === $this->formConfigEnabled) {
+            $loader->load('form_debug.xml');
+        }
+        
         $loader->load('profiling.xml');
         $loader->load('collectors.xml');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Explication here:
https://github.com/symfony/symfony/commit/1972a916539d0bb877df9b16d373c272edd20cfd#commitcomment-4187567
