### PR TITLE
[Security] Typos in Security's ExpressionLanguage

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
@@ -31,21 +31,21 @@ class ExpressionLanguage extends BaseExpressionLanguage
         });
 
         $this->register('is_authenticated', function () {
-            return '!$trust_resolver->isAnonymous($token)';
+            return '$token && !$trust_resolver->isAnonymous($token)';
         }, function (array $variables) {
-            return !$variables['trust_resolver']->isAnonymous($variables['token']);
+            return $variables['token'] && !$variables['trust_resolver']->isAnonymous($variables['token']);
         });
 
         $this->register('is_fully_authenticated', function () {
-            return '!$trust_resolver->isFullFledge($token)';
+            return '$trust_resolver->isFullFledged($token)';
         }, function (array $variables) {
-            return !$variables['trust_resolver']->isFullFledge($variables['token']);
+            return $variables['trust_resolver']->isFullFledged($variables['token']);
         });
 
         $this->register('is_remember_me', function () {
-            return '!$trust_resolver->isRememberMe($token)';
+            return '$trust_resolver->isRememberMe($token)';
         }, function (array $variables) {
-            return !$variables['trust_resolver']->isRememberMe($variables['token']);
+            return $variables['trust_resolver']->isRememberMe($variables['token']);
         });
 
         $this->register('has_role', function ($role) {

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
@@ -20,60 +20,60 @@ use Symfony\Component\Security\Core\User\User;
 
 class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
 {
-	/**
-	 * @dataProvider provider
-	 */
-	public function testIsAuthenticated($token, $expression, $result, array $roles = array())
-	{
-		$anonymousTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\AnonymousToken';
-		$rememberMeTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\RememberMeToken';
-		$expressionLanguage = new ExpressionLanguage();
-		$trustResolver = new AuthenticationTrustResolver($anonymousTokenClass, $rememberMeTokenClass);
+    /**
+     * @dataProvider provider
+     */
+    public function testIsAuthenticated($token, $expression, $result, array $roles = array())
+    {
+        $anonymousTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\AnonymousToken';
+        $rememberMeTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\RememberMeToken';
+        $expressionLanguage = new ExpressionLanguage();
+        $trustResolver = new AuthenticationTrustResolver($anonymousTokenClass, $rememberMeTokenClass);
 
-		$context = array();
-		$context['trust_resolver'] = $trustResolver;
-		$context['token'] = $token;
-		$context['roles'] = $roles;
+        $context = array();
+        $context['trust_resolver'] = $trustResolver;
+        $context['token'] = $token;
+        $context['roles'] = $roles;
 
-		$this->assertEquals($result, $expressionLanguage->evaluate($expression, $context));
-	}
+        $this->assertEquals($result, $expressionLanguage->evaluate($expression, $context));
+    }
 
-	public function provider()
-	{
-		$roles = array('ROLE_USER', 'ROLE_ADMIN');
-		$user = new User('username', 'password', $roles);
+    public function provider()
+    {
+        $roles = array('ROLE_USER', 'ROLE_ADMIN');
+        $user = new User('username', 'password', $roles);
 
-		$noToken = null;
-		$anonymousToken = new AnonymousToken('firewall', 'anon.');
-		$rememberMeToken = new RememberMeToken($user, 'providerkey', 'firewall');
-		$usernamePasswordToken = new UsernamePasswordToken('username', 'password', 'providerkey', $roles);
+        $noToken = null;
+        $anonymousToken = new AnonymousToken('firewall', 'anon.');
+        $rememberMeToken = new RememberMeToken($user, 'providerkey', 'firewall');
+        $usernamePasswordToken = new UsernamePasswordToken('username', 'password', 'providerkey', $roles);
 
-		return array(
-			array($noToken, 'is_anonymous()', false),
-			array($noToken, 'is_authenticated()', false),
-			array($noToken, 'is_fully_authenticated()', false),
-			array($noToken, 'is_remember_me()', false),
-			array($noToken, "has_role('ROLE_USER')", false),
+        return array(
+            array($noToken, 'is_anonymous()', false),
+            array($noToken, 'is_authenticated()', false),
+            array($noToken, 'is_fully_authenticated()', false),
+            array($noToken, 'is_remember_me()', false),
+            array($noToken, "has_role('ROLE_USER')", false),
 
-			array($anonymousToken, 'is_anonymous()', true),
-			array($anonymousToken, 'is_authenticated()', false),
-			array($anonymousToken, 'is_fully_authenticated()', false),
-			array($anonymousToken, 'is_remember_me()', false),
-			array($anonymousToken, "has_role('ROLE_USER')", false),
+            array($anonymousToken, 'is_anonymous()', true),
+            array($anonymousToken, 'is_authenticated()', false),
+            array($anonymousToken, 'is_fully_authenticated()', false),
+            array($anonymousToken, 'is_remember_me()', false),
+            array($anonymousToken, "has_role('ROLE_USER')", false),
 
-			array($rememberMeToken, 'is_anonymous()', false),
-			array($rememberMeToken, 'is_authenticated()', true),
-			array($rememberMeToken, 'is_fully_authenticated()', false),
-			array($rememberMeToken, 'is_remember_me()', true),
-			array($rememberMeToken, "has_role('ROLE_FOO')", false, $roles),
-			array($rememberMeToken, "has_role('ROLE_USER')", true, $roles),
+            array($rememberMeToken, 'is_anonymous()', false),
+            array($rememberMeToken, 'is_authenticated()', true),
+            array($rememberMeToken, 'is_fully_authenticated()', false),
+            array($rememberMeToken, 'is_remember_me()', true),
+            array($rememberMeToken, "has_role('ROLE_FOO')", false, $roles),
+            array($rememberMeToken, "has_role('ROLE_USER')", true, $roles),
 
-			array($usernamePasswordToken, 'is_anonymous()', false),
-			array($usernamePasswordToken, 'is_authenticated()', true),
-			array($usernamePasswordToken, 'is_fully_authenticated()', true),
-			array($usernamePasswordToken, 'is_remember_me()', false),
-			array($usernamePasswordToken, "has_role('ROLE_FOO')", false, $roles),
-			array($usernamePasswordToken, "has_role('ROLE_USER')", true, $roles),
-		);
-	}
+            array($usernamePasswordToken, 'is_anonymous()', false),
+            array($usernamePasswordToken, 'is_authenticated()', true),
+            array($usernamePasswordToken, 'is_fully_authenticated()', true),
+            array($usernamePasswordToken, 'is_remember_me()', false),
+            array($usernamePasswordToken, "has_role('ROLE_FOO')", false, $roles),
+            array($usernamePasswordToken, "has_role('ROLE_USER')", true, $roles),
+        );
+    }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authorization;
+
+use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\User;
+
+class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @dataProvider provider
+	 */
+	public function testIsAuthenticated($token, $expression, $result, array $roles = array())
+	{
+		$anonymousTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\AnonymousToken';
+		$rememberMeTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\RememberMeToken';
+		$expressionLanguage = new ExpressionLanguage();
+		$trustResolver = new AuthenticationTrustResolver($anonymousTokenClass, $rememberMeTokenClass);
+
+		$context = array();
+		$context['trust_resolver'] = $trustResolver;
+		$context['token'] = $token;
+		$context['roles'] = $roles;
+
+		$this->assertEquals($result, $expressionLanguage->evaluate($expression, $context));
+	}
+
+	public function provider()
+	{
+		$roles = array('ROLE_USER', 'ROLE_ADMIN');
+		$user = new User('username', 'password', $roles);
+
+		$noToken = null;
+		$anonymousToken = new AnonymousToken('firewall', 'anon.');
+		$rememberMeToken = new RememberMeToken($user, 'providerkey', 'firewall');
+		$usernamePasswordToken = new UsernamePasswordToken('username', 'password', 'providerkey', $roles);
+
+		return array(
+			array($noToken, 'is_anonymous()', false),
+			array($noToken, 'is_authenticated()', false),
+			array($noToken, 'is_fully_authenticated()', false),
+			array($noToken, 'is_remember_me()', false),
+			array($noToken, "has_role('ROLE_USER')", false),
+
+			array($anonymousToken, 'is_anonymous()', true),
+			array($anonymousToken, 'is_authenticated()', false),
+			array($anonymousToken, 'is_fully_authenticated()', false),
+			array($anonymousToken, 'is_remember_me()', false),
+			array($anonymousToken, "has_role('ROLE_USER')", false),
+
+			array($rememberMeToken, 'is_anonymous()', false),
+			array($rememberMeToken, 'is_authenticated()', true),
+			array($rememberMeToken, 'is_fully_authenticated()', false),
+			array($rememberMeToken, 'is_remember_me()', true),
+			array($rememberMeToken, "has_role('ROLE_FOO')", false, $roles),
+			array($rememberMeToken, "has_role('ROLE_USER')", true, $roles),
+
+			array($usernamePasswordToken, 'is_anonymous()', false),
+			array($usernamePasswordToken, 'is_authenticated()', true),
+			array($usernamePasswordToken, 'is_fully_authenticated()', true),
+			array($usernamePasswordToken, 'is_remember_me()', false),
+			array($usernamePasswordToken, "has_role('ROLE_FOO')", false, $roles),
+			array($usernamePasswordToken, "has_role('ROLE_USER')", true, $roles),
+		);
+	}
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9593 |
| License | MIT |
| Doc PR | none |

Fixed the ExpressionLanguage and added the tests. It looks ok to me, but please, take a close look (some people will depend on this working right, including me :D ).

Thanks !
