### PR TITLE
[Templating] Fix in ChainLoader.php

### DIFF
--- a/src/Symfony/Component/Templating/Loader/ChainLoader.php
+++ b/src/Symfony/Component/Templating/Loader/ChainLoader.php
@@ -75,7 +75,7 @@ class ChainLoader extends Loader
     public function isFresh(TemplateReferenceInterface $template, $time)
     {
         foreach ($this->loaders as $loader) {
-            return $loader->isFresh($template);
+            return $loader->isFresh($template, $time);
         }
 
         return false;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The LoaderInterface requires the _time_ parameter to be passed.
