### PR TITLE
[2.2][Form] Changed FormTypeCsrfExtension to use the form's name as default intention

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -49,7 +49,11 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
 
         $builder
             ->setAttribute('csrf_factory', $builder->getFormFactory())
-            ->addEventSubscriber(new CsrfValidationListener($options['csrf_field_name'], $options['csrf_provider'], $options['intention']))
+            ->addEventSubscriber(new CsrfValidationListener(
+                $options['csrf_field_name'],
+                $options['csrf_provider'],
+                $options['intention'] ?: $builder->getName()
+            ))
         ;
     }
 
@@ -64,7 +68,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
     {
         if ($options['csrf_protection'] && !$view->parent && $options['compound']) {
             $factory = $form->getConfig()->getAttribute('csrf_factory');
-            $data = $options['csrf_provider']->generateCsrfToken($options['intention']);
+            $data = $options['csrf_provider']->generateCsrfToken($options['intention'] ?: $form->getName());
 
             $csrfForm = $factory->createNamed($options['csrf_field_name'], 'hidden', $data, array(
                 'mapped' => false,
@@ -83,7 +87,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             'csrf_protection'   => $this->defaultEnabled,
             'csrf_field_name'   => $this->defaultFieldName,
             'csrf_provider'     => $this->defaultCsrfProvider,
-            'intention'         => 'unknown',
+            'intention'         => null,
         ));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Before, every form used the same "intention"/"csrf_token_id" value by default, namely "unknown". This PR fixes the default value to the form's name, which is at least different for forms with (a) explicit names and (b) different types, where the implicit name equals the type's name.
