### PR TITLE
[SecurityBundle] Added csrf_token_generator and csrf_token_id as new

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 -----
 
  * Added 'host' option to firewall configuration
+ * Added 'csrf_token_generator' and 'csrf_token_id' options to firewall logout
+   listener configuration to supercede/alias 'csrf_provider' and 'intention'
+   respectively
  * Moved 'security.secure_random' service configuration to FrameworkBundle
 
 2.3.0

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -212,10 +212,43 @@ class MainConfiguration implements ConfigurationInterface
             ->arrayNode('logout')
                 ->treatTrueLike(array())
                 ->canBeUnset()
+                ->beforeNormalization()
+                    ->ifTrue(function($v) { return isset($v['csrf_provider']) && isset($v['csrf_token_generator']); })
+                    ->thenInvalid("You should define a value for only one of 'csrf_provider' and 'csrf_token_generator' on a security firewall. Use 'csrf_token_generator' as this replaces 'csrf_provider'.")
+                ->end()
+                ->beforeNormalization()
+                    ->ifTrue(function($v) { return isset($v['intention']) && isset($v['csrf_token_id']); })
+                    ->thenInvalid("You should define a value for only one of 'intention' and 'csrf_token_id' on a security firewall. Use 'csrf_token_id' as this replaces 'intention'.")
+                ->end()
+                ->beforeNormalization()
+                    ->ifTrue(function($v) { return isset($v['csrf_provider']); })
+                    ->then(function($v) {
+                        $v['csrf_token_generator'] = $v['csrf_provider'];
+
+                        return $v;
+                    })
+                ->end()
+                ->beforeNormalization()
+                    ->ifTrue(function($v) { return isset($v['intention']); })
+                    ->then(function($v) {
+                        $v['csrf_token_id'] = $v['intention'];
+
+                        return $v;
+                    })
+                ->end()
+                ->beforeNormalization()
+                    ->always()
+                    ->then(function ($v) {
+                        unset($v['csrf_provider']);
+                        unset($v['intention']);
+
+                        return $v;
+                    })
+                ->end()
                 ->children()
                     ->scalarNode('csrf_parameter')->defaultValue('_csrf_token')->end()
-                    ->scalarNode('csrf_provider')->cannotBeEmpty()->end()
-                    ->scalarNode('intention')->defaultValue('logout')->end()
+                    ->scalarNode('csrf_token_generator')->cannotBeEmpty()->end()
+                    ->scalarNode('csrf_token_id')->defaultValue('logout')->end()
                     ->scalarNode('path')->defaultValue('/logout')->end()
                     ->scalarNode('target')->defaultValue('/')->end()
                     ->scalarNode('success_handler')->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimpleFormFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimpleFormFactory.php
@@ -65,7 +65,7 @@ class SimpleFormFactory extends FormLoginFactory
         $listenerId = parent::createListener($container, $id, $config, $userProvider);
         $listener = $container->getDefinition($listenerId);
 
-        if (!isset($config['csrf_provider'])) {
+        if (!isset($config['csrf_token_generator'])) {
             $listener->addArgument(null);
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -291,7 +291,7 @@ class SecurityExtension extends Extension
             $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.logout_listener'));
             $listener->replaceArgument(3, array(
                 'csrf_parameter' => $firewall['logout']['csrf_parameter'],
-                'intention'      => $firewall['logout']['intention'],
+                'intention'      => $firewall['logout']['csrf_token_id'],
                 'logout_path'    => $firewall['logout']['path'],
             ));
             $listeners[] = new Reference($listenerId);
@@ -307,8 +307,8 @@ class SecurityExtension extends Extension
             $listener->replaceArgument(2, new Reference($logoutSuccessHandlerId));
 
             // add CSRF provider
-            if (isset($firewall['logout']['csrf_provider'])) {
-                $listener->addArgument(new Reference($firewall['logout']['csrf_provider']));
+            if (isset($firewall['logout']['csrf_token_generator'])) {
+                $listener->addArgument(new Reference($firewall['logout']['csrf_token_generator']));
             }
 
             // add session logout handler
@@ -336,9 +336,9 @@ class SecurityExtension extends Extension
                 ->addMethodCall('registerListener', array(
                     $id,
                     $firewall['logout']['path'],
-                    $firewall['logout']['intention'],
+                    $firewall['logout']['csrf_token_id'],
                     $firewall['logout']['csrf_parameter'],
-                    isset($firewall['logout']['csrf_provider']) ? new Reference($firewall['logout']['csrf_provider']) : null,
+                    isset($firewall['logout']['csrf_token_generator']) ? new Reference($firewall['logout']['csrf_token_generator']) : null,
                 ))
             ;
         }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -67,4 +67,49 @@ class MainConfigurationTest extends \PHPUnit_Framework_TestCase
         $configuration = new MainConfiguration(array(), array());
         $config = $processor->processConfiguration($configuration, array($config));
     }
+
+    public function testCsrfAliases()
+    {
+        $config = array(
+            'firewalls' => array(
+                'stub' => array(
+                    'logout' => array(
+                        'csrf_provider' => 'a_token_generator',
+                        'intention' => 'a_token_id',
+                    ),
+                ),
+            ),
+        );
+        $config = array_merge(static::$minimalConfig, $config);
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration(array(), array());
+        $processedConfig = $processor->processConfiguration($configuration, array($config));
+        $this->assertTrue(isset($processedConfig['firewalls']['stub']['logout']['csrf_token_generator']));
+        $this->assertEquals('a_token_generator', $processedConfig['firewalls']['stub']['logout']['csrf_token_generator']);
+        $this->assertTrue(isset($processedConfig['firewalls']['stub']['logout']['csrf_token_id']));
+        $this->assertEquals('a_token_id', $processedConfig['firewalls']['stub']['logout']['csrf_token_id']);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCsrfOriginalAndAliasValueCausesException()
+    {
+        $config = array(
+            'firewalls' => array(
+                'stub' => array(
+                    'logout' => array(
+                        'csrf_token_id' => 'a_token_id',
+                        'intention' => 'old_name',
+                    ),
+                ),
+            ),
+        );
+        $config = array_merge(static::$minimalConfig, $config);
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration(array(), array());
+        $processedConfig = $processor->processConfiguration($configuration, array($config));
+    }
 }


### PR DESCRIPTION
names for csrf_provider and intention options

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #9176 |
| License | MIT |
| Doc PR | n/a |
