### PR TITLE
[Form] fix and unify phpdoc

### DIFF
--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\Exception\BadMethodCallException;
 class Button implements \IteratorAggregate, FormInterface
 {
     /**
-     * @var FormInterface
+     * @var FormInterface|null
      */
     private $parent;
 

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -82,7 +82,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      *
      * @param Constraint $constraint The constraint to guess for
      *
-     * @return TypeGuess The guessed field class and options
+     * @return TypeGuess|null The guessed field class and options
      */
     public function guessTypeForConstraint(Constraint $constraint)
     {
@@ -171,7 +171,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      *
      * @param Constraint $constraint The constraint to guess for
      *
-     * @return Guess The guess whether the field is required
+     * @return ValueGuess|null The guess whether the field is required
      */
     public function guessRequiredForConstraint(Constraint $constraint)
     {
@@ -190,7 +190,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      *
      * @param Constraint $constraint The constraint to guess for
      *
-     * @return Guess The guess for the maximum length
+     * @return ValueGuess|null The guess for the maximum length
      */
     public function guessMaxLengthForConstraint(Constraint $constraint)
     {
@@ -216,7 +216,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      *
      * @param Constraint $constraint The constraint to guess for
      *
-     * @return Guess The guess for the pattern
+     * @return ValueGuess|null The guess for the pattern
      */
     public function guessPatternForConstraint(Constraint $constraint)
     {
@@ -256,7 +256,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      * @param mixed    $defaultValue The default value assumed if no other value
      *                               can be guessed.
      *
-     * @return Guess The guessed value with the highest confidence
+     * @return Guess|null The guessed value with the highest confidence
      */
     protected function guess($class, $property, \Closure $closure, $defaultValue = null)
     {

--- a/src/Symfony/Component/Form/FormFactoryBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilderInterface.php
@@ -39,7 +39,7 @@ interface FormFactoryBuilderInterface
     /**
      * Adds a list of extensions to be loaded by the factory.
      *
-     * @param array $extensions The extensions.
+     * @param FormExtensionInterface[] $extensions The extensions.
      *
      * @return FormFactoryBuilderInterface The builder.
      */
@@ -57,7 +57,7 @@ interface FormFactoryBuilderInterface
     /**
      * Adds a list of form types to the factory.
      *
-     * @param array $types The form types.
+     * @param FormTypeInterface[] $types The form types.
      *
      * @return FormFactoryBuilderInterface The builder.
      */
@@ -75,7 +75,7 @@ interface FormFactoryBuilderInterface
     /**
      * Adds a list of form type extensions to the factory.
      *
-     * @param array $typeExtensions The form type extensions.
+     * @param FormTypeExtensionInterface[] $typeExtensions The form type extensions.
      *
      * @return FormFactoryBuilderInterface The builder.
      */
@@ -93,7 +93,7 @@ interface FormFactoryBuilderInterface
     /**
      * Adds a list of type guessers to the factory.
      *
-     * @param array $typeGuessers The type guessers.
+     * @param FormTypeGuesserInterface[] $typeGuessers The type guessers.
      *
      * @return FormFactoryBuilderInterface The builder.
      */

--- a/src/Symfony/Component/Form/FormRegistryInterface.php
+++ b/src/Symfony/Component/Form/FormRegistryInterface.php
@@ -51,7 +51,7 @@ interface FormRegistryInterface
     /**
      * Returns the extensions loaded by the framework.
      *
-     * @return array
+     * @return FormExtensionInterface[]
      */
     public function getExtensions();
 }

--- a/src/Symfony/Component/Form/FormTypeGuesserChain.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserChain.php
@@ -21,7 +21,7 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
     /**
      * Constructor.
      *
-     * @param array $guessers Guessers as instances of FormTypeGuesserInterface
+     * @param FormTypeGuesserInterface[] $guessers Guessers as instances of FormTypeGuesserInterface
      *
      * @throws UnexpectedTypeException if any guesser does not implement FormTypeGuesserInterface
      */
@@ -87,7 +87,7 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
      * @param \Closure $closure The closure to execute. Accepts a guesser
      *                            as argument and should return a Guess instance
      *
-     * @return Guess The guess with the highest confidence
+     * @return Guess|null The guess with the highest confidence
      */
     private function guess(\Closure $closure)
     {

--- a/src/Symfony/Component/Form/FormTypeGuesserInterface.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserInterface.php
@@ -22,7 +22,7 @@ interface FormTypeGuesserInterface
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
      *
-     * @return Guess\TypeGuess A guess for the field's type and options
+     * @return Guess\TypeGuess|null A guess for the field's type and options
      */
     public function guessType($class, $property);
 
@@ -32,7 +32,7 @@ interface FormTypeGuesserInterface
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
      *
-     * @return Guess\Guess A guess for the field's required setting
+     * @return Guess\ValueGuess A guess for the field's required setting
      */
     public function guessRequired($class, $property);
 
@@ -42,7 +42,7 @@ interface FormTypeGuesserInterface
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
      *
-     * @return Guess\Guess A guess for the field's maximum length
+     * @return Guess\ValueGuess|null A guess for the field's maximum length
      */
     public function guessMaxLength($class, $property);
 
@@ -58,7 +58,7 @@ interface FormTypeGuesserInterface
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
      *
-     * @return Guess\Guess A guess for the field's required pattern
+     * @return Guess\ValueGuess|null A guess for the field's required pattern
      */
     public function guessPattern($class, $property);
 }

--- a/src/Symfony/Component/Form/Guess/Guess.php
+++ b/src/Symfony/Component/Form/Guess/Guess.php
@@ -59,14 +59,14 @@ abstract class Guess
     private $confidence;
 
     /**
-     * Returns the guess most likely to be correct from a list of guesses
+     * Returns the guess most likely to be correct from a list of guesses.
      *
      * If there are multiple guesses with the same, highest confidence, the
      * returned guess is any of them.
      *
-     * @param array $guesses A list of guesses
+     * @param Guess[] $guesses An array of guesses
      *
-     * @return Guess The guess with the highest confidence
+     * @return Guess|null The guess with the highest confidence
      */
     public static function getBestGuess(array $guesses)
     {
@@ -84,7 +84,7 @@ abstract class Guess
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param integer $confidence The confidence
      *
@@ -101,7 +101,7 @@ abstract class Guess
     }
 
     /**
-     * Returns the confidence that the guessed value is correct
+     * Returns the confidence that the guessed value is correct.
      *
      * @return integer One of the constants VERY_HIGH_CONFIDENCE,
      *                 HIGH_CONFIDENCE, MEDIUM_CONFIDENCE and LOW_CONFIDENCE

--- a/src/Symfony/Component/Form/PreloadedExtension.php
+++ b/src/Symfony/Component/Form/PreloadedExtension.php
@@ -38,9 +38,9 @@ class PreloadedExtension implements FormExtensionInterface
     /**
      * Creates a new preloaded extension.
      *
-     * @param array                         $types          The types that the extension should support.
-     * @param array                         $typeExtensions The type extensions that the extension should support.
-     * @param FormTypeGuesserInterface|null $typeGuesser    The guesser that the extension should support.
+     * @param FormTypeInterface[]                 $types         The types that the extension should support.
+     * @param array[FormTypeExtensionInterface[]] typeExtensions The type extensions that the extension should support.
+     * @param FormTypeGuesserInterface|null       $typeGuesser   The guesser that the extension should support.
      */
     public function __construct(array $types, array $typeExtensions, FormTypeGuesserInterface $typeGuesser = null)
     {

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -29,12 +29,12 @@ class ResolvedFormType implements ResolvedFormTypeInterface
     private $innerType;
 
     /**
-     * @var array
+     * @var FormTypeExtensionInterface[]
      */
     private $typeExtensions;
 
     /**
-     * @var ResolvedFormTypeInterface
+     * @var ResolvedFormTypeInterface|null
      */
     private $parent;
 

--- a/src/Symfony/Component/Form/ResolvedFormTypeFactoryInterface.php
+++ b/src/Symfony/Component/Form/ResolvedFormTypeFactoryInterface.php
@@ -25,9 +25,9 @@ interface ResolvedFormTypeFactoryInterface
     /**
      * Resolves a form type.
      *
-     * @param FormTypeInterface         $type
-     * @param array                     $typeExtensions
-     * @param ResolvedFormTypeInterface $parent
+     * @param FormTypeInterface              $type
+     * @param FormTypeExtensionInterface[]   $typeExtensions
+     * @param ResolvedFormTypeInterface|null $parent
      *
      * @return ResolvedFormTypeInterface
      *

--- a/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
+++ b/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
@@ -28,7 +28,7 @@ interface ResolvedFormTypeInterface
     /**
      * Returns the parent type.
      *
-     * @return ResolvedFormTypeInterface The parent type or null.
+     * @return ResolvedFormTypeInterface|null The parent type or null.
      */
     public function getParent();
 

--- a/src/Symfony/Component/Form/SubmitButtonBuilder.php
+++ b/src/Symfony/Component/Form/SubmitButtonBuilder.php
@@ -21,7 +21,7 @@ class SubmitButtonBuilder extends ButtonBuilder
     /**
      * Creates the button.
      *
-     * @return Button The button
+     * @return SubmitButton The button
      */
     public function getForm()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| license? | MIT |
- Fixes FormTypeGuesserInterface that must return ValueGuess for guessRequired etc. instead of abstract Guess because its excepted for example by FormFactory.
- Unify array typehints that was not done consistently.
