### PR TITLE
[HttpKernel] Fixed a test (compiler pass class name has been changed)

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\DependencyInjection\RegisterListenersPass;
 
 class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
@@ -127,7 +126,7 @@ class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
         $container->register('foo', 'stdClass')->setAbstract(true)->addTag('kernel.event_listener', array());
         $container->register('event_dispatcher', 'stdClass');
 
-        $registerListenersPass = new RegisterKernelListenersPass();
+        $registerListenersPass = new RegisterListenersPass();
         $registerListenersPass->process($container);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes, if #9259 also gets merged |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

**I've sent it against wrong branch. It should be merged in 2.3. Sorry.**
