### PR TITLE
Changed Role to RoleInterface

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
-use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * A SecurityIdentity implementation for roles
@@ -30,7 +30,7 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      */
     public function __construct($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof RoleInterface) {
             $role = $role->getRole();
         }
 


### PR DESCRIPTION
Changed Role to RoleInterface so that one doesn't have to extend Role, but simply implement RoleInterface.
Maybe be better to merge to branch 2.3/2.4
