### PR TITLE
Request::overrideGlobals() may call invalid ini value

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -503,7 +503,7 @@ class Request
 
         $request = array('g' => $_GET, 'p' => $_POST, 'c' => $_COOKIE);
 
-        $requestOrder = ini_get('request_order') ?: ini_get('variable_order');
+        $requestOrder = ini_get('request_order') ?: ini_get('variables_order');
         $requestOrder = preg_replace('#[^cgp]#', '', strtolower($requestOrder)) ?: 'gp';
 
         $_REQUEST = array();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | perhaps |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

According to http://php.net/manual/ja/ini.core.php ,
there's not variable_order, but variables_order (with trailing "s").

Perhaps it breaks BC for some developer who unsets (sets falsy value to )
'request_order' ini value and sets 'variable_order' manually?
