### PR TITLE
[Form] Fix DateType for 32bits computers.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -300,7 +300,7 @@ class DateType extends AbstractType
         $result = array();
 
         foreach ($years as $year) {
-            if(($y = gmmktime(0, 0, 0, 6, 15, $year)) !== false) {
+            if(false !== $y = gmmktime(0, 0, 0, 6, 15, $year)) {
                 $result[$year] = $y;
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -300,7 +300,7 @@ class DateType extends AbstractType
         $result = array();
 
         foreach ($years as $year) {
-            if(false !== $y = gmmktime(0, 0, 0, 6, 15, $year)) {
+            if (false !== $y = gmmktime(0, 0, 0, 6, 15, $year)) {
                 $result[$year] = $y;
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -300,7 +300,9 @@ class DateType extends AbstractType
         $result = array();
 
         foreach ($years as $year) {
-            $result[$year] = gmmktime(0, 0, 0, 6, 15, $year);
+            if(($y = gmmktime(0, 0, 0, 6, 15, $year)) !== false) {
+                $result[$year] = $y;
+            }
         }
 
         return $result;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -774,4 +774,25 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertSame(array(), $form['day']->getErrors());
         $this->assertSame(array($error), $form->getErrors());
     }
+    
+    public function testYearsFor32BitsMachines()
+    {
+        if (4 !== PHP_INT_SIZE) {
+            $testCase->markTestSkipped(
+                'PHP must be compiled in 32 bit mode to run this test');
+        }
+        
+        $form = $this->factory->create('date', null, array(
+            'years' => range(1900, 2040),
+        ));
+
+        $view = $form->createView();
+
+        $listChoices = array();
+        foreach(range(1902, 2037) as $y) {
+            $listChoices[] = new ChoiceView($y, $y, $y);
+        }
+        
+        $this->assertEquals($listChoices, $view['year']->vars['choices']);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -778,7 +778,7 @@ class DateTypeTest extends LocalizedTestCase
     public function testYearsFor32BitsMachines()
     {
         if (4 !== PHP_INT_SIZE) {
-            $testCase->markTestSkipped(
+            $this->markTestSkipped(
                 'PHP must be compiled in 32 bit mode to run this test');
         }
         


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5227,#5554 |
| License | MIT |
| Doc PR | - |

Fix an issue due to 32bits machines, date can be only between 1902-2037.
Simply not add date if false. Can be good to add this to 2.3 and master too.
