### PR TITLE
[Validator] Replaced inexistent interface

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/BlackholeMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/BlackholeMetadataFactory.php
@@ -11,15 +11,28 @@
 
 namespace Symfony\Component\Validator\Mapping;
 
+use Symfony\Component\Validator\MetadataFactoryInterface;
+
 /**
- * Simple implementation of ClassMetadataFactoryInterface that can be used when using ValidatorInterface::validateValue().
+ * Simple implementation of MetadataFactoryInterface that can be used when using ValidatorInterface::validateValue().
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class BlackholeMetadataFactory implements ClassMetadataFactoryInterface
+class BlackholeMetadataFactory implements MetadataFactoryInterface
 {
-    public function getClassMetadata($class)
+    /**
+     * @inheritdoc
+     */
+    public function getMetadataFor($value)
     {
         throw new \LogicException('BlackholeClassMetadataFactory only works with ValidatorInterface::validateValue().');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasMetadataFor($value)
+    {
+        return false;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/BlackholeMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/BlackholeMetadataFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Mapping;
+
+use Symfony\Component\Validator\Mapping\BlackholeMetadataFactory;
+
+class BlackholeMetadataFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \LogicException
+     */
+    public function testGetMetadataForThrowsALogicException()
+    {
+        $metadataFactory = new BlackholeMetadataFactory();
+        $metadataFactory->getMetadataFor('foo');
+    }
+
+    public function testHasMetadataForReturnsFalse()
+    {
+        $metadataFactory = new BlackholeMetadataFactory();
+
+        $this->assertFalse($metadataFactory->hasMetadataFor('foo'));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #9631 |
| License | MIT |
| Doc PR | - |

`ClassMetadataFactoryInterface` was removed in 2.3 (#6096) and replaced with `MetadataFactoryInterface`.
