### PR TITLE
[Validator] Force Luhn Validator to only work with strings

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * Validates a PAN using the LUHN Algorithm
@@ -36,6 +37,13 @@ class LuhnValidator extends ConstraintValidator
     {
         if (null === $value || '' === $value) {
             return;
+        }
+
+        /**
+         * need to work with strings only because long numbers are treated as floats and don't work with strlen
+         */
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
         }
 
         if (!is_numeric($value)) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -103,7 +103,28 @@ class LuhnValidatorTest extends \PHPUnit_Framework_TestCase
             array('1234567812345678'),
             array('4222222222222222'),
             array('0000000000000000'),
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
+     * @dataProvider getInvalidTypes
+     */
+    public function testInvalidTypes($number)
+    {
+        $constraint = new Luhn();
+
+        $this->validator->validate($number, $constraint);
+    }
+
+    public function getInvalidTypes()
+    {
+        return array(
             array(0),
+            array(123),
+            array(42424242424242424242),
+            array(378282246310005),
+            array(371449635398431),
         );
     }
 }


### PR DESCRIPTION
The Luhn Validator fails to work with float or large integers (internally turned into float by php, depending on precision setting). This is problematic because developers might use number or integer form fields to capture credit card data, which will lead to a validation error even though the form input itself was valid. This commit makes validator throw UnexpectedTypeException on non-string input to avoid this confusion.

| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [yes] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
