### PR TITLE
unify constructor initialization style throughout symfony

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -24,12 +24,11 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
 {
     protected $registry;
 
-    private $cache;
+    private $cache = array();
 
     public function __construct(ManagerRegistry $registry)
     {
         $this->registry = $registry;
-        $this->cache = array();
     }
 
     /**
@@ -90,7 +89,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
             return null;
         }
 
-        /* @var ClassMetadataInfo $classMetadata */
+        /** @var ClassMetadataInfo $classMetadata */
         $classMetadata = $classMetadatas[0];
 
         // Check whether the field exists and is nullable or not

--- a/src/Symfony/Bridge/Twig/NodeVisitor/Scope.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/Scope.php
@@ -29,12 +29,12 @@ class Scope
     /**
      * @var array
      */
-    private $data;
+    private $data = array();
 
     /**
      * @var boolean
      */
-    private $left;
+    private $left = false;
 
     /**
      * @param Scope $parent
@@ -42,8 +42,6 @@ class Scope
     public function __construct(Scope $parent = null)
     {
         $this->parent = $parent;
-        $this->left = false;
-        $this->data = array();
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -41,7 +41,7 @@ class Router extends BaseRouter implements WarmableInterface
         $this->container = $container;
 
         $this->resource = $resource;
-        $this->context = null === $context ? new RequestContext() : $context;
+        $this->context = $context ?: new RequestContext();
         $this->setOptions($options);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 class TemplateNameParser implements TemplateNameParserInterface
 {
     protected $kernel;
-    protected $cache;
+    protected $cache = array();
 
     /**
      * Constructor.
@@ -35,7 +35,6 @@ class TemplateNameParser implements TemplateNameParserInterface
     public function __construct(KernelInterface $kernel)
     {
         $this->kernel = $kernel;
-        $this->cache = array();
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -24,7 +24,10 @@ use Symfony\Component\Config\ConfigCache;
 class Translator extends BaseTranslator
 {
     protected $container;
-    protected $options;
+    protected $options = array(
+        'cache_dir' => null,
+        'debug'     => false,
+    );
     protected $loaderIds;
 
     /**
@@ -46,11 +49,6 @@ class Translator extends BaseTranslator
     {
         $this->container = $container;
         $this->loaderIds = $loaderIds;
-
-        $this->options = array(
-            'cache_dir' => null,
-            'debug'     => false,
-        );
 
         // check option names
         if ($diff = array_diff(array_keys($options), array_keys($this->options))) {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -23,7 +22,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
 
 /**

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -26,7 +26,7 @@ use Symfony\Component\Templating\Helper\Helper;
 class LogoutUrlHelper extends Helper
 {
     private $container;
-    private $listeners;
+    private $listeners = array();
     private $router;
 
     /**
@@ -39,7 +39,6 @@ class LogoutUrlHelper extends Helper
     {
         $this->container = $container;
         $this->router = $router;
-        $this->listeners = array();
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -32,19 +32,19 @@ abstract class Client
 {
     protected $history;
     protected $cookieJar;
-    protected $server;
+    protected $server = array();
     protected $internalRequest;
     protected $request;
     protected $internalResponse;
     protected $response;
     protected $crawler;
-    protected $insulated;
+    protected $insulated = false;
     protected $redirect;
-    protected $followRedirects;
+    protected $followRedirects = true;
 
-    private $maxRedirects;
-    private $redirectCount;
-    private $isMainRequest;
+    private $maxRedirects = -1;
+    private $redirectCount = 0;
+    private $isMainRequest = true;
 
     /**
      * Constructor.
@@ -58,13 +58,8 @@ abstract class Client
     public function __construct(array $server = array(), History $history = null, CookieJar $cookieJar = null)
     {
         $this->setServerParameters($server);
-        $this->history = null === $history ? new History() : $history;
-        $this->cookieJar = null === $cookieJar ? new CookieJar() : $cookieJar;
-        $this->insulated = false;
-        $this->followRedirects = true;
-        $this->maxRedirects = -1;
-        $this->redirectCount = 0;
-        $this->isMainRequest = true;
+        $this->history = $history ?: new History();
+        $this->cookieJar = $cookieJar ?: new CookieJar();
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/History.php
+++ b/src/Symfony/Component/BrowserKit/History.php
@@ -22,14 +22,6 @@ class History
     protected $position = -1;
 
     /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        $this->clear();
-    }
-
-    /**
      * Clears the history.
      */
     public function clear()

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -22,34 +22,14 @@ use Symfony\Component\Config\Definition\Exception\UnsetKeyException;
  */
 class ArrayNode extends BaseNode implements PrototypeNodeInterface
 {
-    protected $xmlRemappings;
-    protected $children;
-    protected $allowFalse;
-    protected $allowNewKeys;
-    protected $addIfNotSet;
-    protected $performDeepMerging;
-    protected $ignoreExtraKeys;
-    protected $normalizeKeys;
-
-    /**
-     * Constructor.
-     *
-     * @param string        $name   The Node's name
-     * @param NodeInterface $parent The node parent
-     */
-    public function __construct($name, NodeInterface $parent = null)
-    {
-        parent::__construct($name, $parent);
-
-        $this->children = array();
-        $this->xmlRemappings = array();
-        $this->removeKeyAttribute = true;
-        $this->allowFalse = false;
-        $this->addIfNotSet = false;
-        $this->allowNewKeys = true;
-        $this->performDeepMerging = true;
-        $this->normalizeKeys = true;
-    }
+    protected $xmlRemappings = array();
+    protected $children = array();
+    protected $allowFalse = false;
+    protected $allowNewKeys = true;
+    protected $addIfNotSet = false;
+    protected $performDeepMerging = true;
+    protected $ignoreExtraKeys = false;
+    protected $normalizeKeys = true;
 
     public function setNormalizeKeys($normalizeKeys)
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -24,11 +24,11 @@ abstract class BaseNode implements NodeInterface
 {
     protected $name;
     protected $parent;
-    protected $normalizationClosures;
-    protected $finalValidationClosures;
-    protected $allowOverwrite;
-    protected $required;
-    protected $equivalentValues;
+    protected $normalizationClosures = array();
+    protected $finalValidationClosures = array();
+    protected $allowOverwrite = true;
+    protected $required = false;
+    protected $equivalentValues = array();
     protected $attributes = array();
 
     /**
@@ -47,11 +47,6 @@ abstract class BaseNode implements NodeInterface
 
         $this->name = $name;
         $this->parent = $parent;
-        $this->normalizationClosures = array();
-        $this->finalValidationClosures = array();
-        $this->allowOverwrite = true;
-        $this->required = false;
-        $this->equivalentValues = array();
     }
 
     public function setAttribute($key, $value)

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -22,18 +22,18 @@ use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
  */
 class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinitionInterface
 {
-    protected $performDeepMerging;
-    protected $ignoreExtraKeys;
-    protected $children;
+    protected $performDeepMerging = true;
+    protected $ignoreExtraKeys = false;
+    protected $children = array();
     protected $prototype;
-    protected $atLeastOne;
-    protected $allowNewKeys;
+    protected $atLeastOne = false;
+    protected $allowNewKeys = true;
     protected $key;
     protected $removeKeyItem;
-    protected $addDefaults;
-    protected $addDefaultChildren;
+    protected $addDefaults = false;
+    protected $addDefaultChildren = false;
     protected $nodeBuilder;
-    protected $normalizeKeys;
+    protected $normalizeKeys = true;
 
     /**
      * {@inheritDoc}
@@ -42,16 +42,8 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     {
         parent::__construct($name, $parent);
 
-        $this->children = array();
-        $this->addDefaults = false;
-        $this->addDefaultChildren = false;
-        $this->allowNewKeys = true;
-        $this->atLeastOne = false;
-        $this->allowEmptyValue = true;
-        $this->performDeepMerging = true;
         $this->nullEquivalent = array();
         $this->trueEquivalent = array();
-        $this->normalizeKeys = true;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
@@ -19,8 +19,8 @@ namespace Symfony\Component\Config\Definition\Builder;
 class MergeBuilder
 {
     protected $node;
-    public $allowFalse;
-    public $allowOverwrite;
+    public $allowFalse = false;
+    public $allowOverwrite = true;
 
     /**
      * Constructor
@@ -30,8 +30,6 @@ class MergeBuilder
     public function __construct(NodeDefinition $node)
     {
         $this->node = $node;
-        $this->allowFalse = false;
-        $this->allowOverwrite = true;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -25,15 +25,16 @@ abstract class NodeDefinition implements NodeParentInterface
     protected $normalization;
     protected $validation;
     protected $defaultValue;
-    protected $default;
-    protected $required;
+    protected $default = false;
+    protected $required = false;
     protected $merge;
-    protected $allowEmptyValue;
+    protected $allowEmptyValue = true;
     protected $nullEquivalent;
-    protected $trueEquivalent;
-    protected $falseEquivalent;
+    protected $trueEquivalent = true;
+    protected $falseEquivalent = false;
+
     /**
-     * @var NodeParentInterface|NodeInterface
+     * @var NodeParentInterface|null
      */
     protected $parent;
     protected $attributes = array();
@@ -41,17 +42,13 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Constructor
      *
-     * @param string              $name   The name of the node
-     * @param NodeParentInterface $parent The parent
+     * @param string                   $name   The name of the node
+     * @param NodeParentInterface|null $parent The parent
      */
     public function __construct($name, NodeParentInterface $parent = null)
     {
         $this->parent = $parent;
         $this->name = $name;
-        $this->default = false;
-        $this->required = false;
-        $this->trueEquivalent = true;
-        $this->falseEquivalent = false;
     }
 
     /**
@@ -110,7 +107,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Returns the parent node.
      *
-     * @return NodeParentInterface The builder of the parent node
+     * @return NodeParentInterface|null The builder of the parent node
      */
     public function end()
     {

--- a/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
@@ -19,8 +19,8 @@ namespace Symfony\Component\Config\Definition\Builder;
 class NormalizationBuilder
 {
     protected $node;
-    public $before;
-    public $remappings;
+    public $before = array();
+    public $remappings = array();
 
     /**
      * Constructor
@@ -30,9 +30,6 @@ class NormalizationBuilder
     public function __construct(NodeDefinition $node)
     {
         $this->node = $node;
-        $this->keys = false;
-        $this->remappings = array();
-        $this->before = array();
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Config\Definition\Builder;
 class ValidationBuilder
 {
     protected $node;
-    public $rules;
+    public $rules = array();
 
     /**
      * Constructor
@@ -29,8 +29,6 @@ class ValidationBuilder
     public function __construct(NodeDefinition $node)
     {
         $this->node = $node;
-
-        $this->rules = array();
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
@@ -49,10 +49,7 @@ class VariableNodeDefinition extends NodeDefinition
             $node->setDefaultValue($this->defaultValue);
         }
 
-        if (false === $this->allowEmptyValue) {
-            $node->setAllowEmptyValue($this->allowEmptyValue);
-        }
-
+        $node->setAllowEmptyValue($this->allowEmptyValue);
         $node->addEquivalentValue(null, $this->nullEquivalent);
         $node->addEquivalentValue(true, $this->trueEquivalent);
         $node->addEquivalentValue(false, $this->falseEquivalent);

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -25,24 +25,10 @@ class PrototypedArrayNode extends ArrayNode
 {
     protected $prototype;
     protected $keyAttribute;
-    protected $removeKeyAttribute;
-    protected $minNumberOfElements;
-    protected $defaultValue;
+    protected $removeKeyAttribute = false;
+    protected $minNumberOfElements = 0;
+    protected $defaultValue = array();
     protected $defaultChildren;
-
-    /**
-     * Constructor.
-     *
-     * @param string        $name   The Node's name
-     * @param NodeInterface $parent The node parent
-     */
-    public function __construct($name, NodeInterface $parent = null)
-    {
-        parent::__construct($name, $parent);
-
-        $this->minNumberOfElements = 0;
-        $this->defaultValue = array();
-    }
 
     /**
      * Sets the minimum number of elements that a prototype based node must

--- a/src/Symfony/Component/Config/Loader/LoaderResolver.php
+++ b/src/Symfony/Component/Config/Loader/LoaderResolver.php
@@ -24,7 +24,7 @@ class LoaderResolver implements LoaderResolverInterface
     /**
      * @var LoaderInterface[] An array of LoaderInterface objects
      */
-    private $loaders;
+    private $loaders = array();
 
     /**
      * Constructor.
@@ -33,7 +33,6 @@ class LoaderResolver implements LoaderResolverInterface
      */
     public function __construct(array $loaders = array())
     {
-        $this->loaders = array();
         foreach ($loaders as $loader) {
             $this->addLoader($loader);
         }

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Command\Command;
  */
 class HelperSet implements \IteratorAggregate
 {
-    private $helpers;
+    private $helpers = array();
     private $command;
 
     /**
@@ -30,7 +30,6 @@ class HelperSet implements \IteratorAggregate
      */
     public function __construct(array $helpers = array())
     {
-        $this->helpers = array();
         foreach ($helpers as $alias => $helper) {
             $this->set($helper, is_int($alias) ? null : $alias);
         }

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -24,9 +24,12 @@ namespace Symfony\Component\Console\Input;
  */
 abstract class Input implements InputInterface
 {
+    /**
+     * @var InputDefinition
+     */
     protected $definition;
-    protected $options;
-    protected $arguments;
+    protected $options = array();
+    protected $arguments = array();
     protected $interactive = true;
 
     /**
@@ -37,8 +40,6 @@ abstract class Input implements InputInterface
     public function __construct(InputDefinition $definition = null)
     {
         if (null === $definition) {
-            $this->arguments = array();
-            $this->options = array();
             $this->definition = new InputDefinition();
         } else {
             $this->bind($definition);

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -46,7 +46,7 @@ abstract class Output implements OutputInterface
     public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = false, OutputFormatterInterface $formatter = null)
     {
         $this->verbosity = null === $verbosity ? self::VERBOSITY_NORMAL : $verbosity;
-        $this->formatter = null === $formatter ? new OutputFormatter() : $formatter;
+        $this->formatter = $formatter ?: new OutputFormatter();
         $this->formatter->setDecorated($decorated);
     }
 

--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -32,7 +32,7 @@ class Shell
     private $history;
     private $output;
     private $hasReadline;
-    private $processIsolation;
+    private $processIsolation = false;
 
     /**
      * Constructor.
@@ -48,7 +48,6 @@ class Shell
         $this->application = $application;
         $this->history = getenv('HOME').'/.history_'.$application->getName();
         $this->output = new ConsoleOutput();
-        $this->processIsolation = false;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -840,7 +840,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     protected function getDispatcher()
     {
-        $dispatcher = new EventDispatcher;
+        $dispatcher = new EventDispatcher();
         $dispatcher->addListener('console.command', function (ConsoleCommandEvent $event) {
             $event->getOutput()->write('before.');
         });

--- a/src/Symfony/Component/CssSelector/Parser/Reader.php
+++ b/src/Symfony/Component/CssSelector/Parser/Reader.php
@@ -34,7 +34,7 @@ class Reader
     /**
      * @var int
      */
-    private $position;
+    private $position = 0;
 
     /**
      * @param string $source
@@ -43,7 +43,6 @@ class Reader
     {
         $this->source = $source;
         $this->length = strlen($source);
-        $this->position = 0;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 class Compiler
 {
     private $passConfig;
-    private $log;
+    private $log = array();
     private $loggingFormatter;
     private $serviceReferenceGraph;
 
@@ -36,7 +36,6 @@ class Compiler
         $this->passConfig = new PassConfig();
         $this->serviceReferenceGraph = new ServiceReferenceGraph();
         $this->loggingFormatter = new LoggingFormatter();
-        $this->log = array();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -31,9 +31,9 @@ class PassConfig
     const TYPE_REMOVE = 'removing';
 
     private $mergePass;
-    private $afterRemovingPasses;
-    private $beforeOptimizationPasses;
-    private $beforeRemovingPasses;
+    private $afterRemovingPasses = array();
+    private $beforeOptimizationPasses = array();
+    private $beforeRemovingPasses = array();
     private $optimizationPasses;
     private $removingPasses;
 
@@ -43,10 +43,6 @@ class PassConfig
     public function __construct()
     {
         $this->mergePass = new MergeExtensionConfigurationPass();
-
-        $this->afterRemovingPasses = array();
-        $this->beforeOptimizationPasses = array();
-        $this->beforeRemovingPasses = array();
 
         $this->optimizationPasses = array(
             new ResolveDefinitionTemplatesPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -26,15 +26,7 @@ class ServiceReferenceGraph
     /**
      * @var ServiceReferenceGraphNode[]
      */
-    private $nodes;
-
-    /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        $this->nodes = array();
-    }
+    private $nodes = array();
 
     /**
      * Checks if the graph has a specific node.

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
@@ -24,8 +24,8 @@ use Symfony\Component\DependencyInjection\Alias;
 class ServiceReferenceGraphNode
 {
     private $id;
-    private $inEdges;
-    private $outEdges;
+    private $inEdges = array();
+    private $outEdges = array();
     private $value;
 
     /**
@@ -38,8 +38,6 @@ class ServiceReferenceGraphNode
     {
         $this->id = $id;
         $this->value = $value;
-        $this->inEdges = array();
-        $this->outEdges = array();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -67,13 +67,13 @@ class Container implements IntrospectableContainerInterface
      */
     protected $parameterBag;
 
-    protected $services;
-    protected $methodMap;
-    protected $aliases;
-    protected $scopes;
-    protected $scopeChildren;
-    protected $scopedServices;
-    protected $scopeStacks;
+    protected $services = array();
+    protected $methodMap = array();
+    protected $aliases = array();
+    protected $scopes = array();
+    protected $scopeChildren = array();
+    protected $scopedServices = array();
+    protected $scopeStacks = array();
     protected $loading = array();
 
     /**
@@ -85,14 +85,7 @@ class Container implements IntrospectableContainerInterface
      */
     public function __construct(ParameterBagInterface $parameterBag = null)
     {
-        $this->parameterBag = null === $parameterBag ? new ParameterBag() : $parameterBag;
-
-        $this->services       = array();
-        $this->aliases        = array();
-        $this->scopes         = array();
-        $this->scopeChildren  = array();
-        $this->scopedServices = array();
-        $this->scopeStacks    = array();
+        $this->parameterBag = $parameterBag ?: new ParameterBag();
 
         $this->set('service_container', $this);
     }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -28,24 +28,24 @@ class Definition
     private $factoryClass;
     private $factoryMethod;
     private $factoryService;
-    private $scope;
-    private $properties;
-    private $calls;
+    private $scope = ContainerInterface::SCOPE_CONTAINER;
+    private $properties = array();
+    private $calls = array();
     private $configurator;
-    private $tags;
-    private $public;
-    private $synthetic;
-    private $abstract;
-    private $synchronized;
-    private $lazy;
+    private $tags = array();
+    private $public = true;
+    private $synthetic = false;
+    private $abstract = false;
+    private $synchronized = false;
+    private $lazy = false;
 
     protected $arguments;
 
     /**
      * Constructor.
      *
-     * @param string $class     The service class
-     * @param array  $arguments An array of arguments to pass to the service constructor
+     * @param string|null $class     The service class
+     * @param array       $arguments An array of arguments to pass to the service constructor
      *
      * @api
      */
@@ -53,15 +53,6 @@ class Definition
     {
         $this->class = $class;
         $this->arguments = $arguments;
-        $this->calls = array();
-        $this->scope = ContainerInterface::SCOPE_CONTAINER;
-        $this->tags = array();
-        $this->public = true;
-        $this->synthetic = false;
-        $this->synchronized = false;
-        $this->lazy = false;
-        $this->abstract = false;
-        $this->properties = array();
     }
 
     /**
@@ -84,7 +75,7 @@ class Definition
     /**
      * Gets the factory class.
      *
-     * @return string The factory class name
+     * @return string|null The factory class name
      *
      * @api
      */
@@ -112,7 +103,7 @@ class Definition
     /**
      * Gets the factory method.
      *
-     * @return string The factory method name
+     * @return string|null The factory method name
      *
      * @api
      */
@@ -140,7 +131,7 @@ class Definition
     /**
      * Gets the factory service id.
      *
-     * @return string The factory service id
+     * @return string|null The factory service id
      *
      * @api
      */
@@ -168,7 +159,7 @@ class Definition
     /**
      * Gets the service class.
      *
-     * @return string The service class
+     * @return string|null The service class
      *
      * @api
      */
@@ -508,7 +499,7 @@ class Definition
     /**
      * Gets the file to require before creating the service.
      *
-     * @return string The full pathname to include
+     * @return string|null The full pathname to include
      *
      * @api
      */
@@ -704,7 +695,7 @@ class Definition
     /**
      * Gets the configurator to call after the service is fully initialized.
      *
-     * @return callable The PHP callable to call
+     * @return callable|null The PHP callable to call
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 class DefinitionDecorator extends Definition
 {
     private $parent;
-    private $changes;
+    private $changes = array();
 
     /**
      * Constructor.
@@ -38,7 +38,6 @@ class DefinitionDecorator extends Definition
         parent::__construct();
 
         $this->parent = $parent;
-        $this->changes = array();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -24,8 +24,8 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  */
 class ParameterBag implements ParameterBagInterface
 {
-    protected $parameters;
-    protected $resolved;
+    protected $parameters = array();
+    protected $resolved = false;
 
     /**
      * Constructor.
@@ -36,9 +36,7 @@ class ParameterBag implements ParameterBagInterface
      */
     public function __construct(array $parameters = array())
     {
-        $this->parameters = array();
         $this->add($parameters);
-        $this->resolved = false;
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
@@ -35,7 +35,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->event = new Event;
+        $this->event = new Event();
         $this->dispatcher = new EventDispatcher();
     }
 

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -29,12 +29,11 @@ class ExpressionLanguage
     private $parser;
     private $compiler;
 
-    protected $functions;
+    protected $functions = array();
 
     public function __construct(ParserCacheInterface $cache = null)
     {
         $this->cache = $cache ?: new ArrayParserCache();
-        $this->functions = array();
         $this->registerFunctions();
     }
 

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -16,9 +16,9 @@ use Symfony\Component\ExpressionLanguage\Compiler;
 class BinaryNode extends Node
 {
     private static $operators = array(
-        '~'     => '.',
-        'and'   => '&&',
-        'or'    => '||',
+        '~'   => '.',
+        'and' => '&&',
+        'or'  => '||',
     );
 
     private static $functions = array(
@@ -30,8 +30,10 @@ class BinaryNode extends Node
 
     public function __construct($operator, Node $left, Node $right)
     {
-        $this->nodes = array('left' => $left, 'right' => $right);
-        $this->attributes = array('operator' => $operator);
+        parent::__construct(
+            array('left' => $left, 'right' => $right),
+            array('operator' => $operator)
+        );
     }
 
     public function compile(Compiler $compiler)

--- a/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
@@ -17,7 +17,9 @@ class ConditionalNode extends Node
 {
     public function __construct(Node $expr1, Node $expr2, Node $expr3)
     {
-        $this->nodes = array('expr1' => $expr1, 'expr2' => $expr2, 'expr3' => $expr3);
+        parent::__construct(
+            array('expr1' => $expr1, 'expr2' => $expr2, 'expr3' => $expr3)
+        );
     }
 
     public function compile(Compiler $compiler)

--- a/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
@@ -17,7 +17,10 @@ class ConstantNode extends Node
 {
     public function __construct($value)
     {
-        $this->attributes = array('value' => $value);
+        parent::__construct(
+            array(),
+            array('value' => $value)
+        );
     }
 
     public function compile(Compiler $compiler)

--- a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
@@ -17,8 +17,10 @@ class FunctionNode extends Node
 {
     public function __construct($name, Node $arguments)
     {
-        $this->nodes = array('arguments' => $arguments);
-        $this->attributes = array('name' => $name);
+        parent::__construct(
+            array('arguments' => $arguments),
+            array('name' => $name)
+        );
     }
 
     public function compile(Compiler $compiler)

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -21,8 +21,10 @@ class GetAttrNode extends Node
 
     public function __construct(Node $node, Node $attribute, ArrayNode $arguments, $type)
     {
-        $this->nodes = array('node' => $node, 'attribute' => $attribute, 'arguments' => $arguments);
-        $this->attributes = array('type' => $type);
+        parent::__construct(
+            array('node' => $node, 'attribute' => $attribute, 'arguments' => $arguments),
+            array('type' => $type)
+        );
     }
 
     public function compile(Compiler $compiler)

--- a/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
@@ -17,7 +17,10 @@ class NameNode extends Node
 {
     public function __construct($name)
     {
-        $this->attributes = array('name' => $name);
+        parent::__construct(
+            array(),
+            array('name' => $name)
+        );
     }
 
     public function compile(Compiler $compiler)

--- a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
@@ -24,8 +24,10 @@ class UnaryNode extends Node
 
     public function __construct($operator, Node $node)
     {
-        $this->nodes = array('node' => $node);
-        $this->attributes = array('operator' => $operator);
+        parent::__construct(
+            array('node' => $node),
+            array('operator' => $operator)
+        );
     }
 
     public function compile(Compiler $compiler)

--- a/src/Symfony/Component/ExpressionLanguage/TokenStream.php
+++ b/src/Symfony/Component/ExpressionLanguage/TokenStream.php
@@ -21,7 +21,7 @@ class TokenStream
     public $current;
 
     private $tokens;
-    private $position;
+    private $position = 0;
 
     /**
      * Constructor.
@@ -31,7 +31,6 @@ class TokenStream
     public function __construct(array $tokens)
     {
         $this->tokens = $tokens;
-        $this->position = 0;
         $this->current = $tokens[0];
     }
 

--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Finder\Iterator;
  */
 class ExcludeDirectoryFilterIterator extends FilterIterator
 {
-    private $patterns;
+    private $patterns = array();
 
     /**
      * Constructor.
@@ -28,7 +28,6 @@ class ExcludeDirectoryFilterIterator extends FilterIterator
      */
     public function __construct(\Iterator $iterator, array $directories)
     {
-        $this->patterns = array();
         foreach ($directories as $directory) {
             $this->patterns[] = '#(^|/)'.preg_quote($directory, '#').'(/|$)#';
         }

--- a/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
@@ -20,8 +20,8 @@ use Symfony\Component\Finder\Expression\Expression;
  */
 abstract class MultiplePcreFilterIterator extends FilterIterator
 {
-    protected $matchRegexps;
-    protected $noMatchRegexps;
+    protected $matchRegexps = array();
+    protected $noMatchRegexps = array();
 
     /**
      * Constructor.
@@ -32,12 +32,10 @@ abstract class MultiplePcreFilterIterator extends FilterIterator
      */
     public function __construct(\Iterator $iterator, array $matchPatterns, array $noMatchPatterns)
     {
-        $this->matchRegexps = array();
         foreach ($matchPatterns as $pattern) {
             $this->matchRegexps[] = $this->toRegex($pattern);
         }
 
-        $this->noMatchRegexps = array();
         foreach ($noMatchPatterns as $pattern) {
             $this->noMatchRegexps[] = $this->toRegex($pattern);
         }

--- a/src/Symfony/Component/Finder/Shell/Command.php
+++ b/src/Symfony/Component/Finder/Shell/Command.php
@@ -24,12 +24,12 @@ class Command
     /**
      * @var array
      */
-    private $bits;
+    private $bits = array();
 
     /**
      * @var array
      */
-    private $labels;
+    private $labels = array();
 
     /**
      * @var \Closure|null
@@ -44,8 +44,6 @@ class Command
     public function __construct(Command $parent = null)
     {
         $this->parent = $parent;
-        $this->bits   = array();
-        $this->labels = array();
     }
 
     /**

--- a/src/Symfony/Component/Finder/Tests/Iterator/Iterator.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/Iterator.php
@@ -13,11 +13,10 @@ namespace Symfony\Component\Finder\Tests\Iterator;
 
 class Iterator implements \Iterator
 {
-    protected $values;
+    protected $values = array();
 
     public function __construct(array $values = array())
     {
-        $this->values = array();
         foreach ($values as $value) {
             $this->attach(new \SplFileInfo($value));
         }

--- a/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
@@ -27,12 +27,12 @@ class FormFactoryBuilderTest extends \PHPUnit_Framework_TestCase
         $this->registry->setAccessible(true);
 
         $this->guesser = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
-        $this->type = new FooType;
+        $this->type = new FooType();
     }
 
     public function testAddType()
     {
-        $factoryBuilder = new FormFactoryBuilder;
+        $factoryBuilder = new FormFactoryBuilder();
         $factoryBuilder->addType($this->type);
 
         $factory = $factoryBuilder->getFormFactory();
@@ -46,7 +46,7 @@ class FormFactoryBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testAddTypeGuesser()
     {
-        $factoryBuilder = new FormFactoryBuilder;
+        $factoryBuilder = new FormFactoryBuilder();
         $factoryBuilder->addTypeGuesser($this->guesser);
 
         $factory = $factoryBuilder->getFormFactory();

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -20,8 +20,8 @@ namespace Symfony\Component\HttpFoundation;
  */
 class HeaderBag implements \IteratorAggregate, \Countable
 {
-    protected $headers;
-    protected $cacheControl;
+    protected $headers = array();
+    protected $cacheControl = array();
 
     /**
      * Constructor.
@@ -32,8 +32,6 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function __construct(array $headers = array())
     {
-        $this->cacheControl = array();
-        $this->headers = array();
         foreach ($headers as $key => $values) {
             $this->set($key, $values);
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Flash/AutoExpireFlashBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/AutoExpireFlashBag.php
@@ -25,7 +25,7 @@ class AutoExpireFlashBag implements FlashBagInterface
      *
      * @var array
      */
-    private $flashes = array();
+    private $flashes = array('display' => array(), 'new' => array());
 
     /**
      * The storage key for flashes in the session
@@ -42,7 +42,6 @@ class AutoExpireFlashBag implements FlashBagInterface
     public function __construct($storageKey = '_sf2_flashes')
     {
         $this->storageKey = $storageKey;
-        $this->flashes = array('display' => array(), 'new' => array());
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
@@ -39,7 +39,7 @@ class MetadataBag implements SessionBagInterface
     /**
      * @var array
      */
-    protected $meta = array();
+    protected $meta = array(self::CREATED => 0, self::UPDATED => 0, self::LIFETIME => 0);
 
     /**
      * Unix timestamp.
@@ -63,7 +63,6 @@ class MetadataBag implements SessionBagInterface
     {
         $this->storageKey = $storageKey;
         $this->updateThreshold = $updateThreshold;
-        $this->meta = array(self::CREATED => 0, self::UPDATED => 0, self::LIFETIME => 0);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
-use \Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class RedirectResponseTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -881,14 +881,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function testGetContentWorksTwiceInDefaultMode()
     {
-        $req = new Request;
+        $req = new Request();
         $this->assertEquals('', $req->getContent());
         $this->assertEquals('', $req->getContent());
     }
 
     public function testGetContentReturnsResource()
     {
-        $req = new Request;
+        $req = new Request();
         $retval = $req->getContent(true);
         $this->assertInternalType('resource', $retval);
         $this->assertEquals("", fread($retval, 1));
@@ -901,7 +901,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetContentCantBeCalledTwiceWithResources($first, $second)
     {
-        $req = new Request;
+        $req = new Request();
         $req->getContent($first);
         $req->getContent($second);
     }
@@ -1361,7 +1361,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testUrlencodedStringPrefix($string, $prefix, $expect)
     {
-        $request = new Request;
+        $request = new Request();
 
         $me = new \ReflectionMethod($request, 'getUrlencodedPrefix');
         $me->setAccessible(true);

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -758,7 +758,7 @@ class ResponseTest extends ResponseTestCase
     public function validContentProvider()
     {
         return array(
-            'obj'    => array(new StringableObject),
+            'obj'    => array(new StringableObject()),
             'string' => array('Foo'),
             'int'    => array(2),
         );

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -59,7 +59,7 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
     protected function getStorage(array $options = array())
     {
         $storage = new NativeSessionStorage($options);
-        $storage->registerBag(new AttributeBag);
+        $storage->registerBag(new AttributeBag());
 
         return $storage;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -53,7 +53,7 @@ class PhpSessionStorageTest extends \PHPUnit_Framework_TestCase
     protected function getStorage()
     {
         $storage = new PhpBridgeSessionStorage();
-        $storage->registerBag(new AttributeBag);
+        $storage->registerBag(new AttributeBag());
 
         return $storage;
     }

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -18,13 +18,14 @@ namespace Symfony\Component\HttpKernel\CacheWarmer;
  */
 class CacheWarmerAggregate implements CacheWarmerInterface
 {
-    protected $warmers;
-    protected $optionalsEnabled;
+    protected $warmers = array();
+    protected $optionalsEnabled = false;
 
     public function __construct(array $warmers = array())
     {
-        $this->setWarmers($warmers);
-        $this->optionalsEnabled = false;
+        foreach ($warmers as $warmer) {
+            $this->add($warmer);
+        }
     }
 
     public function enableOptionalWarmers()

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -43,10 +43,9 @@ class Client extends BaseClient
      */
     public function __construct(HttpKernelInterface $kernel, array $server = array(), History $history = null, CookieJar $cookieJar = null)
     {
-        $this->kernel = $kernel;
-
         parent::__construct($server, $history, $cookieJar);
 
+        $this->kernel = $kernel;
         $this->followRedirects = false;
     }
 

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -30,11 +30,11 @@ use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface;
 class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEventDispatcherInterface
 {
     private $logger;
-    private $called;
+    private $called = array();
     private $stopwatch;
     private $dispatcher;
-    private $wrappedListeners;
-    private $firstCalledEvent;
+    private $wrappedListeners = array();
+    private $firstCalledEvent = array();
     private $id;
 
     /**
@@ -49,9 +49,6 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
         $this->dispatcher = $dispatcher;
         $this->stopwatch = $stopwatch;
         $this->logger = $logger;
-        $this->called = array();
-        $this->wrappedListeners = array();
-        $this->firstCalledEvent = array();
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -33,7 +33,7 @@ class ProfilerListener implements EventSubscriberInterface
     protected $onlyException;
     protected $onlyMasterRequests;
     protected $exception;
-    protected $requests;
+    protected $requests = array();
     protected $profiles;
     protected $requestStack;
     protected $parents;
@@ -54,7 +54,6 @@ class ProfilerListener implements EventSubscriberInterface
         $this->onlyMasterRequests = (Boolean) $onlyMasterRequests;
         $this->profiles = new \SplObjectStorage();
         $this->parents = new \SplObjectStorage();
-        $this->requests = array();
         $this->requestStack = $requestStack;
     }
 

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
@@ -35,7 +35,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 class FragmentHandler
 {
     private $debug;
-    private $renderers;
+    private $renderers = array();
     private $request;
     private $requestStack;
 
@@ -51,7 +51,6 @@ class FragmentHandler
     public function __construct(array $renderers = array(), $debug = false, RequestStack $requestStack = null)
     {
         $this->requestStack = $requestStack;
-        $this->renderers = array();
         foreach ($renderers as $renderer) {
             $this->addRenderer($renderer);
         }

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -35,7 +35,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     private $request;
     private $esi;
     private $esiCacheStrategy;
-    private $traces;
+    private $options = array();
+    private $traces = array();
 
     /**
      * Constructor.
@@ -81,6 +82,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     {
         $this->store = $store;
         $this->kernel = $kernel;
+        $this->esi = $esi;
 
         // needed in case there is a fatal error because the backend is too slow to respond
         register_shutdown_function(array($this->store, 'cleanup'));
@@ -94,8 +96,6 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             'stale_while_revalidate' => 2,
             'stale_if_error'         => 60,
         ), $options);
-        $this->esi = $esi;
-        $this->traces = array();
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -48,14 +48,14 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     /**
      * @var BundleInterface[]
      */
-    protected $bundles;
+    protected $bundles = array();
 
     protected $bundleMap;
     protected $container;
     protected $rootDir;
     protected $environment;
     protected $debug;
-    protected $booted;
+    protected $booted = false;
     protected $name;
     protected $startTime;
     protected $loadClassCache;
@@ -79,10 +79,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     {
         $this->environment = $environment;
         $this->debug = (Boolean) $debug;
-        $this->booted = false;
         $this->rootDir = $this->getRootDir();
         $this->name = $this->getName();
-        $this->bundles = array();
 
         if ($this->debug) {
             $this->startTime = microtime(true);

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
@@ -42,7 +42,7 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
             $host = $matches[1] ?: $matches[2];
             $port = $matches[3];
 
-            $memcache = new Memcache;
+            $memcache = new Memcache();
             $memcache->addServer($host, $port);
 
             $this->memcache = $memcache;

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
@@ -42,7 +42,7 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
             $host = $matches[1] ?: $matches[2];
             $port = $matches[3];
 
-            $memcached = new Memcached;
+            $memcached = new Memcached();
 
             //disable compression to allow appending
             $memcached->setOption(Memcached::OPT_COMPRESSION, false);

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
@@ -19,7 +19,7 @@ class TimeDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
     public function testCollect()
     {
-        $c = new TimeDataCollector;
+        $c = new TimeDataCollector();
 
         $request = new Request();
         $request->server->set('REQUEST_TIME', 1);
@@ -35,7 +35,7 @@ class TimeDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2000, $c->getStartTime());
 
         $request = new Request();
-        $c->collect($request, new Response);
+        $c->collect($request, new Response());
         $this->assertEquals(0, $c->getStartTime());
 
         $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -23,32 +23,15 @@ class KernelForTest extends Kernel
 
     public function registerBundles()
     {
-    }
-
-    public function init()
-    {
-    }
-
-    public function registerBundleDirs()
-    {
+        return array();
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
     }
 
-    public function initializeBundles()
-    {
-        parent::initializeBundles();
-    }
-
     public function isBooted()
     {
         return $this->booted;
-    }
-
-    public function setIsBooted($value)
-    {
-        $this->booted = (Boolean) $value;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -23,9 +23,9 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
     protected $body;
     protected $status;
     protected $headers;
-    protected $called;
+    protected $called = false;
     protected $customizer;
-    protected $catch;
+    protected $catch = false;
     protected $backendRequest;
 
     public function __construct($body, $status, $headers, \Closure $customizer = null)
@@ -34,8 +34,6 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
         $this->status = $status;
         $this->headers = $headers;
         $this->customizer = $customizer;
-        $this->called = false;
-        $this->catch = false;
 
         parent::__construct(new EventDispatcher(), $this);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
@@ -20,20 +20,14 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class TestMultipleHttpKernel extends HttpKernel implements ControllerResolverInterface
 {
-    protected $bodies;
-    protected $statuses;
-    protected $headers;
-    protected $catch;
-    protected $call;
+    protected $bodies = array();
+    protected $statuses = array();
+    protected $headers = array();
+    protected $call = false;
     protected $backendRequest;
 
     public function __construct($responses)
     {
-        $this->bodies   = array();
-        $this->statuses = array();
-        $this->headers  = array();
-        $this->call     = false;
-
         foreach ($responses as $response) {
             $this->bodies[]   = $response['body'];
             $this->statuses[] = $response['status'];

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests;
 
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -52,33 +51,22 @@ class KernelTest extends \PHPUnit_Framework_TestCase
 
     public function testBootInitializesBundlesAndContainer()
     {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles'))
-            ->getMock();
+        $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer'));
         $kernel->expects($this->once())
             ->method('initializeBundles');
         $kernel->expects($this->once())
             ->method('initializeContainer');
-        $kernel->expects($this->once())
-            ->method('getBundles')
-            ->will($this->returnValue(array()));
 
         $kernel->boot();
     }
 
     public function testBootSetsTheContainerToTheBundles()
     {
-        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\Bundle')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
         $bundle->expects($this->once())
             ->method('setContainer');
 
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles'))
-            ->getMock();
+        $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer', 'getBundles'));
         $kernel->expects($this->once())
             ->method('getBundles')
             ->will($this->returnValue(array($bundle)));
@@ -88,13 +76,11 @@ class KernelTest extends \PHPUnit_Framework_TestCase
 
     public function testBootSetsTheBootedFlagToTrue()
     {
+        // use test kernel to access isBooted()
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles'))
+            ->setConstructorArgs(array('test', false))
+            ->setMethods(array('initializeBundles', 'initializeContainer'))
             ->getMock();
-        $kernel->expects($this->once())
-            ->method('getBundles')
-            ->will($this->returnValue(array()));
 
         $kernel->boot();
 
@@ -103,14 +89,8 @@ class KernelTest extends \PHPUnit_Framework_TestCase
 
     public function testClassCacheIsLoaded()
     {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles', 'doLoadClassCache'))
-            ->getMock();
+        $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer', 'doLoadClassCache'));
         $kernel->loadClassCache('name', '.extension');
-        $kernel->expects($this->any())
-            ->method('getBundles')
-            ->will($this->returnValue(array()));
         $kernel->expects($this->once())
             ->method('doLoadClassCache')
             ->with('name', '.extension');
@@ -120,13 +100,7 @@ class KernelTest extends \PHPUnit_Framework_TestCase
 
     public function testClassCacheIsNotLoadedByDefault()
     {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles', 'doLoadClassCache'))
-            ->getMock();
-        $kernel->expects($this->any())
-            ->method('getBundles')
-            ->will($this->returnValue(array()));
+        $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer'));
         $kernel->expects($this->never())
             ->method('doLoadClassCache');
 
@@ -135,27 +109,17 @@ class KernelTest extends \PHPUnit_Framework_TestCase
 
     public function testClassCacheIsNotLoadedWhenKernelIsNotBooted()
     {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles', 'doLoadClassCache'))
-            ->getMock();
+        $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer', 'doLoadClassCache'));
         $kernel->loadClassCache();
-        $kernel->expects($this->any())
-            ->method('getBundles')
-            ->will($this->returnValue(array()));
         $kernel->expects($this->never())
             ->method('doLoadClassCache');
     }
 
     public function testBootKernelSeveralTimesOnlyInitializesBundlesOnce()
     {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles'))
-            ->getMock();
+        $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer'));
         $kernel->expects($this->once())
-            ->method('getBundles')
-            ->will($this->returnValue(array()));
+            ->method('initializeBundles');
 
         $kernel->boot();
         $kernel->boot();
@@ -163,40 +127,29 @@ class KernelTest extends \PHPUnit_Framework_TestCase
 
     public function testShutdownCallsShutdownOnAllBundles()
     {
-        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\Bundle')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
         $bundle->expects($this->once())
             ->method('shutdown');
 
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getBundles'))
-            ->getMock();
-        $kernel->expects($this->once())
-            ->method('getBundles')
-            ->will($this->returnValue(array($bundle)));
+        $kernel = $this->getKernel(array(), array($bundle));
 
+        $kernel->boot();
         $kernel->shutdown();
     }
 
     public function testShutdownGivesNullContainerToAllBundles()
     {
-        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\Bundle')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $bundle->expects($this->once())
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
+        $bundle->expects($this->at(3))
             ->method('setContainer')
             ->with(null);
 
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getBundles'))
-            ->getMock();
-        $kernel->expects($this->once())
+        $kernel = $this->getKernel(array('getBundles'));
+        $kernel->expects($this->any())
             ->method('getBundles')
             ->will($this->returnValue(array($bundle)));
 
+        $kernel->boot();
         $kernel->shutdown();
     }
 
@@ -214,11 +167,7 @@ class KernelTest extends \PHPUnit_Framework_TestCase
             ->method('handle')
             ->with($request, $type, $catch);
 
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getHttpKernel'))
-            ->getMock();
-
+        $kernel = $this->getKernel(array('getHttpKernel'));
         $kernel->expects($this->once())
             ->method('getHttpKernel')
             ->will($this->returnValue($httpKernelMock));
@@ -236,21 +185,13 @@ class KernelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getHttpKernel', 'boot'))
-            ->getMock();
-
+        $kernel = $this->getKernel(array('getHttpKernel', 'boot'));
         $kernel->expects($this->once())
             ->method('getHttpKernel')
             ->will($this->returnValue($httpKernelMock));
 
         $kernel->expects($this->once())
             ->method('boot');
-
-        // required as this value is initialized
-        // in the kernel constructor, which we don't call
-        $kernel->setIsBooted(false);
 
         $kernel->handle($request, $type, $catch);
     }
@@ -362,10 +303,7 @@ EOF;
     {
         $bundle = new FooBarBundle();
 
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getBundles'))
-            ->getMock();
+        $kernel = $this->getKernel(array('getBundles'));
         $kernel->expects($this->once())
             ->method('getBundles')
             ->will($this->returnValue(array($bundle)));
@@ -409,7 +347,7 @@ EOF;
      */
     public function testLocateResourceThrowsExceptionWhenNameIsNotValid()
     {
-        $this->getKernelForInvalidLocateResource()->locateResource('Foo');
+        $this->getKernel()->locateResource('Foo');
     }
 
     /**
@@ -417,7 +355,7 @@ EOF;
      */
     public function testLocateResourceThrowsExceptionWhenNameIsUnsafe()
     {
-        $this->getKernelForInvalidLocateResource()->locateResource('@FooBundle/../bar');
+        $this->getKernel()->locateResource('@FooBundle/../bar');
     }
 
     /**
@@ -425,7 +363,7 @@ EOF;
      */
     public function testLocateResourceThrowsExceptionWhenBundleDoesNotExist()
     {
-        $this->getKernelForInvalidLocateResource()->locateResource('@FooBundle/config/routing.xml');
+        $this->getKernel()->locateResource('@FooBundle/config/routing.xml');
     }
 
     /**
@@ -433,7 +371,7 @@ EOF;
      */
     public function testLocateResourceThrowsExceptionWhenResourceDoesNotExist()
     {
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->once())
             ->method('getBundle')
@@ -445,7 +383,7 @@ EOF;
 
     public function testLocateResourceReturnsTheFirstThatMatches()
     {
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->once())
             ->method('getBundle')
@@ -460,7 +398,7 @@ EOF;
         $parent = $this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle');
         $child = $this->getBundle(__DIR__.'/Fixtures/Bundle2Bundle');
 
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->exactly(2))
             ->method('getBundle')
@@ -476,7 +414,7 @@ EOF;
         $parent = $this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle');
         $child = $this->getBundle(__DIR__.'/Fixtures/Bundle2Bundle');
 
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->once())
             ->method('getBundle')
@@ -491,7 +429,7 @@ EOF;
 
     public function testLocateResourceReturnsAllMatchesBis()
     {
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->once())
             ->method('getBundle')
@@ -509,7 +447,7 @@ EOF;
 
     public function testLocateResourceIgnoresDirOnNonResource()
     {
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->once())
             ->method('getBundle')
@@ -524,7 +462,7 @@ EOF;
 
     public function testLocateResourceReturnsTheDirOneForResources()
     {
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->once())
             ->method('getBundle')
@@ -539,7 +477,7 @@ EOF;
 
     public function testLocateResourceReturnsTheDirOneForResourcesAndBundleOnes()
     {
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->once())
             ->method('getBundle')
@@ -558,7 +496,7 @@ EOF;
         $parent = $this->getBundle(__DIR__.'/Fixtures/BaseBundle', null, 'BaseBundle', 'BaseBundle');
         $child = $this->getBundle(__DIR__.'/Fixtures/ChildBundle', 'ParentBundle', 'ChildBundle', 'ChildBundle');
 
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->exactly(4))
             ->method('getBundle')
@@ -593,7 +531,7 @@ EOF;
 
     public function testLocateResourceOnDirectories()
     {
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->exactly(2))
             ->method('getBundle')
@@ -609,7 +547,7 @@ EOF;
             $kernel->locateResource('@FooBundle/Resources', __DIR__.'/Fixtures/Resources')
         );
 
-        $kernel = $this->getKernel();
+        $kernel = $this->getKernel(array('getBundle'));
         $kernel
             ->expects($this->exactly(2))
             ->method('getBundle')
@@ -631,13 +569,19 @@ EOF;
         $parent = $this->getBundle(null, null, 'ParentABundle');
         $child = $this->getBundle(null, 'ParentABundle', 'ChildABundle');
 
-        $kernel = $this->getKernel();
+        // use test kernel so we can access getBundleMap()
+        $kernel = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
+            ->setMethods(array('registerBundles'))
+            ->setConstructorArgs(array('test', false))
+            ->getMock()
+        ;
         $kernel
             ->expects($this->once())
             ->method('registerBundles')
             ->will($this->returnValue(array($parent, $child)))
         ;
-        $kernel->initializeBundles();
+        $kernel->boot();
 
         $map = $kernel->getBundleMap();
         $this->assertEquals(array($child, $parent), $map['ParentABundle']);
@@ -649,14 +593,20 @@ EOF;
         $parent = $this->getBundle(null, 'GrandParentBBundle', 'ParentBBundle');
         $child = $this->getBundle(null, 'ParentBBundle', 'ChildBBundle');
 
-        $kernel = $this->getKernel();
+        // use test kernel so we can access getBundleMap()
+        $kernel = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
+            ->setMethods(array('registerBundles'))
+            ->setConstructorArgs(array('test', false))
+            ->getMock()
+        ;
         $kernel
             ->expects($this->once())
             ->method('registerBundles')
             ->will($this->returnValue(array($grandparent, $parent, $child)))
         ;
 
-        $kernel->initializeBundles();
+        $kernel->boot();
 
         $map = $kernel->getBundleMap();
         $this->assertEquals(array($child, $parent, $grandparent), $map['GrandParentBBundle']);
@@ -666,18 +616,13 @@ EOF;
 
     /**
      * @expectedException \LogicException
+     * @expectedExceptionMessage Bundle "ChildCBundle" extends bundle "FooBar", which is not registered.
      */
     public function testInitializeBundlesThrowsExceptionWhenAParentDoesNotExists()
     {
         $child = $this->getBundle(null, 'FooBar', 'ChildCBundle');
-
-        $kernel = $this->getKernel();
-        $kernel
-            ->expects($this->once())
-            ->method('registerBundles')
-            ->will($this->returnValue(array($child)))
-        ;
-        $kernel->initializeBundles();
+        $kernel = $this->getKernel(array(), array($child));
+        $kernel->boot();
     }
 
     public function testInitializeBundlesSupportsArbitraryBundleRegistrationOrder()
@@ -686,14 +631,20 @@ EOF;
         $parent = $this->getBundle(null, 'GrandParentCBundle', 'ParentCBundle');
         $child = $this->getBundle(null, 'ParentCBundle', 'ChildCBundle');
 
-        $kernel = $this->getKernel();
+        // use test kernel so we can access getBundleMap()
+        $kernel = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
+            ->setMethods(array('registerBundles'))
+            ->setConstructorArgs(array('test', false))
+            ->getMock()
+        ;
         $kernel
             ->expects($this->once())
             ->method('registerBundles')
             ->will($this->returnValue(array($parent, $grandparent, $child)))
         ;
 
-        $kernel->initializeBundles();
+        $kernel->boot();
 
         $map = $kernel->getBundleMap();
         $this->assertEquals(array($child, $parent, $grandparent), $map['GrandParentCBundle']);
@@ -703,6 +654,7 @@ EOF;
 
     /**
      * @expectedException \LogicException
+     * @expectedExceptionMessage Bundle "ParentCBundle" is directly extended by two bundles "ChildC2Bundle" and "ChildC1Bundle".
      */
     public function testInitializeBundlesThrowsExceptionWhenABundleIsDirectlyExtendedByTwoBundles()
     {
@@ -710,59 +662,41 @@ EOF;
         $child1 = $this->getBundle(null, 'ParentCBundle', 'ChildC1Bundle');
         $child2 = $this->getBundle(null, 'ParentCBundle', 'ChildC2Bundle');
 
-        $kernel = $this->getKernel();
-        $kernel
-            ->expects($this->once())
-            ->method('registerBundles')
-            ->will($this->returnValue(array($parent, $child1, $child2)))
-        ;
-        $kernel->initializeBundles();
+        $kernel = $this->getKernel(array(), array($parent, $child1, $child2));
+        $kernel->boot();
     }
 
     /**
      * @expectedException \LogicException
+     * @expectedExceptionMessage Trying to register two bundles with the same name "DuplicateName"
      */
     public function testInitializeBundleThrowsExceptionWhenRegisteringTwoBundlesWithTheSameName()
     {
         $fooBundle = $this->getBundle(null, null, 'FooBundle', 'DuplicateName');
         $barBundle = $this->getBundle(null, null, 'BarBundle', 'DuplicateName');
 
-        $kernel = $this->getKernel();
-        $kernel
-            ->expects($this->once())
-            ->method('registerBundles')
-            ->will($this->returnValue(array($fooBundle, $barBundle)))
-        ;
-        $kernel->initializeBundles();
+        $kernel = $this->getKernel(array(), array($fooBundle, $barBundle));
+        $kernel->boot();
     }
 
     /**
      * @expectedException \LogicException
+     * @expectedExceptionMessage Bundle "CircularRefBundle" can not extend itself.
      */
     public function testInitializeBundleThrowsExceptionWhenABundleExtendsItself()
     {
         $circularRef = $this->getBundle(null, 'CircularRefBundle', 'CircularRefBundle');
 
-        $kernel = $this->getKernel();
-        $kernel
-            ->expects($this->once())
-            ->method('registerBundles')
-            ->will($this->returnValue(array($circularRef)))
-        ;
-        $kernel->initializeBundles();
+        $kernel = $this->getKernel(array(), array($circularRef));
+        $kernel->boot();
     }
 
     public function testTerminateReturnsSilentlyIfKernelIsNotBooted()
     {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getHttpKernel'))
-            ->getMock();
-
+        $kernel = $this->getKernel(array('getHttpKernel'));
         $kernel->expects($this->never())
             ->method('getHttpKernel');
 
-        $kernel->setIsBooted(false);
         $kernel->terminate(Request::create('/'), new Response());
     }
 
@@ -777,16 +711,12 @@ EOF;
             ->expects($this->never())
             ->method('terminate');
 
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getHttpKernel'))
-            ->getMock();
-
+        $kernel = $this->getKernel(array('getHttpKernel'));
         $kernel->expects($this->once())
             ->method('getHttpKernel')
             ->will($this->returnValue($httpKernelMock));
 
-        $kernel->setIsBooted(true);
+        $kernel->boot();
         $kernel->terminate(Request::create('/'), new Response());
 
         // implements TerminableInterface
@@ -799,19 +729,20 @@ EOF;
             ->expects($this->once())
             ->method('terminate');
 
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getHttpKernel'))
-            ->getMock();
-
+        $kernel = $this->getKernel(array('getHttpKernel'));
         $kernel->expects($this->exactly(2))
             ->method('getHttpKernel')
             ->will($this->returnValue($httpKernelMock));
 
-        $kernel->setIsBooted(true);
+        $kernel->boot();
         $kernel->terminate(Request::create('/'), new Response());
     }
 
+    /**
+     * Returns a mock for the BundleInterface
+     *
+     * @return BundleInterface
+     */
     protected function getBundle($dir = null, $parent = null, $className = null, $bundleName = null)
     {
         $bundle = $this
@@ -847,22 +778,28 @@ EOF;
         return $bundle;
     }
 
-    protected function getKernel()
+    /**
+     * Returns a mock for the abstract kernel.
+     *
+     * @param array $methods Additional methods to mock (besides the abstract ones)
+     * @param array $bundles Bundles to register
+     *
+     * @return Kernel
+     */
+    protected function getKernel(array $methods = array(), array $bundles = array())
     {
-        return $this
-            ->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->setMethods(array('getBundle', 'registerBundles'))
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-    }
-
-    protected function getKernelForInvalidLocateResource()
-    {
-        return $this
+        $kernel = $this
             ->getMockBuilder('Symfony\Component\HttpKernel\Kernel')
-            ->disableOriginalConstructor()
+            ->setMethods($methods)
+            ->setConstructorArgs(array('test', false))
             ->getMockForAbstractClass()
         ;
+
+        $kernel->expects($this->any())
+            ->method('registerBundles')
+            ->will($this->returnValue($bundles))
+        ;
+
+        return $kernel;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcacheMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcacheMock.php
@@ -18,14 +18,8 @@ namespace Symfony\Component\HttpKernel\Tests\Profiler\Mock;
  */
 class MemcacheMock
 {
-    private $connected;
-    private $storage;
-
-    public function __construct()
-    {
-        $this->connected = false;
-        $this->storage = array();
-    }
+    private $connected = false;
+    private $storage = array();
 
     /**
      * Open memcached server connection

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcachedMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcachedMock.php
@@ -18,14 +18,8 @@ namespace Symfony\Component\HttpKernel\Tests\Profiler\Mock;
  */
 class MemcachedMock
 {
-    private $connected;
-    private $storage;
-
-    public function __construct()
-    {
-        $this->connected = false;
-        $this->storage = array();
-    }
+    private $connected = false;
+    private $storage = array();
 
     /**
      * Set a Memcached option

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
@@ -18,15 +18,8 @@ namespace Symfony\Component\HttpKernel\Tests\Profiler\Mock;
  */
 class RedisMock
 {
-
-    private $connected;
-    private $storage;
-
-    public function __construct()
-    {
-        $this->connected = false;
-        $this->storage = array();
-    }
+    private $connected = false;
+    private $storage = array();
 
     /**
      * Add a server to connection pool

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -23,21 +23,16 @@ class ProcessBuilder
 {
     private $arguments;
     private $cwd;
-    private $env;
+    private $env = array();
     private $stdin;
-    private $timeout;
-    private $options;
-    private $inheritEnv;
+    private $timeout = 60;
+    private $options = array();
+    private $inheritEnv = true;
     private $prefix = array();
 
     public function __construct(array $arguments = array())
     {
         $this->arguments = $arguments;
-
-        $this->timeout = 60;
-        $this->options = array();
-        $this->env = array();
-        $this->inheritEnv = true;
     }
 
     public static function create(array $arguments = array())

--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -22,12 +22,12 @@ class Route
 {
     private $path;
     private $name;
-    private $requirements;
-    private $options;
-    private $defaults;
+    private $requirements = array();
+    private $options = array();
+    private $defaults = array();
     private $host;
-    private $methods;
-    private $schemes;
+    private $methods = array();
+    private $schemes = array();
     private $condition;
 
     /**
@@ -39,12 +39,6 @@ class Route
      */
     public function __construct(array $data)
     {
-        $this->requirements = array();
-        $this->options = array();
-        $this->defaults = array();
-        $this->methods = array();
-        $this->schemes = array();
-
         if (isset($data['value'])) {
             $data['path'] = $data['value'];
             unset($data['value']);

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -82,7 +82,7 @@ class Router implements RouterInterface
         $this->loader = $loader;
         $this->resource = $resource;
         $this->logger = $logger;
-        $this->context = null === $context ? new RequestContext() : $context;
+        $this->context = $context ?: new RequestContext();
         $this->setOptions($options);
     }
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/DumperPrefixCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/DumperPrefixCollectionTest.php
@@ -20,7 +20,7 @@ class DumperPrefixCollectionTest extends \PHPUnit_Framework_TestCase
 {
     public function testAddPrefixRoute()
     {
-        $coll = new DumperPrefixCollection;
+        $coll = new DumperPrefixCollection();
         $coll->setPrefix('');
 
         $route = new DumperRoute('bar', new Route('/foo/bar'));
@@ -66,7 +66,7 @@ EOF;
 
     public function testMergeSlashNodes()
     {
-        $coll = new DumperPrefixCollection;
+        $coll = new DumperPrefixCollection();
         $coll->setPrefix('');
 
         $route = new DumperRoute('bar', new Route('/foo/bar'));

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -40,8 +40,8 @@ class AclProvider implements AclProviderInterface
 
     protected $cache;
     protected $connection;
-    protected $loadedAces;
-    protected $loadedAcls;
+    protected $loadedAces = array();
+    protected $loadedAcls = array();
     protected $options;
     private $permissionGrantingStrategy;
 
@@ -57,8 +57,6 @@ class AclProvider implements AclProviderInterface
     {
         $this->cache = $cache;
         $this->connection = $connection;
-        $this->loadedAces = array();
-        $this->loadedAcls = array();
         $this->options = $options;
         $this->permissionGrantingStrategy = $permissionGrantingStrategy;
     }

--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -37,14 +37,14 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     private $parentAcl;
     private $permissionGrantingStrategy;
     private $objectIdentity;
-    private $classAces;
-    private $classFieldAces;
-    private $objectAces;
-    private $objectFieldAces;
+    private $classAces = array();
+    private $classFieldAces = array();
+    private $objectAces = array();
+    private $objectFieldAces = array();
     private $id;
     private $loadedSids;
     private $entriesInheriting;
-    private $listeners;
+    private $listeners = array();
 
     /**
      * Constructor
@@ -62,12 +62,6 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
         $this->permissionGrantingStrategy = $permissionGrantingStrategy;
         $this->loadedSids = $loadedSids;
         $this->entriesInheriting = $entriesInheriting;
-        $this->parentAcl = null;
-        $this->classAces = array();
-        $this->classFieldAces = array();
-        $this->objectAces = array();
-        $this->objectFieldAces = array();
-        $this->listeners = array();
     }
 
     /**

--- a/src/Symfony/Component/Security/Acl/Tests/Permission/MaskBuilderTest.php
+++ b/src/Symfony/Component/Security/Acl/Tests/Permission/MaskBuilderTest.php
@@ -76,7 +76,7 @@ class MaskBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPattern()
     {
-        $builder = new MaskBuilder;
+        $builder = new MaskBuilder();
         $this->assertEquals(MaskBuilder::ALL_OFF, $builder->getPattern());
 
         $builder->add('view');

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -26,9 +26,9 @@ use Symfony\Component\Security\Core\User\EquatableInterface;
 abstract class AbstractToken implements TokenInterface
 {
     private $user;
-    private $roles;
-    private $authenticated;
-    private $attributes;
+    private $roles = array();
+    private $authenticated = false;
+    private $attributes = array();
 
     /**
      * Constructor.
@@ -39,10 +39,6 @@ abstract class AbstractToken implements TokenInterface
      */
     public function __construct(array $roles = array())
     {
-        $this->authenticated = false;
-        $this->attributes = array();
-
-        $this->roles = array();
         foreach ($roles as $role) {
             if (is_string($role)) {
                 $role = new Role($role);

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -139,7 +139,7 @@ class DigestAuthenticationListener implements ListenerInterface
 
 class DigestData
 {
-    private $elements;
+    private $elements = array();
     private $header;
     private $nonceExpiryTime;
 
@@ -147,7 +147,6 @@ class DigestData
     {
         $this->header = $header;
         preg_match_all('/(\w+)=("((?:[^"\\\\]|\\\\.)+)"|([^\s,$]+))/', $header, $matches, PREG_SET_ORDER);
-        $this->elements = array();
         foreach ($matches as $match) {
             if (isset($match[1]) && isset($match[3])) {
                 $this->elements[$match[1]] = isset($match[4]) ? $match[4] : $match[3];

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -43,7 +43,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     public function testAutoLoginThrowsExceptionWhenImplementationDoesNotReturnUserInterface()
     {
         $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', 'foo');
 
         $service
@@ -106,8 +106,8 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     public function testLoginSuccessIsNotProcessedWhenTokenDoesNotContainUserInterfaceImplementation()
     {
         $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true, 'path' => null, 'domain' => null));
-        $request = new Request;
-        $response = new Response;
+        $request = new Request();
+        $response = new Response();
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token
@@ -129,8 +129,8 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     public function testLoginSuccessIsNotProcessedWhenRememberMeIsNotRequested()
     {
         $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo', 'path' => null, 'domain' => null));
-        $request = new Request;
-        $response = new Response;
+        $request = new Request();
+        $response = new Response();
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token
@@ -153,8 +153,8 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     public function testLoginSuccessWhenRememberMeAlwaysIsTrue()
     {
         $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true, 'path' => null, 'domain' => null));
-        $request = new Request;
-        $response = new Response;
+        $request = new Request();
+        $response = new Response();
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token
@@ -179,9 +179,9 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo[bar]', 'path' => null, 'domain' => null));
 
-        $request = new Request;
+        $request = new Request();
         $request->request->set('foo', array('bar' => $value));
-        $response = new Response;
+        $response = new Response();
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token
@@ -206,9 +206,9 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo', 'path' => null, 'domain' => null));
 
-        $request = new Request;
+        $request = new Request();
         $request->request->set('foo', $value);
-        $response = new Response;
+        $response = new Response();
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -36,7 +36,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     public function testAutoLoginThrowsExceptionOnInvalidCookie()
     {
         $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => false, 'remember_me_parameter' => 'foo'));
-        $request = new Request;
+        $request = new Request();
         $request->request->set('foo', 'true');
         $request->cookies->set('foo', 'foo');
 
@@ -47,7 +47,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     public function testAutoLoginThrowsExceptionOnNonExistentToken()
     {
         $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => false, 'remember_me_parameter' => 'foo'));
-        $request = new Request;
+        $request = new Request();
         $request->request->set('foo', 'true');
         $request->cookies->set('foo', $this->encodeCookie(array(
             $series = 'fooseries',
@@ -70,7 +70,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     {
         $userProvider = $this->getProvider();
         $service = $this->getService($userProvider, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => true, 'lifetime' => 3600, 'secure' => false, 'httponly' => false));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', $this->encodeCookie(array('fooseries', 'foovalue')));
 
         $tokenProvider = $this->getMock('Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface');
@@ -95,7 +95,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     {
         $userProvider = $this->getProvider();
         $service = $this->getService($userProvider, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => true));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', $this->encodeCookie(array('fooseries', 'foovalue')));
 
         $tokenProvider = $this->getMock('Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface');
@@ -125,7 +125,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     public function testAutoLoginDoesNotAcceptAnExpiredCookie()
     {
         $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => true, 'lifetime' => 3600));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', $this->encodeCookie(array('fooseries', 'foovalue')));
 
         $tokenProvider = $this->getMock('Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface');
@@ -159,7 +159,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
         ;
 
         $service = $this->getService($userProvider, array('name' => 'foo', 'path' => null, 'domain' => null, 'secure' => false, 'httponly' => false, 'always_remember_me' => true, 'lifetime' => 3600));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', $this->encodeCookie(array('fooseries', 'foovalue')));
 
         $tokenProvider = $this->getMock('Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface');
@@ -207,8 +207,8 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     public function testLogoutSimplyIgnoresNonSetRequestCookie()
     {
         $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null));
-        $request = new Request;
-        $response = new Response;
+        $request = new Request();
+        $response = new Response();
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
         $tokenProvider = $this->getMock('Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface');
@@ -229,9 +229,9 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     public function testLogoutSimplyIgnoresInvalidCookie()
     {
         $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', 'somefoovalue');
-        $response = new Response;
+        $response = new Response();
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
         $tokenProvider = $this->getMock('Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface');
@@ -259,8 +259,8 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     public function testLoginSuccessSetsCookieWhenLoggedInWithNonRememberMeTokenInterfaceImplementation()
     {
         $service = $this->getService(null, array('name' => 'foo', 'domain' => 'myfoodomain.foo', 'path' => '/foo/path', 'secure' => true, 'httponly' => true, 'lifetime' => 3600, 'always_remember_me' => true));
-        $request = new Request;
-        $response = new Response;
+        $request = new Request();
+        $response = new Response();
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $account

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -44,7 +44,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         $userProvider = $this->getProvider();
         $service = $this->getService($userProvider, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => true, 'lifetime' => 3600));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', $this->getCookie('fooclass', 'foouser', time()+3600, 'foopass'));
 
         $userProvider
@@ -61,7 +61,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         $userProvider = $this->getProvider();
         $service = $this->getService($userProvider, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => true, 'lifetime' => 3600));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', base64_encode('class:'.base64_encode('foouser').':123456789:fooHash'));
 
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
@@ -86,7 +86,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         $userProvider = $this->getProvider();
         $service = $this->getService($userProvider, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => true, 'lifetime' => 3600));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', $this->getCookie('fooclass', 'foouser', time() - 1, 'foopass'));
 
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
@@ -130,7 +130,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
         ;
 
         $service = $this->getService($userProvider, array('name' => 'foo', 'always_remember_me' => true, 'lifetime' => 3600));
-        $request = new Request;
+        $request = new Request();
         $request->cookies->set('foo', $this->getCookie('fooclass', 'foouser', time()+3600, 'foopass'));
 
         $returnedToken = $service->autoLogin($request);
@@ -172,8 +172,8 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     public function testLoginSuccessIgnoresTokensWhichDoNotContainAnUserInterfaceImplementation()
     {
         $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true, 'path' => null, 'domain' => null));
-        $request = new Request;
-        $response = new Response;
+        $request = new Request();
+        $response = new Response();
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token
             ->expects($this->once())
@@ -193,8 +193,8 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     public function testLoginSuccess()
     {
         $service = $this->getService(null, array('name' => 'foo', 'domain' => 'myfoodomain.foo', 'path' => '/foo/path', 'secure' => true, 'httponly' => true, 'lifetime' => 3600, 'always_remember_me' => true));
-        $request = new Request;
-        $response = new Response;
+        $request = new Request();
+        $response = new Response();
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -32,8 +32,8 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
 
     public function __construct(JsonEncode $encodingImpl = null, JsonDecode $decodingImpl = null)
     {
-        $this->encodingImpl = null === $encodingImpl ? new JsonEncode() : $encodingImpl;
-        $this->decodingImpl = null === $decodingImpl ? new JsonDecode(true) : $decodingImpl;
+        $this->encodingImpl = $encodingImpl ?: new JsonEncode();
+        $this->decodingImpl = $decodingImpl ?: new JsonDecode(true);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
@@ -19,7 +19,7 @@ class JsonEncoderTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        $this->encoder = new JsonEncoder;
+        $this->encoder = new JsonEncoder();
         $this->serializer = new Serializer(array(new CustomNormalizer()), array('json' => new JsonEncoder()));
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -24,14 +24,14 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->encoder = new XmlEncoder;
+        $this->encoder = new XmlEncoder();
         $serializer = new Serializer(array(new CustomNormalizer()), array('xml' => new XmlEncoder()));
         $this->encoder->setSerializer($serializer);
     }
 
     public function testEncodeScalar()
     {
-        $obj = new ScalarDummy;
+        $obj = new ScalarDummy();
         $obj->xmlFoo = "foo";
 
         $expected = '<?xml version="1.0"?>'."\n".
@@ -42,7 +42,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testSetRootNodeName()
     {
-        $obj = new ScalarDummy;
+        $obj = new ScalarDummy();
         $obj->xmlFoo = "foo";
 
         $this->encoder->setRootNodeName('test');
@@ -63,7 +63,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testAttributes()
     {
-        $obj = new ScalarDummy;
+        $obj = new ScalarDummy();
         $obj->xmlFoo = array(
             'foo-bar' => array(
                 '@id' => 1,
@@ -92,7 +92,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testElementNameValid()
     {
-        $obj = new ScalarDummy;
+        $obj = new ScalarDummy();
         $obj->xmlFoo = array(
             'foo-bar' => 'a',
             'foo_bar' => 'a',
@@ -206,7 +206,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
     public function testEncodeSerializerXmlRootNodeNameOption()
     {
         $options = array('xml_root_node_name' => 'test');
-        $this->encoder = new XmlEncoder;
+        $this->encoder = new XmlEncoder();
         $serializer = new Serializer(array(), array('xml' => new XmlEncoder()));
         $this->encoder->setSerializer($serializer);
 
@@ -289,7 +289,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testDecodeWithoutItemHash()
     {
-        $obj = new ScalarDummy;
+        $obj = new ScalarDummy();
         $obj->xmlFoo = array(
             'foo-bar' => array(
                 '@key' => "value",
@@ -362,7 +362,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
     protected function getObject()
     {
-        $obj = new Dummy;
+        $obj = new Dummy();
         $obj->foo = 'foo';
         $obj->bar = array('a', 'b');
         $obj->baz = array('key' => 'val', 'key2' => 'val', 'A B' => 'bar', 'item' => array(array('title' => 'title1'), array('title' => 'title2')), 'Barry' => array('FooBar' => array('Baz' => 'Ed', '@id' => 1)));

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/CustomNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/CustomNormalizerTest.php
@@ -19,13 +19,13 @@ class CustomNormalizerTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        $this->normalizer = new CustomNormalizer;
-        $this->normalizer->setSerializer(new Serializer);
+        $this->normalizer = new CustomNormalizer();
+        $this->normalizer->setSerializer(new Serializer());
     }
 
     public function testSerialize()
     {
-        $obj = new ScalarDummy;
+        $obj = new ScalarDummy();
         $obj->foo = 'foo';
         $obj->xmlFoo = 'xml';
         $this->assertEquals('foo', $this->normalizer->normalize($obj, 'json'));
@@ -34,18 +34,18 @@ class CustomNormalizerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeserialize()
     {
-        $obj = $this->normalizer->denormalize('foo', get_class(new ScalarDummy), 'xml');
+        $obj = $this->normalizer->denormalize('foo', get_class(new ScalarDummy()), 'xml');
         $this->assertEquals('foo', $obj->xmlFoo);
         $this->assertNull($obj->foo);
 
-        $obj = $this->normalizer->denormalize('foo', get_class(new ScalarDummy), 'json');
+        $obj = $this->normalizer->denormalize('foo', get_class(new ScalarDummy()), 'json');
         $this->assertEquals('foo', $obj->foo);
         $this->assertNull($obj->xmlFoo);
     }
 
     public function testSupportsNormalization()
     {
-        $this->assertTrue($this->normalizer->supportsNormalization(new ScalarDummy));
+        $this->assertTrue($this->normalizer->supportsNormalization(new ScalarDummy()));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass));
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -17,13 +17,13 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        $this->normalizer = new GetSetMethodNormalizer;
+        $this->normalizer = new GetSetMethodNormalizer();
         $this->normalizer->setSerializer($this->getMock('Symfony\Component\Serializer\Serializer'));
     }
 
     public function testNormalize()
     {
-        $obj = new GetSetDummy;
+        $obj = new GetSetDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
         $obj->setCamelCase('camelcase');
@@ -118,7 +118,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->normalizer->setIgnoredAttributes(array('foo', 'bar', 'camelCase'));
 
-        $obj = new GetSetDummy;
+        $obj = new GetSetDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -34,14 +34,14 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
     public function testNormalizeTraversable()
     {
         $this->serializer = new Serializer(array(), array('json' => new JsonEncoder()));
-        $result = $this->serializer->serialize(new TraversableDummy, 'json');
+        $result = $this->serializer->serialize(new TraversableDummy(), 'json');
         $this->assertEquals('{"foo":"foo","bar":"bar"}', $result);
     }
 
     public function testNormalizeGivesPriorityToInterfaceOverTraversable()
     {
-        $this->serializer = new Serializer(array(new CustomNormalizer), array('json' => new JsonEncoder()));
-        $result = $this->serializer->serialize(new NormalizableTraversableDummy, 'json');
+        $this->serializer = new Serializer(array(new CustomNormalizer()), array('json' => new JsonEncoder()));
+        $result = $this->serializer->serialize(new NormalizableTraversableDummy(), 'json');
         $this->assertEquals('{"foo":"normalizedFoo","bar":"normalizedBar"}', $result);
     }
 

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -21,7 +21,7 @@ class StopwatchEvent
     /**
      * @var StopwatchPeriod[]
      */
-    private $periods;
+    private $periods = array();
 
     /**
      * @var float
@@ -36,13 +36,13 @@ class StopwatchEvent
     /**
      * @var float[]
      */
-    private $started;
+    private $started = array();
 
     /**
      * Constructor.
      *
-     * @param float  $origin   The origin time in milliseconds
-     * @param string $category The event category
+     * @param float       $origin   The origin time in milliseconds
+     * @param string|null $category The event category or null to use the default
      *
      * @throws \InvalidArgumentException When the raw time is not valid
      */
@@ -50,8 +50,6 @@ class StopwatchEvent
     {
         $this->origin = $this->formatTime($origin);
         $this->category = is_string($category) ? $category : 'default';
-        $this->started = array();
-        $this->periods = array();
     }
 
     /**
@@ -67,7 +65,7 @@ class StopwatchEvent
     /**
      * Gets the origin.
      *
-     * @return integer The origin in milliseconds
+     * @return float The origin in milliseconds
      */
     public function getOrigin()
     {
@@ -178,7 +176,7 @@ class StopwatchEvent
             $total += $period->getDuration();
         }
 
-        return $this->formatTime($total);
+        return $total;
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -23,10 +23,10 @@ class StopwatchPeriod
     private $memory;
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param integer $start The relative time of the start of the period
-     * @param integer $end   The relative time of the end of the period
+     * @param integer $start The relative time of the start of the period (in milliseconds)
+     * @param integer $end   The relative time of the end of the period (in milliseconds)
      */
     public function __construct($start, $end)
     {

--- a/src/Symfony/Component/Templating/DelegatingEngine.php
+++ b/src/Symfony/Component/Templating/DelegatingEngine.php
@@ -23,7 +23,7 @@ class DelegatingEngine implements EngineInterface, StreamingEngineInterface
     /**
      * @var EngineInterface[]
      */
-    protected $engines;
+    protected $engines = array();
 
     /**
      * Constructor.
@@ -34,7 +34,6 @@ class DelegatingEngine implements EngineInterface, StreamingEngineInterface
      */
     public function __construct(array $engines = array())
     {
-        $this->engines = array();
         foreach ($engines as $engine) {
             $this->addEngine($engine);
         }

--- a/src/Symfony/Component/Templating/Helper/CoreAssetsHelper.php
+++ b/src/Symfony/Component/Templating/Helper/CoreAssetsHelper.php
@@ -28,7 +28,7 @@ use Symfony\Component\Templating\Asset\PackageInterface;
 class CoreAssetsHelper extends Helper implements PackageInterface
 {
     protected $defaultPackage;
-    protected $namedPackages;
+    protected $namedPackages = array();
 
     /**
      * Constructor.
@@ -39,7 +39,6 @@ class CoreAssetsHelper extends Helper implements PackageInterface
     public function __construct(PackageInterface $defaultPackage, array $namedPackages = array())
     {
         $this->defaultPackage = $defaultPackage;
-        $this->namedPackages = array();
 
         foreach ($namedPackages as $name => $package) {
             $this->addPackage($name, $package);

--- a/src/Symfony/Component/Templating/Loader/ChainLoader.php
+++ b/src/Symfony/Component/Templating/Loader/ChainLoader.php
@@ -21,7 +21,7 @@ use Symfony\Component\Templating\TemplateReferenceInterface;
  */
 class ChainLoader extends Loader
 {
-    protected $loaders;
+    protected $loaders = array();
 
     /**
      * Constructor.
@@ -30,7 +30,6 @@ class ChainLoader extends Loader
      */
     public function __construct(array $loaders = array())
     {
-        $this->loaders = array();
         foreach ($loaders as $loader) {
             $this->addLoader($loader);
         }

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -32,14 +32,14 @@ class PhpEngine implements EngineInterface, \ArrayAccess
 {
     protected $loader;
     protected $current;
-    protected $helpers;
-    protected $parents;
-    protected $stack;
-    protected $charset;
-    protected $cache;
-    protected $escapers;
-    protected static $escaperCache;
-    protected $globals;
+    protected $helpers = array();
+    protected $parents = array();
+    protected $stack = array();
+    protected $charset = 'UTF-8';
+    protected $cache = array();
+    protected $escapers = array();
+    protected static $escaperCache = array();
+    protected $globals = array();
     protected $parser;
 
     private $evalTemplate;
@@ -56,13 +56,8 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     {
         $this->parser  = $parser;
         $this->loader  = $loader;
-        $this->parents = array();
-        $this->stack   = array();
-        $this->charset = 'UTF-8';
-        $this->cache   = array();
-        $this->globals = array();
 
-        $this->setHelpers($helpers);
+        $this->addHelpers($helpers);
 
         $this->initializeEscapers();
         foreach ($this->escapers as $context => $escaper) {

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -25,7 +25,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class Collection extends Constraint
 {
-    public $fields;
+    public $fields = array();
     public $allowExtraFields = false;
     public $allowMissingFields = false;
     public $extraFieldsMessage = 'This field was not expected.';

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -143,14 +143,14 @@ class ConstraintTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTargetsCanBeString()
     {
-        $constraint = new ClassConstraint;
+        $constraint = new ClassConstraint();
 
         $this->assertEquals('class', $constraint->getTargets());
     }
 
     public function testGetTargetsCanBeArray()
     {
-        $constraint = new ConstraintA;
+        $constraint = new ConstraintA();
 
         $this->assertEquals(array('property', 'class'), $constraint->getTargets());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | n/a |

In almost all classes symfony uses property initialization when the value is static. Constructor initialization is only used for things that actually have logic, like passed parameters or dynamic values. IMHO it makes the code much more readable because property definition, phpdoc and default value is in one place. Also one can easily see what the constructor implements for logic like overridden default value of a parent class. Otherwise the real deal is just hidden behind 10 property initializations. One more advantage is that it requires less code. As you can see, the code was almost cut in half (210 additions and 395 deletions).
I unified it accordingly across symfony. Sometimes it was [not even consistent within one class](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Config/Definition/BaseNode.php#L32). At the same time I recognized some errors like missing parent constructor call, or undefined properties or private properties that are not even used.

I then realized that a few Kernel tests were not passing because they were deeply implementation specific like modifying booted flag with a custom `KernelForTest->setIsBooted();`. I improved and refactored the kernel tests in the **second commit**.

**Third commit** unifies short ternary operator, e.g. `$foo ?: new Foo()`. **Forth commit** unifies missing parentheses, e.g. `new Foo()`.
