### PR TITLE
[HttpFoundation] Fixes a possible regression in SessionStorage top classes

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -164,7 +164,6 @@ class MockArraySessionStorage implements SessionStorageInterface
         }
         // nothing to do since we don't persist the session data
         $this->closed = false;
-        $this->started = false;
     }
 
     /**
@@ -213,7 +212,7 @@ class MockArraySessionStorage implements SessionStorageInterface
      */
     public function isStarted()
     {
-        return $this->started;
+        return $this->started && !$this->closed;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -162,8 +162,10 @@ class MockArraySessionStorage implements SessionStorageInterface
         if (!$this->started || $this->closed) {
             throw new \RuntimeException("Trying to save a session that was not started yet or was already closed");
         }
+
         // nothing to do since we don't persist the session data
         $this->closed = false;
+        $this->started = false;
     }
 
     /**
@@ -212,7 +214,7 @@ class MockArraySessionStorage implements SessionStorageInterface
      */
     public function isStarted()
     {
-        return $this->started && !$this->closed;
+        return $this->started;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -239,7 +239,6 @@ class NativeSessionStorage implements SessionStorageInterface
         }
 
         $this->closed = true;
-        $this->started = false;
     }
 
     /**
@@ -314,7 +313,7 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function isStarted()
     {
-        return $this->started;
+        return $this->started && !$this->closed;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
@@ -103,4 +103,21 @@ class MockArraySessionStorageTest extends \PHPUnit_Framework_TestCase
     {
         $this->storage->save();
     }
+
+    public function testClosedIsStarted()
+    {
+        $this->storage->start();
+
+        $refl = new \ReflectionProperty($this->storage, 'started');
+        $refl->setAccessible(true);
+
+        $this->assertTrue($this->storage->isStarted());
+        $this->assertTrue($refl->getValue($this->storage));
+
+        $this->storage->save();
+
+        // isStarted should return false once the storage saves the session
+        $this->assertFalse($this->storage->isStarted());
+        $this->assertFalse($refl->getValue($this->storage));
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -249,6 +249,24 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($_SESSION[$key]));
         $storage->start();
     }
+
+    public function testClosedIsStarted()
+    {
+        $storage = $this->getStorage();
+        $storage->start();
+
+        $refl = new \ReflectionProperty($storage, 'started');
+        $refl->setAccessible(true);
+
+        $this->assertTrue($storage->isStarted());
+        $this->assertTrue($refl->getValue($storage));
+
+        $storage->save();
+
+        // isStarted should return false once the storage saves the session
+        $this->assertFalse($storage->isStarted());
+        $this->assertTrue($refl->getValue($storage));
+    }
 }
 
 class SessionHandler implements \SessionHandlerInterface


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no (shouldn't be) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This _should_ fix a regression which was introduced by #9246 ; if this PR
was to set the session to "not started" was it was saved (and thus
closed), for an unknown reason, the PHPSESSID cookie was never
created for some apps (aka not the recent ones installed with the latest
versions of symfony).

But if we modify the `isStarted` method, and take into account the
`$this->closed` state, then it should enact the sought behaviour
without introducing this (possible) regression

I pointed this fix to master, but this regression (if this is one) is present since
2.2.10, 2.3.7, and 2.4.0-beta2.
