### PR TITLE
[HelpCommand] reset command definition if instance of self

### DIFF
--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\Console\Command;
 
-use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * HelpCommand displays the help for a given command.
@@ -42,9 +42,9 @@ The <info>%command.name%</info> command displays help for a given command:
 
   <info>php %command.full_name% list</info>
 
-You can also output the help in other formats by using the <comment>--format</comment> option:
+You can also output the help as XML by using the <comment>--xml</comment> option:
 
-  <info>php %command.full_name% --format=xml list</info>
+  <info>php %command.full_name% --xml list</info>
 
 To display the list of available commands, please use the <info>list</info> command.
 EOF
@@ -76,21 +76,19 @@ EOF
         }
 
         if ($input->getOption('xml')) {
-            $input->setOption('format', 'xml');
+            $output->writeln($this->command->asXml(), OutputInterface::OUTPUT_RAW);
+        } else {
+            $output->writeln($this->command->asText());
         }
 
-        $helper = new DescriptorHelper();
-        $helper->describe($output, $this->command, $input->getOption('format'), $input->getOption('raw'));
         $this->command = null;
     }
-    
+
     private function getInputDefinition()
     {
         return array(
             new InputArgument('command_name', InputArgument::OPTIONAL, 'The command name', 'help'),
             new InputOption('xml', null, InputOption::VALUE_NONE, 'To output help as XML'),
-            new InputOption('format', null, InputOption::VALUE_REQUIRED, 'To output help in other formats'),
-            new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw command help'),
         );
     }
 }

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -74,6 +74,10 @@ EOF
             $this->command = $this->getApplication()->find($input->getArgument('command_name'));
         }
 
+        if ($this->command instanceof self) {
+            $this->command->configure();
+        }
+
         if ($input->getOption('xml')) {
             $output->writeln($this->command->asXml(), OutputInterface::OUTPUT_RAW);
         } else {

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\Console\Command;
 
+use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Command\Command;
 
 /**
  * HelpCommand displays the help for a given command.
@@ -35,19 +35,16 @@ class HelpCommand extends Command
 
         $this
             ->setName('help')
-            ->setDefinition(array(
-                new InputArgument('command_name', InputArgument::OPTIONAL, 'The command name', 'help'),
-                new InputOption('xml', null, InputOption::VALUE_NONE, 'To output help as XML'),
-            ))
+            ->setDefinition($this->getInputDefinition())
             ->setDescription('Displays help for a command')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command displays help for a given command:
 
   <info>php %command.full_name% list</info>
 
-You can also output the help as XML by using the <comment>--xml</comment> option:
+You can also output the help in other formats by using the <comment>--format</comment> option:
 
-  <info>php %command.full_name% --xml list</info>
+  <info>php %command.full_name% --format=xml list</info>
 
 To display the list of available commands, please use the <info>list</info> command.
 EOF
@@ -75,15 +72,25 @@ EOF
         }
 
         if ($this->command instanceof self) {
-            $this->command->configure();
+            $this->command->setDefinition($this->getInputDefinition());
         }
 
         if ($input->getOption('xml')) {
-            $output->writeln($this->command->asXml(), OutputInterface::OUTPUT_RAW);
-        } else {
-            $output->writeln($this->command->asText());
+            $input->setOption('format', 'xml');
         }
 
+        $helper = new DescriptorHelper();
+        $helper->describe($output, $this->command, $input->getOption('format'), $input->getOption('raw'));
         $this->command = null;
+    }
+    
+    private function getInputDefinition()
+    {
+        return array(
+            new InputArgument('command_name', InputArgument::OPTIONAL, 'The command name', 'help'),
+            new InputOption('xml', null, InputOption::VALUE_NONE, 'To output help as XML'),
+            new InputOption('format', null, InputOption::VALUE_REQUIRED, 'To output help in other formats'),
+            new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw command help'),
+        );
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -2,7 +2,6 @@ Usage:
  help [--xml] [command_name]
 
 Arguments:
- command               The command to execute
  command_name          The command name (default: "help")
 
 Options:


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes 
Todo: squash if accepted
License of the code: MIT

When running `php app/console help`, it displays an extra `command` argument at the beginning.

It's because application definition is getting merged into help command (when running it the first time), then, when help command is retrieving "help", application returns the same object (with this extra argument).

Resetting command configuration in that special case removes the extra arg.
