### PR TITLE
[Console][ProgressHelper] Added estimated time and memory usage

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -26,7 +26,7 @@ class ProgressHelper extends Helper
     const FORMAT_VERBOSE       = ' %current%/%max% [%bar%] %percent%% Elapsed: %elapsed%';
     const FORMAT_QUIET_NOMAX   = ' %current%';
     const FORMAT_NORMAL_NOMAX  = ' %current% [%bar%]';
-    const FORMAT_VERBOSE_NOMAX = ' %current% [%bar%] Elapsed: %elapsed%';
+    const FORMAT_VERBOSE_NOMAX = ' %current% [%bar%] Elapsed: %elapsed% Estimated: %estimated% (%memory%)';
 
     // options
     private $barWidth     = 28;
@@ -76,6 +76,8 @@ class ProgressHelper extends Helper
         'bar',
         'percent',
         'elapsed',
+        'estimated',
+        'memory'
     );
 
     /**
@@ -91,10 +93,12 @@ class ProgressHelper extends Helper
      * @var array
      */
     private $widths = array(
-        'current' => 4,
-        'max'     => 4,
-        'percent' => 3,
-        'elapsed' => 6,
+        'current'   => 4,
+        'max'       => 4,
+        'percent'   => 3,
+        'elapsed'   => 6,
+        'estimated' => 6,
+        'memory'    => 6
     );
 
     /**
@@ -392,7 +396,36 @@ class ProgressHelper extends Helper
             $vars['percent'] = str_pad(floor($percent * 100), $this->widths['percent'], ' ', STR_PAD_LEFT);
         }
 
+        if (isset($this->formatVars['memory'])) {
+            $vars['memory'] = str_pad($this->humaneMemory(), $this->widths['memory'], ' ', STR_PAD_LEFT);
+        }
+
+        if (isset($this->formatVars['estimated'])) {
+            $eta = round((time() - $this->startTime) * ($this->max - $this->current)) / $this->current;
+            $vars['estimated'] = str_pad($this->humaneTime($eta), $this->widths['estimated'], ' ', STR_PAD_LEFT);
+        }
+
         return $vars;
+    }
+
+    /**
+     * Converts memory usage to human-readable format.
+     *
+     * @return string
+     */
+    private function humaneMemory()
+    {
+        $memory = memory_get_usage(true);
+        if ($memory>1024*1024*1024*10) {
+            return sprintf('%.2fGB', $memory/1024/1024/1024);
+        } elseif ($memory>1024*1024*10) {
+            return sprintf('%.2fMB', $memory/1024/1024);
+        } elseif ($memory>1024*10) {
+            return sprintf('%.2fkB', $memory/1024);
+        }
+
+        return sprintf('%.2fB', $memory);
+
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -23,7 +23,7 @@ class ProgressHelper extends Helper
 {
     const FORMAT_QUIET         = ' %percent%%';
     const FORMAT_NORMAL        = ' %current%/%max% [%bar%] %percent%%';
-    const FORMAT_VERBOSE       = ' %current%/%max% [%bar%] %percent%% Elapsed: %elapsed%';
+    const FORMAT_VERBOSE       = ' %current%/%max% [%bar%] %percent%% Elapsed: %elapsed% (%memory%)';
     const FORMAT_QUIET_NOMAX   = ' %current%';
     const FORMAT_NORMAL_NOMAX  = ' %current% [%bar%]';
     const FORMAT_VERBOSE_NOMAX = ' %current% [%bar%] Elapsed: %elapsed% Estimated: %estimated% (%memory%)';


### PR DESCRIPTION
see issue #9560

How to use it.

``` php
$progress = new ProgressHelper();
$progress->setFormat(ProgressHelper::FORMAT_VERBOSE_NOMAX);
$progress->start($this->output, count($rows));
```

And the output will be something like this

```
3 [>---------------------------] Elapsed: 10 secs Estimated: 6 mins (17.00MB)
```

The estimated is actually quite close to the time it took for my command (it took 5 min and 53 sec) - but of course it requires that all elements take the same time to execute.

The estimated time will be recalculated on each advance() (same time elapsed gets updated)

I havent quite figured out in which format the estimated should be in, so I only added it to FORMAT_VERBOSE_NOMAX, but should maybe be added to others as well?
