### PR TITLE
[Form] Add a 'submitted' attribute to the form view

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -97,6 +97,7 @@ class FormType extends BaseType
             'compound'   => $form->getConfig()->getCompound(),
             'method'     => $form->getConfig()->getMethod(),
             'action'     => $form->getConfig()->getAction(),
+            'submitted'  => $form->isSubmitted(),
         ));
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -534,6 +534,21 @@ class FormTypeTest extends BaseTypeTest
         $this->assertFalse($view->vars['valid']);
     }
 
+    public function testViewSubmittedNotSubmitted()
+    {
+        $form = $this->factory->create('form');
+        $view = $form->createView();
+        $this->assertFalse($view->vars['submitted']);
+    }
+
+    public function testViewSubmittedSubmitted()
+    {
+        $form = $this->factory->create('form');
+        $form->submit(array());
+        $view = $form->createView();
+        $this->assertTrue($view->vars['submitted']);
+    }
+
     public function testDataOptionSupersedesSetDataCalls()
     {
         $form = $this->factory->create('form', null, array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | symfony/symfony-docs#3029 |

Basically, the use case of this PR is to determine in the view if a form has been validated by the validator. By default, the valid attribute is true and we can't know if the form has been submitted. Now, we can use `form.vars.submitted && form.vars.valid`.
