### PR TITLE
allow to create an empty BinaryFileResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -46,7 +46,9 @@ class BinaryFileResponse extends Response
     {
         parent::__construct(null, $status, $headers);
 
-        $this->setFile($file, $contentDisposition, $autoEtag, $autoLastModified);
+        if (null !== $file) {
+            $this->setFile($file, $contentDisposition, $autoEtag, $autoLastModified);
+        }
 
         if ($public) {
             $this->setPublic();

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -47,6 +47,12 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertFalse($response->getContent());
     }
 
+    public function testCreateWithEmptyFile()
+    {
+        $response = BinaryFileResponse::create();
+        $this->assertNull($response->getFile());
+    }
+
     /**
      * @dataProvider provideRanges
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The static `create()` method allows for calls without any parameters. These calls lead to a `FileNotFoundException` stating that `The file "" does not exist`.
