### PR TITLE
Fix problem with Windows file links (backslash in JavaScript string)

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -5,7 +5,7 @@
         {% if collector.controller.class is defined %}
             {% set link = collector.controller.file|file_link(collector.controller.line) %}
             <span class="sf-toolbar-info-class sf-toolbar-info-with-next-pointer">{{ collector.controller.class|abbr_class }}</span>
-            <span class="sf-toolbar-info-method" onclick="{% if link %}window.location='{{link}}';window.event.stopPropagation();return false;{% endif %}">
+            <span class="sf-toolbar-info-method" onclick="{% if link %}window.location='{{link|e('js')}}';window.event.stopPropagation();return false;{% endif %}">
                 {{ collector.controller.method }}
             </span>
         {% else %}


### PR DESCRIPTION
This PR was submitted on the symfony/WebProfilerBundle read-only repository and moved automatically to the main Symfony repository (closes symfony/WebProfilerBundle#5).

When you have set php.ini setting xdebug.file_link_format, under Windows this window.location call here isn't escaped properly, so it results in something like:

``` HTML
<span class="sf-toolbar-info-method" onclick="window.location='pstorm://open/?url=file://F:\HtDocs\myproject\src\Foo\Core\Controller\PageController.php&amp;line=28';window.event.stopPropagation();return false;">
    pageAction
</span>
```

All backslashes in window.location are treated as escape sequences witch result in an incorrect link:
pstorm://open/?url=file://F:HtDocsmyprojectsrcFooCoreControllerPageController.php&line=28

So clicking this link my IDE (phpStorm) couldn't find that file.

The patch fixes this by escaping the backslashes.
