### PR TITLE
Fix `extract` method to avoid recalculating count() for each iteration.

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -552,6 +552,7 @@ class Crawler extends \SplObjectStorage
     public function extract($attributes)
     {
         $attributes = (array) $attributes;
+        $count = count($attributes);
 
         $data = array();
         foreach ($this as $node) {
@@ -564,7 +565,7 @@ class Crawler extends \SplObjectStorage
                 }
             }
 
-            $data[] = count($attributes) > 1 ? $elements : $elements[0];
+            $data[] = $count > 1 ? $elements : $elements[0];
         }
 
         return $data;


### PR DESCRIPTION
This PR was submitted on the symfony/DomCrawler read-only repository and moved automatically to the main Symfony repository (closes symfony/DomCrawler#16).

Cache the value of `count($attributes)` to avoid recalculating it for each iteration of the loop.

Since this count will never change during the method execution, this change make the code a bit more efficient.
