### PR TITLE
[2.2][Form] add support for Length and Range constraint in ValidatorTypeGuesser

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -155,11 +155,13 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
 
             case 'Symfony\Component\Validator\Constraints\MaxLength':
             case 'Symfony\Component\Validator\Constraints\MinLength':
+            case 'Symfony\Component\Validator\Constraints\Length':
             case 'Symfony\Component\Validator\Constraints\Regex':
                 return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
 
             case 'Symfony\Component\Validator\Constraints\Min':
             case 'Symfony\Component\Validator\Constraints\Max':
+            case 'Symfony\Component\Validator\Constraints\Range':
                 return new TypeGuess('number', array(), Guess::LOW_CONFIDENCE);
 
             case 'Symfony\Component\Validator\Constraints\MinCount':
@@ -206,6 +208,12 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\MaxLength':
                 return new ValueGuess($constraint->limit, Guess::HIGH_CONFIDENCE);
 
+            case 'Symfony\Component\Validator\Constraints\Length':
+                if (is_numeric($constraint->max)) {
+                    return new ValueGuess($constraint->max, Guess::HIGH_CONFIDENCE);
+                }
+                break;
+
             case 'Symfony\Component\Validator\Constraints\Type':
                 if (in_array($constraint->type, array('double', 'float', 'numeric', 'real'))) {
                         return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
@@ -214,6 +222,12 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
 
             case 'Symfony\Component\Validator\Constraints\Max':
                 return new ValueGuess(strlen((string) $constraint->limit), Guess::LOW_CONFIDENCE);
+
+            case 'Symfony\Component\Validator\Constraints\Range':
+                if (is_numeric($constraint->max)) {
+                    return new ValueGuess(strlen((string) $constraint->max), Guess::LOW_CONFIDENCE);
+                }
+                break;
         }
 
         return null;
@@ -232,6 +246,12 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\MinLength':
                 return new ValueGuess(sprintf('.{%s,}', (string) $constraint->limit), Guess::LOW_CONFIDENCE);
 
+            case 'Symfony\Component\Validator\Constraints\Length':
+                if (is_numeric($constraint->min)) {
+                    return new ValueGuess(sprintf('.{%s,}', (string) $constraint->min), Guess::LOW_CONFIDENCE);
+                }
+                break;
+
             case 'Symfony\Component\Validator\Constraints\Regex':
                 $htmlPattern = $constraint->getHtmlPattern();
 
@@ -242,6 +262,12 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
 
             case 'Symfony\Component\Validator\Constraints\Min':
                 return new ValueGuess(sprintf('.{%s,}', strlen((string) $constraint->limit)), Guess::LOW_CONFIDENCE);
+
+            case 'Symfony\Component\Validator\Constraints\Range':
+                if (is_numeric($constraint->min)) {
+                    return new ValueGuess(sprintf('.{%s,}', strlen((string) $constraint->min)), Guess::LOW_CONFIDENCE);
+                }
+                break;
 
             case 'Symfony\Component\Validator\Constraints\Type':
                 if (in_array($constraint->type, array('double', 'float', 'numeric', 'real'))) {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+* This file is part of the Symfony package.
+*
+* (c) Fabien Potencier <fabien@symfony.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Symfony\Component\Form\Tests\Extension\Validator;
+
+use Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser;
+use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Type;
+
+/**
+* @author franek <franek@chicour.net>
+*/
+class ValidatorTypeGuesserTest extends \PHPUnit_Framework_TestCase
+{
+    private $typeGuesser;
+
+    public function setUp()
+    {
+        if (!class_exists('Symfony\Component\Validator\Constraint')) {
+            $this->markTestSkipped('The "Validator" component is not available');
+        }
+
+        $metadataFactory = $this->getMock('Symfony\Component\Validator\MetadataFactoryInterface');
+
+        $this->typeGuesser = new ValidatorTypeGuesser($metadataFactory);
+    }
+
+    public function testGuessMaxLengthForConstraintWithMaxValue()
+    {
+        $constraint = new Length(array('max' => '2'));
+
+        $result = $this->typeGuesser->guessMaxLengthForConstraint($constraint);
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\ValueGuess', $result);
+        $this->assertEquals(2, $result->getValue());
+        $this->assertEquals(Guess::HIGH_CONFIDENCE, $result->getConfidence());
+    }
+
+    public function testGuessMaxLengthForConstraintWithMinValue()
+    {
+        $constraint = new Length(array('min' => '2'));
+
+        $result = $this->typeGuesser->guessMaxLengthForConstraint($constraint);
+        $this->assertNull($result);
+    }
+
+    /**
+* @dataProvider dataProviderTestGuessMaxLengthForConstraintWithType
+*/
+    public function testGuessMaxLengthForConstraintWithType($type)
+    {
+        $constraint = new Type($type);
+
+        $result = $this->typeGuesser->guessMaxLengthForConstraint($constraint);
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\ValueGuess', $result);
+        $this->assertEquals(null, $result->getValue());
+        $this->assertEquals(Guess::MEDIUM_CONFIDENCE, $result->getConfidence());
+    }
+
+    public static function dataProviderTestGuessMaxLengthForConstraintWithType()
+    {
+        return array (
+            array('double'),
+            array('float'),
+            array('numeric'),
+            array('real')
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9132 |
| License | MIT |
| Doc PR |  |

MaxLength, MinLength, Min and Max constraints are deprecated on 2.2. Will be removed in 2.3.

Add support for type guessing of Length and Range constraints.

fix #9132 on 2.2 branch
