### PR TITLE
[HttpFoundation] Do not return an empty session id if the session was closed

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -163,7 +163,7 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function getId()
     {
-        if (!$this->started) {
+        if (!$this->started && !$this->closed) {
             return ''; // returning empty is consistent with session_id() behaviour
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -85,7 +85,11 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
     {
         $storage = $this->getStorage();
         $this->assertEquals('', $storage->getId());
+
         $storage->start();
+        $this->assertNotEquals('', $storage->getId());
+
+        $storage->save();
         $this->assertNotEquals('', $storage->getId());
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no (shouldn't be) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7936 |
| License | MIT |
| Doc PR | ~ |

This introduced a regression from #9246, with an incomplete fix ;

As the `started` flag on the NativeSessionStorage was not `true` anymore when saving the session, the session id was always empty when saving it, and thus when sending the `PHPSESSID` cookie.

The previous PR I made (#9530) was another approach to solve this regression, but this one should keep the fix made by @tecbot on #9246, and finish it with another verification. I may miss another place where `started` is used, but I don't really see which other conditions depending on this property should be altered...

I tried to alter the getId tests on the `NativeSessionStorage`, but I think it is missing a functionnal test to show it indeed broke before and is now fixed... Any idea ?

ping @drak, @jakzal

**Note :** The test are failing due to the StopWatch component (something date related I guess ?)
