### PR TITLE
[Debug] Avoid notice from being "eaten" by fatal error.

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -134,6 +134,7 @@ class ErrorHandler
 
             if (is_array($exceptionHandler) && $exceptionHandler[0] instanceof ExceptionHandler) {
                 $exceptionHandler[0]->handle($exception);
+
                 return true;
             }
         }


### PR DESCRIPTION
Workaround for https://bugs.php.net/bug.php?id=54275. Follow-up to PR #9428 and #9449.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8703 |
| License | MIT |
| Doc PR | n/a |
