### PR TITLE
[PropertyAccessor] Throw exception on nonexistant "index" on read access

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Exception/AccessException.php
+++ b/src/Symfony/Component/PropertyAccess/Exception/AccessException.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\PropertyAccess\Exception;
 
 /**
- * Thrown when a property cannot be found.
+ * Thrown when a property path is not available.
  *
- * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Stéphane Escandell <stephane.escandell@gmail.com>
  */
-class NoSuchPropertyException extends AccessException
+class AccessException extends RuntimeException
 {
 }

--- a/src/Symfony/Component/PropertyAccess/Exception/NoSuchIndexException.php
+++ b/src/Symfony/Component/PropertyAccess/Exception/NoSuchIndexException.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\PropertyAccess\Exception;
 
 /**
- * Thrown when a property cannot be found.
+ * Thrown when an index cannot be found.
  *
- * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Stéphane Escandell <stephane.escandell@gmail.com>
  */
-class NoSuchPropertyException extends AccessException
+class NoSuchIndexException extends AccessException
 {
 }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
@@ -24,6 +24,11 @@ class PropertyAccessorBuilder
     private $magicCall = false;
 
     /**
+     * @var Boolean
+     */
+    private $throwExceptionOnInvalidIndex = false;
+
+    /**
      * Enables the use of "__call" by the PropertyAccessor.
      *
      * @return PropertyAccessorBuilder The builder object
@@ -48,12 +53,45 @@ class PropertyAccessorBuilder
     }
 
     /**
-     * @return Boolean true if the use of "__call" by the ProperyAccessor is enabled
+     * @return Boolean true if the use of "__call" by the PropertyAccessor is enabled
      */
     public function isMagicCallEnabled()
     {
         return $this->magicCall;
     }
+
+    /**
+     * Enables exceptions in read context for array by PropertyAccessor
+     *
+     * @return PropertyAccessorBuilder The builder object
+     */
+    public function enableExceptionOnInvalidIndex()
+    {
+        $this->throwExceptionOnInvalidIndex = true;
+
+        return $this;
+    }
+
+    /**
+     * Disables exceptions in read context for array by PropertyAccessor
+     *
+     * @return PropertyAccessorBuilder The builder object
+     */
+    public function disableExceptionOnInvalidIndex()
+    {
+        $this->throwExceptionOnInvalidIndex = false;
+
+        return $this;
+    }
+
+    /**
+     * @return Boolean true is exceptions in read context for array is enabled
+     */
+    public function isExceptionOnInvalidIndexEnabled()
+    {
+        return $this->throwExceptionOnInvalidIndex;
+    }
+
 
     /**
      * Builds and returns a new propertyAccessor object.
@@ -62,6 +100,6 @@ class PropertyAccessorBuilder
      */
     public function getPropertyAccessor()
     {
-        return new PropertyAccessor($this->magicCall);
+        return new PropertyAccessor($this->magicCall, $this->throwExceptionOnInvalidIndex);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | a kind of? |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 7881 |
| License | MIT |
| Doc PR |  |

See discussion on issue #7881.
