### PR TITLE
[Console] added a compact layout for the table helper

### DIFF
--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -23,6 +23,7 @@ class TableHelper extends Helper
 {
     const LAYOUT_DEFAULT = 0;
     const LAYOUT_BORDERLESS = 1;
+    const LAYOUT_COMPACT = 2;
 
     /**
      * Table headers.
@@ -45,6 +46,7 @@ class TableHelper extends Helper
     private $crossingChar;
     private $cellHeaderFormat;
     private $cellRowFormat;
+    private $cellRowContentFormat;
     private $borderFormat;
     private $padType;
 
@@ -89,7 +91,22 @@ class TableHelper extends Helper
                     ->setVerticalBorderChar(' ')
                     ->setCrossingChar(' ')
                     ->setCellHeaderFormat('<info>%s</info>')
-                    ->setCellRowFormat('<comment>%s</comment>')
+                    ->setCellRowFormat('%s')
+                    ->setCellRowContentFormat(' %s ')
+                    ->setBorderFormat('%s')
+                    ->setPadType(STR_PAD_RIGHT)
+                ;
+                break;
+
+            case self::LAYOUT_COMPACT:
+                $this
+                    ->setPaddingChar(' ')
+                    ->setHorizontalBorderChar('')
+                    ->setVerticalBorderChar(' ')
+                    ->setCrossingChar('')
+                    ->setCellHeaderFormat('<info>%s</info>')
+                    ->setCellRowFormat('%s')
+                    ->setCellRowContentFormat('%s')
                     ->setBorderFormat('%s')
                     ->setPadType(STR_PAD_RIGHT)
                 ;
@@ -102,7 +119,8 @@ class TableHelper extends Helper
                     ->setVerticalBorderChar('|')
                     ->setCrossingChar('+')
                     ->setCellHeaderFormat('<info>%s</info>')
-                    ->setCellRowFormat('<comment>%s</comment>')
+                    ->setCellRowFormat('%s')
+                    ->setCellRowContentFormat(' %s ')
                     ->setBorderFormat('%s')
                     ->setPadType(STR_PAD_RIGHT)
                 ;
@@ -242,6 +260,20 @@ class TableHelper extends Helper
     }
 
     /**
+     * Sets row cell content format.
+     *
+     * @param string $cellRowContentFormat
+     *
+     * @return TableHelper
+     */
+    public function setCellRowContentFormat($cellRowContentFormat)
+    {
+        $this->cellRowContentFormat = $cellRowContentFormat;
+
+        return $this;
+    }
+
+    /**
      * Sets table border format.
      *
      * @param string $borderFormat
@@ -313,11 +345,13 @@ class TableHelper extends Helper
             return;
         }
 
+        if (!$this->horizontalBorderChar && !$this->crossingChar) {
+            return;
+        }
+
         $markup = $this->crossingChar;
         for ($column = 0; $column < $count; $column++) {
-            $markup .= str_repeat($this->horizontalBorderChar, $this->getColumnWidth($column))
-                    .$this->crossingChar
-            ;
+            $markup .= str_repeat($this->horizontalBorderChar, $this->getColumnWidth($column)).$this->crossingChar;
         }
 
         $this->output->writeln(sprintf($this->borderFormat, $markup));
@@ -370,15 +404,9 @@ class TableHelper extends Helper
             $width += strlen($cell) - mb_strlen($cell, $encoding);
         }
 
-        $this->output->write(sprintf(
-            $cellFormat,
-            str_pad(
-                $this->paddingChar.$cell.$this->paddingChar,
-                $width,
-                $this->paddingChar,
-                $this->padType
-            )
-        ));
+        $content = sprintf($this->cellRowContentFormat, $cell);
+
+        $this->output->write(sprintf($cellFormat, str_pad($content, $width, $this->paddingChar, $this->padType)));
     }
 
     /**
@@ -420,7 +448,7 @@ class TableHelper extends Helper
             $lengths[] = $this->getCellWidth($row, $column);
         }
 
-        return $this->columnWidths[$column] = max($lengths) + 2;
+        return $this->columnWidths[$column] = max($lengths) + strlen($this->cellRowContentFormat) - 2;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -162,6 +162,10 @@ class TableHelper extends Helper
      */
     public function setPaddingChar($paddingChar)
     {
+        if (!$paddingChar) {
+            throw new \LogicException('The padding char must not be empty');
+        }
+
         $this->paddingChar = $paddingChar;
 
         return $this;

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -81,15 +81,17 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderProvider()
     {
+        $books = array(
+            array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
+            array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
+            array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
+            array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
+        );
+
         return array(
             array(
                 array('ISBN', 'Title', 'Author'),
-                array(
-                    array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
-                    array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
-                    array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
-                    array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
-                ),
+                $books,
                 TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+--------------------------+------------------+
@@ -105,14 +107,32 @@ TABLE
             ),
             array(
                 array('ISBN', 'Title', 'Author'),
-                array(
-                    array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
-                    array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
-                    array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
-                    array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
-                ),
+                $books,
+                TableHelper::LAYOUT_COMPACT,
+<<<TABLE
+ ISBN          Title                    Author           
+ 99921-58-10-7 Divine Comedy            Dante Alighieri  
+ 9971-5-0210-0 A Tale of Two Cities     Charles Dickens  
+ 960-425-059-0 The Lord of the Rings    J. R. R. Tolkien 
+ 80-902734-1-6 And Then There Were None Agatha Christie  
+
+TABLE
+            ),
+            array(
+                array('ISBN', 'Title', 'Author'),
+                $books,
                 TableHelper::LAYOUT_BORDERLESS,
-                " =============== ========================== ================== \n  ISBN            Title                      Author            \n =============== ========================== ================== \n  99921-58-10-7   Divine Comedy              Dante Alighieri   \n  9971-5-0210-0   A Tale of Two Cities       Charles Dickens   \n  960-425-059-0   The Lord of the Rings      J. R. R. Tolkien  \n  80-902734-1-6   And Then There Were None   Agatha Christie   \n =============== ========================== ================== \n"
+<<<TABLE
+ =============== ========================== ================== 
+  ISBN            Title                      Author            
+ =============== ========================== ================== 
+  99921-58-10-7   Divine Comedy              Dante Alighieri   
+  9971-5-0210-0   A Tale of Two Cities       Charles Dickens   
+  960-425-059-0   The Lord of the Rings      J. R. R. Tolkien  
+  80-902734-1-6   And Then There Were None   Agatha Christie   
+ =============== ========================== ================== 
+
+TABLE
             ),
             array(
                 array('ISBN', 'Title'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#3025 |

That helps with large tables like the ones we have in container:debug and router:debug.
