### PR TITLE
removed legacy artifact from Component/Routing/Router

### DIFF
--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -266,7 +266,7 @@ class Router implements RouterInterface
         } else {
             $class = $this->options['generator_cache_class'];
             $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
-            if (!$cache->isFresh($class)) {
+            if (!$cache->isFresh()) {
                 $dumper = $this->getGeneratorDumperInstance();
 
                 $options = array(


### PR DESCRIPTION
I found another legacy call of isFresh in src/Symfony/Component/Routing/Router.php
Guess that was the last one.

same as:

https://github.com/axhm3a/symfony/commit/8b11ae7c5a374cdc3e0a145def2a772c9697baa6
