### PR TITLE
[HttpFoundation] Removed useless check if self::$trustProxies is set

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -780,12 +780,11 @@ class Request
         $clientIps = array_map('trim', explode(',', $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_IP])));
         $clientIps[] = $ip; // Complete the IP chain with the IP the request actually came from
 
-        $trustedProxies = !self::$trustedProxies ? array($ip) : self::$trustedProxies;
         $ip = $clientIps[0]; // Fallback to this when the client IP falls into the range of trusted proxies
 
         // Eliminate all IPs from the forwarded IP chain which are trusted proxies
         foreach ($clientIps as $key => $clientIp) {
-            if (IpUtils::checkIp($clientIp, $trustedProxies)) {
+            if (IpUtils::checkIp($clientIp, self::$trustedProxies)) {
                 unset($clientIps[$key]);
             }
         }


### PR DESCRIPTION
In Request::getClientIps() on line 772 there is a check if self::$trustedProxies is not set. If this condition evaluates to true the method will return.
Because of this, the second identical check on line 783 will never evaluate to true.
