### PR TITLE
[FrameworkBundle] updated XML route description

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -128,9 +128,11 @@ class XmlDescriptor extends Descriptor
             $routeXML->setAttribute('name', $name);
         }
 
-        $routeXML->setAttribute('path', $route->getPath());
         $routeXML->setAttribute('class', get_class($route));
-        $routeXML->setAttribute('path_regex', $route->compile()->getRegex());
+
+        $routeXML->appendChild($pathXML = $dom->createElement('path'));
+        $pathXML->setAttribute('regex', $route->compile()->getRegex());
+        $pathXML->appendChild(new \DOMText($route->getPath()));
 
         if ('' !== $route->getHost()) {
             $routeXML->appendChild($hostXML = $dom->createElement('host'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<route path="/hello/{name}" class="Symfony\Component\Routing\Route" path_regex="#^/hello(?:/(?P&lt;name&gt;[a-z]+))?$#s">
+<route class="Symfony\Component\Routing\Route">
+  <path regex="#^/hello(?:/(?P&lt;name&gt;[a-z]+))?$#s">/hello/{name}</path>
   <host regex="#^localhost$#s">localhost</host>
   <scheme>http</scheme>
   <scheme>https</scheme>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<route path="/name/add" class="Symfony\Component\Routing\Route" path_regex="#^/name/add$#s">
+<route class="Symfony\Component\Routing\Route">
+  <path regex="#^/name/add$#s">/name/add</path>
   <host regex="#^localhost$#s">localhost</host>
   <scheme>http</scheme>
   <scheme>https</scheme>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes>
-  <route name="route_1" path="/hello/{name}" class="Symfony\Component\Routing\Route" path_regex="#^/hello(?:/(?P&lt;name&gt;[a-z]+))?$#s">
+  <route name="route_1" class="Symfony\Component\Routing\Route">
+    <path regex="#^/hello(?:/(?P&lt;name&gt;[a-z]+))?$#s">/hello/{name}</path>
     <host regex="#^localhost$#s">localhost</host>
     <scheme>http</scheme>
     <scheme>https</scheme>
@@ -18,7 +19,8 @@
       <option key="opt2">val2</option>
     </options>
   </route>
-  <route name="route_2" path="/name/add" class="Symfony\Component\Routing\Route" path_regex="#^/name/add$#s">
+  <route name="route_2" class="Symfony\Component\Routing\Route">
+    <path regex="#^/name/add$#s">/name/add</path>
     <host regex="#^localhost$#s">localhost</host>
     <scheme>http</scheme>
     <scheme>https</scheme>


### PR DESCRIPTION
This PR turns

``` xml
<route name="route_1" path="/hello/{name}" class="Symfony\Component\Routing\Route" path_regex="#^/hello(?:/(?P&lt;name&gt;[a-z]+))?$#s">
```

into

``` xml
<route name="route_1" class="Symfony\Component\Routing\Route">
    <path regex="#^/hello(?:/(?P&lt;name&gt;[a-z]+))?$#s">/hello/{name}</path>
```

in XML routing description.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7887 |
| License | MIT |
| Doc PR | n/a |
