### PR TITLE
[Routing] ApacheMatcher does not handle scheme requirement

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
@@ -50,6 +50,8 @@ class RouterApacheDumperCommand extends ContainerAwareCommand
             ->setName('router:dump-apache')
             ->setDefinition(array(
                 new InputArgument('script_name', InputArgument::OPTIONAL, 'The script name of the application\'s front controller.'),
+                new InputOption('http-port', null, InputOption::VALUE_REQUIRED, 'The http-port.'),
+                new InputOption('https-port', null, InputOption::VALUE_REQUIRED, 'The https-port.'),
                 new InputOption('base-uri', null, InputOption::VALUE_REQUIRED, 'The base URI'),
             ))
             ->setDescription('Dumps all routes as Apache rewrite rules')
@@ -77,6 +79,12 @@ EOF
         }
         if ($input->getOption('base-uri')) {
             $dumpOptions['base_uri'] = $input->getOption('base-uri');
+        }
+        if ($input->getOption('http-port')) {
+            $dumpOptions['http_port'] = $input->getOption('http-port');
+        }
+        if ($input->getOption('https-port')) {
+            $dumpOptions['https_port'] = $input->getOption('https-port');
         }
 
         $dumper = new ApacheMatcherDumper($router->getRouteCollection());

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -40,6 +40,8 @@ class ApacheMatcherDumper extends MatcherDumper
         $options = array_merge(array(
             'script_name' => 'app.php',
             'base_uri'    => '',
+            'http_port'   => '',
+            'https_port'  => ''
         ), $options);
 
         $options['script_name'] = self::escape($options['script_name'], ' ', '\\');
@@ -173,14 +175,40 @@ class ApacheMatcherDumper extends MatcherDumper
             $rule[] = 'RewriteRule .* $0/ [QSA,L,R=301]';
         }
 
-        // the main rule
+        $requiredSchemes = $route->getSchemes();
+        if (count($requiredSchemes) === 1) {
 
-        if ($compiledRoute->getHostRegex()) {
-            $rule[] = sprintf("RewriteCond %%{ENV:__ROUTING_host_%s} =1", $hostRegexUnique);
+            $scheme = $requiredSchemes[0];
+
+            // redirect for wrong scheme
+            if ($compiledRoute->getHostRegex()) {
+                $rule[] = sprintf("RewriteCond %%{ENV:__ROUTING_host_%s} =1", $hostRegexUnique);
+            }
+
+            $targetPort = (!empty($options[$scheme . '_port']) ? ':' . $options[$scheme . '_port'] : '');
+
+            $rule[] = 'RewriteCond %{HTTPS} ' . ($scheme === 'http' ? 'on' : 'off');
+            $rule[] = "RewriteCond %{REQUEST_URI} $regex";
+            $rule[] = 'RewriteRule ^(.*)$ ' . $scheme . '://%{SERVER_NAME}' . $targetPort . '%{REQUEST_URI} [L,R=301]';
+
+            // main rule for correct scheme
+            if ($compiledRoute->getHostRegex()) {
+                $rule[] = sprintf("RewriteCond %%{ENV:__ROUTING_host_%s} =1", $hostRegexUnique);
+            }
+            $rule[] = 'RewriteCond %{HTTPS} ' . ($scheme === 'http' ? 'off' : 'on');
+            $rule[] = "RewriteCond %{REQUEST_URI} $regex";
+            $rule[] = "RewriteRule .* {$options['script_name']} [QSA,L,$variables]";
+
+        } else {
+
+            // the main rule
+            if ($compiledRoute->getHostRegex()) {
+                $rule[] = sprintf("RewriteCond %%{ENV:__ROUTING_host_%s} =1", $hostRegexUnique);
+            }
+
+            $rule[] = "RewriteCond %{REQUEST_URI} $regex";
+            $rule[] = "RewriteRule .* {$options['script_name']} [QSA,L,$variables]";
         }
-
-        $rule[] = "RewriteCond %{REQUEST_URI} $regex";
-        $rule[] = "RewriteRule .* {$options['script_name']} [QSA,L,$variables]";
 
         return implode("\n", $rule);
     }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.apache
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.apache
@@ -24,6 +24,26 @@ RewriteRule .* - [S=1,E=_ROUTING_allow_GET:1,E=_ROUTING_allow_POST:1,E=_ROUTING_
 RewriteCond %{REQUEST_URI} ^/baragain/([^/]++)$
 RewriteRule .* app.php [QSA,L,E=_ROUTING_route:baragain,E=_ROUTING_param_foo:%1]
 
+# barhttp
+RewriteCond %{HTTPS} on
+RewriteCond %{REQUEST_URI} ^/barhttp/([^/]++)$
+RewriteRule ^(.*)$ http://%{SERVER_NAME}%{REQUEST_URI} [L,R=301]
+RewriteCond %{HTTPS} off
+RewriteCond %{REQUEST_URI} ^/barhttp/([^/]++)$
+RewriteRule .* app.php [QSA,L,E=_ROUTING_route:barhttp,E=_ROUTING_param_foo:%1]
+
+# barhttps
+RewriteCond %{HTTPS} off
+RewriteCond %{REQUEST_URI} ^/barhttps/([^/]++)$
+RewriteRule ^(.*)$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301]
+RewriteCond %{HTTPS} on
+RewriteCond %{REQUEST_URI} ^/barhttps/([^/]++)$
+RewriteRule .* app.php [QSA,L,E=_ROUTING_route:barhttps,E=_ROUTING_param_foo:%1]
+
+# barhttphttps
+RewriteCond %{REQUEST_URI} ^/barhttphttps/([^/]++)$
+RewriteRule .* app.php [QSA,L,E=_ROUTING_route:barhttphttps,E=_ROUTING_param_foo:%1]
+
 # baz
 RewriteCond %{REQUEST_URI} ^/test/baz$
 RewriteRule .* app.php [QSA,L,E=_ROUTING_route:baz]

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/ApacheMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/ApacheMatcherDumperTest.php
@@ -87,6 +87,24 @@ class ApacheMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array(),
             array('_method' => 'get|post')
         ));
+        // scheme requirement (http)
+        $collection->add('barhttp', new Route(
+            '/barhttp/{foo}',
+            array(),
+            array('_scheme' => 'http')
+        ));
+        // method requirement (https)
+        $collection->add('barhttps', new Route(
+            '/barhttps/{foo}',
+            array(),
+            array('_scheme' => 'https')
+        ));
+        // method requirement (http + https)
+        $collection->add('barhttphttps', new Route(
+            '/barhttphttps/{foo}',
+            array(),
+            array('_scheme' => 'http|https')
+        ));
         // simple
         $collection->add('baz', new Route(
             '/test/baz'


### PR DESCRIPTION
[Matcher] [Routing] Added: ApacheMatcher can handle scheme requirement

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes - Component Routing, Bundle FrameworkBundle |
| Fixed tickets | #5995 |
| License | MIT |
| Doc PR |  |

I added the possibility to handle scheme requirements.
The ApacheMatcherDumper generates a redirection-rule, if the request matches the wrong scheme.

I also added two options to the dumper command:
--http-port=
--https-port=
