### PR TITLE
[Translator] PoFileDumper - PO headers

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -29,6 +29,7 @@ class PoFileDumper extends FileDumper
         $output .= 'msgstr ""'."\n";
         $output .= '"Content-Type: text/plain; charset=UTF-8\n"'."\n";
         $output .= '"Content-Transfer-Encoding: 8bit\n"'."\n";
+        $output .= '"Language: '.$messages->getLocale().'\n"'."\n";
         $output .= "\n";
 
         $newLine = false;

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -25,7 +25,12 @@ class PoFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
-        $output = '';
+        $output = 'msgid ""'."\n";
+        $output .= 'msgstr ""'."\n";
+        $output .= '"Content-Type: text/plain; charset=UTF-8\n"'."\n";
+        $output .= '"Content-Transfer-Encoding: 8bit\n"'."\n";
+        $output .= "\n";
+
         $newLine = false;
         foreach ($messages->all($domain) as $source => $target) {
             if ($newLine) {

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources.po
@@ -1,2 +1,7 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
 msgid "foo"
 msgstr "bar"

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources.po
@@ -2,6 +2,7 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
 
 msgid "foo"
 msgstr "bar"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6765 - partially |
| License | MIT |
| Doc PR |  |

Po files should not be dumped without a header. It causes a lot of problems, including charset issues.

See #6765 / 1 for more info
