### PR TITLE
[Form] Added a configuration that allow form extra data

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -187,6 +187,7 @@ class FormType extends BaseType
             // According to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt)
             // section 4.2., empty URIs are considered same-document references
             'action'             => '',
+            'allow_extra_fields' => false,
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -122,7 +122,7 @@ class FormValidator extends ConstraintValidator
         }
 
         // Mark the form with an error if it contains extra fields
-        if (count($form->getExtraData()) > 0) {
+        if (count($form->getExtraData()) > 0 && !$config->getOption('allow_extra_fields', false)) {
             $this->context->addViolation(
                 $config->getOption('extra_fields_message'),
                 array('{{ extra_fields }}' => implode('", "', array_keys($form->getExtraData()))),

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -615,6 +615,25 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($form, new Form());
     }
 
+    public function testViolationIfExtraDataAllowed()
+    {
+        $context = $this->getMockExecutionContext();
+
+        $form = $this->getBuilder('parent', null, array('allow_extra_fields'=>true))
+        ->setCompound(true)
+        ->setDataMapper($this->getDataMapper())
+        ->add($this->getBuilder('child'))
+        ->getForm();
+
+        $form->submit(array('foo' => 'bar'));
+
+        $context->expects($this->never())
+        ->method('addViolation');
+
+        $this->validator->initialize($context);
+        $this->validator->validate($form, new Form());
+    }
+
     /**
      * @dataProvider getPostMaxSizeFixtures
      */

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -620,15 +620,15 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         $context = $this->getMockExecutionContext();
 
         $form = $this->getBuilder('parent', null, array('allow_extra_fields'=>true))
-        ->setCompound(true)
-        ->setDataMapper($this->getDataMapper())
-        ->add($this->getBuilder('child'))
-        ->getForm();
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->add($this->getBuilder('child'))
+            ->getForm();
 
         $form->submit(array('foo' => 'bar'));
 
         $context->expects($this->never())
-        ->method('addViolation');
+            ->method('addViolation');
 
         $this->validator->initialize($context);
         $this->validator->validate($form, new Form());

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -615,7 +615,7 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($form, new Form());
     }
 
-    public function testViolationIfExtraDataAllowed()
+    public function testNoViolationIfExtraDataAllowed()
     {
         $context = $this->getMockExecutionContext();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7209 |
| License | MIT |

I can not understand how https://github.com/symfony/symfony/commit/10998586787f31e5d1e33d4e21035c83cbe23489 can solve #7209 or #7229, so i created this PR.
I can not also understand why #7209 can be considered as duplicate of #1341 (https://github.com/symfony/symfony/commit/10998586787f31e5d1e33d4e21035c83cbe23489).

The commit https://github.com/symfony/symfony/commit/10998586787f31e5d1e33d4e21035c83cbe23489 will solve problem if some fields is missing, but says nothing about extra fields.
