### PR TITLE
[HttpFoundation] Docblock fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -35,12 +35,12 @@ class BinaryFileResponse extends Response
      * Constructor.
      *
      * @param \SplFileInfo|string $file               The file to stream
-     * @param integer            $status             The response status code
-     * @param array              $headers            An array of response headers
-     * @param boolean            $public             Files are public by default
-     * @param null|string        $contentDisposition The type of Content-Disposition to set automatically with the filename
-     * @param boolean            $autoEtag           Whether the ETag header should be automatically set
-     * @param boolean            $autoLastModified   Whether the Last-Modified header should be automatically set
+     * @param integer             $status             The response status code
+     * @param array               $headers            An array of response headers
+     * @param boolean             $public             Files are public by default
+     * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
+     * @param boolean             $autoEtag           Whether the ETag header should be automatically set
+     * @param boolean             $autoLastModified   Whether the Last-Modified header should be automatically set
      */
     public function __construct($file, $status = 200, $headers = array(), $public = true, $contentDisposition = null, $autoEtag = false, $autoLastModified = true)
     {
@@ -54,7 +54,13 @@ class BinaryFileResponse extends Response
     }
 
     /**
-     * {@inheritdoc}
+     * @param \SplFileInfo|string $file               The file to stream
+     * @param integer             $status             The response status code
+     * @param array               $headers            An array of response headers
+     * @param boolean             $public             Files are public by default
+     * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
+     * @param boolean             $autoEtag           Whether the ETag header should be automatically set
+     * @param boolean             $autoLastModified   Whether the Last-Modified header should be automatically set
      */
     public static function create($file = null, $status = 200, $headers = array(), $public = true, $contentDisposition = null, $autoEtag = false, $autoLastModified = true)
     {
@@ -65,9 +71,9 @@ class BinaryFileResponse extends Response
      * Sets the file to stream.
      *
      * @param \SplFileInfo|string $file The file to stream
-     * @param string             $contentDisposition
-     * @param Boolean            $autoEtag
-     * @param Boolean            $autoLastModified
+     * @param string              $contentDisposition
+     * @param Boolean             $autoEtag
+     * @param Boolean             $autoLastModified
      *
      * @return BinaryFileResponse
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

`BinaryFileResponse::create()` has a different signature than `Response::create()` and cannot inherit its doc. I also fixed indentation in other blocks in this file.
