### PR TITLE
[2.2] Fixed ModelChoiceList tests in Propel1 bridge

### DIFF
--- a/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/CompatModelChoiceListTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/CompatModelChoiceListTest.php
@@ -61,6 +61,13 @@ class CompatModelChoiceListTest extends AbstractChoiceListTest
             'filterById',
         ), array(), '', true, true, true, false, true);
 
+        $this->query
+            ->expects($this->any())
+            ->method('filterById')
+            ->with($this->anything())
+            ->will($this->returnSelf())
+        ;
+
         $this->createItems();
 
         ItemQuery::$result = array(


### PR DESCRIPTION
Tests on 2.2 are broken since #9469 was merged.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
