### PR TITLE
[FrameworkBundle] Fix mistake in translation's service definition.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -82,7 +82,7 @@
             <tag name="translation.loader" alias="res" />
         </service>
 
-        <service id="translation.loader.dat" class="%translation.loader.res.class%">
+        <service id="translation.loader.dat" class="%translation.loader.dat.class%">
             <tag name="translation.loader" alias="dat" />
         </service>
 


### PR DESCRIPTION
Wrong class parameter fixed.
