### PR TITLE
[acl] Possibility to override ACL PermissionGrantingStrategy

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -100,6 +100,7 @@ class MainConfiguration implements ConfigurationInterface
                                 ->scalarNode('prefix')->defaultValue('sf2_acl_')->end()
                             ->end()
                         ->end()
+                        ->scalarNode('granting_strategy')->defaultValue('Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy')->end()
                         ->scalarNode('provider')->end()
                         ->arrayNode('tables')
                             ->addDefaultsIfNotSet()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -109,6 +109,8 @@ class SecurityExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('security_acl.xml');
 
+        $container->setParameter('security.acl.permission_granting_strategy.class', $config['granting_strategy']);
+
         if (isset($config['cache']['id'])) {
             $container->setAlias('security.acl.cache', $config['cache']['id']);
         }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl.xml
@@ -5,8 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="security.acl.permission_granting_strategy.class">Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy</parameter>
-
         <parameter key="security.acl.voter.class">Symfony\Component\Security\Acl\Voter\AclVoter</parameter>
         <parameter key="security.acl.permission.map.class">Symfony\Component\Security\Acl\Permission\BasicPermissionMap</parameter>
 


### PR DESCRIPTION
This class should be overridable.
An example, isFieldGranted don't check if isGranted, sometimes you need that :

class PermissionGrantingStrategy extends BasePermissionGrantingStrategy
{
    public function isFieldGranted(AclInterface $acl, $field, array $masks, array $sids, $administrativeMode = false)
    {
        try{
            return parent::isFieldGranted($acl, $field, $masks, $sids, $administrativeMode);
        }catch (NoAceFoundException $noFieldAces){
            return $this->isGranted($acl,$masks,$sids,$administrativeMode);
        }
    }
}
