### PR TITLE
[Console] make InputArgument::setDefault() chainable

### DIFF
--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -108,6 +108,7 @@ class InputArgument
         }
 
         $this->default = $default;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | maybe |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

To allow chaining of methods, setDefault should return the InputArgument. I'm not quite sure if you would tread this as a BC break?

best regards
Philipp
