### PR TITLE
[Form] Implemented CoreTypeGuesser for submit button detection

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -9,6 +9,7 @@
         <parameter key="form.registry.class">Symfony\Component\Form\FormRegistry</parameter>
         <parameter key="form.factory.class">Symfony\Component\Form\FormFactory</parameter>
         <parameter key="form.extension.class">Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension</parameter>
+        <parameter key="form.type_guesser.core.class">Symfony\Component\Form\Extension\Core\CoreTypeGuesser</parameter>
         <parameter key="form.type_guesser.validator.class">Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser</parameter>
     </parameters>
 
@@ -45,6 +46,11 @@
             <argument type="collection" />
             <!-- All services with tag "form.type_guesser" are inserted here by FormPass -->
             <argument type="collection" />
+        </service>
+
+        <!-- CoreTypeGuesser -->
+        <service id="form.type_guesser.core" class="%form.type_guesser.core.class%">
+            <tag name="form.type_guesser" />
         </service>
 
         <!-- ValidatorTypeGuesser -->

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -56,4 +56,9 @@ class CoreExtension extends AbstractExtension
             new Type\CurrencyType(),
         );
     }
+
+    public function loadTypeGuesser()
+    {
+        return new CoreTypeGuesser();
+    }
 }

--- a/src/Symfony/Component/Form/Extension/Core/CoreTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreTypeGuesser.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core;
+
+use Symfony\Component\Form\FormTypeGuesserInterface;
+use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Guess\TypeGuess;
+use Symfony\Component\Form\Util\ClassReflectionUtil;
+
+/**
+ * @author Andrew Moore <me@andrewmoore.ca>
+ */
+class CoreTypeGuesser implements FormTypeGuesserInterface
+{
+    private static $nameToTypeMapping = array(
+        'submit' => 'submit',
+        'reset' => 'reset',
+    );
+
+    /**
+     * {@inheritDoc}
+     */
+    public function guessType($class, $property)
+    {
+        // Guess types for specialized button types
+        if (!array_key_exists($property, self::$nameToTypeMapping)) {
+            return null;
+        }
+
+        if (!ClassReflectionUtil::hasPropertyAvailable($class, $property)) {
+            return new TypeGuess(self::$nameToTypeMapping[$property], array(), Guess::LOW_CONFIDENCE);
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function guessRequired($class, $property)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function guessMaxLength($class, $property)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function guessPattern($class, $property)
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/CoreTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/CoreTypeGuesserTest.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core;
+
+use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Extension\Core\CoreTypeGuesser;
+
+class CoreTypeGuesserTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var CoreTypeGuesser */
+    private $guesser;
+
+    const AUTHOR_FIXTURE = 'Symfony\Component\Form\Tests\Fixtures\Author';
+    const PROPERTIES_DEFINED_FIXTURE = 'Symfony\Component\Form\Tests\Fixtures\SubmitResetPropertyFixture';
+
+    protected function setUp()
+    {
+        $this->guesser = new CoreTypeGuesser();
+    }
+
+    public function testButtonTypeInferral()
+    {
+        $submitGuess = $this->guesser->guessType(self::AUTHOR_FIXTURE, 'submit');
+        $resetGuess = $this->guesser->guessType(self::AUTHOR_FIXTURE, 'reset');
+
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\TypeGuess', $submitGuess);
+        $this->assertEquals('submit', $submitGuess->getType());
+        $this->assertEquals(Guess::LOW_CONFIDENCE, $submitGuess->getConfidence());
+
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\TypeGuess', $resetGuess);
+        $this->assertEquals('reset', $resetGuess->getType());
+        $this->assertEquals(Guess::LOW_CONFIDENCE, $resetGuess->getConfidence());
+    }
+
+    public function testButtonPropertyExists()
+    {
+        $submitGuess = $this->guesser->guessType(self::PROPERTIES_DEFINED_FIXTURE, 'submit');
+        $resetGuess = $this->guesser->guessType(self::PROPERTIES_DEFINED_FIXTURE, 'reset');
+
+        $this->assertNull($submitGuess);
+        $this->assertNull($resetGuess);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/SubmitResetPropertyFixture.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/SubmitResetPropertyFixture.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+class SubmitResetPropertyFixture
+{
+    private $submit;
+    public $reset;
+
+    /**
+     * @return mixed
+     */
+    public function getSubmit()
+    {
+        return $this->submit;
+    }
+
+    /**
+     * @param mixed $submit
+     */
+    public function setSubmit($submit)
+    {
+        $this->submit = $submit;
+    }
+}

--- a/src/Symfony/Component/Form/Util/ClassReflectionUtil.php
+++ b/src/Symfony/Component/Form/Util/ClassReflectionUtil.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Util;
+
+use Symfony\Component\PropertyAccess\StringUtil;
+
+/**
+ * @author Andrew Moore <me@andrewmoore.ca>
+ */
+class ClassReflectionUtil
+{
+    /**
+     * This class should not be instantiated
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Detects if a property or adder/setter is available for a given
+     * property.
+     *
+     * @param string $class    The class to verify against
+     * @param string $property The property to verify
+     *
+     * @return Boolean
+     */
+    public static function hasPropertyAvailable($class, $property)
+    {
+        if (!class_exists($class)) {
+            return false;
+        }
+
+        $reflClass = new \ReflectionClass($class);
+
+        $setter = 'set' . self::camelize($property);
+        $classHasProperty = $reflClass->hasProperty($property);
+
+        if ($reflClass->hasMethod($setter) && $reflClass->getMethod($setter)->isPublic()) {
+            return true;
+        }
+        if ($reflClass->hasMethod('__set') && $reflClass->getMethod('__set')->isPublic()) {
+            return true;
+        }
+        if ($classHasProperty && $reflClass->getProperty($property)->isPublic()) {
+            return true;
+        }
+
+        $plural = self::camelize($property);
+        $singular = StringUtil::singularify($plural);
+
+        $adder = 'add' . $singular;
+        $remover = 'remove' . $singular;
+
+        $adderFound = self::isMethodAccessible($reflClass, $adder, 1);
+        $removerFound = self::isMethodAccessible($reflClass, $remover, 1);
+
+        if ($adderFound && $removerFound) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Camelizes a given string.
+     *
+     * @param string $string Some string
+     *
+     * @return string The camelized version of the string
+     */
+    private static function camelize($string)
+    {
+        return preg_replace_callback(
+            '/(^|_|\.)+(.)/',
+            function ($match) {
+                return ('.' === $match[1] ? '_' : '') . strtoupper($match[2]);
+            },
+            $string
+        );
+    }
+
+    /**
+     * Returns whether a method is public and has a specific number of required parameters.
+     *
+     * @param \ReflectionClass $class      The class of the method
+     * @param string           $methodName The method name
+     * @param integer          $parameters The number of parameters
+     *
+     * @return Boolean Whether the method is public and has $parameters
+     *                                      required parameters
+     */
+    private static function isMethodAccessible(\ReflectionClass $class, $methodName, $parameters)
+    {
+        if ($class->hasMethod($methodName)) {
+            $method = $class->getMethod($methodName);
+
+            if ($method->isPublic() && $method->getNumberOfRequiredParameters() === $parameters) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+} 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no* |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8785 |
| License | MIT |
| Doc PR | N/A |

\* The old behavior would of caused an exception to be thrown while binding the data.

Created during the Symfony Montreal Hackathon
