### PR TITLE
[Bridge] [Propel1] Fixed guessed relations

### DIFF
--- a/src/Symfony/Bridge/Propel1/Form/PropelTypeGuesser.php
+++ b/src/Symfony/Bridge/Propel1/Form/PropelTypeGuesser.php
@@ -35,11 +35,18 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
         }
 
         foreach ($table->getRelations() as $relation) {
-            if (in_array($relation->getType(), array(\RelationMap::MANY_TO_ONE, \RelationMap::ONE_TO_MANY))) {
-                if ($property == $relation->getForeignTable()->getName()) {
+            if ($relation->getType() === \RelationMap::MANY_TO_ONE) {
+                if (strtolower($property) === strtolower($relation->getName())) {
                     return new TypeGuess('model', array(
                         'class'    => $relation->getForeignTable()->getClassName(),
-                        'multiple' => \RelationMap::MANY_TO_ONE === $relation->getType() ? false : true,
+                        'multiple' => false,
+                    ), Guess::HIGH_CONFIDENCE);
+                }
+            } elseif ($relation->getType() === \RelationMap::ONE_TO_MANY) {
+                if (strtolower($property) === strtolower($relation->getPluralName())) {
+                    return new TypeGuess('model', array(
+                        'class'    => $relation->getForeignTable()->getClassName(),
+                        'multiple' => true,
                     ), Guess::HIGH_CONFIDENCE);
                 }
             } elseif ($relation->getType() === \RelationMap::MANY_TO_MANY) {

--- a/src/Symfony/Bridge/Propel1/Tests/Fixtures/ItemQuery.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Fixtures/ItemQuery.php
@@ -20,6 +20,10 @@ class ItemQuery
         'is_active'     => \PropelColumnTypes::BOOLEAN,
         'enabled'       => \PropelColumnTypes::BOOLEAN_EMU,
         'updated_at'    => \PropelColumnTypes::TIMESTAMP,
+
+        'updated_at'    => \PropelColumnTypes::TIMESTAMP,
+        'updated_at'    => \PropelColumnTypes::TIMESTAMP,
+        'updated_at'    => \PropelColumnTypes::TIMESTAMP,
     );
 
     public function getTableMap()
@@ -62,6 +66,30 @@ class ItemQuery
      */
     public function getRelations()
     {
-        return array();
+        // table maps
+        $authorTable = new \TableMap();
+        $authorTable->setClassName('\Foo\Author');
+
+        $resellerTable = new \TableMap();
+        $resellerTable->setClassName('\Foo\Reseller');
+
+        // relations
+        $mainAuthorRelation = new \RelationMap('MainAuthor');
+        $mainAuthorRelation->setType(\RelationMap::MANY_TO_ONE);
+        $mainAuthorRelation->setForeignTable($authorTable);
+
+        $authorRelation = new \RelationMap('Author');
+        $authorRelation->setType(\RelationMap::ONE_TO_MANY);
+        $authorRelation->setForeignTable($authorTable);
+
+        $resellerRelation = new \RelationMap('Reseller');
+        $resellerRelation->setType(\RelationMap::MANY_TO_MANY);
+        $resellerRelation->setLocalTable($resellerTable);
+
+        return array(
+            $mainAuthorRelation,
+            $authorRelation,
+            $resellerRelation
+        );
     }
 }

--- a/src/Symfony/Bridge/Propel1/Tests/Form/PropelTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/PropelTypeGuesserTest.php
@@ -96,13 +96,19 @@ class PropelTypeGuesserTest extends Propel1TestCase
     /**
      * @dataProvider dataProviderForGuessType
      */
-    public function testGuessType($property, $type, $confidence)
+    public function testGuessType($property, $type, $confidence, $multiple = null)
     {
         $value = $this->guesser->guessType(self::CLASS_NAME, $property);
 
         $this->assertNotNull($value);
         $this->assertEquals($type, $value->getType());
         $this->assertEquals($confidence, $value->getConfidence());
+
+        if ($type === 'model') {
+            $options = $value->getOptions();
+
+            $this->assertSame($multiple, $options['multiple']);
+        }
     }
 
     public static function dataProviderForGuessType()
@@ -114,6 +120,10 @@ class PropelTypeGuesserTest extends Propel1TestCase
             array('value',      'text',     Guess::MEDIUM_CONFIDENCE),
             array('price',      'number',   Guess::MEDIUM_CONFIDENCE),
             array('updated_at', 'datetime', Guess::HIGH_CONFIDENCE),
+
+            array('Authors',    'model',    Guess::HIGH_CONFIDENCE,     true),
+            array('Resellers',  'model',    Guess::HIGH_CONFIDENCE,     true),
+            array('MainAuthor', 'model',    Guess::HIGH_CONFIDENCE,     false),
         );
     }
 }


### PR DESCRIPTION
<table>
  <tr><th>Q</th><th>A</th></tr>
  <tr><td>Bug fix</td><td>yes</td></tr>
  <tr><td>Feature addition</td><td>no</td></tr>
  <tr><td>Backwards compatibility break</td><td>no</td></tr>
  <tr><td>Symfony2 tests pass</td><td>yes</td></tr>
  <tr><td>Fixes the following tickets</td><td>N/A</td></tr>
  <tr><td>Todo</td><td>N/A</td></tr>
  <tr><td>License of the code</td><td>MIT</td></tr>
  <tr><td>Documentation PR</td><td>N/A</td></tr>
</table>


The `PropelTypeGuesser` did not match OneToMany relations properly. For example if you have a `Author` class with `Comments` attributes the guesser would guess "Comment" instead of "Comments".

I added some tests to ensure the non regression.
