### PR TITLE
[FrameworkBundle], [TwigBundle] Fixed wrong paths to the resources due to the classes that are in the class cache.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ClassesToCompilePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ClassesToCompilePass.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * @author Martin Hasoň <martin.hason@gmail.com>
+ */
+class ClassesToCompilePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $classes = array_merge($container->getParameter('kernel.bundles'), array(
+            'Symfony\Component\Form\Form',
+            'Symfony\Component\Form\FormInterface',
+            'Symfony\Component\Validator\Validator',
+            'Symfony\Component\Security\Core\Exception\AuthenticationException',
+        ));
+
+        foreach ($container->getExtensions() as $extension) {
+            if (!$extension instanceof Extension) {
+                continue;
+            }
+
+            $matchClasses = array_intersect($classes, $extension->getClassesToCompile());
+            if (!empty($matchClasses)) {
+                throw new \RuntimeException(sprintf(
+                    'The "%s" extension cannot add "%s" class%s to the class cache, because it is necessary to know the path to the original file.',
+                    $extension->getAlias(),
+                    implode('", "', $matchClasses),
+                    count($matchClasses) > 1 ? 'es' : ''
+                ));
+            }
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidatorsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddValidatorInitializersPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ClassesToCompilePass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TemplatingPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RoutingResolverPass;
@@ -81,6 +82,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new TranslationDumperPass());
         $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new SerializerPass());
+        $container->addCompilerPass(new ClassesToCompilePass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ClassesToCompilePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ClassesToCompilePassTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ClassesToCompilePass;
+
+class ClassesToCompilePassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The "foo" extension cannot add "Vendor\FooBundle\VendorFooBundle", "Symfony\Component\Form\FormInterface" classes to the class cache, because it is necessary to know the path to the original file.
+     */
+    public function testInvalidClasses()
+    {
+        $extension = $this->getMock('Symfony\Component\HttpKernel\DependencyInjection\Extension');
+        $extension->expects($this->once())->method('getClassesToCompile')->will($this->returnValue(array(
+            'Symfony\Component\Form\FormInterface',
+            'Vendor\FooBundle\VendorFooBundle',
+            'Vendor\FooBundle\Model\Model',
+        )));
+        $extension->expects($this->once())->method('getAlias')->will($this->returnValue('foo'));
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container->expects($this->once())->method('getParameter')->with('kernel.bundles')->will($this->returnValue(array(
+            'VendorFooBundle' => 'Vendor\FooBundle\VendorFooBundle',
+        )));
+        $container->expects($this->once())->method('getExtensions')->will($this->returnValue(array(
+            $this->getMock('Symfony\Component\DependencyInjection\Extension\ExtensionInterface'),
+                $extension,
+        )));
+
+        $pass = new ClassesToCompilePass();
+        $pass->process($container);
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\TwigBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
@@ -23,6 +24,16 @@ class ExtensionPass implements CompilerPassInterface
     {
         if ($container->has('form.extension')) {
             $container->getDefinition('twig.extension.form')->addTag('twig.extension');
+
+            foreach ($container->getExtensions() as $extension) {
+                if ($extension instanceof Extension && in_array('Symfony\Bridge\Twig\Extension\FormExtension', $extension->getClassesToCompile(), true)) {
+                    throw new \RuntimeException(sprintf(
+                        'The "%s" extension cannot add "Symfony\Bridge\Twig\Extension\FormExtension" class to the class cache, because it is necessary to know the path to the original file.',
+                        $extension->getAlias()
+                    ));
+                }
+            }
+
             $reflClass = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
             $container->getDefinition('twig.loader.filesystem')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
