### PR TITLE
[Security] Check account isn't locked before user authentication

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/User/AccountCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/AccountCheckerTest.php
@@ -28,6 +28,7 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
         $account->expects($this->once())->method('isCredentialsNonExpired')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
 
         $this->assertNull($checker->checkPreAuth($account));
     }
@@ -45,6 +46,20 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
         $checker->checkPreAuth($account);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\LockedException
+     */
+    public function testCheckPreAuthAccountLocked()
+    {
+        $checker = new UserChecker();
+
+        $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
+        $account->expects($this->once())->method('isCredentialsNonExpired')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(false));
+
+        $checker->checkPreAuth($account);
+    }
+
     public function testCheckPostAuthNotAdvancedUserInterface()
     {
         $checker = new UserChecker();
@@ -57,24 +72,10 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
         $checker = new UserChecker();
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
         $account->expects($this->once())->method('isEnabled')->will($this->returnValue(true));
         $account->expects($this->once())->method('isAccountNonExpired')->will($this->returnValue(true));
 
         $this->assertNull($checker->checkPostAuth($account));
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\LockedException
-     */
-    public function testCheckPostAuthAccountLocked()
-    {
-        $checker = new UserChecker();
-
-        $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(false));
-
-        $checker->checkPostAuth($account);
     }
 
     /**
@@ -85,7 +86,6 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
         $checker = new UserChecker();
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
         $account->expects($this->once())->method('isEnabled')->will($this->returnValue(false));
 
         $checker->checkPostAuth($account);
@@ -99,7 +99,6 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
         $checker = new UserChecker();
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
         $account->expects($this->once())->method('isEnabled')->will($this->returnValue(true));
         $account->expects($this->once())->method('isAccountNonExpired')->will($this->returnValue(false));
 

--- a/src/Symfony/Component/Security/Core/User/UserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/UserChecker.php
@@ -36,6 +36,10 @@ class UserChecker implements UserCheckerInterface
             $ex = new CredentialsExpiredException('User credentials have expired.');
             $ex->setUser($user);
             throw $ex;
+        } elseif (!$user->isAccountNonLocked()) {
+            $ex = new LockedException('User account is locked.');
+            $ex->setUser($user);
+            throw $ex;
         }
     }
 
@@ -46,12 +50,6 @@ class UserChecker implements UserCheckerInterface
     {
         if (!$user instanceof AdvancedUserInterface) {
             return;
-        }
-
-        if (!$user->isAccountNonLocked()) {
-            $ex = new LockedException('User account is locked.');
-            $ex->setUser($user);
-            throw $ex;
         }
 
         if (!$user->isEnabled()) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | #8510 |
| License | MIT |
| Doc PR | N/A |

I agreed with the point raised in #8510 that if the user's account is locked we should no longer attempt to authenticate them, assuming that account locking in this case is a response to too many failed login attempts. A malicious user should be prevented from authenticating if they are attempting a brute force attack.

This PR implements the change suggested by @mmucklo in that issue, and updates the `UserChecker` class' tests appropriately.
