### PR TITLE
[BUG][Form] Fix nonexistent key id in twig of data collector

### DIFF
--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
@@ -123,7 +123,9 @@ class FormDataExtractor implements FormDataExtractorInterface
      */
     public function extractViewVariables(FormView $view)
     {
-        $data = array();
+        $data = array(
+            'id' => $view->vars['id']
+        );
 
         foreach ($view->vars as $varName => $value) {
             $data['view_vars'][$varName] = $this->valueExporter->exportValue($value);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When you create a single button form type, the id of data collector does not exist. It's caused by the PR #9394.
