### PR TITLE
[Console] Set proper column width when TableHelper cell value uses Output styling tags

### DIFF
--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -434,7 +434,29 @@ class TableHelper extends Helper
         }
 
         if (isset($row[$column])) {
-            return $this->strlen($row[$column]);
+            $value = $row[$column];
+            $defaultLength = $this->strlen($value);
+            $strippedLength = $this->strlen(strip_tags($value));
+
+            if ($strippedLength === $defaultLength) {
+                // No tags in output
+                return $defaultLength;
+            }
+
+            $tags = $this->getTagsIn($value);
+            if (empty($tags)) {
+                // Malformed tags?
+                return $defaultLength;
+            }
+
+            $styleTags = $this->isolateStyleTags($tags);
+            if (empty($styleTags)) {
+                return $defaultLength;
+            }
+
+            $value = $this->removeTags($styleTags, $value);
+
+            return $this->strlen($value);
         }
 
         return $this->getCellWidth($row, $column - 1);
@@ -455,5 +477,51 @@ class TableHelper extends Helper
     public function getName()
     {
         return 'table';
+    }
+
+    /**
+     * Find tags present in a string
+     *
+     * @param string $str
+     * @return array
+     */
+    private function getTagsIn($str)
+    {
+        $pattern = '/<\/?([a-z\-\_\s]+)>/i';
+        preg_match_all($pattern, $str, $matches);
+
+        return array_unique($matches[1]);
+    }
+
+    /**
+     * Given set of tags, find those that are output styles
+     *
+     * @param array $tags
+     * @return array
+     */
+    private function isolateStyleTags($tags)
+    {
+        $style = array();
+        foreach ($tags as $tag) {
+            if ($this->output->getFormatter()->hasStyle($tag)) {
+                $style[$tag] = $tag;
+            }
+        }
+
+        return $style;
+    }
+
+    /**
+     * Remove given opening and closing tags from string
+     *
+     * @param array $tags
+     * @param string $str
+     * @return string
+     */
+    private function removeTags($tags, $str)
+    {
+        $pattern = sprintf('/<\/?(%s)>/i', implode('|', $tags));
+
+        return preg_replace($pattern, '', $str);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -171,6 +171,40 @@ TABLE
                 TableHelper::LAYOUT_DEFAULT,
                 '',
             ),
+            'Cell text with tags used for Output styling' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array('<info>99921-58-10-7</info>', 'Divine Comedy', 'Dante Alighieri'),
+                    array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
+                ),
+                TableHelper::LAYOUT_DEFAULT,
+<<<TABLE
++---------------+----------------------+-----------------+
+| ISBN          | Title                | Author          |
++---------------+----------------------+-----------------+
+| 99921-58-10-7 | Divine Comedy        | Dante Alighieri |
+| 9971-5-0210-0 | A Tale of Two Cities | Charles Dickens |
++---------------+----------------------+-----------------+
+
+TABLE
+            ),
+            'Cell text with tags not used for Output styling' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array('<strong>99921-58-10-7</strong>', 'Divine Comedy', 'Dante Alighieri'),
+                    array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
+                ),
+                TableHelper::LAYOUT_DEFAULT,
+<<<TABLE
++--------------------------------+----------------------+-----------------+
+| ISBN                           | Title                | Author          |
++--------------------------------+----------------------+-----------------+
+| <strong>99921-58-10-7</strong> | Divine Comedy        | Dante Alighieri |
+| 9971-5-0210-0                  | A Tale of Two Cities | Charles Dickens |
++--------------------------------+----------------------+-----------------+
+
+TABLE
+            ),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [#8152, #9366] |
| License | MIT |
| Doc PR | [none] |

Before this patch, the TableHelper would improperly calculate the total width required for a table column whose displayable text uses Console Output style tags, resulting in a table column header too wide.

Cell Text: `<info>Value</info>`
Expected Length: 7 (5 for the value, 1 padding space before and after)
Actual Length: 18
