### PR TITLE
[Translation] make IdentityTranslator consistent with normal translator

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
@@ -30,7 +30,7 @@ abstract class FileDumper implements DumperInterface
     public function dump(MessageCatalogue $messages, $options = array())
     {
         if (!array_key_exists('path', $options)) {
-            throw new \InvalidArgumentException('The file dumper need a path options.');
+            throw new \InvalidArgumentException('The file dumper needs a path option.');
         }
 
         // save a file for each domain

--- a/src/Symfony/Component/Translation/IdentityTranslator.php
+++ b/src/Symfony/Component/Translation/IdentityTranslator.php
@@ -26,13 +26,13 @@ class IdentityTranslator implements TranslatorInterface
     /**
      * Constructor.
      *
-     * @param MessageSelector $selector The message selector for pluralization
+     * @param MessageSelector|null $selector The message selector for pluralization
      *
      * @api
      */
-    public function __construct(MessageSelector $selector)
+    public function __construct(MessageSelector $selector = null)
     {
-        $this->selector = $selector;
+        $this->selector = $selector ?: new MessageSelector();
     }
 
     /**
@@ -60,7 +60,7 @@ class IdentityTranslator implements TranslatorInterface
      *
      * @api
      */
-    public function trans($id, array $parameters = array(), $domain = 'messages', $locale = null)
+    public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
         return strtr((string) $id, $parameters);
     }
@@ -70,7 +70,7 @@ class IdentityTranslator implements TranslatorInterface
      *
      * @api
      */
-    public function transChoice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
+    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
         return strtr($this->selector->choose((string) $id, (int) $number, $locale ?: $this->getLocale()), $parameters);
     }

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -31,9 +31,9 @@ class PluralizationRules
      */
     public static function get($number, $locale)
     {
-        if ("pt_BR" == $locale) {
+        if ('pt_BR' === $locale) {
             // temporary set a locale for brazilian
-            $locale = "xbr";
+            $locale = 'xbr';
         }
 
         if (strlen($locale) > 3) {
@@ -197,9 +197,9 @@ class PluralizationRules
      */
     public static function set($rule, $locale)
     {
-        if ("pt_BR" == $locale) {
+        if ('pt_BR' === $locale) {
             // temporary set a locale for brazilian
-            $locale = "xbr";
+            $locale = 'xbr';
         }
 
         if (strlen($locale) > 3) {

--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Translation\Tests;
 
 use Symfony\Component\Translation\IdentityTranslator;
-use Symfony\Component\Translation\MessageSelector;
 
 class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,7 +20,7 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTrans($expected, $id, $parameters)
     {
-        $translator = new IdentityTranslator(new MessageSelector());
+        $translator = new IdentityTranslator();
 
         $this->assertEquals($expected, $translator->trans($id, $parameters));
     }
@@ -31,7 +30,7 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransChoiceWithExplicitLocale($expected, $id, $number, $parameters)
     {
-        $translator = new IdentityTranslator(new MessageSelector());
+        $translator = new IdentityTranslator();
         $translator->setLocale('en');
 
         $this->assertEquals($expected, $translator->transChoice($id, $number, $parameters));
@@ -44,14 +43,14 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
     {
         \Locale::setDefault('en');
 
-        $translator = new IdentityTranslator(new MessageSelector());
+        $translator = new IdentityTranslator();
 
         $this->assertEquals($expected, $translator->transChoice($id, $number, $parameters));
     }
 
     public function testGetSetLocale()
     {
-        $translator = new IdentityTranslator(new MessageSelector());
+        $translator = new IdentityTranslator();
         $translator->setLocale('en');
 
         $this->assertEquals('en', $translator->getLocale());
@@ -59,7 +58,7 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetLocaleReturnsDefaultLocaleIfNotSet()
     {
-        $translator = new IdentityTranslator(new MessageSelector());
+        $translator = new IdentityTranslator();
 
         \Locale::setDefault('en');
         $this->assertEquals('en', $translator->getLocale());

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -12,14 +12,13 @@
 namespace Symfony\Component\Translation\Tests;
 
 use Symfony\Component\Translation\Translator;
-use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 
 class TranslatorTest extends \PHPUnit_Framework_TestCase
 {
     public function testSetGetLocale()
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en');
 
         $this->assertEquals('en', $translator->getLocale());
 
@@ -29,7 +28,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFallbackLocales()
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en');
         $translator->addResource('array', array('bar' => 'foobar'), 'fr');
@@ -43,7 +42,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFallbackLocalesMultiple()
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foo (en)'), 'en');
         $translator->addResource('array', array('bar' => 'bar (fr)'), 'fr');
@@ -57,7 +56,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransWithFallbackLocale()
     {
-        $translator = new Translator('fr_FR', new MessageSelector());
+        $translator = new Translator('fr_FR');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en_US');
         $translator->addResource('array', array('bar' => 'foobar'), 'en');
@@ -69,7 +68,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testAddResourceAfterTrans()
     {
-        $translator = new Translator('fr', new MessageSelector());
+        $translator = new Translator('fr');
         $translator->addLoader('array', new ArrayLoader());
 
         $translator->setFallbackLocale(array('en'));
@@ -88,7 +87,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     public function testTransWithoutFallbackLocaleFile($format, $loader)
     {
         $loaderClass = 'Symfony\\Component\\Translation\\Loader\\'.$loader;
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en');
         $translator->addLoader($format, new $loaderClass());
         $translator->addResource($format, __DIR__.'/fixtures/non-existing', 'en');
         $translator->addResource($format, __DIR__.'/fixtures/resources.'.$format, 'en');
@@ -103,7 +102,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     public function testTransWithFallbackLocaleFile($format, $loader)
     {
         $loaderClass = 'Symfony\\Component\\Translation\\Loader\\'.$loader;
-        $translator = new Translator('en_GB', new MessageSelector());
+        $translator = new Translator('en_GB');
         $translator->addLoader($format, new $loaderClass());
         $translator->addResource($format, __DIR__.'/fixtures/non-existing', 'en_GB');
         $translator->addResource($format, __DIR__.'/fixtures/resources.'.$format, 'en', 'resources');
@@ -113,7 +112,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransWithFallbackLocaleBis()
     {
-        $translator = new Translator('en_US', new MessageSelector());
+        $translator = new Translator('en_US');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en_US');
         $translator->addResource('array', array('bar' => 'foobar'), 'en');
@@ -122,7 +121,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransWithFallbackLocaleTer()
     {
-        $translator = new Translator('fr_FR', new MessageSelector());
+        $translator = new Translator('fr_FR');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foo (en_US)'), 'en_US');
         $translator->addResource('array', array('bar' => 'bar (en)'), 'en');
@@ -135,7 +134,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransNonExistentWithFallback()
     {
-        $translator = new Translator('fr', new MessageSelector());
+        $translator = new Translator('fr');
         $translator->setFallbackLocales(array('en'));
         $translator->addLoader('array', new ArrayLoader());
         $this->assertEquals('non-existent', $translator->trans('non-existent'));
@@ -146,7 +145,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testWhenAResourceHasNoRegisteredLoader()
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en');
         $translator->addResource('array', array('foo' => 'foofoo'), 'en');
 
         $translator->trans('foo');
@@ -157,7 +156,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTrans($expected, $id, $translation, $parameters, $locale, $domain)
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array((string) $id => $translation), $locale, $domain);
 
@@ -169,7 +168,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testFlattenedTrans($expected, $messages, $id)
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', $messages, 'fr', '');
 
@@ -181,7 +180,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransChoice($expected, $id, $translation, $number, $parameters, $locale, $domain)
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array((string) $id => $translation), $locale, $domain);
 
@@ -260,7 +259,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransChoiceFallback()
     {
-        $translator = new Translator('ru', new MessageSelector());
+        $translator = new Translator('ru');
         $translator->setFallbackLocales(array('en'));
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('some_message2' => 'one thing|%count% things'), 'en');
@@ -270,7 +269,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransChoiceFallbackBis()
     {
-        $translator = new Translator('ru', new MessageSelector());
+        $translator = new Translator('ru');
         $translator->setFallbackLocales(array('en_US', 'en'));
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('some_message2' => 'one thing|%count% things'), 'en_US');
@@ -280,7 +279,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransChoiceFallbackWithNoTranslation()
     {
-        $translator = new Translator('ru', new MessageSelector());
+        $translator = new Translator('ru');
         $translator->setFallbackLocales(array('en'));
         $translator->addLoader('array', new ArrayLoader());
 

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -23,10 +23,10 @@ interface TranslatorInterface
     /**
      * Translates the given message.
      *
-     * @param string $id         The message id (may also be an object that can be cast to string)
-     * @param array  $parameters An array of parameters for the message
-     * @param string $domain     The domain for the message
-     * @param string $locale     The locale
+     * @param string      $id         The message id (may also be an object that can be cast to string)
+     * @param array       $parameters An array of parameters for the message
+     * @param string|null $domain     The domain for the message or null to use the default
+     * @param string|null $locale     The locale or null to use the default
      *
      * @return string The translated string
      *
@@ -37,11 +37,11 @@ interface TranslatorInterface
     /**
      * Translates the given choice message by choosing a translation according to a number.
      *
-     * @param string  $id         The message id (may also be an object that can be cast to string)
-     * @param integer $number     The number to use to find the indice of the message
-     * @param array   $parameters An array of parameters for the message
-     * @param string  $domain     The domain for the message
-     * @param string  $locale     The locale
+     * @param string      $id         The message id (may also be an object that can be cast to string)
+     * @param integer     $number     The number to use to find the indice of the message
+     * @param array       $parameters An array of parameters for the message
+     * @param string|null $domain     The domain for the message or null to use the default
+     * @param string|null $locale     The locale or null to use the default
      *
      * @return string The translated string
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | n/a |

The MessageSelector should not be required in the constructor of the IdentityTranslator because it's also optional for the [Translator](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Translation/Translator.php#L64).
I also fixed the TranslatorInterface phpdoc and the IdentityTranslator params similar to https://github.com/symfony/symfony/commit/90a20d78357f720493ec8905f41c962766506b83
