### PR TITLE
unify and fix callable phpdoc throughout symfony

### DIFF
--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -31,8 +31,8 @@ class XmlUtils
     /**
      * Loads an XML file.
      *
-     * @param string $file                      An XML file path
-     * @param string|callable $schemaOrCallable An XSD schema file path or callable
+     * @param string               $file             An XML file path
+     * @param string|callable|null $schemaOrCallable An XSD schema file path, a callable, or null to disable validation
      *
      * @return \DOMDocument
      *

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -154,9 +154,9 @@ class EventDispatcher implements EventDispatcherInterface
      * This method can be overridden to add functionality that is executed
      * for each listener.
      *
-     * @param array[callback] $listeners The event listeners.
-     * @param string          $eventName The name of the event to dispatch.
-     * @param Event           $event     The event object to pass to the event handlers/listeners.
+     * @param callable[] $listeners The event listeners.
+     * @param string     $eventName The name of the event to dispatch.
+     * @param Event      $event     The event object to pass to the event handlers/listeners.
      */
     protected function doDispatch($listeners, $eventName, Event $event)
     {

--- a/src/Symfony/Component/Finder/Shell/Command.php
+++ b/src/Symfony/Component/Finder/Shell/Command.php
@@ -39,7 +39,7 @@ class Command
     /**
      * Constructor.
      *
-     * @param Command $parent Parent command
+     * @param Command|null $parent Parent command
      */
     public function __construct(Command $parent = null)
     {
@@ -61,7 +61,7 @@ class Command
     /**
      * Creates a new Command instance.
      *
-     * @param Command $parent Parent command
+     * @param Command|null $parent Parent command
      *
      * @return Command New Command instance
      */
@@ -232,7 +232,7 @@ class Command
     }
 
     /**
-     * @return callable|null
+     * @return \Closure|null
      */
     public function getErrorHandler()
     {

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -55,11 +55,11 @@ class JsonResponse extends Response
     /**
      * Sets the JSONP callback.
      *
-     * @param string $callback
+     * @param string|null $callback The JSONP callback or null to use none
      *
      * @return JsonResponse
      *
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException When the callback name is not valid
      */
     public function setCallback($callback = null)
     {

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -188,7 +188,7 @@ class Response
     /**
      * Constructor.
      *
-     * @param string  $content The response content
+     * @param mixed   $content The response content, see setContent()
      * @param integer $status  The response status code
      * @param array   $headers An array of response headers
      *
@@ -215,7 +215,7 @@ class Response
      *     return Response::create($body, 200)
      *         ->setSharedMaxAge(300);
      *
-     * @param string  $content The response content
+     * @param mixed   $content The response content, see setContent()
      * @param integer $status  The response status code
      * @param array   $headers An array of response headers
      *
@@ -403,9 +403,9 @@ class Response
     /**
      * Sets the response content.
      *
-     * Valid types are strings, numbers, and objects that implement a __toString() method.
+     * Valid types are strings, numbers, null, and objects that implement a __toString() method.
      *
-     * @param mixed $content
+     * @param mixed $content Content that can be cast to string
      *
      * @return Response
      *

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -34,9 +34,9 @@ class StreamedResponse extends Response
     /**
      * Constructor.
      *
-     * @param mixed   $callback A valid PHP callback
-     * @param integer $status   The response status code
-     * @param array   $headers  An array of response headers
+     * @param callable|null $callback A valid PHP callback or null to set it later
+     * @param integer       $status   The response status code
+     * @param array         $headers  An array of response headers
      *
      * @api
      */
@@ -51,7 +51,13 @@ class StreamedResponse extends Response
     }
 
     /**
-     * {@inheritDoc}
+     * Factory method for chainability
+     *
+     * @param callable|null $callback A valid PHP callback or null to set it later
+     * @param integer       $status   The response status code
+     * @param array         $headers  An array of response headers
+     *
+     * @return StreamedResponse
      */
     public static function create($callback = null, $status = 200, $headers = array())
     {
@@ -61,7 +67,7 @@ class StreamedResponse extends Response
     /**
      * Sets the PHP callback associated with this Response.
      *
-     * @param mixed $callback A valid PHP callback
+     * @param callable $callback A valid PHP callback
      *
      * @throws \LogicException
      */

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -40,17 +40,10 @@ class ControllerResolver implements ControllerResolverInterface
     }
 
     /**
-     * Returns the Controller instance associated with a Request.
+     * {@inheritdoc}
      *
      * This method looks for a '_controller' request attribute that represents
      * the controller name (a string like ClassName::MethodName).
-     *
-     * @param Request $request A Request instance
-     *
-     * @return mixed|Boolean A PHP callable representing the Controller,
-     *                       or false if this resolver is not able to determine the controller
-     *
-     * @throws \InvalidArgumentException|\LogicException If the controller can't be found
      *
      * @api
      */
@@ -86,14 +79,7 @@ class ControllerResolver implements ControllerResolverInterface
     }
 
     /**
-     * Returns the arguments to pass to the controller.
-     *
-     * @param Request $request    A Request instance
-     * @param mixed   $controller A PHP callable
-     *
-     * @return array
-     *
-     * @throws \RuntimeException When value for argument given is not provided
+     * {@inheritdoc}
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
@@ -38,10 +38,10 @@ interface ControllerResolverInterface
      *
      * @param Request $request A Request instance
      *
-     * @return mixed|Boolean A PHP callable representing the Controller,
-     *                       or false if this resolver is not able to determine the controller
+     * @return callable|false A PHP callable representing the Controller,
+     *                        or false if this resolver is not able to determine the controller
      *
-     * @throws \InvalidArgumentException|\LogicException If the controller can't be found
+     * @throws \LogicException If the controller can't be found
      *
      * @api
      */
@@ -50,8 +50,8 @@ interface ControllerResolverInterface
     /**
      * Returns the arguments to pass to the controller.
      *
-     * @param Request $request    A Request instance
-     * @param mixed   $controller A PHP callable
+     * @param Request  $request    A Request instance
+     * @param callable $controller A PHP callable
      *
      * @return array An array of arguments to pass to the controller
      *

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -184,7 +184,7 @@ class Process
      * The STDOUT and STDERR are also available after the process is finished
      * via the getOutput() and getErrorOutput() methods.
      *
-     * @param callback|null $callback A PHP callback to run whenever there is some
+     * @param callable|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR
      *
      * @return integer The exit status code
@@ -215,7 +215,7 @@ class Process
      * with true as a second parameter then the callback will get all data occurred
      * in (and since) the start call.
      *
-     * @param callback|null $callback A PHP callback to run whenever there is some
+     * @param callable|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR
      *
      * @return Process The process itself
@@ -261,8 +261,8 @@ class Process
      *
      * Be warned that the process is cloned before being started.
      *
-     * @param callable $callback A PHP callback to run whenever there is some
-     *                           output available on STDOUT or STDERR
+     * @param callable|null $callback A PHP callback to run whenever there is some
+     *                                output available on STDOUT or STDERR
      *
      * @return Process The new process
      *
@@ -290,7 +290,7 @@ class Process
      * from the output in real-time while writing the standard input to the process.
      * It allows to have feedback from the independent process during execution.
      *
-     * @param callback|null $callback A valid PHP callback
+     * @param callable|null $callback A valid PHP callback
      *
      * @return integer The exitcode of the process
      *
@@ -1018,9 +1018,9 @@ class Process
      * The callbacks adds all occurred output to the specific buffer and calls
      * the user callback (if present) with the received output.
      *
-     * @param callback|null $callback The user defined PHP callback
+     * @param callable|null $callback The user defined PHP callback
      *
-     * @return callback A PHP callable
+     * @return callable A PHP callable
      */
     protected function buildCallback($callback)
     {

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -41,9 +41,9 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
     protected $camelizedAttributes = array();
 
     /**
-     * Set normalization callbacks
+     * Set normalization callbacks.
      *
-     * @param array $callbacks help normalize the result
+     * @param callable[] $callbacks help normalize the result
      *
      * @throws InvalidArgumentException if a non-callable callback is set
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | n/a |

I unified the phpdoc to use "callable" as type. It wasn't done consistently. It varied between mixed, callback, callable.
I think callable is best because php 5.4 even has a typehint callable.
