### PR TITLE
[DI] Improve error message when namespace is not found

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -288,12 +288,26 @@ class YamlFileLoader extends FileLoader
 
             if (!$this->container->hasExtension($namespace)) {
                 $extensionNamespaces = array_filter(array_map(function ($ext) { return $ext->getAlias(); }, $this->container->getExtensions()));
+
+                list($vendor, $bundle) = explode('_', $namespace, 2);
+
+                $relatedExtensionNamespaces = array_filter($extensionNamespaces, function ($ns) use ($vendor, $bundle) {
+                    if (0 === strpos($ns, $vendor)) {
+                        return true;
+                    }
+
+                    return 1 === preg_match('{'.preg_quote($bundle).'}', $ns);
+                });
+                if (0 === count($relatedExtensionNamespaces)) {
+                    $relatedExtensionNamespaces = $extensionNamespaces;
+                }
+
                 throw new InvalidArgumentException(sprintf(
-                    'There is no extension able to load the configuration for "%s" (in %s). Looked for namespace "%s", found %s',
+                    'There is no extension able to load the configuration for "%s" (in %s). Did you mean one of these %s?',
                     $namespace,
                     $file,
                     $namespace,
-                    $extensionNamespaces ? sprintf('"%s"', implode('", "', $extensionNamespaces)) : 'none'
+                    $extensionNamespaces ? sprintf('"%s"', implode('", "', $relatedExtensionNamespaces)) : 'none'
                 ));
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When an application has a lot of registered bundles and you misspelled the DI alias of a bundle, dumping all aliases results in a not that easy to read error message. This PR edits the error message to find related aliases and only dump those. It does it by dumping all aliases with the same vendor (this helps you when you had a typo in the bundle name) and dumping all aliases that matches the bundle name (this helps when you had a typo in the vendor name).

Examples: (gherkin style)

```
Given aliases "cmf_menu", "cmf_block" and "knp_menu" are registered
When the configuration has config for "kpn_menu"
Then the fileloader should fail
And the dumped aliases are "cmf_menu" and "knp_menu"

Given aliases "cmf_menu", "cmf_block", "sonata_block" are registered
When the cofiguration has config for "cmf_blok"
Then the fileloader should fail
And the dumped aliases are "cmf_block" and "sonata_block"

Given aliases "cmf_menu", "cmf_block", "acme_demo" and "knp_menu" are registered
When the configuration has config for "cfm_blok"
Then the fileloader should fail
And the dumped aliases are "cmf_menu", "cmf_block", "acme_demo" and "knp_menu"
```
