### PR TITLE
[Process][2.2] Fix 9182 : random failure on pipes tests

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -59,6 +59,7 @@ class Process
     private $incrementalErrorOutputOffset;
 
     private $useFileHandles = false;
+    /** @var ProcessPipes */
     private $processPipes;
 
     private static $sigchild;
@@ -304,30 +305,20 @@ class Process
         if (null !== $callback) {
             $this->callback = $this->buildCallback($callback);
         }
-        while ($this->processInformation['running']) {
+        
+        do {
             $this->checkTimeout();
-            $this->updateStatus(true);
+            $running = defined('PHP_WINDOWS_VERSION_BUILD') ? $this->isRunning() : $this->processPipes->hasOpenHandles();
+            $close = !defined('PHP_WINDOWS_VERSION_BUILD') || !$running;;
+            $this->readPipes(true, $close);
+        } while ($running);
+        
+        while ($this->isRunning()) {
+            usleep(1000);
         }
-        $this->updateStatus(false);
 
-        // Unix pipes must be closed before calling proc_close to void deadlock
-        // see manual http://php.net/manual/en/function.proc-close.php
-        $this->processPipes->closeUnixPipes();
-        $exitcode = proc_close($this->process);
-
-        // Windows only : when using file handles, some activity may occur after
-        // calling proc_close
-        while($this->processPipes->hasOpenHandles()) {
-            usleep(100);
-            foreach ($this->processPipes->readAndCloseHandles(true) as $type => $data) {
-                if (3 == $type) {
-                    $this->fallbackExitcode = (int) $data;
-                } else {
-                    call_user_func($this->callback, $type === self::STDOUT ? self::OUT : self::ERR, $data);
-                }
-            }
-        }
         $this->processPipes->close();
+        $exitcode = proc_close($this->process);
 
         if ($this->processInformation['signaled']) {
             if ($this->isSigchildEnabled()) {
@@ -355,7 +346,7 @@ class Process
      */
     public function getOutput()
     {
-        $this->readPipes(false);
+        $this->readPipes(false, defined('PHP_WINDOWS_VERSION_BUILD') ? !$this->processInformation['running'] : true);
 
         return $this->stdout;
     }
@@ -387,7 +378,7 @@ class Process
      */
     public function getErrorOutput()
     {
-        $this->readPipes(false);
+        $this->readPipes(false, defined('PHP_WINDOWS_VERSION_BUILD') ? !$this->processInformation['running'] : true);
 
         return $this->stderr;
     }
@@ -932,9 +923,9 @@ class Process
             return;
         }
 
-        $this->readPipes($blocking);
-
         $this->processInformation = proc_get_status($this->process);
+        $this->readPipes($blocking, defined('PHP_WINDOWS_VERSION_BUILD') ? !$this->processInformation['running'] : true);
+
         if (!$this->processInformation['running']) {
             $this->status = self::STATUS_TERMINATED;
             if (-1 !== $this->processInformation['exitcode']) {
@@ -965,9 +956,15 @@ class Process
      *
      * @param Boolean $blocking Whether to use blocking calls or not.
      */
-    private function readPipes($blocking)
+    private function readPipes($blocking, $close)
     {
-        foreach ($this->processPipes->read($blocking) as $type => $data) {
+        if ($close) {
+            $result = $this->processPipes->readAndCloseHandles($blocking);
+        } else {
+            $result = $this->processPipes->read($blocking);
+        }
+        
+        foreach ($result as $type => $data) {
             if (3 == $type) {
                 $this->fallbackExitcode = (int) $data;
             } else {

--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -222,6 +222,7 @@ class ProcessPipes
                 continue;
             }
             $data = '';
+            $dataread = null;
             while (!feof($fileHandle)) {
                 if (false !== $dataread = fread($fileHandle, 16392)) {
                     $data .= $dataread;
@@ -232,7 +233,7 @@ class ProcessPipes
                 $read[$type] = $data;
             }
 
-            if (true === $close && feof($fileHandle)) {
+            if (false === $dataread || (true === $close && feof($fileHandle) && '' === $data)) {
                 fclose($this->fileHandles[$type]);
                 unset($this->fileHandles[$type]);
             }
@@ -280,7 +281,7 @@ class ProcessPipes
                 $read[$type] = $data;
             }
 
-            if (true === $close && feof($pipe)) {
+            if (false === $data || (true === $close && feof($pipe) && '' === $data)) {
                 fclose($this->pipes[$type]);
                 unset($this->pipes[$type]);
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9182 |
| License | MIT |

I'm not a big fan of this fix, but - at least - it works.

With this code, finally, Process does not behave the same at all on Windows and Linux.
This patch does not smells very good but it solves the random failing test issue (that produced at runtime too).

Actually, calling `proc_get_status` within the waiting loop introduced the bug. 
So this PR reverts to the previous behavior (consider a process running as long as pipes give data). On Windows, this is not the same behavior as we're not using streams but file handles. Whereas the feof of a stream is detected when the other side closes, the feof of a file handle can be reached at any time. So, on Windows, `proc_get_status` is called (checking the feof of the file handle might be positive until the executable outputs something), and we consider a process running as long as the information returned says it's running.

We could think of decouple windows and linux logic in two separated objects, using the interfaces I introduced in #8753. This could bring much more readability and make the code more easy to understand.
