### PR TITLE
[ExpressionLanguage] Fixed conflict between punctation and range

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -65,10 +65,6 @@ class Lexer
 
                 $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);
                 ++$cursor;
-            } elseif (false !== strpos('.,?:', $expression[$cursor])) {
-                // punctuation
-                $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);
-                ++$cursor;
             } elseif (preg_match('/"([^#"\\\\]*(?:\\\\.[^#"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\'/As', $expression, $match, null, $cursor)) {
                 // strings
                 $tokens[] = new Token(Token::STRING_TYPE, stripcslashes(substr($match[0], 1, -1)), $cursor + 1);
@@ -77,6 +73,10 @@ class Lexer
                 // operators
                 $tokens[] = new Token(Token::OPERATOR_TYPE, $match[0], $cursor + 1);
                 $cursor += strlen($match[0]);
+            } elseif (false !== strpos('.,?:', $expression[$cursor])) {
+                // punctuation
+                $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);
+                ++$cursor;
             } elseif (preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A', $expression, $match, null, $cursor)) {
                 // names
                 $tokens[] = new Token(Token::NAME_TYPE, $match[0], $cursor + 1);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -70,6 +70,10 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 ),
                 '(3 + 5) ~ foo("bar").baz[4]',
             ),
+            array(
+                array(new Token('operator', '..', 1)),
+                '..',
+            ),
         );
     }
 }


### PR DESCRIPTION
The range operator (`..`) was actually lexed as 2 punctations (`.`). That causes any expression using the range to fail.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
