### PR TITLE
[HttpFoundation] Recheck method if httpMethodParameterOverride enabled

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -647,6 +647,8 @@ class Request
     public static function enableHttpMethodParameterOverride()
     {
         self::$httpMethodParameterOverride = true;
+        
+        $this->method = null;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -647,8 +647,6 @@ class Request
     public static function enableHttpMethodParameterOverride()
     {
         self::$httpMethodParameterOverride = true;
-        
-        $this->method = null;
     }
 
     /**
@@ -1166,7 +1164,7 @@ class Request
      */
     public function getMethod()
     {
-        if (null === $this->method) {
+        if (null === $this->method || self::$httpMethodParameterOverride) {
             $this->method = strtoupper($this->server->get('REQUEST_METHOD', 'GET'));
 
             if ('POST' === $this->method) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9464 |
| License | MIT |
| Doc PR | n/a |

This PR fixes an issue where method parameter overriding fails if the `getMethod` is called BEFORE the overriding is enabled, because the value is cached.

See https://github.com/symfony/symfony/issues/9464
