### PR TITLE
[ExpressionLanguage] Fixed #9606: leading spaces in expressions lead to 'Uninitialized string offset: X' warnings

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -29,7 +29,7 @@ class Lexer
      */
     public function tokenize($expression)
     {
-        $expression = str_replace(array("\r", "\n", "\t", "\v", "\f"), ' ', $expression);
+        $expression = rtrim(str_replace(array("\r", "\n", "\t", "\v", "\f"), ' ', $expression));
         $cursor = 0;
         $tokens = array();
         $brackets = array();

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -22,7 +22,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
      */
     public function testTokenize($tokens, $expression)
     {
-        $tokens[] = new Token('end of expression', null, strlen($expression) + 1);
+        $tokens[] = new Token('end of expression', null, strlen(rtrim($expression)) + 1);
         $lexer = new Lexer();
         $this->assertEquals(new TokenStream($tokens), $lexer->tokenize($expression));
     }
@@ -30,6 +30,10 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     public function getTokenizeData()
     {
         return array(
+            array(
+                array(),
+                ' ',
+            ),
             array(
                 array(new Token('name', 'a', 1)),
                 'a',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9606 |
| License | MIT |
| Doc PR |  |

Bug fix for #9606
