### PR TITLE
[Validator] Typo and better wording for german validator translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -248,7 +248,7 @@
             </trans-unit>
             <trans-unit id="65">
                 <source>This value should be equal to {{ compared_value }}.</source>
-                <target>Dieser Wert sollte übereinstimmen mit {{ compared_value }}.</target>
+                <target>Dieser Wert sollte gleich {{ compared_value }} sein.</target>
             </trans-unit>
             <trans-unit id="66">
                 <source>This value should be greater than {{ compared_value }}.</source>
@@ -256,7 +256,7 @@
             </trans-unit>
             <trans-unit id="67">
                 <source>This value should be greater than or equal to {{ compared_value }}.</source>
-                <target>Dieser Wert sollte größer sein oder übereinstimmen mit {{ compared_value }}.</target>
+                <target>Dieser Wert sollte größer oder gleich {{ compared_value }} sein.</target>
             </trans-unit>
             <trans-unit id="68">
                 <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
@@ -268,7 +268,7 @@
             </trans-unit>
             <trans-unit id="70">
                 <source>This value should be less than or equal to {{ compared_value }}.</source>
-                <target>Dieser Wert sollte kleiner sein oder übereinstimmen mit {{ compared_value }}.</target>
+                <target>Dieser Wert sollte kleiner oder gleich {{ compared_value }} sein.</target>
             </trans-unit>
             <trans-unit id="71">
                 <source>This value should not be equal to {{ compared_value }}.</source>
@@ -276,7 +276,7 @@
             </trans-unit>
             <trans-unit id="72">
                 <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-                <target>Dieser Wert sollte nicht identische sein mit {{ compared_value_type }} {{ compared_value }}.</target>
+                <target>Dieser Wert sollte nicht identisch sein mit {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Follow up of #9588 as supposed by @craue
