### PR TITLE
[AclProvider] Fix incorrect behavior when partial results returned from cache

### DIFF
--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -165,8 +165,17 @@ class AclProvider implements AclProviderInterface
 
             // Is it time to load the current batch?
             if ((self::MAX_BATCH_SIZE === count($currentBatch) || ($i + 1) === $c) && count($currentBatch) > 0) {
-                $loadedBatch = $this->lookupObjectIdentities($currentBatch, $sids, $oidLookup);
-
+                try {
+                    $loadedBatch = $this->lookupObjectIdentities($currentBatch, $sids, $oidLookup);
+                } catch (AclNotFoundException $aclNotFoundexception) {
+                    if ($result->count()) {
+                        $partialResultException = new NotAllAclsFoundException('The provider could not find ACLs for all object identities.');
+                        $partialResultException->setPartialResult($result);
+                        throw $partialResultException;
+                    } else {
+                        throw $aclNotFoundexception;
+                    }
+                }
                 foreach ($loadedBatch as $loadedOid) {
                     $loadedAcl = $loadedBatch->offsetGet($loadedOid);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9515 |
| License | MIT |
| Doc PR | none |

[AclProvider] Fix incorrect behavior when partial results returned from cache

findAcls wasn't throwing the NotAllAclsFoundException with the partial result when some acls were retrieved from the cache. This will fix that behavior. Ideally we would update it to cache items that were not found so it wouldn't have to query the db every time for non existent items, but I'm not sure if that is possible. 
I'm not sure if the ACL cache is being used very much, I didn't find any docs about it but it seems to work except for this issue. It might be more appropriate to merge the fix in master if no one is relying on it to work in 2.2.
