### PR TITLE
Fix: duplicate usage of Symfony\Component\HttpFoundation\Response

### DIFF
--- a/src/Symfony/Component/Security/Http/Authorization/AccessDeniedHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authorization/AccessDeniedHandlerInterface.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Http\Authorization;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * This is used by the ExceptionListener to translate an AccessDeniedException


### PR DESCRIPTION
Duplicate usage of Symfony\Component\HttpFoundation\Response causes an error:

> PHP Fatal error:  Cannot use Symfony\Component\HttpFoundation\Response as Response because the name is already in use in src/Symfony/Component/Security/Http/Authorization/AccessDeniedHandlerInterface.php on line 17
