### PR TITLE
[ProxyManager] performance optimization for lazy loaded services

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -76,6 +76,7 @@ class ProxyDumper implements DumperInterface
             $instantiation new $proxyClass(
                 function (&\$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface \$proxy) use (\$container) {
                     \$wrappedInstance = \$container->$methodName(false);
+                    \$container->set('$id', \$wrappedInstance);
 
                     \$proxy->setProxyInitializer(null);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes (well more a performance enhancement |
| BC breaks? | no |
| Deprecations? | - |
| Tests pass? | - |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Result of a discussion at DrupalCamp Vienna.
The idea is essentially to no longer have to use a proxy once the service has been loaded.

Given a lazy loaded service `foo` with a method `foo()`:

```
// proxy
var_dump(get_class($this->container->get('foo')));
// still proxy
var_dump(get_class($this->container->get('foo')));
$this->container->get('foo')->foo();
// no longer a proxy
var_dump(get_class($this->container->get('foo')));
```

Haven't looked at the tests yet, wanted to get feedback if this makes sense first.

/cc @dawehner @ocramius
