### PR TITLE
[Console] Verbose long option value does not work in ArgvInput

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -623,6 +623,20 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->run($input, $output);
     }
 
+    public function testVerboseLongValueInArgv()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->add(new \FooCommand());
+
+        $output = new StreamOutput(fopen('php://memory', 'w', false));
+
+        $input = new ArgvInput(array('cli.php', '--verbose=3', 'foo:bar'));
+        $application->run($input, $output);
+        $this->assertEquals(Output::VERBOSITY_VERY_VERBOSE, $output->getVerbosity());
+    }
+
     public function testRunReturnsIntegerExitCode()
     {
         $exception = new \Exception('', 4);


### PR DESCRIPTION
This PR just add a test and opens the issue, which relates #9566 to start a discussion about the problem.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | no |
| License | MIT |
| Doc PR | ~ |

I added a test for long option value. Which does not work for `ArgvInput`. So syntax

```
cli.php --verbose=3 command
cli.php command --verbose=3
```

is **not working since 2.3**.

What can be done:
- Remove all hacks like hasParameterOption('--verbose=3')
- Remove tests for long option value
- Add checks in ArrayInput for options without value

But there a low chance of user problems still exists if they rely on this option in ArrayInput (long verbose option value works for `ArrayInput` with `VALUE_NONE` because it does not check that value is acceptable, and does not work for `String` or `Argv` because of this check).

The another way is to add some more hacks to fix this support. But any change in this way have to be a hack, because option should stay to be `VALUE_NONE` for BC.
