### PR TITLE
[Serializer] Fixed the error handling when decoding invalid XML to avoid a Warning

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -76,6 +76,10 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         libxml_use_internal_errors($internalErrors);
         libxml_disable_entity_loader($disableEntities);
 
+        if ($error = libxml_get_last_error()) {
+            throw new UnexpectedValueException($error->message);
+        }
+
         foreach ($dom->childNodes as $child) {
             if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
                 throw new UnexpectedValueException('Document types are not allowed.');

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 
 class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 {
+    private $encoder;
+
     protected function setUp()
     {
         $this->encoder = new XmlEncoder;
@@ -299,6 +301,14 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         );
         $xml = $this->encoder->encode($obj, 'xml');
         $this->assertEquals($expected, $this->encoder->decode($xml, 'xml'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     */
+    public function testDecodeInvalidXml()
+    {
+        $this->encoder->decode('<?xml version="1.0"?><invalid><xml>', 'xml');
     }
 
     public function testPreventsComplexExternalEntities()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Without the exception being thrown here, the call to `simplexml_import_dom` throws a warning saying `Invalid Nodetype to import`.
This has been reported by @Tobion after we refactored FOSRestBundle to use this XmlEncoder instead of a duplication of a previous version of the class: https://github.com/FriendsOfSymfony/FOSRestBundle/pull/583/files#r7221045
