### PR TITLE
[Session] fixed wrong started states

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -180,7 +180,13 @@ class MockArraySessionStorage implements SessionStorageInterface
         $this->data = array();
 
         // reconnect the bags to the session
-        $this->loadSession();
+        $bags = array_merge($this->bags, array($this->metadataBag));
+
+        foreach ($bags as $bag) {
+            $key = $bag->getStorageKey();
+            $this->data[$key] = array();
+            $bag->initialize($this->data[$key]);
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -238,6 +238,7 @@ class NativeSessionStorage implements SessionStorageInterface
             $this->saveHandler->setActive(false);
         }
 
+        $this->started = false;
         $this->closed = true;
     }
 
@@ -255,7 +256,13 @@ class NativeSessionStorage implements SessionStorageInterface
         $_SESSION = array();
 
         // reconnect the bags to the session
-        $this->loadSession();
+        $bags = array_merge($this->bags, array($this->metadataBag));
+
+        foreach ($bags as $bag) {
+            $key = $bag->getStorageKey();
+            $_SESSION[$key] = array();
+            $bag->initialize($_SESSION[$key]);
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
@@ -64,6 +64,12 @@ class PhpBridgeSessionStorage extends NativeSessionStorage
         }
 
         // reconnect the bags to the session
-        $this->loadSession();
+        $bags = array_merge($this->bags, array($this->metadataBag));
+
+        foreach ($bags as $bag) {
+            $key = $bag->getStorageKey();
+            $_SESSION[$key] = isset($_SESSION[$key]) ? $_SESSION[$key] : array();
+            $bag->initialize($_SESSION[$key]);
+        }
     }
 }


### PR DESCRIPTION
Currently the `started` flag will not reached the `false` state after a session is closed (happens in `save()`). Also its wrong that the `clear()` method changes the `started` and `closed` state (happens in `loadSession()`. This PR will fix the problem and make it possible that the session works correctly after multiple requests on a long running php process.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
