### PR TITLE
[Invalid] Fix ProgressHelper redraw when redrawFreq is greater than 1

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -235,8 +235,12 @@ class ProgressHelper extends Helper
             $redraw = true;
         }
 
+        $prevSlot = intval($this->current / $this->redrawFreq);
+
         $this->current += $step;
-        if ($redraw || 0 === $this->current % $this->redrawFreq) {
+
+        $currSlot = intval($this->current / $this->redrawFreq);
+        if ($redraw || $prevSlot != $currSlot) {
             $this->display();
         }
     }
@@ -265,8 +269,12 @@ class ProgressHelper extends Helper
             $redraw = true;
         }
 
+        $prevSlot = intval($this->current / $this->redrawFreq);
+
         $this->current = $current;
-        if ($redraw || 0 === $this->current % $this->redrawFreq) {
+        
+        $currSlot = intval($this->current / $this->redrawFreq);
+        if ($redraw || $prevSlot != $currSlot) {
             $this->display();
         }
     }


### PR DESCRIPTION
When using a ProgressHelper object with redrawFreq > 1, there are situation where redraw may never occur.
E.g.
- redrawFreq = 2
- setContent = 1
- advance(2)
  ... the redraw event is detected by 0 == current % redrawFreq.

I've tested the patch against phpunit and my local environment.

Maybe, a new test can be implemented to avoid the previous example, but I'm not familiar with mock object... :)
