### PR TITLE
[Console] Fix undefined offset when formatting namespace suggestions

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -515,8 +515,8 @@ class Application
         }
 
         $exact = in_array($namespace, $namespaces, true);
-        if (1 < count($namespaces) && !$exact) {
-            throw new \InvalidArgumentException(sprintf('The namespace "%s" is ambiguous (%s).', $namespace, $this->getAbbreviationSuggestions($namespaces)));
+        if (count($namespaces) > 1 && !$exact) {
+            throw new \InvalidArgumentException(sprintf('The namespace "%s" is ambiguous (%s).', $namespace, $this->getAbbreviationSuggestions(array_values($namespaces))));
         }
 
         return $exact ? $namespace : reset($namespaces);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -44,6 +44,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         require_once self::$fixturesPath.'/Foo4Command.php';
         require_once self::$fixturesPath.'/Foo5Command.php';
         require_once self::$fixturesPath.'/FoobarCommand.php';
+        require_once self::$fixturesPath.'/BarBucCommand.php';
     }
 
     protected function normalizeLineBreaks($text)
@@ -207,6 +208,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     public function testFindAmbiguousNamespace()
     {
         $application = new Application();
+        $application->add(new \BarBucCommand());
         $application->add(new \FooCommand());
         $application->add(new \Foo2Command());
         $application->findNamespace('f');

--- a/src/Symfony/Component/Console/Tests/Fixtures/BarBucCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/BarBucCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+
+class BarBucCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName('bar:buc');
+    }
+}


### PR DESCRIPTION
[`preg_grep`](http://www.php.net/manual/en/function.preg-grep.php) returns an array indexed using the keys from the input array. `array_values` is used in the method `find`, but was missing in `findNamespace`.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9614 |
| License | MIT |
| Doc PR | n/a |

Edit: should be merged to 2.4
