### PR TITLE
[FrameworkBundle] assets:install command should mirror .dotfiles (.htaccess)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -103,7 +103,7 @@ EOT
                 } else {
                     $filesystem->mkdir($targetDir, 0777);
                     // We use a custom iterator to ignore VCS files
-                    $filesystem->mirror($originDir, $targetDir, Finder::create()->in($originDir));
+                    $filesystem->mirror($originDir, $targetDir, Finder::create()->ignoreDotFiles(false)->in($originDir));
                 }
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The `assets:install` command currently ignores all _.dotfiles_ when mirroring the `Resources\public` folders of bundles. This can lead to issues when _.htaccess_ files are required for some public assets (ie.: CORS headers for font files to be served via Cloudfront).

Since the assets being installed are clearly in a folder called `public`, we can safely assume that those files are in fact supposed to be accessible and copy them over with the normal files.
