### PR TITLE
[HttpKernel] added missing argument to listener call

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -446,7 +446,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
         return function (Event $event) use ($self, $eventName, $listener) {
             $e = $self->preListenerCall($eventName, $listener);
 
-            call_user_func($listener, $event);
+            call_user_func($listener, $event, $eventName, $this);
 
             $e->stop();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | na |
| License | MIT |
| Doc PR | n/a |

When calling a listener, the dispatcher now must pass the event name and the dispatcher (see 7852), but the traceable event dispatcher did not do that.
