### PR TITLE
[Console][ProgressHelper] Fix ProgressHelper redraw when redrawFreq is greater than 1

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -235,8 +235,12 @@ class ProgressHelper extends Helper
             $redraw = true;
         }
 
+        $prevPeriod = intval($this->current / $this->redrawFreq);
+
         $this->current += $step;
-        if ($redraw || 0 === $this->current % $this->redrawFreq) {
+
+        $currPeriod = intval($this->current / $this->redrawFreq);
+        if ($redraw || $prevPeriod !== $currPeriod || $this->max === $this->current) {
             $this->display();
         }
     }
@@ -265,8 +269,12 @@ class ProgressHelper extends Helper
             $redraw = true;
         }
 
+        $prevPeriod = intval($this->current / $this->redrawFreq);
+
         $this->current = $current;
-        if ($redraw || 0 === $this->current % $this->redrawFreq) {
+        
+        $currPeriod = intval($this->current / $this->redrawFreq);
+        if ($redraw || $prevPeriod !== $currPeriod || $this->max === $this->current) {
             $this->display();
         }
     }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
@@ -136,6 +136,21 @@ class ProgressHelperTest extends \PHPUnit_Framework_TestCase
         $progress->setCurrent(10);
     }
 
+    public function testRedrawFrequency()
+    {
+        $progress = $this->getMock('Symfony\Component\Console\Helper\ProgressHelper', array('display'));
+        $progress->expects($this->exactly(4))
+                 ->method('display');
+
+        $progress->setRedrawFrequency(2);
+
+        $progress->start($output = $this->getOutputStream(), 6);
+        $progress->setCurrent(1);
+        $progress->advance(2);
+        $progress->advance(2);
+        $progress->advance(1);
+    }
+
     public function testMultiByteSupport()
     {
         if (!function_exists('mb_strlen') || (false === $encoding = mb_detect_encoding('■'))) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When using a ProgressHelper object with redrawFreq > 1, there are situation where redraw may never occur.
E.g.

```
redrawFreq = 2
setContent = 1
advance(2) ... the redraw event is detected by 0 == current % redrawFreq.
```

I've tested the patch against phpunit and my local environment.

Maybe, a new test can be implemented to avoid the previous example, but I'm not familiar with mock object... :)
