### PR TITLE
[WIP] [Validator] GroupSequenceProvider 

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Fixtures/GroupSequenceProviderEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/GroupSequenceProviderEntity.php
@@ -21,7 +21,8 @@ class GroupSequenceProviderEntity implements GroupSequenceProviderInterface
 {
     public $firstName;
     public $lastName;
-    public $street;
+    public $address;
+    public $author;
 
     protected $groups = array();
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/GroupSequenceProviderEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/GroupSequenceProviderEntity.php
@@ -21,6 +21,7 @@ class GroupSequenceProviderEntity implements GroupSequenceProviderInterface
 {
     public $firstName;
     public $lastName;
+    public $street;
 
     protected $groups = array();
 

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -177,6 +177,53 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new ConstraintViolationList(), $result);
     }
 
+    public function testValidateGroupSequenceProviderWithMultipleGroups()
+    {
+        $entity = new GroupSequenceProviderEntity();
+        $metadata = new ClassMetadata(get_class($entity));
+        $metadata->addPropertyConstraint('firstName', new FailingConstraint(array(
+                'groups' => array('First'),
+            )));
+        $metadata->addPropertyConstraint('lastName', new FailingConstraint(array(
+                'groups' => array('Second'),
+            )));
+        $metadata->addPropertyConstraint('street', new FailingConstraint(array(
+                'groups' => array('Third'),
+            )));
+        $metadata->setGroupSequenceProvider(true);
+        $this->metadataFactory->addMetadata($metadata);
+
+        $violations = new ConstraintViolationList();
+        $violations->add(new ConstraintViolation(
+                'Failed',
+                'Failed',
+                array(),
+                $entity,
+                'firstName',
+                ''
+            ));
+        $violations->add(new ConstraintViolation(
+                'Failed',
+                'Failed',
+                array(),
+                $entity,
+                'lastName',
+                ''
+            ));
+        $violations->add(new ConstraintViolation(
+                'Failed',
+                'Failed',
+                array(),
+                $entity,
+                'street',
+                ''
+            ));
+
+        $entity->setGroups(array('First', 'Second', 'Third'));
+        $result = $this->validator->validate($entity);
+        $this->assertEquals($violations, $result);
+    }
+
     public function testValidateProperty()
     {
         $entity = new Entity();

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -187,7 +187,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $metadata->addPropertyConstraint('lastName', new FailingConstraint(array(
                 'groups' => array('Second'),
             )));
-        $metadata->addPropertyConstraint('street', new FailingConstraint(array(
+        $metadata->addPropertyConstraint('address', new FailingConstraint(array(
                 'groups' => array('Third'),
             )));
         $metadata->setGroupSequenceProvider(true);
@@ -215,11 +215,67 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 'Failed',
                 array(),
                 $entity,
-                'street',
+                'address',
                 ''
             ));
 
         $entity->setGroups(array('First', 'Second', 'Third'));
+        $result = $this->validator->validate($entity);
+        $this->assertEquals($violations, $result);
+    }
+
+    public function testValidateGroupSequenceProviderWithMultipleGroupsAndDefault()
+    {
+        $entity = new GroupSequenceProviderEntity();
+        $metadata = new ClassMetadata(get_class($entity));
+        $metadata->addPropertyConstraint('firstName', new FailingConstraint(array(
+                'groups' => array('First'),
+            )));
+        $metadata->addPropertyConstraint('lastName', new FailingConstraint(array(
+                'groups' => array('Second'),
+            )));
+        $metadata->addPropertyConstraint('address', new FailingConstraint(array(
+                'groups' => array('Third'),
+            )));
+        $metadata->addPropertyConstraint('author', new FailingConstraint(array()));
+        $metadata->setGroupSequenceProvider(true);
+        $this->metadataFactory->addMetadata($metadata);
+
+        $violations = new ConstraintViolationList();
+        $violations->add(new ConstraintViolation(
+                'Failed',
+                'Failed',
+                array(),
+                $entity,
+                'firstName',
+                ''
+            ));
+        $violations->add(new ConstraintViolation(
+                'Failed',
+                'Failed',
+                array(),
+                $entity,
+                'lastName',
+                ''
+            ));
+        $violations->add(new ConstraintViolation(
+                'Failed',
+                'Failed',
+                array(),
+                $entity,
+                'address',
+                ''
+            ));
+        $violations->add(new ConstraintViolation(
+                'Failed',
+                'Failed',
+                array(),
+                $entity,
+                'author',
+                ''
+            ));
+
+        $entity->setGroups(array('GroupSequenceProviderEntity', 'First', 'Second', 'Third'));
         $result = $this->validator->validate($entity);
         $this->assertEquals($violations, $result);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [no] |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When working with the GroupSequenceProvider I discovered a strange behavior when returning multiple groups. It seems that only the first group is being validated.

To describe the issue I added a failing test. Is this intended behavior?
