### PR TITLE
WebTestCase: Assume relative KERNEL_DIR is relative to phpunit.xml[.dist]?

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -124,7 +124,15 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
      */
     protected static function getKernelClass()
     {
-        $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : static::getPhpUnitXmlDir();
+        $dir = $phpUnitDir = static::getPhpUnitXmlDir();
+
+        if (isset($_SERVER['KERNEL_DIR'])) {
+            $dir = $_SERVER['KERNEL_DIR'];
+
+            if (!is_dir($dir) && is_dir("$phpUnitDir/$dir")) {
+                $dir = "$phpUnitDir/$dir";
+            }
+        }
 
         $finder = new Finder();
         $finder->name('*Kernel.php')->depth(0)->in($dir);


### PR DESCRIPTION
When using the `KERNEL_DIR` setting in phpunit.xml[.dist] files for the `WebTestCase`, a relative path seems to be interpreted relative to the cwd.

That makes no difference in the probably most common case of having the phpunit config in the project's top level directory and just running `phpunit`. It makes a difference however when running it from a lower level dir and referencing the config with `-c ../../phpunit.xml`.

A conservative change would be to interpret the `KERNEL_DIR` as relative to cwd and only try it as relative to the phpunit.xml[.dist] file if the first path does not exist.

A more consistent approach would be to always have it (in case of relative paths) being relative to the config file. That might break things for folks who intentionally start phpunit from different directories to use different kernels.

The docs seem not to say anything about how it is supposed to used, the example values provided suggest using an absolute path.

Opinions?
