### PR TITLE
use the correct class name to retrieve mapped class' metadata and reposi...

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -74,8 +74,7 @@ class UniqueEntityValidator extends ConstraintValidator
             }
         }
 
-        $className = $this->context->getClassName();
-        $class = $em->getClassMetadata($className);
+        $class = $em->getClassMetadata(get_class($entity));
         /* @var $class \Doctrine\Common\Persistence\Mapping\ClassMetadata */
 
         $criteria = array();
@@ -110,7 +109,7 @@ class UniqueEntityValidator extends ConstraintValidator
             }
         }
 
-        $repository = $em->getRepository($className);
+        $repository = $em->getRepository(get_class($entity));
         $result = $repository->{$constraint->repositoryMethod}($criteria);
 
         /* If the result is a MongoCursor, it must be advanced to the first


### PR DESCRIPTION
...tory

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9646 |
| License | MIT |
| Doc PR |  |

The validation context isn't necessarily the entity being validated. In case that you added the Unique Entity constraint inside your custom type via the `constraints` option the validation context will be the `Form` class itself. Thus, not the validation context should be used to get the class metadata and the repository of the validated entity, but the entity itself should be used.
