### PR TITLE
[Debug] Fixed `ClassNotFoundFatalErrorHandler`

### DIFF
--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -122,7 +122,7 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
     private function findClassInPath($loader, $path, $class)
     {
         if (!$path = realpath($path)) {
-            continue;
+            return array();
         }
 
         $classes = array();


### PR DESCRIPTION
After running the test suite, this produced a Fatal Error. Having continue in a child method is not allowed.

| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | None |
| License | MIT |
| Doc PR | None |
