### PR TITLE
[RC][Form] Let null values clear fields in PATCH requests

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -548,7 +548,7 @@ class Form implements \IteratorAggregate, FormInterface
                 }
 
                 foreach ($this->children as $name => $child) {
-                    if (isset($submittedData[$name]) || $clearMissing) {
+                    if (array_key_exists($name, $submittedData) || $clearMissing) {
                         $child->submit(isset($submittedData[$name]) ? $submittedData[$name] : null, $clearMissing);
                         unset($submittedData[$name]);
                     }

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -82,6 +82,19 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertTrue($form->isValid());
     }
 
+    public function testSubmitForwardsNullIfNotClearMissingButValueIsExplicitlyNull()
+    {
+        $child = $this->getMockForm('firstName');
+
+        $this->form->add($child);
+
+        $child->expects($this->once())
+            ->method('submit')
+            ->with($this->equalTo(null));
+
+        $this->form->submit(array('firstName' => null), false);
+    }
+
     public function testSubmitForwardsNullIfValueIsMissing()
     {
         $child = $this->getMockForm('firstName');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |

I've changed the way form checks wherever or not to submit childs by checking submitted data with array_key_exists and not with just isset.

This way in PATCH requests values are not processed when they are not in array and not also when the value is null. Currently there is no way to null a value with a PATCH request, even passing it null.

This can lead to some BC breaks depending on how users used form in their code.
