### PR TITLE
Set cost type to integer

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -42,7 +42,7 @@ class BCryptPasswordEncoder extends BasePasswordEncoder
             throw new \InvalidArgumentException('Cost must be in the range of 4-31.');
         }
 
-        $this->cost = sprintf('%02d', $cost);
+        $this->cost = $cost;
     }
 
     /**


### PR DESCRIPTION
This seems to be a remnant of when the code dealt with crypt() directly. The password_hash() function expects the cost option to be an LVAL (it does a type conversion for strings).
