### PR TITLE
[Form] Pass interfaces in "data_class"

### DIFF
--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -192,7 +192,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     {
         self::validateName($name);
 
-        if (null !== $dataClass && !class_exists($dataClass)) {
+        if (null !== $dataClass && !class_exists($dataClass) && !interface_exists($dataClass)) {
             throw new InvalidArgumentException(sprintf('The data class "%s" is not a valid class.', $dataClass));
         }
 


### PR DESCRIPTION
I'd like to discuss allowing the form builder to accept interfaces. I have five classes that all implement the same interface, but cannot extend the same abstract. Would be nice to not have five identical forms.

Thoughts?
