### PR TITLE
[WebProfilerBundle] Small bugfix in CSS: don't make links bold. 

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -366,3 +366,11 @@
         display: none;
     }
 }
+
+/***** Media query print: Do not print the Toolbar. *****/
+@media print {
+    .sf-toolbar {
+        display: none;
+        visibility: hidden;
+    }
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -196,6 +196,10 @@
     color: black !important;
 }
 
+.sf-toolbar-block .sf-toolbar-icon > a[href]:after {
+    content: "";
+}
+
 .sf-toolbar-block .sf-toolbar-icon img {
     border-width: 0;
     vertical-align: middle;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -181,6 +181,7 @@
 .sf-toolbar-block .sf-toolbar-icon > a,
 .sf-toolbar-block .sf-toolbar-icon > span {
     display: block;
+    font-weight: normal;
     text-decoration: none;
     margin: 0;
     padding: 5px 8px;


### PR DESCRIPTION
If the CSS in your application has something like `a { font-weight: bold; }` to make links bold by default, they will also show up **bold** in the profilers toolbar, which doesn't look right. This patch explicitly sets the font-weight to 'normal', as it should be. 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
