### PR TITLE
Feedback in cache:clear

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -66,7 +66,7 @@ EOF
         }
 
         $kernel = $this->getContainer()->get('kernel');
-        $output->writeln(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+        $output->writeln(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>:', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
         $this->getContainer()->get('cache_clearer')->clear($realCacheDir);
 
         if ($input->getOption('no-warmup')) {
@@ -77,9 +77,11 @@ EOF
             $warmupDir = substr($realCacheDir, 0, -1).'_';
 
             if ($filesystem->exists($warmupDir)) {
+                $output->writeln('Clearing outdated warmup directory...');
                 $filesystem->remove($warmupDir);
             }
 
+            $output->writeln('Warming up cache...');
             $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
 
             $filesystem->rename($realCacheDir, $oldCacheDir);
@@ -87,9 +89,12 @@ EOF
                 sleep(1);  // workaround for windows php rename bug
             }
             $filesystem->rename($warmupDir, $realCacheDir);
+            $output->writeln('Warm up completed...');
         }
 
+        $output->writeln('Removing old cache directory...');
         $filesystem->remove($oldCacheDir);
+        $output->writeln('Completed clearing cache' . ($input->getOption('no-warmup') ? " ." : " and warmup."));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -66,7 +66,8 @@ EOF
         }
 
         $kernel = $this->getContainer()->get('kernel');
-        $output->writeln(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>:', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+        $output->writeln($this->getClearingCacheMessage($output, $kernel));
+
         $this->getContainer()->get('cache_clearer')->clear($realCacheDir);
 
         if ($input->getOption('no-warmup')) {
@@ -77,11 +78,11 @@ EOF
             $warmupDir = substr($realCacheDir, 0, -1).'_';
 
             if ($filesystem->exists($warmupDir)) {
-                $output->writeln('Clearing outdated warmup directory...');
+                $this->writelnIfVerbose($output, 'Clearing outdated warmup directory...');
                 $filesystem->remove($warmupDir);
             }
 
-            $output->writeln('Warming up cache...');
+            $this->writelnIfVerbose($output, 'Warming up cache...');
             $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
 
             $filesystem->rename($realCacheDir, $oldCacheDir);
@@ -89,12 +90,41 @@ EOF
                 sleep(1);  // workaround for windows php rename bug
             }
             $filesystem->rename($warmupDir, $realCacheDir);
-            $output->writeln('Warm up completed...');
+            $this->writelnIfVerbose($output, 'Warm up completed...');
         }
 
-        $output->writeln('Removing old cache directory...');
+        $this->writelnIfVerbose($output, 'Removing old cache directory...');
         $filesystem->remove($oldCacheDir);
-        $output->writeln('Completed clearing cache' . ($input->getOption('no-warmup') ? "!" : " and warmup!"));
+        $this->writelnIfVerbose($output, 'Completed clearing cache' . ($input->getOption('no-warmup') ? "!" : " and warmup!"));
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param KernelInterface $kernel
+     * @return string
+     */
+    protected function getClearingCacheMessage(OutputInterface $output, KernelInterface $kernel){
+        $message = 'Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>';
+        $message .= $this->isVerbose($output) ? ":" : "";
+        return sprintf($message, $kernel->getEnvironment(), var_export($kernel->isDebug(), true));
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param string $message
+     */
+    protected function writelnIfVerbose(OutputInterface $output, $message){
+        if ($this->isVerbose($output)){
+            $output->writeln($message);
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @return bool
+     */
+    protected function isVerbose(OutputInterface $output){
+        return OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity();
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -94,7 +94,7 @@ EOF
 
         $output->writeln('Removing old cache directory...');
         $filesystem->remove($oldCacheDir);
-        $output->writeln('Completed clearing cache' . ($input->getOption('no-warmup') ? " ." : " and warmup."));
+        $output->writeln('Completed clearing cache' . ($input->getOption('no-warmup') ? "!" : " and warmup!"));
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -123,7 +123,7 @@ class ExpressionLanguage
     protected function getParser()
     {
         if (null === $this->parser) {
-            $this->parser = new $this->parserClass($this->functions);
+            $this->parser = new Parser($this->functions);
         }
 
         return $this->parser;

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -25,18 +25,16 @@ class ExpressionLanguage
     /**
      * @var ParserCacheInterface
      */
-    private $cache;
-    private $lexer;
-    private $parser;
-    private $parserClass;
-    private $compiler;
+    protected $cache;
+    protected $lexer;
+    protected $parser;
+    protected $compiler;
 
     protected $functions;
 
-    public function __construct(ParserCacheInterface $cache = null, $parserClass = null)
+    public function __construct(ParserCacheInterface $cache = null)
     {
         $this->cache = $cache ?: new ArrayParserCache();
-        $this->parserClass = $parserClass ?: "Symfony\\Component\\ExpressionLanguage\\Parser";
         $this->functions = array();
         $this->registerFunctions();
     }
@@ -113,7 +111,7 @@ class ExpressionLanguage
         });
     }
 
-    private function getLexer()
+    protected function getLexer()
     {
         if (null === $this->lexer) {
             $this->lexer = new Lexer();
@@ -122,7 +120,7 @@ class ExpressionLanguage
         return $this->lexer;
     }
 
-    private function getParser()
+    protected function getParser()
     {
         if (null === $this->parser) {
             $this->parser = new $this->parserClass($this->functions);

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -21,19 +21,22 @@ use Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface;
  */
 class ExpressionLanguage
 {
+
     /**
      * @var ParserCacheInterface
      */
     private $cache;
     private $lexer;
     private $parser;
+    private $parserClass;
     private $compiler;
 
     protected $functions;
 
-    public function __construct(ParserCacheInterface $cache = null)
+    public function __construct(ParserCacheInterface $cache = null, $parserClass = null)
     {
         $this->cache = $cache ?: new ArrayParserCache();
+        $this->parserClass = $parserClass ?: "Symfony\\Component\\ExpressionLanguage\\Parser";
         $this->functions = array();
         $this->registerFunctions();
     }
@@ -122,7 +125,7 @@ class ExpressionLanguage
     private function getParser()
     {
         if (null === $this->parser) {
-            $this->parser = new Parser($this->functions);
+            $this->parser = new $this->parserClass($this->functions);
         }
 
         return $this->parser;

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -26,11 +26,11 @@ class Parser
     const OPERATOR_LEFT = 1;
     const OPERATOR_RIGHT = 2;
 
-    private $stream;
-    private $unaryOperators;
-    private $binaryOperators;
-    private $functions;
-    private $names;
+    protected $stream;
+    protected $unaryOperators;
+    protected $binaryOperators;
+    protected $functions;
+    protected $names;
 
     public function __construct(array $functions)
     {


### PR DESCRIPTION
Especially in production it is sometimes critical to know exactly when your cache is cleared or warmed up. Currently cache:clear provides no feedback whats however. As sites get bigger, so become their cache files. Removing old cache files may sometimes even take minutes. Without any feedback from the cache:clear you do not know the current status.

That's why i added more feedback to the cache:clear command that it makes it possible to see when your cache is warmed up and ready to go.
