### PR TITLE
[Debug] ensured that a fatal PHP error is actually fatal after being handled by our error handler

### DIFF
--- a/src/Symfony/Component/Debug/Exception/DummyException.php
+++ b/src/Symfony/Component/Debug/Exception/DummyException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Exception;
+
+/**
+ * Used to stop execution of a PHP script after handling a fatal error.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class DummyException extends \ErrorException
+{
+}


### PR DESCRIPTION
This is a follow-up for #9641 where I try to restore the previous code behavior as much as possible.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
