### PR TITLE
[WebProfilerBundle] Fixed invalid condition in form panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -175,7 +175,7 @@
     <li>
         <a href="#details_{{ data.view_vars.id|default("") }}">{{ name }}</a>
 
-        {% if data.children|length > 1 %}
+        {% if data.children is not empty %}
             <ul>
                 {% for childName, childData in data.children %}
                     {{ _self.form_tree_entry(childName, childData) }}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Before, the children of a form with just one child were not shown. This is fixed now.
