### PR TITLE
[Finder] Fix finder date constraints and tests

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
@@ -44,10 +44,6 @@ class DateRangeFilterIterator extends FilterIterator
     {
         $fileinfo = $this->current();
 
-        if (!$fileinfo->isFile()) {
-            return true;
-        }
-
         $filedate = $fileinfo->getMTime();
         foreach ($this->comparators as $compare) {
             if (!$compare->test($filedate)) {

--- a/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
@@ -57,12 +57,8 @@ class DateRangeFilterIteratorTest extends RealIteratorTestCase
         );
 
         $untilLastMonth = array(
-            '.git',
-            'foo',
             'foo/bar.tmp',
             'test.php',
-            'toto',
-            '.foo',
         );
 
         return array(


### PR DESCRIPTION
Description:
When you search some files with date constraints, all folders are given, even if they are not in the date scope.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9303 |
| License | MIT |
