### PR TITLE
[Filesystem] Mirror should keep the original symlink target and not the ...

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -393,7 +393,7 @@ class Filesystem
                 }
             } else {
                 if (is_link($file)) {
-                    $this->symlink($file, $target);
+                    $this->symlink($file->getLinkTarget(), $target);
                 } elseif (is_dir($file)) {
                     $this->mkdir($target);
                 } elseif (is_file($file)) {


### PR DESCRIPTION
...real path

When having a link that is already in a linked directory, the mirror function set the mirrored link with the realpath and not the original target directory of the symlink.
