### PR TITLE
Fixed cache warmup of paths which contain back-slashes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -129,8 +129,10 @@ EOF
         }
 
         // fix references to cached files with the real cache directory name
+        $search  = array($warmupDir, str_replace('\\', '\\\\', $warmupDir));
+        $replace = str_replace('\\', '/', $realCacheDir);
         foreach (Finder::create()->files()->in($warmupDir) as $file) {
-            $content = str_replace($warmupDir, $realCacheDir, file_get_contents($file));
+            $content = str_replace($search, $replace, file_get_contents($file));
             file_put_contents($file, $content);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8781 |
| License | MIT |
| Doc PR | n/a |

From #8781

"
At this step in the warmup process there is a string replacement made, but paths with backslashes
are written into the cache file as something like `C:\\path\\to\\cache/pro_/...` but the str_replace
searches for the plain string `C:\path\to\cache/pro_/...`, which produces no matches.

The fix solves this by using var_export to escape the search (and replace) paths so they match the
format originally output into the cache file.
"
