### PR TITLE
Clean up of WebProfiler Controller classes

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\WebProfilerBundle\Controller;
 
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use Symfony\Component\HttpKernel\Debug\ExceptionHandler;
+use Symfony\Component\Debug\ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -40,6 +40,8 @@ class ExceptionController
      * @param string $token The profiler token
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function showAction($token)
     {
@@ -78,6 +80,8 @@ class ExceptionController
      * @param string $token The profiler token
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function cssAction($token)
     {

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -56,6 +56,8 @@ class ProfilerController
      * Redirects to the last profiles.
      *
      * @return RedirectResponse A RedirectResponse instance
+     *
+     * @throws NotFoundHttpException
      */
     public function homeAction()
     {
@@ -140,6 +142,8 @@ class ProfilerController
      * Purges all tokens.
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function purgeAction()
     {
@@ -159,6 +163,8 @@ class ProfilerController
      * @param Request $request The current HTTP Request
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function importAction(Request $request)
     {
@@ -187,6 +193,8 @@ class ProfilerController
      * @param string $about The about message
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function infoAction($about)
     {
@@ -208,6 +216,8 @@ class ProfilerController
      * @param string  $token    The profiler token
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function toolbarAction(Request $request, $token)
     {
@@ -259,6 +269,8 @@ class ProfilerController
      * @param Request $request The current HTTP Request
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function searchBarAction(Request $request)
     {
@@ -304,6 +316,8 @@ class ProfilerController
      * @param string  $token   The token
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function searchResultsAction(Request $request, $token)
     {
@@ -342,6 +356,8 @@ class ProfilerController
      * @param Request $request The current HTTP Request
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function searchAction(Request $request)
     {
@@ -390,6 +406,8 @@ class ProfilerController
      * Displays the PHP info.
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function phpinfoAction()
     {

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -16,6 +16,7 @@ use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 
 /**
@@ -48,6 +49,8 @@ class RouterController
      * @param string $token The profiler token
      *
      * @return Response A Response instance
+     *
+     * @throws NotFoundHttpException
      */
     public function panelAction($token)
     {


### PR DESCRIPTION
- Added missing "@throws" PHPdoc comments in controllers
- Updated deprecated reference to Symfony\Component\HttpKernel\Debug\ExceptionHandler to use Symfony\Component\Debug\ExceptionHandler instead

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
