### PR TITLE
[Form] fix deprecated usage and clarify constructor defaults for number formatter

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
@@ -26,7 +26,7 @@ class IntegerToLocalizedStringTransformer extends NumberToLocalizedStringTransfo
      * @param Boolean $grouping     Whether thousands should be grouped.
      * @param integer $roundingMode One of the ROUND_ constants in this class.
      */
-    public function __construct($precision = null, $grouping = null, $roundingMode = self::ROUND_DOWN)
+    public function __construct($precision = 0, $grouping = false, $roundingMode = self::ROUND_DOWN)
     {
         if (null === $roundingMode) {
             $roundingMode = self::ROUND_DOWN;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -21,10 +21,9 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransformer
 {
-
     private $divisor;
 
-    public function __construct($precision = null, $grouping = null, $roundingMode = null, $divisor = null)
+    public function __construct($precision = 2, $grouping = true, $roundingMode = self::ROUND_HALF_UP, $divisor = 1)
     {
         if (null === $grouping) {
             $grouping = true;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -99,14 +99,14 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
 
     protected $roundingMode;
 
-    public function __construct($precision = null, $grouping = null, $roundingMode = null)
+    public function __construct($precision = null, $grouping = false, $roundingMode = self::ROUND_HALF_UP)
     {
         if (null === $grouping) {
             $grouping = false;
         }
 
         if (null === $roundingMode) {
-            $roundingMode = self::ROUND_HALFUP;
+            $roundingMode = self::ROUND_HALF_UP;
         }
 
         $this->precision = $precision;

--- a/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
@@ -41,19 +41,19 @@ class IntegerType extends AbstractType
             'precision'     => null,
             'grouping'      => false,
             // Integer cast rounds towards 0, so do the same when displaying fractions
-            'rounding_mode' => \NumberFormatter::ROUND_DOWN,
+            'rounding_mode' => IntegerToLocalizedStringTransformer::ROUND_DOWN,
             'compound'      => false,
         ));
 
         $resolver->setAllowedValues(array(
             'rounding_mode' => array(
-                \NumberFormatter::ROUND_FLOOR,
-                \NumberFormatter::ROUND_DOWN,
-                \NumberFormatter::ROUND_HALFDOWN,
-                \NumberFormatter::ROUND_HALFEVEN,
-                \NumberFormatter::ROUND_HALFUP,
-                \NumberFormatter::ROUND_UP,
-                \NumberFormatter::ROUND_CEILING,
+                IntegerToLocalizedStringTransformer::ROUND_FLOOR,
+                IntegerToLocalizedStringTransformer::ROUND_DOWN,
+                IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN,
+                IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN,
+                IntegerToLocalizedStringTransformer::ROUND_HALF_UP,
+                IntegerToLocalizedStringTransformer::ROUND_UP,
+                IntegerToLocalizedStringTransformer::ROUND_CEILING,
             ),
         ));
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
@@ -39,19 +39,19 @@ class NumberType extends AbstractType
             // default precision is locale specific (usually around 3)
             'precision'     => null,
             'grouping'      => false,
-            'rounding_mode' => \NumberFormatter::ROUND_HALFUP,
+            'rounding_mode' => NumberToLocalizedStringTransformer::ROUND_HALF_UP,
             'compound'      => false,
         ));
 
         $resolver->setAllowedValues(array(
             'rounding_mode' => array(
-                \NumberFormatter::ROUND_FLOOR,
-                \NumberFormatter::ROUND_DOWN,
-                \NumberFormatter::ROUND_HALFDOWN,
-                \NumberFormatter::ROUND_HALFEVEN,
-                \NumberFormatter::ROUND_HALFUP,
-                \NumberFormatter::ROUND_UP,
-                \NumberFormatter::ROUND_CEILING,
+                NumberToLocalizedStringTransformer::ROUND_FLOOR,
+                NumberToLocalizedStringTransformer::ROUND_DOWN,
+                NumberToLocalizedStringTransformer::ROUND_HALF_DOWN,
+                NumberToLocalizedStringTransformer::ROUND_HALF_EVEN,
+                NumberToLocalizedStringTransformer::ROUND_HALF_UP,
+                NumberToLocalizedStringTransformer::ROUND_UP,
+                NumberToLocalizedStringTransformer::ROUND_CEILING,
             ),
         ));
     }


### PR DESCRIPTION
By using the real default one can see the actual value without having to look into the implementation what NULL stands for

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | n/a |
