### PR TITLE
[2.2][Form] Improved FormTypeCsrfExtension to use the type class as default intention if the form name is empty

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -52,7 +52,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             ->addEventSubscriber(new CsrfValidationListener(
                 $options['csrf_field_name'],
                 $options['csrf_provider'],
-                $options['intention'] ?: $builder->getName()
+                $options['intention'] ?: ($builder->getName() ?: get_class($builder->getType()->getInnerType()))
             ))
         ;
     }
@@ -68,7 +68,8 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
     {
         if ($options['csrf_protection'] && !$view->parent && $options['compound']) {
             $factory = $form->getConfig()->getAttribute('csrf_factory');
-            $data = $options['csrf_provider']->generateCsrfToken($options['intention'] ?: $form->getName());
+            $intention = $options['intention'] ?: ($form->getName() ?: get_class($form->getConfig()->getType()->getInnerType()));
+            $data = $options['csrf_provider']->generateCsrfToken($intention);
 
             $csrfForm = $factory->createNamed($options['csrf_field_name'], 'hidden', $data, array(
                 'mapped' => false,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

ping @stof

follow-up PR to #9327
