### PR TITLE
[DependencyInjection] Non-default XML namespaces not supported

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/namespaces.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/namespaces.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+    <srv:services>
+        <srv:service id="foo" class="FooClass">
+            <srv:tag name="foo.tag" />
+            <srv:call method="setBar">
+                <srv:argument>foo</srv:argument>
+            </srv:call>
+        </srv:service>
+    </srv:services>
+</srv:container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -405,4 +405,16 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
             $this->assertSame('Document types are not allowed.', $e->getMessage(), '->load() throws an InvalidArgumentException if the configuration contains a document type');
         }
     }
+
+    public function testXmlNamespaces()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('namespaces.xml');
+        $services = $container->getDefinitions();
+
+        $this->assertTrue(isset($services['foo']), '->load() parses <srv:service> elements');
+        $this->assertEquals(1, count($services['foo']->getTag('foo.tag')), '->load parses <srv:tag> elements');
+        $this->assertEquals(array(array('setBar', array('foo'))), $services['foo']->getMethodCalls(), '->load() parses the <srv:call> tag');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The DIC is not able to parse XML configs where the container configuration is not the default namespaces. Such configurations are used for example, in the [DoctrineBundle test suite](https://github.com/doctrine/DoctrineBundle/tree/master/Tests/DependencyInjection/Fixtures/config/xml).

This PR adds a failing unittest for that case.

I have tried to fix the issue as well, but I didn't find a good way of fixing it without rewriting the entire XmlFileLoader using DOM instead of SimpleXML. Hence I am just submitting the test case, in the hope that someone smarter than me can fix this issue.
