### PR TITLE
Bumping dependency to ProxyManager to allow testing against the new 0.5.x versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "monolog/monolog": "~1.3",
         "propel/propel1": "1.6.*",
         "ircmaxell/password-compat": "1.0.*",
-        "ocramius/proxy-manager": ">=0.3.1,<0.5-dev"
+        "ocramius/proxy-manager": ">=0.3.1,<0.6-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\": "src/" },

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/dependency-injection": "~2.3",
-        "ocramius/proxy-manager": ">=0.3.1,<0.5-dev"
+        "ocramius/proxy-manager": ">=0.3.1,<0.6-dev"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no (looks like an unrelated failure, though) |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Nothing to see here. Move along.
