### PR TITLE
Add missing dependency to expression-language

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -25,6 +25,7 @@
         "symfony/form": "~2.2",
         "symfony/http-kernel": "~2.2",
         "symfony/security": "~2.2",
+        "symfony/expression-language": "~2.2",
         "symfony/validator": "~2.2",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.2",


### PR DESCRIPTION
Add missing dependency, without this dependency, PHPUnit can't run successfully.
