### PR TITLE
[FormType][DateType] added option 'pad' into DateType to display (or not) zeros in a date

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -99,7 +99,7 @@ class DateType extends AbstractType
                 ->add('month', $options['widget'], $monthOptions)
                 ->add('day', $options['widget'], $dayOptions)
                 ->addViewTransformer(new DateTimeToArrayTransformer(
-                    $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day')
+                    $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day'), $options['pad']
                 ))
                 ->setAttribute('formatter', $formatter)
             ;
@@ -209,6 +209,7 @@ class DateType extends AbstractType
             // this option.
             'data_class'     => null,
             'compound'       => $compound,
+            'pad'            => false
         ));
 
         $resolver->setNormalizers(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -209,7 +209,7 @@ class DateType extends AbstractType
             // this option.
             'data_class'     => null,
             'compound'       => $compound,
-            'pad'            => false
+            'pad'            => false,
         ));
 
         $resolver->setNormalizers(array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -162,7 +162,7 @@ class DateTypeTest extends TypeTestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'text',
-            'pad'    => true
+            'pad'    => true,
         ));
 
         $text = array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -155,6 +155,29 @@ class DateTypeTest extends TypeTestCase
         $this->assertDateTimeEquals($dateTime, $form->getData());
         $this->assertEquals($text, $form->getViewData());
     }
+    
+    public function testSubmitFromTextWithPad()
+    {
+        $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'text',
+            'pad'    => true
+        ));
+
+        $text = array(
+            'day' => '02',
+            'month' => '06',
+            'year' => '2010',
+        );
+
+        $form->submit($text);
+
+        $dateTime = new \DateTime('2010-06-02 UTC');
+
+        $this->assertDateTimeEquals($dateTime, $form->getData());
+        $this->assertEquals($text, $form->getViewData());
+    }
 
     public function testSubmitFromChoice()
     {


### PR DESCRIPTION
Added option 'pad' (default=false) in order to display zeros for days and months who begin with zero in a date
