### PR TITLE
[DependencyInjection] Add normalization to tag options

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -187,6 +187,10 @@ class XmlFileLoader extends FileLoader
                     continue;
                 }
 
+                if (false !== strpos($name, '-') && false === strpos($name, '_') && !array_key_exists($normalizedName = str_replace('-', '_', $name), $parameters)) {
+                    $parameters[$normalizedName] = SimpleXMLElement::phpize($value);
+                }
+                // keep not normalized key for BC too
                 $parameters[$name] = SimpleXMLElement::phpize($value);
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services10.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services10.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo" class="BarClass">
+        <tag name="foo_tag"
+            some-option="cat"
+            some_option="ciz"
+            other-option="lorem"
+            an_other-option="ipsum"
+        />
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -231,6 +231,29 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($aliases['another_alias_for_foo']->isPublic());
     }
 
+    public function testParsesTags()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services10.xml');
+
+        $services = $container->findTaggedServiceIds('foo_tag');
+        $this->assertCount(1, $services);
+
+        foreach ($services as $id => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                $this->assertArrayHasKey('other_option', $attributes);
+                $this->assertEquals('lorem', $attributes['other_option']);
+                $this->assertArrayHasKey('other-option', $attributes, 'unnormalized tag attributes should not be removed');
+
+                $this->assertEquals('ciz', $attributes['some_option'], 'no overriding should be done when normalizing');
+                $this->assertEquals('cat', $attributes['some-option']);
+
+                $this->assertArrayNotHasKey('an_other_option', $attributes, 'normalization should not be done when an underscore is already found');
+            }
+        }
+    }
+
     public function testConvertDomElementToArray()
     {
         $doc = new \DOMDocument("1.0");

--- a/src/Symfony/Component/DependencyInjection/services10.xml
+++ b/src/Symfony/Component/DependencyInjection/services10.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo" class="BarClass" />
+  </services>
+</container>


### PR DESCRIPTION
Currently, when using tags in XML, the options aren't normalized. This means that the following code is wrong:

```
<tag name="sonata_admin" manager-type="doctrine_phpcr" ... />
```

It should be `manager_name` to remove errors, but that's not following the XML rules. The solution is to use the same normalization as the configuration: replacing - with _.

To be BC, both options (with and without normalization) are kept

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
