### PR TITLE
Fixed wrong property in test teardown

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
@@ -46,7 +46,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         $this->event = null;
-        $this->eventDispatcher = null;
+        $this->dispatcher = null;
     }
 
     public function testIsPropagationStopped()


### PR DESCRIPTION
This PR was submitted on the symfony/EventDispatcher read-only repository and moved automatically to the main Symfony repository (closes symfony/EventDispatcher#2).
