### PR TITLE
[Debug] Fixed ClassNotFoundFatalErrorHandler which could cause a fatal error

### DIFF
--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -81,4 +81,25 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
+
+    public function testCannotRedeclareClass()
+    {
+        if (!file_exists(__DIR__.'/../FIXTURES/REQUIREDTWICE.PHP')) {
+            $this->markTestSkipped('Can only be run on case insensitive filesystems');
+        }
+
+        require_once __DIR__.'/../FIXTURES/REQUIREDTWICE.PHP';
+
+        $error = array(
+            'type' => 1,
+            'line' => 12,
+            'file' => 'foo.php',
+            'message' => 'Class \'Foo\\Bar\\RequiredTwice\' not found',
+        );
+
+        $handler = new ClassNotFoundFatalErrorHandler();
+        $exception = $handler->handleError($error, new FatalErrorException('', 0, $error['type'], $error['file'], $error['line']));
+
+        $this->assertInstanceof('Symfony\Component\Debug\Exception\ClassNotFoundException', $exception);
+    }
 }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/RequiredTwice.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/RequiredTwice.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+class RequiredTwice
+{
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9104 |
| License | MIT |
| Doc PR | - |

It might happen that `require_once` will include a file second time (for example with links or case-changed paths). Therefore we need to check if a class exists before requiring the file.

I also removed an unused argument from two methods (`$loader`).
