### PR TITLE
[Session] fixed wrong started state

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -164,6 +164,7 @@ class MockArraySessionStorage implements SessionStorageInterface
         }
         // nothing to do since we don't persist the session data
         $this->closed = false;
+        $this->started = false;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -239,6 +239,7 @@ class NativeSessionStorage implements SessionStorageInterface
         }
 
         $this->closed = true;
+        $this->started = false;
     }
 
     /**


### PR DESCRIPTION
Currently the session stays in the started mode after the call of  `save()` which will close the session. We found the issue in our custom SAPI which keeps the symfony stack initialized over multiple requests.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
