### PR TITLE
[DomCrawler] [HttpFoundation] Make `Content-Type` attributes identification case-insensitive

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -97,7 +97,7 @@ class Crawler extends \SplObjectStorage
         }
 
         $charset = null;
-        if (false !== $pos = strpos($type, 'charset=')) {
+        if (false !== $pos = stripos($type, 'charset=')) {
             $charset = substr($type, $pos + 8);
             if (false !== $pos = strpos($charset, ';')) {
                 $charset = substr($charset, 0, $pos);

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -223,7 +223,7 @@ class Response
         $charset = $this->charset ?: 'UTF-8';
         if (!$headers->has('Content-Type')) {
             $headers->set('Content-Type', 'text/html; charset='.$charset);
-        } elseif (0 === strpos($headers->get('Content-Type'), 'text/') && false === strpos($headers->get('Content-Type'), 'charset')) {
+        } elseif (0 === stripos($headers->get('Content-Type'), 'text/') && false === stripos($headers->get('Content-Type'), 'charset')) {
             // add the charset
             $headers->set('Content-Type', $headers->get('Content-Type').'; charset='.$charset);
         }


### PR DESCRIPTION
According to [section 3.7 of RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7), media-type attribute names in the `Content-Type` header are case-insensitive.
Therefore, identification of the `text` type and the `charset` parameter in the `Content-Type` header should be case-insensitive.
