### PR TITLE
Change of scope

### DIFF
--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Security\Core\Role;
 class RoleHierarchy implements RoleHierarchyInterface
 {
     private $hierarchy;
-    private $map;
+    protected $map;
 
     /**
      * Constructor.
@@ -56,7 +56,7 @@ class RoleHierarchy implements RoleHierarchyInterface
         return $reachableRoles;
     }
 
-    private function buildRoleMap()
+    protected function buildRoleMap()
     {
         $this->map = array();
         foreach ($this->hierarchy as $main => $roles) {


### PR DESCRIPTION
Hi,

when overriding the Symfony RoleHierarchy it would be great to be able to get access to the buildRoleMap-method and map-variable for more advanced usage.

Don't hesitate to ask for further clarification if necessary - thanks in advance for merging the PR!

Kind regards,
David
