### PR TITLE
Adjusting CacheClear Warmup method to namespaced kernels

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -120,10 +120,13 @@ EOF
         $warmer->warmUp($warmupDir);
 
         // fix references to the Kernel in .meta files
+        $safeTempKernel = str_replace('\\', '\\\\', get_class($tempKernel));
+        $realKernelFQN = get_class($realKernel);
+        
         foreach (Finder::create()->files()->name('*.meta')->in($warmupDir) as $file) {
             file_put_contents($file, preg_replace(
-                '/(C\:\d+\:)"'.get_class($tempKernel).'"/',
-                sprintf('$1"%s"', $realKernelClass),
+                '/(C\:\d+\:)"'.$safeTempKernel.'"/',
+                sprintf('$1"%s"', $realKernelFQN),
                 file_get_contents($file)
             ));
         }


### PR DESCRIPTION
Backported the patch in #9525 to the 2.3 branch.

| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | have not tried yet |
| License | MIT |
| Fixed tickets | further fixes #1431 |

My kernel has been moved and namespaced to `Cfs\Bundle\MultiSiteBundle\Kernel\CfsKernel`. This worked fine until a change was made to how the kernel temp stuff is handled in the warmup phase.

When the app generates its own cache (i.e you run cache without warmup and access the site) everything is generated ok and the .meta files generate the proper reference to the FQN of the Kernel.

However if the warmup is used, it uses `Cfs\Bundle\MultiSiteBundle\Kernel\CfsKerne_` as the temporary Kernel, and when it does "fix references to the Kernel in .meta files" it generates 2 errors.
1. It does not use a string safe tempKernel name, so it never finds the reference to the kernel
2. If you fix that, then it replaces the FQN of the tempKernel with `CfsKernel`, the non-namespaced name of the proper Kernel (it also leaves the character count wrong in the serialization `C:43:<class>` where 43 is the char count for the FQN above)

The two changes above fix this, by escaping the string and replacing it with a FQN Kernel Class name.

What are your thoughts on this? If this sounds reasonable i'll do further enhancements and check tests.
