### PR TITLE
fixed issue with clone now the children of the original form are preserved and the clone form is given new children

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -170,6 +170,8 @@ class Form implements \IteratorAggregate, FormInterface
 
     public function __clone()
     {
+        $this->children = clone $this->children;
+        
         foreach ($this->children as $key => $child) {
             $this->children[$key] = clone $child;
         }

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -141,6 +141,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $this->assertNotSame($this->form, $clone);
         $this->assertNotSame($child, $clone['child']);
+        $this->assertNotSame($this->form['child'], $clone['child']);
     }
 
     public function testNotEmptyIfChildNotEmpty()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 9414 |
| License | MIT |
| Doc PR |  |

this commit fixes #9414
