### PR TITLE
[FrameworkBundle] Extract KernelTestCase from WebTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * KernelTestCase is the base class for tests needing a Kernel.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+abstract class KernelTestCase extends \PHPUnit_Framework_TestCase
+{
+    protected static $class;
+
+    /**
+     * @var KernelInterface
+     */
+    protected static $kernel;
+
+    /**
+     * Finds the directory where the phpunit.xml(.dist) is stored.
+     *
+     * If you run tests with the PHPUnit CLI tool, everything will work as expected.
+     * If not, override this method in your test classes.
+     *
+     * @return string The directory where phpunit.xml(.dist) is stored
+     *
+     * @throws \RuntimeException
+     */
+    protected static function getPhpUnitXmlDir()
+    {
+        if (!isset($_SERVER['argv']) || false === strpos($_SERVER['argv'][0], 'phpunit')) {
+            throw new \RuntimeException('You must override the WebTestCase::createKernel() method.');
+        }
+
+        $dir = static::getPhpUnitCliConfigArgument();
+        if ($dir === null &&
+            (is_file(getcwd().DIRECTORY_SEPARATOR.'phpunit.xml') ||
+            is_file(getcwd().DIRECTORY_SEPARATOR.'phpunit.xml.dist'))) {
+            $dir = getcwd();
+        }
+
+        // Can't continue
+        if ($dir === null) {
+            throw new \RuntimeException('Unable to guess the Kernel directory.');
+        }
+
+        if (!is_dir($dir)) {
+            $dir = dirname($dir);
+        }
+
+        return $dir;
+    }
+
+    /**
+     * Finds the value of the CLI configuration option.
+     *
+     * PHPUnit will use the last configuration argument on the command line, so this only returns
+     * the last configuration argument.
+     *
+     * @return string The value of the PHPUnit cli configuration option
+     */
+    private static function getPhpUnitCliConfigArgument()
+    {
+        $dir = null;
+        $reversedArgs = array_reverse($_SERVER['argv']);
+        foreach ($reversedArgs as $argIndex => $testArg) {
+            if (preg_match('/^-[^ \-]*c$/', $testArg) || $testArg === '--configuration') {
+                $dir = realpath($reversedArgs[$argIndex - 1]);
+                break;
+            } elseif (strpos($testArg, '--configuration=') === 0) {
+                $argPath = substr($testArg, strlen('--configuration='));
+                $dir = realpath($argPath);
+                break;
+            }
+        }
+
+        return $dir;
+    }
+
+    /**
+     * Attempts to guess the kernel location.
+     *
+     * When the Kernel is located, the file is required.
+     *
+     * @return string The Kernel class name
+     *
+     * @throws \RuntimeException
+     */
+    protected static function getKernelClass()
+    {
+        $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : static::getPhpUnitXmlDir();
+
+        $finder = new Finder();
+        $finder->name('*Kernel.php')->depth(0)->in($dir);
+        $results = iterator_to_array($finder);
+        if (!count($results)) {
+            throw new \RuntimeException('Either set KERNEL_DIR in your phpunit.xml according to http://symfony.com/doc/current/book/testing.html#your-first-functional-test or override the WebTestCase::createKernel() method.');
+        }
+
+        $file = current($results);
+        $class = $file->getBasename('.php');
+
+        require_once $file;
+
+        return $class;
+    }
+
+    /**
+     * Creates a Kernel.
+     *
+     * Available options:
+     *
+     *  * environment
+     *  * debug
+     *
+     * @param array $options An array of options
+     *
+     * @return KernelInterface A KernelInterface instance
+     */
+    protected static function createKernel(array $options = array())
+    {
+        if (null === static::$class) {
+            static::$class = static::getKernelClass();
+        }
+
+        return new static::$class(
+            isset($options['environment']) ? $options['environment'] : 'test',
+            isset($options['debug']) ? $options['debug'] : true
+        );
+    }
+
+    /**
+     * Shuts the kernel down if it was used in the test.
+     */
+    protected function tearDown()
+    {
+        if (null !== static::$kernel) {
+            static::$kernel->shutdown();
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -12,23 +12,14 @@
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use Symfony\Bundle\FrameworkBundle\Client;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * WebTestCase is the base class for functional tests.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class WebTestCase extends \PHPUnit_Framework_TestCase
+abstract class WebTestCase extends KernelTestCase
 {
-    protected static $class;
-
-    /**
-     * @var KernelInterface
-     */
-    protected static $kernel;
-
     /**
      * Creates a Client.
      *
@@ -50,128 +41,5 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
         $client->setServerParameters($server);
 
         return $client;
-    }
-
-    /**
-     * Finds the directory where the phpunit.xml(.dist) is stored.
-     *
-     * If you run tests with the PHPUnit CLI tool, everything will work as expected.
-     * If not, override this method in your test classes.
-     *
-     * @return string The directory where phpunit.xml(.dist) is stored
-     *
-     * @throws \RuntimeException
-     */
-    protected static function getPhpUnitXmlDir()
-    {
-        if (!isset($_SERVER['argv']) || false === strpos($_SERVER['argv'][0], 'phpunit')) {
-            throw new \RuntimeException('You must override the WebTestCase::createKernel() method.');
-        }
-
-        $dir = static::getPhpUnitCliConfigArgument();
-        if ($dir === null &&
-            (is_file(getcwd().DIRECTORY_SEPARATOR.'phpunit.xml') ||
-            is_file(getcwd().DIRECTORY_SEPARATOR.'phpunit.xml.dist'))) {
-            $dir = getcwd();
-        }
-
-        // Can't continue
-        if ($dir === null) {
-            throw new \RuntimeException('Unable to guess the Kernel directory.');
-        }
-
-        if (!is_dir($dir)) {
-            $dir = dirname($dir);
-        }
-
-        return $dir;
-    }
-
-    /**
-     * Finds the value of the CLI configuration option.
-     *
-     * PHPUnit will use the last configuration argument on the command line, so this only returns
-     * the last configuration argument.
-     *
-     * @return string The value of the PHPUnit cli configuration option
-     */
-    private static function getPhpUnitCliConfigArgument()
-    {
-        $dir = null;
-        $reversedArgs = array_reverse($_SERVER['argv']);
-        foreach ($reversedArgs as $argIndex => $testArg) {
-            if (preg_match('/^-[^ \-]*c$/', $testArg) || $testArg === '--configuration') {
-                $dir = realpath($reversedArgs[$argIndex - 1]);
-                break;
-            } elseif (strpos($testArg, '--configuration=') === 0) {
-                $argPath = substr($testArg, strlen('--configuration='));
-                $dir = realpath($argPath);
-                break;
-            }
-        }
-
-        return $dir;
-    }
-
-    /**
-     * Attempts to guess the kernel location.
-     *
-     * When the Kernel is located, the file is required.
-     *
-     * @return string The Kernel class name
-     *
-     * @throws \RuntimeException
-     */
-    protected static function getKernelClass()
-    {
-        $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : static::getPhpUnitXmlDir();
-
-        $finder = new Finder();
-        $finder->name('*Kernel.php')->depth(0)->in($dir);
-        $results = iterator_to_array($finder);
-        if (!count($results)) {
-            throw new \RuntimeException('Either set KERNEL_DIR in your phpunit.xml according to http://symfony.com/doc/current/book/testing.html#your-first-functional-test or override the WebTestCase::createKernel() method.');
-        }
-
-        $file = current($results);
-        $class = $file->getBasename('.php');
-
-        require_once $file;
-
-        return $class;
-    }
-
-    /**
-     * Creates a Kernel.
-     *
-     * Available options:
-     *
-     *  * environment
-     *  * debug
-     *
-     * @param array $options An array of options
-     *
-     * @return KernelInterface A KernelInterface instance
-     */
-    protected static function createKernel(array $options = array())
-    {
-        if (null === static::$class) {
-            static::$class = static::getKernelClass();
-        }
-
-        return new static::$class(
-            isset($options['environment']) ? $options['environment'] : 'test',
-            isset($options['debug']) ? $options['debug'] : true
-        );
-    }
-
-    /**
-     * Shuts the kernel down if it was used in the test.
-     */
-    protected function tearDown()
-    {
-        if (null !== static::$kernel) {
-            static::$kernel->shutdown();
-        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | No |
| New feature? | No |
| BC breaks? | No |
| Deprecations? | No |
| Tests pass? | Yes |
| Fixed tickets | None |
| License | MIT |
| Doc PR | symfony/symfony-docs#3311 |

This idea came to me while reading the Cookbook article [How to create a Console Command - Testing Commands](http://symfony.com/doc/master/cookbook/console/console_command.html#testing-commands) and I wanted to hear feedback from others before submitting a patch.

Basically the Cookbook article states that when testing a Command that extending `WebTestCase` is a good way to get access to the Kernel and thus the Container. This struck me as weird because I was wanting to test a Command, which doesn't really have anything to do with "the web."

Currently `WebTestCase` doesn't do anything internally that looks like web-specific work, and the class docblock itself states "WebTestCase is the base class for functional tests.".

I'm not sure how far-reaching this class is used by others, so I'm not sure on the BC implications. I think we could go one of two ways:
1. Rename WebTestCase to FunctionalTestCase, thus removing WebTestCase. Add a note in the `UPGRADE` documentation to note the new class name and action required by someone upgrading their application. This issue should be noticed pretty quickly by anyone upgrading as their test suite would break. But finding the easy fix in `UPGRADE` should require little work from project owners.
2. Move WebTestCase to FunctionalTestCase, then change WebTestCase to extend FunctionalTestCase but contain no functionality. Then add a `@deprecated` flag for WebTestCase to be removed in Symfony 2.4 after 2.3 LTS. This would ensure all existing bundles using WebTestCase would still work, but we could encourage a more-properly named class starting in 2.4.

Do you agree, and if so, which method sounds best?

**EDIT 1:**
@beberlei made a great third suggestion below that I think is better than the two above:

3) Extract a new class `KernelTestCase` from `WebTestCase` and instead allow WebTestCase to extend KernelTestCase. Pull all methods up into KernelTestCase except `createClient()` because `createClient()` is focused solely on creating a Client for issuing web-based requests.

Benjamin's solution provides us a clear extension point from `KernelTestCase` for Command-based tests and also provides 100% backwards-compatibility without the need to deprecate WebTestCase.
