### PR TITLE
[SecurityBundle] Fix options & providerKey not passed to custom success_handler & failure_handler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -169,13 +169,11 @@ abstract class AbstractFactory implements SecurityFactoryInterface
 
     protected function createAuthenticationSuccessHandler($container, $id, $config)
     {
-        if (isset($config['success_handler'])) {
-            return $config['success_handler'];
-        }
+        $handlerName = isset($config['success_handler']) ? $config['success_handler'] : 'security.authentication.success_handler';
 
         $successHandlerId = 'security.authentication.success_handler.'.$id.'.'.str_replace('-', '_', $this->getKey());
 
-        $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator('security.authentication.success_handler'));
+        $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator($handlerName));
         $successHandler->replaceArgument(1, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
         $successHandler->addMethodCall('setProviderKey', array($id));
 
@@ -184,13 +182,11 @@ abstract class AbstractFactory implements SecurityFactoryInterface
 
     protected function createAuthenticationFailureHandler($container, $id, $config)
     {
-        if (isset($config['failure_handler'])) {
-            return $config['failure_handler'];
-        }
+        $handlerName = isset($config['failure_handler']) ? $config['failure_handler'] : 'security.authentication.failure_handler';
 
         $id = 'security.authentication.failure_handler.'.$id.'.'.str_replace('-', '_', $this->getKey());
 
-        $failureHandler = $container->setDefinition($id, new DefinitionDecorator('security.authentication.failure_handler'));
+        $failureHandler = $container->setDefinition($id, new DefinitionDecorator($handlerName));
         $failureHandler->replaceArgument(2, array_intersect_key($config, $this->defaultFailureHandlerOptions));
 
         return $id;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -146,7 +146,14 @@ abstract class AbstractToken implements TokenInterface
      */
     public function serialize()
     {
-        return serialize(array($this->user, $this->authenticated, $this->roles, $this->attributes));
+        return serialize(
+            array(
+                is_object($this->user) ? clone $this->user : $this->user,
+                $this->authenticated,
+                $this->roles,
+                $this->attributes
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | Don't know |
| Fixed tickets | #9272 |
| License | MIT |

Allow options & providerKey from firewall configuration to be passed to custom handlers.
