### PR TITLE
Container::camelize also takes backslashes into consideration

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -525,7 +525,7 @@ class Container implements IntrospectableContainerInterface
      */
     public static function camelize($id)
     {
-        return strtr(ucwords(strtr($id, array('_' => ' ', '.' => '_ '))), array(' ' => ''));
+        return strtr(ucwords(strtr($id, array('_' => ' ', '.' => '_ ', '\\' => '_ '))), array(' ' => ''));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -51,6 +51,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
             array('.foo', '_Foo'),
             array('foo_', 'Foo'),
             array('foo.', 'Foo_'),
+            array('foo\bar', 'Foo_Bar'),
         );
     }
 


### PR DESCRIPTION
I [complained](https://github.com/symfony/symfony/pull/8494) about unreported and unnoticed BC break.

Service names in our DI container contain backslashes and that pull request rendered newer versions of Symfony unusable for us.

This commit fixes this - it normalizes backslashes in service names into underscores.
