### PR TITLE
Remove redundant code

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -490,8 +490,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             if (!isset($this->extensionConfigs[$name])) {
                 $this->extensionConfigs[$name] = array();
             }
-
-            $this->extensionConfigs[$name] = array_merge($this->extensionConfigs[$name], $container->getExtensionConfig($name));
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The code in the foreach and `getExtensionConfig` were exactly the same. The `array_merge` merges `$this->extensionConfigs[$name]` and `$this->extensionConfigs[$name]`, so nothing to merge...
