### PR TITLE
[Translator] [FrameworkBundle] Translation loader - ignore locale

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -107,10 +107,15 @@ EOF
         $extractor->extract($foundBundle->getPath().'/Resources/views/', $extractedCatalogue);
 
         // load any existing messages from the translation files
-        $currentCatalogue = new MessageCatalogue($input->getArgument('locale'));
         $output->writeln('Loading translation files');
         $loader = $this->getContainer()->get('translation.loader');
+
+        $fallbackCatalogue = new MessageCatalogue(null);
+        $loader->loadMessages($bundleTransPath, $fallbackCatalogue);
+
+        $currentCatalogue = new MessageCatalogue($input->getArgument('locale'));
         $loader->loadMessages($bundleTransPath, $currentCatalogue);
+        $currentCatalogue->addFallbackCatalogue($fallbackCatalogue);
 
         // process catalogues
         $operation = $input->getOption('clean')

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -100,7 +100,7 @@ EOF
         $output->writeln(sprintf('Generating "<info>%s</info>" translation files for "<info>%s</info>"', $input->getArgument('locale'), $foundBundle->getName()));
 
         // load any messages from templates
-        $extractedCatalogue = new MessageCatalogue($input->getArgument('locale'));
+        $extractedCatalogue = new MessageCatalogue(null);
         $output->writeln('Parsing templates');
         $extractor = $this->getContainer()->get('translation.extractor');
         $extractor->setPrefix($input->getOption('prefix'));

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -50,7 +50,7 @@ class TranslationLoader
         foreach ($this->loaders as $format => $loader) {
             // load any existing translation files
             $finder = new Finder();
-            $extension = $catalogue->getLocale().'.'.$format;
+            $extension = $catalogue->getLocale() === null ? $format : $catalogue->getLocale().'.'.$format;
             $files = $finder->files()->name('*.'.$extension)->in($directory);
             foreach ($files as $file) {
                 $domain = substr($file->getFileName(), 0, -1 * strlen($extension) - 1);

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -150,6 +150,10 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function add($messages, $domain = 'messages')
     {
+        if ($this->locale === null) {
+            $messages = array_fill_keys(array_keys($messages), null);
+        }
+
         if (!isset($this->messages[$domain])) {
             $this->messages[$domain] = $messages;
         } else {
@@ -164,7 +168,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function addCatalogue(MessageCatalogueInterface $catalogue)
     {
-        if ($catalogue->getLocale() !== $this->locale) {
+        if ($this->locale !== null && $catalogue->getLocale() !== $this->locale) {
             throw new \LogicException(sprintf('Cannot add a catalogue for locale "%s" as the current locale for this catalogue is "%s"', $catalogue->getLocale(), $this->locale));
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? |  |
| Deprecations? | no |
| Tests pass? |  |
| Fixed tickets | #6765 - partially |
| License | MIT |
| Doc PR |  |

The TranslationLoader should ignore(or should have the option to ignore) locale when collecting keys from translation files. This would help identify missing translations, unecessary keys, and make the translation keys consistent.

My idea would be to create the message catalogue with null locale `$catalogue = new MessageCatalogue(null);`. This would mark the cataloge as not locale aware, and it would only contain translation keys.

What do you think?
