### PR TITLE
[DoctrineBridge] Loosened CollectionToArrayTransformer::transform() to accept arrays

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
@@ -36,6 +36,12 @@ class CollectionToArrayTransformer implements DataTransformerInterface
             return array();
         }
 
+        // For cases when the collection getter returns $collection->toArray()
+        // in order to prevent modifications of the returned collection
+        if (is_array($collection)) {
+            return $collection;
+        }
+
         if (!$collection instanceof Collection) {
             throw new TransformationFailedException('Expected a Doctrine\Common\Collections\Collection object.');
         }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Form\DataTransformer;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Bridge\Doctrine\Form\DataTransformer\CollectionToArrayTransformer;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class CollectionToArrayTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CollectionToArrayTransformer
+     */
+    private $transformer;
+
+    protected function setUp()
+    {
+        $this->transformer = new CollectionToArrayTransformer();
+    }
+
+    public function testTransform()
+    {
+        $array = array(
+            2 => 'foo',
+            3 => 'bar',
+        );
+
+        $this->assertSame($array, $this->transformer->transform(new ArrayCollection($array)));
+    }
+
+    /**
+     * This test is needed for cases when getXxxs() in the entity returns the
+     * result of $collection->toArray(), in order to prevent modifications of
+     * the inner collection.
+     *
+     * See https://github.com/symfony/symfony/pull/9308
+     */
+    public function testTransformArray()
+    {
+        $array = array(
+            2 => 'foo',
+            3 => 'bar',
+        );
+
+        $this->assertSame($array, $this->transformer->transform($array));
+    }
+
+    public function testTransformNull()
+    {
+        $this->assertSame(array(), $this->transformer->transform(null));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testTransformExpectsArrayOrCollection()
+    {
+        $this->transformer->transform('Foo');
+    }
+
+    public function testReverseTransform()
+    {
+        $array = array(
+            2 => 'foo',
+            3 => 'bar',
+        );
+
+        $this->assertEquals(new ArrayCollection($array), $this->transformer->reverseTransform($array));
+    }
+
+    public function testReverseTransformEmpty()
+    {
+        $this->assertEquals(new ArrayCollection(), $this->transformer->reverseTransform(''));
+    }
+
+    public function testReverseTransformNull()
+    {
+        $this->assertEquals(new ArrayCollection(), $this->transformer->reverseTransform(null));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Previously, writing an association getter like this was impossible:

``` php
public function addTag(Tag $tag) { ... }
public function removeTag(Tag $tag) { ... }

public function getTags()
{
    return $this->tags->toArray();
}
```

Using `toArray()` is a useful way to restrict modifications of the collection to the specified methods. But previously, CollectionToArrayTransformer failed in this case, because it did not accept arrays as input.
