### PR TITLE
[FrameworkBundle] made sure that the debug event dispatcher is used everywhere

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -63,16 +63,14 @@ class FrameworkExtension extends Extension
         if ($container->getParameter('kernel.debug')) {
             $loader->load('debug.xml');
 
-            // we can't replace the event_dispatcher service with the debug
-            // one as it would lead to circular references (mainly because the debug
-            // event dispatcher needs the profiler, which triggers the creation of many
-            // other services that can depend on the dispatcher itself -- CLI commands
-            // like assetic:dump and twig:lint exhibits this issue for instance)
             $definition = $container->findDefinition('http_kernel');
-            $arguments = $definition->getArguments();
-            $arguments[0] = new Reference('debug.event_dispatcher');
-            $arguments[2] = new Reference('debug.controller_resolver');
-            $definition->setArguments($arguments);
+            $definition->replaceArgument(2, new Reference('debug.controller_resolver'));
+
+            // replace the regular event_dispatcher service with the debug one
+            $definition = $container->findDefinition('event_dispatcher');
+            $definition->setPublic(false);
+            $container->setDefinition('debug.event_dispatcher.parent', $definition);
+            $container->setAlias('event_dispatcher', 'debug.event_dispatcher');
         }
 
         $configuration = $this->getConfiguration($configs, $container);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -16,7 +16,7 @@
 
         <service id="debug.event_dispatcher" class="%debug.event_dispatcher.class%">
             <tag name="monolog.logger" channel="event" />
-            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher.parent" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterListenersPass.php
@@ -50,11 +50,11 @@ class RegisterListenersPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition($this->dispatcherService)) {
+        if (!$container->hasDefinition($this->dispatcherService) && !$container->hasAlias($this->dispatcherService)) {
             return;
         }
 
-        $definition = $container->getDefinition($this->dispatcherService);
+        $definition = $container->findDefinition($this->dispatcherService);
 
         foreach ($container->findTaggedServiceIds($this->listenerTag) as $id => $events) {
             $def = $container->getDefinition($id);

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -84,8 +84,11 @@ class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
             ->method('getDefinition')
             ->will($this->returnValue($definition));
 
-        $registerListenersPass = new RegisterListenersPass();
+        $builder->expects($this->atLeastOnce())
+            ->method('findDefinition')
+            ->will($this->returnValue($definition));
 
+        $registerListenersPass = new RegisterListenersPass();
         $registerListenersPass->process($builder);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6686, #7673 |
| License | MIT |
| Doc PR | n/a |

The removal of the Profiler dependency on the TraceableEventDispatcher (#9170) allows to remerge the patch from #9068 that fixes #6686.

This PR also cleans up how profiles are stored. A Profile is now always stored only once.

The fix will only be available on 2.4+ as the changes are too deep to be backported to 2.2 and 2.3.
