### PR TITLE
[WIP] [Form] Fixed TimeType: inconsistent behavior between input as "array" and as "string" in form data

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -114,7 +114,7 @@ class TimeType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'H:i:s')
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], $format)
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -52,7 +52,7 @@ class TimeTypeTest extends LocalizedTestCase
 
         $form->bind($input);
 
-        $this->assertEquals('03:04:00', $form->getData());
+        $this->assertEquals('03:04', $form->getData());
         $this->assertEquals($input, $form->getViewData());
     }
 
@@ -200,7 +200,7 @@ class TimeTypeTest extends LocalizedTestCase
 
         $form->bind('03:04');
 
-        $this->assertEquals('03:04:00', $form->getData());
+        $this->assertEquals('03:04', $form->getData());
         $this->assertEquals('03:04', $form->getViewData());
     }
 
@@ -216,8 +216,24 @@ class TimeTypeTest extends LocalizedTestCase
 
         $form->bind('03');
 
-        $this->assertEquals('03:00:00', $form->getData());
+        $this->assertEquals('03', $form->getData());
         $this->assertEquals('03', $form->getViewData());
+    }
+
+    public function testSubmitStringSingleTextWithSeconds()
+    {
+        $form = $this->factory->create('time', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'input' => 'string',
+            'widget' => 'single_text',
+            'with_seconds' => true,
+        ));
+
+        $form->bind('03:04:05');
+
+        $this->assertEquals('03:04:05', $form->getData());
+        $this->assertEquals('03:04:05', $form->getViewData());
     }
 
     public function testSetDataWithoutMinutes()


### PR DESCRIPTION
If you use the TimeType with option "input => array" and provide hour + minute then the model data is an array with 2 values (of course hour + minute)
But if you change the option "input" to "string" the model data is something like this: "02:02:02" but it should be "02:02"

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes (?) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

TODO
- [ ] provide compatibility layer to support the old behavior
