### PR TITLE
moved logic for the session listeners into the HttpKernel component

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php
@@ -11,17 +11,15 @@
 
 namespace Symfony\Bundle\FrameworkBundle\EventListener;
 
+use Symfony\Component\HttpKernel\EventListener\SessionListener as BaseSessionListener;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Sets the session in the request.
  *
- * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Fabien Potencier <fabien@symfony.com>
  */
-class SessionListener implements EventSubscriberInterface
+class SessionListener extends BaseSessionListener
 {
     /**
      * @var ContainerInterface
@@ -33,24 +31,12 @@ class SessionListener implements EventSubscriberInterface
         $this->container = $container;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function getSession()
     {
-        if (!$event->isMasterRequest()) {
-            return;
+        if (!$this->container->has('session')) {
+            return null;
         }
 
-        $request = $event->getRequest();
-        if (!$this->container->has('session') || $request->hasSession()) {
-            return;
-        }
-
-        $request->setSession($this->container->get('session'));
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return array(
-            KernelEvents::REQUEST => array('onKernelRequest', 128),
-        );
+        return $this->container->get('session');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
@@ -11,22 +11,15 @@
 
 namespace Symfony\Bundle\FrameworkBundle\EventListener;
 
-use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\TestSessionListener as BaseTestSessionListener;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * TestSessionListener.
  *
- * Saves session in test environment.
- *
- * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class TestSessionListener implements EventSubscriberInterface
+class TestSessionListener extends BaseTestSessionListener
 {
     protected $container;
 
@@ -35,50 +28,12 @@ class TestSessionListener implements EventSubscriberInterface
         $this->container = $container;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function getSession()
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
-        // bootstrap the session
         if (!$this->container->has('session')) {
-            return;
+            return null;
         }
 
-        $session = $this->container->get('session');
-        $cookies = $event->getRequest()->cookies;
-
-        if ($cookies->has($session->getName())) {
-            $session->setId($cookies->get($session->getName()));
-        }
-    }
-
-    /**
-     * Checks if session was initialized and saves if current request is master
-     * Runs on 'kernel.response' in test environment
-     *
-     * @param FilterResponseEvent $event
-     */
-    public function onKernelResponse(FilterResponseEvent $event)
-    {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
-        $session = $event->getRequest()->getSession();
-        if ($session && $session->isStarted()) {
-            $session->save();
-            $params = session_get_cookie_params();
-            $event->getResponse()->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
-        }
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return array(
-            KernelEvents::REQUEST => array('onKernelRequest', 192),
-            KernelEvents::RESPONSE => array('onKernelResponse', -128),
-        );
+        return $this->container->get('session');
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.4.0
 -----
 
+ * added event listeners for the session
  * added the KernelEvents::FINISH_REQUEST event
 
 2.3.0

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Sets the session in the request.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+abstract class SessionListener implements EventSubscriberInterface
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $session = $this->getSession();
+        if (null === $session || $request->hasSession()) {
+            return;
+        }
+
+        $request->setSession($session);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array('onKernelRequest', 128),
+        );
+    }
+
+    /**
+     * Gets the session object.
+     *
+     * @return SessionInterface|null A SessionInterface instance of null if no session is available
+     */
+    abstract protected function getSession();
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * TestSessionListener.
+ *
+ * Saves session in test environment.
+ *
+ * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+abstract class TestSessionListener implements EventSubscriberInterface
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+            return;
+        }
+
+        // bootstrap the session
+        $session = $this->getSession();
+        if (!$session) {
+            return;
+        }
+
+        $cookies = $event->getRequest()->cookies;
+
+        if ($cookies->has($session->getName())) {
+            $session->setId($cookies->get($session->getName()));
+        }
+    }
+
+    /**
+     * Checks if session was initialized and saves if current request is master
+     * Runs on 'kernel.response' in test environment
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+            return;
+        }
+
+        $session = $event->getRequest()->getSession();
+        if ($session && $session->isStarted()) {
+            $session->save();
+            $params = session_get_cookie_params();
+            $event->getResponse()->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array('onKernelRequest', 192),
+            KernelEvents::RESPONSE => array('onKernelResponse', -128),
+        );
+    }
+
+    /**
+     * Gets the session object.
+     *
+     * @return SessionInterface|null A SessionInterface instance of null if no session is available
+     */
+    abstract protected function getSession();
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -9,9 +9,8 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Tests\EventListener;
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
-use Symfony\Bundle\FrameworkBundle\EventListener\TestSessionListener;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -39,14 +38,8 @@ class TestSessionListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->listener = new TestSessionListener($this->getMock('Symfony\Component\DependencyInjection\ContainerInterface'));
+        $this->listener = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\EventListener\TestSessionListener');
         $this->session  = $this->getSession();
-    }
-
-    protected function tearDown()
-    {
-        $this->listener = null;
-        $this->session = null;
     }
 
     public function testShouldSaveMasterRequestSession()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When working on Silex, I realize that even if we are not using the same container, the logic of the session listeners were the same. So, this PR moves the listeners to HttpKernel to make them reusable outside of the context of the Symfony full-stack framework.
