### PR TITLE
[Form] Allow to extend multiple types in a type extension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -51,7 +51,10 @@ class FormPass implements CompilerPassInterface
                 ? $tag[0]['alias']
                 : $serviceId;
 
-            $typeExtensions[$alias][] = $serviceId;
+            $aliasArray = explode(',', $alias);
+            foreach ($aliasArray as $typeName) {
+                $typeExtensions[$typeName][] = $serviceId;
+            }
         }
 
         $definition->replaceArgument(2, $typeExtensions);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -51,9 +51,8 @@ class FormPass implements CompilerPassInterface
                 ? $tag[0]['alias']
                 : $serviceId;
 
-            $aliasArray = explode(',', $alias);
-            foreach ($aliasArray as $typeName) {
-                $typeExtensions[$typeName][] = $serviceId;
+            foreach (explode(',', $alias) as $extendedType) {
+                $typeExtensions[$extendedType][] = $serviceId;
             }
         }
 

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -171,8 +171,16 @@ abstract class AbstractExtension implements FormExtensionInterface
                 throw new UnexpectedTypeException($extension, 'Symfony\Component\Form\FormTypeExtensionInterface');
             }
 
-            foreach ((array) $extension->getExtendedType() as $type) {
-                $this->typeExtensions[$type][] = $extension;
+            if ($extension instanceof FormTypeExtensionMultiInterface) {
+                $extendedTypes = $extension->getExtendedTypes();
+            } else {
+                $extendedTypes = array(
+                    $extension->getExtendedType()
+                );
+            }
+
+            foreach ($extendedTypes as $extendedType) {
+                $this->typeExtensions[$extendedType][] = $extension;
             }
         }
     }

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -171,9 +171,9 @@ abstract class AbstractExtension implements FormExtensionInterface
                 throw new UnexpectedTypeException($extension, 'Symfony\Component\Form\FormTypeExtensionInterface');
             }
 
-            $type = $extension->getExtendedType();
-
-            $this->typeExtensions[$type][] = $extension;
+            foreach ((array) $extension->getExtendedType() as $type) {
+                $this->typeExtensions[$type][] = $extension;
+            }
         }
     }
 

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -171,13 +171,9 @@ abstract class AbstractExtension implements FormExtensionInterface
                 throw new UnexpectedTypeException($extension, 'Symfony\Component\Form\FormTypeExtensionInterface');
             }
 
-            if ($extension instanceof FormTypeExtensionMultiInterface) {
-                $extendedTypes = $extension->getExtendedTypes();
-            } else {
-                $extendedTypes = array(
-                    $extension->getExtendedType()
-                );
-            }
+            $extendedTypes = $extension instanceof FormTypeExtensionMultiInterface
+                ? $extension->getExtendedTypes()
+                : array($extension->getExtendedType());
 
             foreach ($extendedTypes as $extendedType) {
                 $this->typeExtensions[$extendedType][] = $extension;

--- a/src/Symfony/Component/Form/AbstractTypeExtension.php
+++ b/src/Symfony/Component/Form/AbstractTypeExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class AbstractTypeExtension implements FormTypeExtensionInterface
+abstract class AbstractTypeExtension implements FormTypeExtensionInterface, FormTypeExtensionMultiInterface
 {
     /**
      * {@inheritdoc}
@@ -44,5 +44,15 @@ abstract class AbstractTypeExtension implements FormTypeExtensionInterface
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedTypes()
+    {
+        return array(
+            $this->getExtendedType()
+        );
     }
 }

--- a/src/Symfony/Component/Form/AbstractTypeExtension.php
+++ b/src/Symfony/Component/Form/AbstractTypeExtension.php
@@ -51,8 +51,6 @@ abstract class AbstractTypeExtension implements FormTypeExtensionInterface, Form
      */
     public function getExtendedTypes()
     {
-        return array(
-            $this->getExtendedType()
-        );
+        return array($this->getExtendedType());
     }
 }

--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -100,7 +100,9 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
      */
     public function addTypeExtension(FormTypeExtensionInterface $typeExtension)
     {
-        $this->typeExtensions[$typeExtension->getExtendedType()][] = $typeExtension;
+        foreach ((array) $typeExtension->getExtendedType() as $type) {
+            $this->typeExtensions[$type][] = $typeExtension;
+        }
 
         return $this;
     }
@@ -111,7 +113,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
     public function addTypeExtensions(array $typeExtensions)
     {
         foreach ($typeExtensions as $typeExtension) {
-            $this->typeExtensions[$typeExtension->getExtendedType()][] = $typeExtension;
+            $this->addTypeExtension($typeExtension);
         }
 
         return $this;

--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -100,8 +100,16 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
      */
     public function addTypeExtension(FormTypeExtensionInterface $typeExtension)
     {
-        foreach ((array) $typeExtension->getExtendedType() as $type) {
-            $this->typeExtensions[$type][] = $typeExtension;
+        if ($typeExtension instanceof FormTypeExtensionMultiInterface) {
+            $extendedTypes = $typeExtension->getExtendedTypes();
+        } else {
+            $extendedTypes = array(
+                $typeExtension->getExtendedType()
+            );
+        }
+
+        foreach ($extendedTypes as $extendedType) {
+            $this->typeExtensions[$extendedType][] = $typeExtension;
         }
 
         return $this;

--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -100,13 +100,9 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
      */
     public function addTypeExtension(FormTypeExtensionInterface $typeExtension)
     {
-        if ($typeExtension instanceof FormTypeExtensionMultiInterface) {
-            $extendedTypes = $typeExtension->getExtendedTypes();
-        } else {
-            $extendedTypes = array(
-                $typeExtension->getExtendedType()
-            );
-        }
+        $extendedTypes = $typeExtension instanceof FormTypeExtensionMultiInterface
+            ? $typeExtension->getExtendedTypes()
+            : array($typeExtension->getExtendedType());
 
         foreach ($extendedTypes as $extendedType) {
             $this->typeExtensions[$extendedType][] = $typeExtension;

--- a/src/Symfony/Component/Form/FormTypeExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormTypeExtensionInterface.php
@@ -67,9 +67,9 @@ interface FormTypeExtensionInterface
     public function setDefaultOptions(OptionsResolverInterface $resolver);
 
     /**
-     * Returns the name of the type being extended.
+     * Returns the names of the types being extended.
      *
-     * @return string The name of the type being extended
+     * @return string|array The names of the types being extended.
      */
     public function getExtendedType();
 }

--- a/src/Symfony/Component/Form/FormTypeExtensionMultiInterface.php
+++ b/src/Symfony/Component/Form/FormTypeExtensionMultiInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author Andrei Liutec <andrei@liutec.ro>
+ */
+interface FormTypeExtensionMultiInterface
+{
+    /**
+     * Returns an array with the names of the types being extended.
+     *
+     * @return array The names of the types being extended
+     */
+    public function getExtendedTypes();
+}

--- a/src/Symfony/Component/Form/FormTypeExtensionMultiInterface.php
+++ b/src/Symfony/Component/Form/FormTypeExtensionMultiInterface.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 /**
  * @author Andrei Liutec <andrei@liutec.ro>
  */
@@ -21,7 +19,7 @@ interface FormTypeExtensionMultiInterface
     /**
      * Returns an array with the names of the types being extended.
      *
-     * @return array The names of the types being extended
+     * @return array The names of the types being extended.
      */
     public function getExtendedTypes();
 }

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
@@ -38,7 +38,9 @@ class DataCollectorTypeExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetExtendedTypes()
     {
         $types = $this->extension->getExtendedTypes();
-        $this->assertEquals(true, is_array($types));
+
+        $this->assertInternalType('array', $types);
+        $this->assertArrayHasKey(0, $types);
         $this->assertEquals($this->extension->getExtendedType(), $types[0]);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
@@ -35,6 +35,13 @@ class DataCollectorTypeExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('form', $this->extension->getExtendedType());
     }
 
+    public function testGetExtendedTypes()
+    {
+        $types = $this->extension->getExtendedTypes();
+        $this->assertEquals(true, is_array($types));
+        $this->assertEquals($this->extension->getExtendedType(), $types[0]);
+    }
+
     public function testBuildForm()
     {
         $builder = $this->getMock('Symfony\Component\Form\Test\FormBuilderInterface');

--- a/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
@@ -46,13 +46,9 @@ class TestExtension implements FormExtensionInterface
 
     public function addTypeExtension(FormTypeExtensionInterface $extension)
     {
-        if ($extension instanceof FormTypeExtensionMultiInterface) {
-            $extendedTypes = $extension->getExtendedTypes();
-        } else {
-            $extendedTypes = array(
-                $extension->getExtendedType()
-            );
-        }
+        $extendedTypes = $extension instanceof FormTypeExtensionMultiInterface
+            ? $extension->getExtendedTypes()
+            : array($extension->getExtendedType());
 
         foreach ($extendedTypes as $extendedType) {
             $this->extensions[$extendedType][] = $extension;

--- a/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
@@ -46,8 +46,16 @@ class TestExtension implements FormExtensionInterface
 
     public function addTypeExtension(FormTypeExtensionInterface $extension)
     {
-        foreach ((array) $extension->getExtendedType() as $type) {
-            $this->extensions[$type][] = $extension;
+        if ($extension instanceof FormTypeExtensionMultiInterface) {
+            $extendedTypes = $extension->getExtendedTypes();
+        } else {
+            $extendedTypes = array(
+                $extension->getExtendedType()
+            );
+        }
+
+        foreach ($extendedTypes as $extendedType) {
+            $this->extensions[$extendedType][] = $extension;
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
@@ -46,13 +46,9 @@ class TestExtension implements FormExtensionInterface
 
     public function addTypeExtension(FormTypeExtensionInterface $extension)
     {
-        $type = $extension->getExtendedType();
-
-        if (!isset($this->extensions[$type])) {
-            $this->extensions[$type] = array();
+        foreach ((array) $extension->getExtendedType() as $type) {
+            $this->extensions[$type][] = $extension;
         }
-
-        $this->extensions[$type][] = $extension;
     }
 
     public function getTypeExtensions($name)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9507 |
| License | MIT |
| Doc PR | - |

The use case of this PR is to allow to extend all form types with a single type extension. Since the button type does not extend the form one, there is no root type which can be extended.

As pointed in the referenced ticket, I'm not sure what can be done/happened if a type extension extends two types where the first is a child of the second. The problem can become much more complex if we extend more than 2 types...

For the test part, I don't see where I can put them. Someone can give me the good direction?
