### PR TITLE
[DomCrawler]fix #9321 Crawler::addHtmlContent add gbk encoding support

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -144,15 +144,15 @@ class Crawler extends \SplObjectStorage
         $dom->validateOnParse = true;
 
         if (function_exists('mb_convert_encoding')) {
-            $has_error = false;
-            $previous = set_error_handler(function()use(&$has_error){
-                $has_error = true;
+            $hasError = false;
+            set_error_handler(function()use(&$hasError){
+                $hasError = true;
             });
             $tmpContent = @mb_convert_encoding($content, 'HTML-ENTITIES', $charset);
 
-            set_error_handler($previous);
+            restore_error_handler();
 
-            if (!$has_error) {
+            if (!$hasError) {
                 $content = $tmpContent;
             }
         }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -145,7 +145,7 @@ class Crawler extends \SplObjectStorage
 
         if (function_exists('mb_convert_encoding')) {
             $hasError = false;
-            set_error_handler(function()use(&$hasError){
+            set_error_handler(function () use (&$hasError) {
                 $hasError = true;
             });
             $tmpContent = @mb_convert_encoding($content, 'HTML-ENTITIES', $charset);

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -143,8 +143,18 @@ class Crawler extends \SplObjectStorage
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
 
-        if (function_exists('mb_convert_encoding') && in_array(strtolower($charset), array_map('strtolower', mb_list_encodings()))) {
-            $content = mb_convert_encoding($content, 'HTML-ENTITIES', $charset);
+        if (function_exists('mb_convert_encoding')) {
+            $has_error = false;
+            $previous = set_error_handler(function()use(&$has_error){
+                $has_error = true;
+            });
+            $tmpContent = @mb_convert_encoding($content, 'HTML-ENTITIES', $charset);
+
+            set_error_handler($previous);
+
+            if (!$has_error) {
+                $content = $tmpContent;
+            }
         }
 
         @$dom->loadHTML($content);

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -106,6 +106,18 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
      */
+    public function testAddHtmlContentCharsetGbk()
+    {
+        $crawler = new Crawler();
+        //gbk encode of <html><p>中文</p></html>
+        $crawler->addHtmlContent(base64_decode('PGh0bWw+PHA+1tDOxDwvcD48L2h0bWw+'), 'gbk');
+
+        $this->assertEquals('中文', $crawler->filterXPath('//p')->text());
+    }
+
+    /**
+     * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
+     */
     public function testAddHtmlContentWithErrors()
     {
         libxml_use_internal_errors(true);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9321 |
| License | MIT |
| Doc PR | n/a |

This is solution 1 in https://github.com/symfony/symfony/issues/9321#issuecomment-26508649
