### PR TITLE
 [Validator] Fixed time constraint (support formats H, H:i and H:i:s)

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -33,7 +33,7 @@ class Time extends Constraint
             $this->withSeconds = false;
         }
 
-        if ($this->withSeconds == true && $this->withMinutes == false) {
+        if ($this->withSeconds && !$this->withMinutes) {
             throw new InvalidConfigurationException('You can not disable minutes if you have enabled seconds.');
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\InvalidConfigurationException;
 
 /**
  * @Annotation
@@ -21,4 +22,19 @@ use Symfony\Component\Validator\Constraint;
 class Time extends Constraint
 {
     public $message = 'This value is not a valid time.';
+    public $withMinutes = true;
+    public $withSeconds = true;
+
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+
+        if (isset($options['withMinutes']) && !isset($options['withSeconds']) && $options['withMinutes'] == false) {
+            $this->withSeconds = false;
+        }
+
+        if ($this->withSeconds == true && $this->withMinutes == false) {
+            throw new InvalidConfigurationException('You can not disable minutes if you have enabled seconds.');
+        }
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -22,8 +22,6 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class TimeValidator extends ConstraintValidator
 {
-    const PATTERN = '/^(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/';
-
     /**
      * {@inheritDoc}
      */
@@ -39,8 +37,37 @@ class TimeValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        if (!preg_match(static::PATTERN, $value)) {
+        $pattern = $this->getPattern($constraint->withMinutes, $constraint->withSeconds);
+
+        if (!preg_match($pattern, $value)) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
         }
+    }
+
+    /**
+     * Returns the regex pattern for validating
+     *
+     * @param $withMinutes
+     * @param $withSeconds
+     * @return string
+     */
+    protected function getPattern($withMinutes, $withSeconds)
+    {
+        // pattern for hours
+        $pattern = "(0[0-9]|1[0-9]|2[0-3])";
+
+        if ($withMinutes)
+        {
+            // pattern for minutes
+            $pattern .= "(:([0-5][0-9]))";
+
+            if ($withSeconds)
+            {
+                // because the pattern for seconds is the same as that for minutes, we repeat it twice
+                $pattern .= "{2}";
+            }
+        }
+
+        return "/^".$pattern."$/";
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -47,8 +47,8 @@ class TimeValidator extends ConstraintValidator
     /**
      * Returns the regex pattern for validating
      *
-     * @param $withMinutes
-     * @param $withSeconds
+     * @param Boolean $withMinutes
+     * @param Boolean $withSeconds
      * @return string
      */
     protected function getPattern($withMinutes, $withSeconds)
@@ -56,13 +56,11 @@ class TimeValidator extends ConstraintValidator
         // pattern for hours
         $pattern = "(0[0-9]|1[0-9]|2[0-3])";
 
-        if ($withMinutes)
-        {
+        if ($withMinutes) {
             // pattern for minutes
             $pattern .= "(:([0-5][0-9]))";
 
-            if ($withSeconds)
-            {
+            if ($withSeconds) {
                 // because the pattern for seconds is the same as that for minutes, we repeat it twice
                 $pattern .= "{2}";
             }

--- a/src/Symfony/Component/Validator/Exception/InvalidConfigurationException.php
+++ b/src/Symfony/Component/Validator/Exception/InvalidConfigurationException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Exception;
+
+class InvalidConfigurationException extends InvalidArgumentException
+{
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Time;
 use Symfony\Component\Validator\Constraints\TimeValidator;
+use Symfony\Component\Validator\Tests\Fixtures\InvalidConstraint;
 
 class TimeValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -30,6 +31,17 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->context = null;
         $this->validator = null;
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\InvalidConfigurationException
+     */
+    public function testThrowsExceptionIfConfigurationIsInvalid()
+    {
+        new Time(array(
+            'withMinutes' => false,
+            'withSeconds' => true,
+        ));
     }
 
     public function testNullIsValid()
@@ -85,6 +97,50 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider getValidTimesWithoutMinutes
+     */
+    public function testValidTimesWithoutMinutes($time)
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($time, new Time(array(
+            'withMinutes' => false,
+        )));
+    }
+
+    public function getValidTimesWithoutMinutes()
+    {
+        return array(
+            array('01'),
+            array('00'),
+            array('23'),
+        );
+    }
+
+    /**
+     * @dataProvider getValidTimesWithoutSeconds
+     */
+    public function testValidTimesWithoutSeconds($time)
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($time, new Time(array(
+            'withSeconds' => false,
+        )));
+    }
+
+    public function getValidTimesWithoutSeconds()
+    {
+        return array(
+            array('01:02'),
+            array('00:00'),
+            array('23:59'),
+        );
+    }
+
+    /**
      * @dataProvider getInvalidTimes
      */
     public function testInvalidTimes($time)
@@ -112,6 +168,67 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
             array('24:00:00'),
             array('00:60:00'),
             array('00:00:60'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidTimesWithoutMinutes
+     */
+    public function testInvalidTimesWithoutMinutes($time)
+    {
+        $constraint = new Time(array(
+            'message' => 'myMessage',
+            'withMinutes' => false,
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $time,
+            ));
+
+        $this->validator->validate($time, $constraint);
+    }
+
+    public function getInvalidTimesWithoutMinutes()
+    {
+        return array(
+            array('foobar'),
+            array('foobar 12'),
+            array('12 foobar'),
+            array('24'),
+            array('60'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidTimesWithoutSeconds
+     */
+    public function testInvalidTimesWithoutSeconds($time)
+    {
+        $constraint = new Time(array(
+            'message' => 'myMessage',
+            'withSeconds' => false,
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $time,
+            ));
+
+        $this->validator->validate($time, $constraint);
+    }
+
+    public function getInvalidTimesWithoutSeconds()
+    {
+        return array(
+            array('foobar'),
+            array('foobar 12:34'),
+            array('12:34 foobar'),
+            array('01:02:03'),
+            array('24:00'),
+            array('00:60'),
         );
     }
 }


### PR DESCRIPTION
Time constraint should support values with hours only, hours with minutes and hours with minutes and seconds

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
