### PR TITLE
[Console] Throw an exception if the Command __construct() method is not called

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -407,6 +407,10 @@ class Application
             return;
         }
 
+        if (null === $command->getAliases()) {
+            throw new \InvalidArgumentException(sprintf('You must call the parent constructor in "%s::__construct()"', get_class($command)));
+        }
+
         $this->commands[$command->getName()] = $command;
 
         foreach ($command->getAliases() as $alias) {

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -40,6 +40,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         require_once self::$fixturesPath.'/Foo2Command.php';
         require_once self::$fixturesPath.'/Foo3Command.php';
         require_once self::$fixturesPath.'/Foo4Command.php';
+        require_once self::$fixturesPath.'/Foo5Command.php';
         require_once self::$fixturesPath.'/FoobarCommand.php';
     }
 
@@ -123,6 +124,16 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->addCommands(array($foo = new \FooCommand(), $foo1 = new \Foo1Command()));
         $commands = $application->all();
         $this->assertEquals(array($foo, $foo1), array($commands['foo:bar'], $commands['foo:bar1']), '->addCommands() registers an array of commands');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage You must call the parent constructor in "Foo5Command::__construct()"
+     */
+    public function testAddCommandWithEmptyContructor()
+    {
+        $application = new Application();
+        $application->add($foo = new \Foo5Command());
     }
 
     public function testHasGet()

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo5Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo5Command.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+
+class Foo5Command extends Command
+{
+    public function __construct()
+    {
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| license? | MIT |

It can only happend if the constructor has been overridden
