### PR TITLE
[HttpKernel] Check for lock existence before unlinking

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -50,7 +50,7 @@ class Store implements StoreInterface
     {
         // unlock everything
         foreach ($this->locks as $lock) {
-            @unlink($lock);
+            !file_exists($lock) ?: @unlink($lock);
         }
 
         $error = error_get_last();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

My logs are filled with a bazillion errors stating "Warning: unlink(/var/www/mysite/app/cache/prod/http_cache/md/cf/47/c693da5dab3eccb65fa36a9b4b07ad0f7cc4.lck): No such file or directory in /var/www/mysite/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/Store.php line 53"
