### PR TITLE
[HttpKernel] Fix a bug when using the kernel property in overridden method Client::setServerParameters()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -43,10 +43,11 @@ class Client extends BaseClient
      */
     public function __construct(HttpKernelInterface $kernel, array $server = array(), History $history = null, CookieJar $cookieJar = null)
     {
-        parent::__construct($server, $history, $cookieJar);
-
+        // These class properties must be set before calling the parent constructor, as it may depend on it.
         $this->kernel = $kernel;
         $this->followRedirects = false;
+
+        parent::__construct($server, $history, $cookieJar);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

**TL;DR**
Fixes a fatal error when using `$this->kernel` in overridden `Client::setServerParameters` method happening since @Tobion commit https://github.com/symfony/symfony/commit/111ac18232dd660a3d23d9d0f1935aa914ffc43c.

**Long story**

In my tests, I'm overriding the `test.client.class` parameter to use a custom class which overrides the `setServerParameters` method with the following code :

```
    public function setServerParameters(array $server)
    {
        if (!isset($server['HTTP_HOST'])) {
            $server['HTTP_HOST'] = $this->getContainer()->getParameter('website_domain');
        }

        parent::setServerParameters($server);
    }
```

The purpose is to set the HTTP_HOST variable on every client request in the tests with the application domain (instead of the default value "localhost"). This fixed issues when switching between domains (standard, secure, etc) and also issues with CSRF protection.

If you know of a better idea on how to set this attribute with a value from a DIC parameter to every client request done in any tests in one place without overriding Symfony stuff, I'd be **very glad** to hear it. :)

**Detailed error**

```
 [Exception]                                                                                                                                                                  
  PHP Fatal error:  Call to a member function getContainer() on a non-object in /home/gnutix/lamp/sf-2.4/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Clie  
  nt.php on line 48                                                                                                                                                            
  PHP Stack trace:                                                                                                                                                             
  PHP   1. {main}() /usr/bin/phpunit:0                                                                                                                                         
  PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:46                                                                                                                  
  PHP   3. PHPUnit_TextUI_Command->run() /usr/share/php/PHPUnit/TextUI/Command.php:129                                                                                         
  PHP   4. PHPUnit_TextUI_TestRunner->doRun() /usr/share/php/PHPUnit/TextUI/Command.php:176                                                                                    
  PHP   5. PHPUnit_Framework_TestSuite->run() /home/gnutix/lamp/sf-2.4/vendor/phpunit/phpunit/PHPUnit/TextUI/TestRunner.php:349                                          
  PHP   6. PHPUnit_Framework_TestSuite->runTest() /home/gnutix/lamp/sf-2.4/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php:745                                    
  PHP   7. PHPUnit_Framework_TestCase->run() /home/gnutix/lamp/sf-2.4/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php:775                                         
  PHP   8. PHPUnit_Framework_TestResult->run() /home/gnutix/lamp/sf-2.4/vendor/phpunit/phpunit/PHPUnit/Framework/TestCase.php:783                                        
  PHP   9. PHPUnit_Framework_TestCase->runBare() /home/gnutix/lamp/sf-2.4/vendor/phpunit/phpunit/PHPUnit/Framework/TestResult.php:648                                    
  PHP  10. Gnutix\Tests\FunctionalTestsHelper->setUp() /home/gnutix/lamp/sf-2.4/vendor/phpunit/phpunit/PHPUnit/Framework/TestCase.php:835                      
  PHP  11. Gnutix\Tests\FunctionalTestsHelper::createClient() /home/gnutix/lamp/sf-2.4/src/Gnutix/Tests/FunctionalTestsHelper.php:82                 
  PHP  12. Symfony\Bundle\FrameworkBundle\Test\WebTestCase::createClient() /home/gnutix/lamp/sf-2.4/src/Gnutix/CommonBundle/Tests/FunctionalTestsHelper.php:440             
  PHP  13. Symfony\Component\DependencyInjection\Container->get() /home/gnutix/lamp/sf-2.4/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.p  
  hp:49                                                                                                                                                                        
  PHP  14. appTestDebugProjectContainer->getTest_ClientService() /home/gnutix/lamp/sf-2.4/app/bootstrap.php.cache:2033                                                   
  PHP  15. Symfony\Bundle\FrameworkBundle\Client->__construct() /home/gnutix/lamp/sf-2.4/app/cache/test/appTestDebugProjectContainer.php:5806                            
  PHP  16. Symfony\Component\HttpKernel\Client->__construct() /home/gnutix/lamp/sf-2.4/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Client.php:38           
  PHP  17. Symfony\Component\BrowserKit\Client->__construct() /home/gnutix/lamp/sf-2.4/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Client.php:46             
  PHP  18. SymfonyExtension\Bundle\FrameworkBundle\Client->setServerParameters() /home/gnutix/lamp/sf-2.4/vendor/symfony/symfony/src/Symfony/Component/BrowserKit/Clien  
  t.php:60                                                                                                                                                                     
  PHP  19. Symfony\Bundle\FrameworkBundle\Client->getContainer() /home/gnutix/lamp/sf-2.4/src/SymfonyExtension/Bundle/FrameworkBundle/Client.php:24
```
