### PR TITLE
Add X-Debug-Url profiler url header

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * WebDebugToolbarListener injects the Web Debug Toolbar.
@@ -33,13 +34,15 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     const ENABLED  = 2;
 
     protected $twig;
+    protected $urlGenerator;
     protected $interceptRedirects;
     protected $mode;
     protected $position;
 
-    public function __construct(\Twig_Environment $twig, $interceptRedirects = false, $mode = self::ENABLED, $position = 'bottom')
+    public function __construct(\Twig_Environment $twig, $interceptRedirects = false, $mode = self::ENABLED, $position = 'bottom', UrlGeneratorInterface $urlGenerator = null)
     {
         $this->twig = $twig;
+        $this->urlGenerator = $urlGenerator;
         $this->interceptRedirects = (Boolean) $interceptRedirects;
         $this->mode = (integer) $mode;
         $this->position = $position;
@@ -52,12 +55,19 @@ class WebDebugToolbarListener implements EventSubscriberInterface
 
     public function onKernelResponse(FilterResponseEvent $event)
     {
+        $response = $event->getResponse();
+        $request = $event->getRequest();
+
+        if ($response->headers->has('X-Debug-Token') && null !== $this->urlGenerator) {
+            $response->headers->set(
+                'X-Debug-Token-Link',
+                $this->urlGenerator->generate('_profiler', array('token' => $response->headers->get('X-Debug-Token')))
+            );
+        }
+
         if (!$event->isMasterRequest()) {
             return;
         }
-
-        $response = $event->getResponse();
-        $request = $event->getRequest();
 
         // do not capture redirects or modify XML HTTP Requests
         if ($request->isXmlHttpRequest()) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
@@ -15,6 +15,7 @@
             <argument>%web_profiler.debug_toolbar.intercept_redirects%</argument>
             <argument>%web_profiler.debug_toolbar.mode%</argument>
             <argument>%web_profiler.debug_toolbar.position%</argument>
+            <argument type="service" id="router" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | None |

Hey, working with rest APIs I find it way more convenient to have the profiler url directly in the header ... We human are used to deal with hypermedia!
A little bit of hateoas in symfony :)
