### PR TITLE
Modified guessDefaultEscapingStrategy to not escape txt templates

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -57,6 +57,10 @@ class TwigEngine extends BaseEngine implements EngineInterface
         if ('js' === $format) {
             return 'js';
         }
+        
+        if ('txt' === $format) {
+            return false;
+        }
 
         return 'html';
     }


### PR DESCRIPTION
This PR was submitted on the symfony/TwigBundle read-only repository and moved automatically to the main Symfony repository (closes symfony/TwigBundle#2).

Useful for plaintext emails.
