### PR TITLE
[ExpressionLanguage] fixed lexing expression ending with spaces

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -36,8 +36,10 @@ class Lexer
         $end = strlen($expression);
 
         while ($cursor < $end) {
-            while (' ' == $expression[$cursor]) {
+            if (' ' == $expression[$cursor]) {
                 ++$cursor;
+
+                continue;
             }
 
             if (preg_match('/[0-9]+(?:\.[0-9]+)?/A', $expression, $match, null, $cursor)) {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -31,6 +31,10 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(
+                array(new Token('name', 'a', 3)),
+                '  a  ',
+            ),
+            array(
                 array(new Token('name', 'a', 1)),
                 'a',
             ),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9606, #9615 |
| License | MIT |
| Doc PR |  |

Alternative fix for #9615
