### PR TITLE
[Process] fixed fatal errors in getOutput and getErrorOutput when process was not started

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -298,9 +298,14 @@ class Process
      *
      * @throws RuntimeException When process timed out
      * @throws RuntimeException When process stopped after receiving signal
+     * @throws LogicException When process is not started
      */
     public function wait($callback = null)
     {
+        if (!$this->isStarted()) {
+            throw new LogicException(sprintf('Process must be started before calling %s', __FUNCTION__));
+        }
+
         $this->updateStatus(false);
         if (null !== $callback) {
             $this->callback = $this->buildCallback($callback);

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -378,10 +378,16 @@ class Process
      *
      * @return string The process output
      *
+     * @throws LogicException In case the process is not started
+     *
      * @api
      */
     public function getOutput()
     {
+        if (!$this->isStarted()) {
+            throw new LogicException(sprintf('Process must be started before calling %s', __FUNCTION__));
+        }
+
         $this->readPipes(false, defined('PHP_WINDOWS_VERSION_BUILD') ? !$this->processInformation['running'] : true);
 
         return $this->stdout;
@@ -410,10 +416,16 @@ class Process
      *
      * @return string The process error output
      *
+     * @throws LogicException In case the process is not started
+     *
      * @api
      */
     public function getErrorOutput()
     {
+        if (!$this->isStarted()) {
+            throw new LogicException(sprintf('Process must be started before calling %s', __FUNCTION__));
+        }
+
         $this->readPipes(false, defined('PHP_WINDOWS_VERSION_BUILD') ? !$this->processInformation['running'] : true);
 
         return $this->stderr;

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -592,6 +592,16 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $process->getErrorOutput();
     }
 
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     * @expectedExceptionMessage Process must be started before calling wait
+     */
+    public function testWaitProcessWithoutTimeoutNotStarted()
+    {
+        $process = $this->getProcess('php -m')->setTimeout(null);
+        $process->wait();
+    }
+
     private function verifyPosixIsEnabled()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -572,6 +572,26 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $process->signal(SIGHUP);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     * @expectedExceptionMessage Process must be started before calling getOutput
+     */
+    public function testGetOutputProcessNotStarted()
+    {
+        $process = $this->getProcess('php -m');
+        $process->getOutput();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     * @expectedExceptionMessage Process must be started before calling getErrorOutput
+     */
+    public function testGetErrorOutputProcessNotStarted()
+    {
+        $process = $this->getProcess('php -m');
+        $process->getErrorOutput();
+    }
+
     private function verifyPosixIsEnabled()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10022 |
| License | MIT |
| Doc PR |  |

Added logic exceptions for prevent fatal errors in `getOutput` and `getErrorOutput` when process was not started.

```
Fatal error: Call to a member function readAndCloseHandles() on a non-object in /home/max/symfony/src/Symfony/Component/Process/Process.php on line 1117

Call Stack:
    0.0002     231816   1. {main}() /home/max/phpunit/composer/bin/phpunit:0
    0.0038     526688   2. PHPUnit_TextUI_Command::main() /home/max/phpunit/composer/bin/phpunit:63
    0.0038     526912   3. PHPUnit_TextUI_Command->run() /home/max/phpunit/PHPUnit/TextUI/Command.php:126
    0.2261    4022696   4. PHPUnit_TextUI_TestRunner->doRun() /home/max/phpunit/PHPUnit/TextUI/Command.php:173
    0.2302    4353544   5. PHPUnit_Framework_TestSuite->run() /home/max/phpunit/PHPUnit/TextUI/TestRunner.php:415
    0.3218    5675504   6. PHPUnit_Framework_TestSuite->run() /home/max/phpunit/PHPUnit/Framework/TestSuite.php:729
   15.1171   38257632   7. PHPUnit_Framework_TestCase->run() /home/max/phpunit/PHPUnit/Framework/TestSuite.php:729
   15.1172   38257632   8. PHPUnit_Framework_TestResult->run() /home/max/phpunit/PHPUnit/Framework/TestCase.php:782
   15.1173   38258544   9. PHPUnit_Framework_TestCase->runBare() /home/max/phpunit/PHPUnit/Framework/TestResult.php:661
   15.1174   38275544  10. PHPUnit_Framework_TestCase->runTest() /home/max/phpunit/PHPUnit/Framework/TestCase.php:839
   15.1175   38276408  11. ReflectionMethod->invokeArgs() /home/max/phpunit/PHPUnit/Framework/TestCase.php:987
   15.1175   38276440  12. Symfony\Component\Process\Tests\AbstractProcessTest->testGetOutputProcessNotRunning() /home/max/phpunit/PHPUnit/Framework/TestCase.php:987
   15.1175   38277728  13. Symfony\Component\Process\Process->getOutput() /home/max/symfony/src/Symfony/Component/Process/Tests/AbstractProcessTest.php:636
   15.1175   38277824  14. Symfony\Component\Process\Process->readPipes() /home/max/symfony/src/Symfony/Component/Process/Process.php:383
```
- [x] fix code after review by @Tobion
- [x] fix code after review by @jakzal 
- [ ] fix code after merging #10412 (@romainneutron's notice)
