### PR TITLE
[DomCrawler] Disable CssSelector HTML extension if xml content was added

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -38,6 +38,11 @@ class Crawler extends \SplObjectStorage
     private $namespaces = array();
 
     /**
+     * @var bool Indicates if XML was added as content
+     */
+    private $xmlAddedAsContent = false;
+
+    /**
      * Constructor.
      *
      * @param mixed  $node A Node to use as the base for the crawling
@@ -211,6 +216,8 @@ class Crawler extends \SplObjectStorage
         libxml_disable_entity_loader($disableEntities);
 
         $this->addDocument($dom);
+
+        $this->xmlAddedAsContent = true;
     }
 
     /**
@@ -616,7 +623,17 @@ class Crawler extends \SplObjectStorage
             // @codeCoverageIgnoreEnd
         }
 
-        return $this->filterXPath(CssSelector::toXPath($selector));
+        if (true === $this->xmlAddedAsContent) {
+            CssSelector::disableHtmlExtension();
+        }
+
+        $crawler = $this->filterXPath(CssSelector::toXPath($selector));
+
+        if (true === $this->xmlAddedAsContent) {
+            CssSelector::enableHtmlExtension();
+        }
+
+        return $crawler;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/8404 |
| License | MIT |
| Doc PR |  |

Don't like the solution too much. Crawler can hold different node types (no restrictions where made to prevent this) but this PR allows disabling HtmlExtension if XML content was added as a string
