### PR TITLE
[FrameworkBundle] Update 2 dependencies (currently broken)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -21,7 +21,7 @@
         "symfony/config" : "~2.4",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "~2.4",
-        "symfony/http-kernel": "~2.3",
+        "symfony/http-kernel": "~2.4",
         "symfony/filesystem": "~2.3",
         "symfony/routing": "~2.2",
         "symfony/security-core": "~2.4",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/dependency-injection" : "~2.2",
-        "symfony/config" : "~2.2",
+        "symfony/config" : "~2.4",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "~2.4",
         "symfony/http-kernel": "~2.3",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -20,6 +20,7 @@
         "symfony/dependency-injection" : "~2.2",
         "symfony/config" : "~2.2",
         "symfony/event-dispatcher": "~2.1",
+        "symfony/http-foundation": "~2.4",
         "symfony/http-kernel": "~2.3",
         "symfony/filesystem": "~2.3",
         "symfony/routing": "~2.2",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
## Dependency on http-foundation

In https://github.com/symfony/symfony/commit/b1a062d232866164ae5112c702ceab361213ce44 the `RequestStack` was moved to `http-foundation`, because of this the `framework-bundle` now also depends on `http-foundation`: https://github.com/symfony/symfony/commit/b1a062d232866164ae5112c702ceab361213ce44#diff-3 (at least in services.xml).

We got an error while installing the framework-bundle `2.4.*` with `prefer-stable` in our composer.json. We currently get framework-bundle 2.4 with http-kernel and http-foundation 2.3. An alternative fix would be raising the requirement of http-kernel to 2.4, but I think this is the "purest" declaration of dependencies.

Update 1
## Dependency on config

In https://github.com/symfony/symfony/commit/05e9ca7509c6f084c602d7f0116c966992b0e7b9 the config component was updated with an xml reference dumper for configuration. In the same commit the frameworkbundle dump command is updated to make use of the 2 newly introduced classes. It is currently possible to get an installation with config `2.3`, which in turn leads to an exception when running the dump-reference command:

```
 $ app/console config:dump-reference framework
# Default configuration for extension with alias: "framework"
PHP Fatal error:  Class 'Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper
```

Update 2
## Dependency on http-kernel

We just found out that the dependency on http-kernel should also be updated to `2.4`. That's because the framework-bundle injects the `RequestStack` now and doesn't set the request on the `RouterListener` service anymore. Without updating the dependency it is possible to get a `RouterListener` that is not aware of the request stack (< 2.4) and none of your routes will work.

_tests are failing because of some race condition I guess?_
