### PR TITLE
[Yaml] Fixed the escaping of strings starting with a dash when dumping

### DIFF
--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -71,7 +71,7 @@ class Escaper
      */
     public static function requiresSingleQuoting($value)
     {
-        return preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ - ? | < > = ! % @ ` ]/x', $value);
+        return preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ \- ? | < > = ! % @ ` ]/x', $value);
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Yaml\Tests;
 
-use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Inline;
 
 class InlineTest extends \PHPUnit_Framework_TestCase
@@ -31,11 +30,11 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($yaml, Inline::dump($value), sprintf('::dump() converts a PHP structure to an inline YAML (%s)', $yaml));
         }
 
-        foreach ($this->getTestsForParse() as $yaml => $value) {
+        foreach ($this->getTestsForParse() as $value) {
             $this->assertEquals($value, Inline::parse(Inline::dump($value)), 'check consistency');
         }
 
-        foreach ($testsForDump as $yaml => $value) {
+        foreach ($testsForDump as $value) {
             $this->assertEquals($value, Inline::parse(Inline::dump($value)), 'check consistency');
         }
     }
@@ -204,6 +203,9 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             "'#cfcfcf'" => '#cfcfcf',
 
             "'a \"string\" with ''quoted strings inside'''" => 'a "string" with \'quoted strings inside\'',
+
+            "'-dash'" => '-dash',
+            "'-'" => '-',
 
             // sequences
             '[foo, bar, false, null, 12]' => array('foo', 'bar', false, null, 12),


### PR DESCRIPTION
Dashes need to be escaped in character sets in regexes as they are used to specify a range otherwise.
It fixes the dumper bug reported in #9039 (the parsing issue is not fix here)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | partially #9039 |
| License | MIT |
| Doc PR | n/a |
