### PR TITLE
[HttpFoundation] fixed getClientIps() and getClientIp()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -733,42 +733,43 @@ class Request
      * Returns the client IP addresses.
      *
      * The least trusted IP address is first, and the most trusted one last.
-     * The "real" client IP address is the first one, but this is also the
-     * least trusted one.
+     * The "real" client IP address is the first one. The addresses of trusted
+     * proxies are not included.
      *
-     * Use this method carefully; you should use getClientIp() instead.
+     * Use this method carefully; you should probably use getClientIp() instead.
      *
-     * @return array The client IP addresses
+     * @return array A list of untrusted addresses, ordered from least to most trusted
      *
      * @see getClientIp()
      */
     public function getClientIps()
     {
-        $ip = $this->server->get('REMOTE_ADDR');
+        $mostTrusted = $this->server->get('REMOTE_ADDR');
 
-        if (!self::$trustedProxies) {
-            return array($ip);
+        // do not bother checking if...
+        //  * there are no trusted proxies configured
+        //  * there is no header configured
+        //  * there is no header present
+        if (!self::$trustedProxies || !self::$trustedHeaders[self::HEADER_CLIENT_IP] || !$this->headers->has(self::$trustedHeaders[self::HEADER_CLIENT_IP])) {
+            return array($mostTrusted);
         }
 
-        if (!self::$trustedHeaders[self::HEADER_CLIENT_IP] || !$this->headers->has(self::$trustedHeaders[self::HEADER_CLIENT_IP])) {
-            return array($ip);
-        }
-
+        // a list of addresses from least to most trusted
         $clientIps = array_map('trim', explode(',', $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_IP])));
-        $clientIps[] = $ip;
+        $clientIps[] = $mostTrusted;
 
-        $trustedProxies = !self::$trustedProxies ? array($ip) : self::$trustedProxies;
-        $ip = $clientIps[0];
+        // remember the least trusted
+        $leastTrusted = $clientIps[0];
 
+        // remove the addresses of any trusted proxies from the list
         foreach ($clientIps as $key => $clientIp) {
-            if (IpUtils::checkIp($clientIp, $trustedProxies)) {
+            if (IpUtils::checkIp($clientIp, self::$trustedProxies)) {
                 unset($clientIps[$key]);
-
-                continue;
             }
         }
 
-        return $clientIps ? array_reverse($clientIps) : array($ip);
+        // return a list of untrusted addresses, from least to most trusted
+        return array_values($clientIps) ?: array($leastTrusted);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -833,49 +833,155 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function testGetClientIpsProvider()
     {
-        //        $expected                   $remoteAddr                $httpForwardedFor            $trustedProxies
+        // $expected
+        // $remoteAddr
+        // $httpForwardedFor
+        // $trustedProxies
+
         return array(
             // simple IPv4
-            array(array('88.88.88.88'),              '88.88.88.88',              null,                        null),
+            array(
+                array('88.88.88.88'),
+                '88.88.88.88',
+                null,
+                null,
+            ),
+
             // trust the IPv4 remote addr
-            array(array('88.88.88.88'),              '88.88.88.88',              null,                        array('88.88.88.88')),
+            array(
+                array('88.88.88.88'),
+                '88.88.88.88',
+                null,
+                array('88.88.88.88'),
+            ),
 
             // simple IPv6
-            array(array('::1'),                      '::1',                      null,                        null),
+            array(
+                array('::1'),
+                '::1',
+                null,
+                null,
+            ),
+
             // trust the IPv6 remote addr
-            array(array('::1'),                      '::1',                      null,                        array('::1')),
+            array(
+                array('::1'),
+                '::1',
+                null,
+                array('::1'),
+            ),
 
             // forwarded for with remote IPv4 addr not trusted
-            array(array('127.0.0.1'),                '127.0.0.1',                '88.88.88.88',               null),
+            array(
+                array('127.0.0.1'),
+                '127.0.0.1',
+                '88.88.88.88',
+                null,
+            ),
+
             // forwarded for with remote IPv4 addr trusted
-            array(array('88.88.88.88'),              '127.0.0.1',                '88.88.88.88',               array('127.0.0.1')),
+            array(
+                array('88.88.88.88'),
+                '127.0.0.1',
+                '88.88.88.88',
+                array('127.0.0.1'),
+            ),
+
             // forwarded for with remote IPv4 and all FF addrs trusted
-            array(array('88.88.88.88'),              '127.0.0.1',                '88.88.88.88',               array('127.0.0.1', '88.88.88.88')),
+            array(
+                array('88.88.88.88'),
+                '127.0.0.1',
+                '88.88.88.88',
+                array('127.0.0.1', '88.88.88.88'),
+            ),
+
             // forwarded for with remote IPv4 range trusted
-            array(array('88.88.88.88'),              '123.45.67.89',             '88.88.88.88',               array('123.45.67.0/24')),
+            array(
+                array('88.88.88.88'),
+                '123.45.67.89',
+                '88.88.88.88',
+                array('123.45.67.0/24'),
+            ),
 
             // forwarded for with remote IPv6 addr not trusted
-            array(array('1620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3',  null),
+            array(
+                array('1620:0:1cfe:face:b00c::3'),
+                '1620:0:1cfe:face:b00c::3',
+                '2620:0:1cfe:face:b00c::3',
+                null,
+            ),
+
             // forwarded for with remote IPv6 addr trusted
-            array(array('2620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3',  array('1620:0:1cfe:face:b00c::3')),
+            array(
+                array('2620:0:1cfe:face:b00c::3'),
+                '1620:0:1cfe:face:b00c::3',
+                '2620:0:1cfe:face:b00c::3',
+                array('1620:0:1cfe:face:b00c::3'),
+            ),
+
             // forwarded for with remote IPv6 range trusted
-            array(array('88.88.88.88'),              '2a01:198:603:0:396e:4789:8e99:890f', '88.88.88.88',     array('2a01:198:603:0::/65')),
+            array(
+                array('88.88.88.88'),
+                '2a01:198:603:0:396e:4789:8e99:890f',
+                '88.88.88.88',
+                array('2a01:198:603:0::/65'),
+            ),
 
             // multiple forwarded for with remote IPv4 addr trusted
-            array(array('88.88.88.88', '87.65.43.21', '127.0.0.1'), '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89')),
+            array(
+                array('88.88.88.88', '87.65.43.21', '127.0.0.1'),
+                '123.45.67.89',
+                '127.0.0.1, 87.65.43.21, 88.88.88.88',
+                array('123.45.67.89'),
+            ),
+
             // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted
-            array(array('87.65.43.21', '127.0.0.1'), '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
+            array(
+                array('87.65.43.21', '127.0.0.1'),
+                '123.45.67.89',
+                '127.0.0.1, 87.65.43.21, 88.88.88.88',
+                array('123.45.67.89', '88.88.88.88'),
+            ),
+
             // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted but in the middle
-            array(array('88.88.88.88', '127.0.0.1'), '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '87.65.43.21')),
+            array(
+                array('88.88.88.88', '127.0.0.1'),
+                '123.45.67.89',
+                '127.0.0.1, 87.65.43.21, 88.88.88.88',
+                array('123.45.67.89', '87.65.43.21'),
+            ),
+
             // multiple forwarded for with remote IPv4 addr and all reverse proxies trusted
-            array(array('127.0.0.1'),                '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '87.65.43.21', '88.88.88.88', '127.0.0.1')),
+            array(
+                array('127.0.0.1'),
+                '123.45.67.89',
+                '127.0.0.1, 87.65.43.21, 88.88.88.88',
+                array('123.45.67.89', '87.65.43.21', '88.88.88.88', '127.0.0.1'),
+            ),
 
             // multiple forwarded for with remote IPv6 addr trusted
-            array(array('2620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3', array('1620:0:1cfe:face:b00c::3')),
+            array(
+                array('2620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3'),
+                '1620:0:1cfe:face:b00c::3',
+                '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3',
+                array('1620:0:1cfe:face:b00c::3'),
+            ),
+
             // multiple forwarded for with remote IPv6 addr and some reverse proxies trusted
-            array(array('3620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3', array('1620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3')),
+            array(
+                array('3620:0:1cfe:face:b00c::3'),
+                '1620:0:1cfe:face:b00c::3',
+                '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3',
+                array('1620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3'),
+            ),
+
             // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted but in the middle
-            array(array('2620:0:1cfe:face:b00c::3', '4620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '4620:0:1cfe:face:b00c::3,3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3', array('1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3')),
+            array(
+                array('2620:0:1cfe:face:b00c::3', '4620:0:1cfe:face:b00c::3'),
+                '1620:0:1cfe:face:b00c::3',
+                '4620:0:1cfe:face:b00c::3,3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3',
+                array('1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3'),
+            ),
         );
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -839,7 +839,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         // $trustedProxies
 
         return array(
-            // simple IPv4
+            // simple
             array(
                 array('88.88.88.88'),
                 '88.88.88.88',
@@ -847,7 +847,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 null,
             ),
 
-            // trust the IPv4 remote addr
+            // trust the remote addr
             array(
                 array('88.88.88.88'),
                 '88.88.88.88',
@@ -855,23 +855,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 array('88.88.88.88'),
             ),
 
-            // simple IPv6
-            array(
-                array('::1'),
-                '::1',
-                null,
-                null,
-            ),
-
-            // trust the IPv6 remote addr
-            array(
-                array('::1'),
-                '::1',
-                null,
-                array('::1'),
-            ),
-
-            // forwarded for with remote IPv4 addr not trusted
+            // forwarded for with remote addr not trusted
             array(
                 array('127.0.0.1'),
                 '127.0.0.1',
@@ -879,7 +863,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 null,
             ),
 
-            // forwarded for with remote IPv4 addr trusted
+            // forwarded for with remote addr trusted
             array(
                 array('88.88.88.88'),
                 '127.0.0.1',
@@ -887,7 +871,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 array('127.0.0.1'),
             ),
 
-            // forwarded for with remote IPv4 and all FF addrs trusted
+            // forwarded for with remote and all FF addrs trusted
             array(
                 array('88.88.88.88'),
                 '127.0.0.1',
@@ -895,7 +879,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 array('127.0.0.1', '88.88.88.88'),
             ),
 
-            // forwarded for with remote IPv4 range trusted
+            // forwarded for with remote range trusted
             array(
                 array('88.88.88.88'),
                 '123.45.67.89',
@@ -903,31 +887,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 array('123.45.67.0/24'),
             ),
 
-            // forwarded for with remote IPv6 addr not trusted
-            array(
-                array('1620:0:1cfe:face:b00c::3'),
-                '1620:0:1cfe:face:b00c::3',
-                '2620:0:1cfe:face:b00c::3',
-                null,
-            ),
-
-            // forwarded for with remote IPv6 addr trusted
-            array(
-                array('2620:0:1cfe:face:b00c::3'),
-                '1620:0:1cfe:face:b00c::3',
-                '2620:0:1cfe:face:b00c::3',
-                array('1620:0:1cfe:face:b00c::3'),
-            ),
-
-            // forwarded for with remote IPv6 range trusted
-            array(
-                array('88.88.88.88'),
-                '2a01:198:603:0:396e:4789:8e99:890f',
-                '88.88.88.88',
-                array('2a01:198:603:0::/65'),
-            ),
-
-            // multiple forwarded for with remote IPv4 addr trusted
+            // multiple forwarded for with remote addr trusted
             array(
                 array('88.88.88.88', '87.65.43.21', '127.0.0.1'),
                 '123.45.67.89',
@@ -935,7 +895,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 array('123.45.67.89'),
             ),
 
-            // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted
+            // multiple forwarded for with remote addr and some reverse proxies trusted
             array(
                 array('87.65.43.21', '127.0.0.1'),
                 '123.45.67.89',
@@ -943,7 +903,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 array('123.45.67.89', '88.88.88.88'),
             ),
 
-            // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted but in the middle
+            // multiple forwarded for with remote addr and some reverse proxies trusted but in the middle
             array(
                 array('88.88.88.88', '127.0.0.1'),
                 '123.45.67.89',
@@ -951,36 +911,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 array('123.45.67.89', '87.65.43.21'),
             ),
 
-            // multiple forwarded for with remote IPv4 addr and all reverse proxies trusted
+            // multiple forwarded for with remote addr and all reverse proxies trusted
             array(
                 array('127.0.0.1'),
                 '123.45.67.89',
                 '127.0.0.1, 87.65.43.21, 88.88.88.88',
                 array('123.45.67.89', '87.65.43.21', '88.88.88.88', '127.0.0.1'),
-            ),
-
-            // multiple forwarded for with remote IPv6 addr trusted
-            array(
-                array('2620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3'),
-                '1620:0:1cfe:face:b00c::3',
-                '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3',
-                array('1620:0:1cfe:face:b00c::3'),
-            ),
-
-            // multiple forwarded for with remote IPv6 addr and some reverse proxies trusted
-            array(
-                array('3620:0:1cfe:face:b00c::3'),
-                '1620:0:1cfe:face:b00c::3',
-                '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3',
-                array('1620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3'),
-            ),
-
-            // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted but in the middle
-            array(
-                array('2620:0:1cfe:face:b00c::3', '4620:0:1cfe:face:b00c::3'),
-                '1620:0:1cfe:face:b00c::3',
-                '4620:0:1cfe:face:b00c::3,3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3',
-                array('1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3'),
             ),
         );
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -836,90 +836,85 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         // in each case, 88.88.88.88 is our user's address
         $human = '88.88.88.88';
 
-        // $expected
-        // $remoteAddr
-        // $httpForwardedFor
-        // $trustedProxies
-
         return array(
             // simple
             array(
-                array($human),
-                $human,
-                null,
-                null,
+                'expected'        => array($human),
+                'remote_addr'     => $human,
+                'forwarded_for'   => null,
+                'trusted_proxies' => null,
             ),
 
             // trust the remote addr, no FF
             array(
-                array($human),
-                $human,
-                null,
-                array($human),
+                'expected'        => array($human),
+                'remote_addr'     => $human,
+                'forwarded_for'   => null,
+                'trusted_proxies' => array($human),
             ),
 
             // FF with proxy support disabled
             array(
-                array($human),
-                $human,
-                '127.0.0.1',
-                null,
+                'expected'        => array($human),
+                'remote_addr'     => $human,
+                'forwarded_for'   => '127.0.0.1',
+                'trusted_proxies' => null,
             ),
 
             // FF with remote addr trusted
             array(
-                array($human),
-                '127.0.0.1',
-                $human,
-                array('127.0.0.1'),
+                'expected'        => array($human),
+                'remote_addr'     => '127.0.0.1',
+                'forwarded_for'   => $human,
+                'trusted_proxies' => array('127.0.0.1'),
             ),
 
             // FF with remote and all FF addrs trusted
             array(
-                array($human),
-                '127.0.0.1',
-                $human,
-                array('127.0.0.1', $human),
+                'expected'        => array($human),
+                'remote_addr'     => '127.0.0.1',
+                'forwarded_for'   => $human,
+                'trusted_proxies' => array('127.0.0.1', $human),
             ),
 
             // FF with remote range trusted
             array(
-                array($human),
-                '123.45.67.89',
-                $human,
-                array("123.45.67.0/24"),
+                'expected'        => array($human),
+                'remote_addr'     => '123.45.67.89',
+                'forwarded_for'   => $human,
+                'trusted_proxies' => array("123.45.67.0/24"),
             ),
 
             // multiple FF with remote addr trusted
             array(
-                array($human, "87.65.43.21", '127.0.0.1'),
-                '123.45.67.89',
-                "$human, 87.65.43.21, 127.0.0.1",
-                array('123.45.67.89'),
+                'expected'        => array($human, "87.65.43.21", '127.0.0.1'),
+                'remote_addr'     => '123.45.67.89',
+                'forwarded_for'   => "$human, 87.65.43.21, 127.0.0.1",
+                'trusted_proxies' => array('123.45.67.89'),
             ),
 
             // multiple FF with remote addr and some reverse proxies trusted
             array(
-                array($human, '127.0.0.1'),
-                '123.45.67.89',
-                "$human, 127.0.0.1, 87.65.43.21",
-                array('123.45.67.89', '87.65.43.21'),
+                'expected'        => array($human, '127.0.0.1'),
+                'remote_addr'     => '123.45.67.89',
+                'forwarded_for'   => "$human, 127.0.0.1, 87.65.43.21",
+                'trusted_proxies' => array('123.45.67.89', '87.65.43.21'),
             ),
 
             // multiple FF with remote addr and some reverse proxies trusted but in the middle
             array(
-                array($human, '127.0.0.1'),
-                '123.45.67.89',
-                "$human, 127.0.0.1, 87.65.43.21",
-                array('123.45.67.89', "87.65.43.21"),
+                'expected'        => array($human, '127.0.0.1'),
+                'remote_addr'     => '123.45.67.89',
+                'forwarded_for'   => "$human, 127.0.0.1, 87.65.43.21",
+                'trusted_proxies' => array('123.45.67.89', "87.65.43.21"),
             ),
 
             // multiple FF with remote addr and all reverse proxies trusted
             array(
-                array($human),
-                '123.45.67.89',
-                "$human, 127.0.0.1, 87.65.43.21",
-                array('123.45.67.89', "87.65.43.21", $human, '127.0.0.1'),
+                'expected'        => array($human),
+                'remote_addr'     => '123.45.67.89',
+                'forwarded_for'   => "$human, 127.0.0.1, 87.65.43.21",
+                'trusted_proxies' => array('123.45.67.89', "87.65.43.21", $human, '127.0.0.1'),
             ),
         );
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -833,6 +833,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function testGetClientIpsProvider()
     {
+        // in each case, 88.88.88.88 is our user's address
+        $human = '88.88.88.88';
+
         // $expected
         // $remoteAddr
         // $httpForwardedFor
@@ -841,82 +844,82 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         return array(
             // simple
             array(
-                array('88.88.88.88'),
-                '88.88.88.88',
+                array($human),
+                $human,
                 null,
                 null,
             ),
 
-            // trust the remote addr
+            // trust the remote addr, no FF
             array(
-                array('88.88.88.88'),
-                '88.88.88.88',
+                array($human),
+                $human,
                 null,
-                array('88.88.88.88'),
+                array($human),
             ),
 
-            // forwarded for with remote addr not trusted
+            // FF with proxy support disabled
             array(
+                array($human),
+                $human,
+                '127.0.0.1',
+                null,
+            ),
+
+            // FF with remote addr trusted
+            array(
+                array($human),
+                '127.0.0.1',
+                $human,
                 array('127.0.0.1'),
-                '127.0.0.1',
-                '88.88.88.88',
-                null,
             ),
 
-            // forwarded for with remote addr trusted
+            // FF with remote and all FF addrs trusted
             array(
-                array('88.88.88.88'),
+                array($human),
                 '127.0.0.1',
-                '88.88.88.88',
-                array('127.0.0.1'),
+                $human,
+                array('127.0.0.1', $human),
             ),
 
-            // forwarded for with remote and all FF addrs trusted
+            // FF with remote range trusted
             array(
-                array('88.88.88.88'),
-                '127.0.0.1',
-                '88.88.88.88',
-                array('127.0.0.1', '88.88.88.88'),
-            ),
-
-            // forwarded for with remote range trusted
-            array(
-                array('88.88.88.88'),
+                array($human),
                 '123.45.67.89',
-                '88.88.88.88',
-                array('123.45.67.0/24'),
+                $human,
+                array("123.45.67.0/24"),
             ),
 
-            // multiple forwarded for with remote addr trusted
+            // multiple FF with remote addr trusted
             array(
-                array('88.88.88.88', '87.65.43.21', '127.0.0.1'),
+                array($human, "87.65.43.21", '127.0.0.1'),
                 '123.45.67.89',
-                '127.0.0.1, 87.65.43.21, 88.88.88.88',
+                "$human, 87.65.43.21, 127.0.0.1",
                 array('123.45.67.89'),
             ),
 
-            // multiple forwarded for with remote addr and some reverse proxies trusted
+            // multiple FF with remote addr and some reverse proxies trusted
             array(
-                array('87.65.43.21', '127.0.0.1'),
+                array($human, '127.0.0.1'),
                 '123.45.67.89',
-                '127.0.0.1, 87.65.43.21, 88.88.88.88',
-                array('123.45.67.89', '88.88.88.88'),
-            ),
-
-            // multiple forwarded for with remote addr and some reverse proxies trusted but in the middle
-            array(
-                array('88.88.88.88', '127.0.0.1'),
-                '123.45.67.89',
-                '127.0.0.1, 87.65.43.21, 88.88.88.88',
+                "$human, 127.0.0.1, 87.65.43.21",
                 array('123.45.67.89', '87.65.43.21'),
             ),
 
-            // multiple forwarded for with remote addr and all reverse proxies trusted
+            // multiple FF with remote addr and some reverse proxies trusted but in the middle
             array(
-                array('127.0.0.1'),
+                array($human, '127.0.0.1'),
                 '123.45.67.89',
-                '127.0.0.1, 87.65.43.21, 88.88.88.88',
-                array('123.45.67.89', '87.65.43.21', '88.88.88.88', '127.0.0.1'),
+                "$human, 127.0.0.1, 87.65.43.21",
+                array('123.45.67.89', "87.65.43.21"),
+            ),
+
+            // multiple FF with remote addr and all reverse proxies trusted
+            array(
+                array($human),
+                '123.45.67.89',
+                "$human, 127.0.0.1, 87.65.43.21",
+                array('123.45.67.89', "87.65.43.21", $human, '127.0.0.1'),
             ),
         );
     }


### PR DESCRIPTION
The order of IP addresses being returned by `getClientIps()` was incorrect. Consequently, the address returned by `getClientIp()` was incorrect.

The data provider for the tests was confusing and some of the expectations were incorrect, so I cleaned that up as well.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
