### PR TITLE
[FrameworkBundle] Enabled csrf_protection by default if form.csrf_protection is enabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -93,13 +93,17 @@ class FrameworkExtension extends Extension
 
         $loader->load('security.xml');
 
-        $this->registerSecurityCsrfConfiguration($config['csrf_protection'], $container, $loader);
-
         if ($this->isConfigEnabled($container, $config['form'])) {
             $this->formConfigEnabled = true;
             $this->registerFormConfiguration($config, $container, $loader);
             $config['validation']['enabled'] = true;
+
+            if ($this->isConfigEnabled($container, $config['form']['csrf_protection'])) {
+                $config['csrf_protection']['enabled'] = true;
+            }
         }
+
+        $this->registerSecurityCsrfConfiguration($config['csrf_protection'], $container, $loader);
 
         if (isset($config['templating'])) {
             $this->registerTemplatingConfiguration($config['templating'], $config['ide'], $container, $loader);
@@ -159,10 +163,6 @@ class FrameworkExtension extends Extension
     {
         $loader->load('form.xml');
         if ($this->isConfigEnabled($container, $config['form']['csrf_protection'])) {
-            if (!$this->isConfigEnabled($container, $config['csrf_protection'])) {
-                throw new \LogicException('CSRF protection needs to be enabled in order to use CSRF protection for forms.');
-            }
-
             $loader->load('form_csrf.xml');
 
             $container->setParameter('form.type_extension.csrf.enabled', true);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -41,13 +41,11 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->createContainerFromFile('csrf_needs_session');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage CSRF protection needs to be enabled in order to use CSRF protection for forms.
-     */
-    public function testCsrfProtectionForFormsNeedCsrfProtectionToBeEnabled()
+    public function testCsrfProtectionForFormsEnablesCsrfProtectionAutomatically()
     {
-        $this->createContainerFromFile('csrf');
+        $container = $this->createContainerFromFile('csrf');
+
+        $this->assertTrue($container->hasDefinition('security.csrf.token_manager'));
     }
 
     public function testSecureRandomIsAvailableIfCsrfIsDisabled()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9429 |
| License | MIT |
| Doc PR | - |

This PR enables the CSRF protection services automatically if CSRF protection for forms is enabled. In this case, the CSRF protection services cannot be disabled anymore manually (the same as with the validation services).
