### PR TITLE
[Process] Renamed flushOutput() and flushErrorOutput() to clearOutput() and clearErrorOutput()

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -408,7 +408,7 @@ class Process
      *
      * @return Process
      */
-    public function flushOutput()
+    public function clearOutput()
     {
         $this->stdout = '';
         $this->incrementalOutputOffset = 0;
@@ -454,7 +454,7 @@ class Process
      *
      * @return Process
      */
-    public function flushErrorOutput()
+    public function clearErrorOutput()
     {
         $this->stderr = '';
         $this->incrementalErrorOutputOffset = 0;

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -174,7 +174,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $p = new Process(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }')));
 
         $p->run();
-        $p->flushErrorOutput();
+        $p->clearErrorOutput();
         $this->assertEmpty($p->getErrorOutput());
     }
 
@@ -202,7 +202,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $p = new Process(sprintf('php -r %s', escapeshellarg('$n=0;while ($n<3) {echo \' foo \';$n++;}')));
 
         $p->run();
-        $p->flushOutput();
+        $p->clearOutput();
         $this->assertEmpty($p->getOutput());
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I renamed `flushOutput()` and `flushErrorOutput()` to `clearOutput()` and `clearErrorOutput()` since I find the current naming unintuitive. When reading [the blog post about this feature](http://symfony.com/blog/new-in-symfony-2-4-flushing-stdout-and-stderr-on-a-process) I initially thought that the output would be flushed to the console (as in `ob_flush()`).

Using "clear" on the other hand conforms well with [our conventions](http://symfony.com/doc/current/contributing/code/conventions.html).
