### PR TITLE
Updated error to show attempted controller's name

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -79,7 +79,7 @@ class ControllerResolver implements ControllerResolverInterface
         $callable = $this->createController($controller);
 
         if (!is_callable($callable)) {
-            throw new \InvalidArgumentException(sprintf('The controller for URI "%s" is not callable.', $request->getPathInfo()));
+            throw new \InvalidArgumentException(sprintf('The controller (%s) for URI "%s" is not callable.', $controller, $request->getPathInfo()));
         }
 
         return $callable;


### PR DESCRIPTION
When you try to invoke a non-callable controller the existing error didn't say what you were trying to call. This PR changes that behaviour to display the name of the controller you were attempting to call, making the error message more verbose (and hence more useful).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |
