### PR TITLE
[FrameworkBundle] use the new request_stack service to get the Request object in the base Controller class

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -178,6 +178,41 @@ UPGRADE FROM 2.x to 3.0
 
 ### FrameworkBundle
 
+ * The `getRequest` method of the base `Controller` class has been deprecated
+   since Symfony 2.4 and must be therefore removed in 3.0. The only reliable
+   way to get the `Request` object is to inject it in the action method.
+
+   Before:
+
+   ```
+   namespace Acme\FooBundle\Controller;
+
+   class DemoController
+   {
+       public function showAction()
+       {
+           $request = $this->getRequest();
+           // ...
+       }
+   }
+   ```
+
+   After:
+
+   ```
+   namespace Acme\FooBundle\Controller;
+
+   use Symfony\Component\HttpFoundation\Request;
+
+   class DemoController
+   {
+       public function showAction(Request $request)
+       {
+           // ...
+       }
+   }
+   ```
+
  * The `enctype` method of the `form` helper was removed. You should use the
    new method `start` instead.
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -180,10 +180,14 @@ class Controller extends ContainerAware
      * Shortcut to return the request service.
      *
      * @return Request
+     *
+     * @deprecated Deprecated since version 2.4, to be removed in 3.0. Ask
+     *             Symfony to inject the Request object into your controller
+     *             method instead by type hinting it in the method's signature.
      */
     public function getRequest()
     {
-        return $this->container->get('request');
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
