### PR TITLE
Removed observer pattern, in favour of mediator

### DIFF
--- a/src/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\EventDispatcher;
 class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
 {
     /**
-     * Observer pattern subject.
+     * Event subject.
      *
      * @var mixed usually object or callable
      */

--- a/src/Symfony/Component/EventDispatcher/README.md
+++ b/src/Symfony/Component/EventDispatcher/README.md
@@ -1,8 +1,9 @@
 EventDispatcher Component
 =========================
 
-EventDispatcher implements a lightweight version of the Observer design
-pattern.
+The Symfony2 Event Dispatcher component implements the Mediator pattern
+in a simple and effective way to make all these things possible and
+to make your projects truly extensible.
 
     use Symfony\Component\EventDispatcher\EventDispatcher;
     use Symfony\Component\EventDispatcher\Event;

--- a/src/Symfony/Component/EventDispatcher/README.md
+++ b/src/Symfony/Component/EventDispatcher/README.md
@@ -1,9 +1,8 @@
 EventDispatcher Component
 =========================
 
-The Symfony2 Event Dispatcher component implements the Mediator pattern
-in a simple and effective way to make all these things possible and
-to make your projects truly extensible.
+The Symfony2 EventDispatcher component implements the Mediator pattern in a
+simple and effective way to make your projects truly extensible.
 
     use Symfony\Component\EventDispatcher\EventDispatcher;
     use Symfony\Component\EventDispatcher\Event;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | * |
| Fixed tickets | #9344 |

I don't think this is the best tool to implement the observer pattern.

I just have copied the sentence from:
https://github.com/symfony/symfony-docs/edit/2.3/components/event_dispatcher/introduction.rst

but maybe could be improved with something like:

"Symfony Event Dispatcher is a tool that allows to make your projects truly extensible, facilitating the implementation of Mediator pattern and Publish subscribe pattern"

[edit-1]
I think this could be modified also here:
https://github.com/symfony/symfony-marketing/edit/master/views/en/get_started/components.html.twig
