### PR TITLE
Improved tests stability on travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ before_script:
     - export USE_INTL_ICU_DATA_VERSION=1
 
 script:
-    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || exit 1
-    - echo "Running tests requiring tty"; phpunit --group tty
+    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group noparallel,benchmark {};' || exit 1
+    - echo "Running non-parallel tests"; phpunit --group noparallel

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -88,7 +88,7 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group tty
+     * @group noparallel
      */
     public function testAskHiddenResponse()
     {

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -103,6 +103,8 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
      * tests results from sub processes
      *
      * @dataProvider pipesCodeProvider
+     *
+     * @group noparallel
      */
     public function testProcessPipes($code, $size)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (not on 2.2 with 5.3.3 due to a segmentation fault happening for other reasons) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Process pipe tests seem to be failing more often after we parallelised the build. It looks like sometimes there's an additional output generated (might be that other tests are interferring).

This PR makes sure that the problematic tests are run in a non-parallel mode. It also changes the "tty" group to "noparallel" to better reflect its intention.
