### PR TITLE
[Console] fix #9325 extend table helper to have a row divider

### DIFF
--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -39,11 +39,20 @@ class TableHelper extends Helper
      */
     private $rows = array();
 
+    /**
+     * Dividers at row positions.
+     *
+     * @var array
+     */
+    private $dividersAt = array();
+
     // Rendering options
     private $paddingChar;
     private $horizontalBorderChar;
+    private $horizontalDividerChar;
     private $verticalBorderChar;
     private $crossingChar;
+    private $crossingDividerChar;
     private $cellHeaderFormat;
     private $cellRowFormat;
     private $cellRowContentFormat;
@@ -88,8 +97,10 @@ class TableHelper extends Helper
                 $this
                     ->setPaddingChar(' ')
                     ->setHorizontalBorderChar('=')
+                    ->setHorizontalDividerChar(' ')
                     ->setVerticalBorderChar(' ')
                     ->setCrossingChar(' ')
+                    ->setCrossingDividerChar(' ')
                     ->setCellHeaderFormat('<info>%s</info>')
                     ->setCellRowFormat('%s')
                     ->setCellRowContentFormat(' %s ')
@@ -102,8 +113,10 @@ class TableHelper extends Helper
                 $this
                     ->setPaddingChar(' ')
                     ->setHorizontalBorderChar('')
+                    ->setHorizontalDividerChar('-')
                     ->setVerticalBorderChar(' ')
                     ->setCrossingChar('')
+                    ->setCrossingDividerChar('-')
                     ->setCellHeaderFormat('<info>%s</info>')
                     ->setCellRowFormat('%s')
                     ->setCellRowContentFormat('%s')
@@ -116,8 +129,10 @@ class TableHelper extends Helper
                 $this
                     ->setPaddingChar(' ')
                     ->setHorizontalBorderChar('-')
+                    ->setHorizontalDividerChar(' ')
                     ->setVerticalBorderChar('|')
                     ->setCrossingChar('+')
+                    ->setCrossingDividerChar('*')
                     ->setCellHeaderFormat('<info>%s</info>')
                     ->setCellRowFormat('%s')
                     ->setCellRowContentFormat(' %s ')
@@ -187,11 +202,16 @@ class TableHelper extends Helper
         return $this;
     }
 
-    public function setRow($column, array $row)
+    public function setRow($position, array $row)
     {
-        $this->rows[$column] = $row;
+        $this->rows[$position] = $row;
 
         return $this;
+    }
+
+    public function setDividersAt(array $positions)
+    {
+        $this->dividersAt = $positions;
     }
 
     /**
@@ -227,6 +247,20 @@ class TableHelper extends Helper
     }
 
     /**
+     * Sets horizontal divider character.
+     *
+     * @param string $horizontalDividerChar
+     *
+     * @return TableHelper
+     */
+    public function setHorizontalDividerChar($horizontalDividerChar)
+    {
+        $this->horizontalDividerChar = $horizontalDividerChar;
+
+        return $this;
+    }
+
+    /**
      * Sets vertical border character.
      *
      * @param string $verticalBorderChar
@@ -250,6 +284,20 @@ class TableHelper extends Helper
     public function setCrossingChar($crossingChar)
     {
         $this->crossingChar = $crossingChar;
+
+        return $this;
+    }
+
+    /**
+     * Sets crossing divider character.
+     *
+     * @param string $crossingDividerChar
+     *
+     * @return TableHelper
+     */
+    public function setCrossingDividerChar($crossingDividerChar)
+    {
+        $this->crossingDividerChar = $crossingDividerChar;
 
         return $this;
     }
@@ -347,8 +395,11 @@ class TableHelper extends Helper
         if (!empty($this->headers)) {
             $this->renderRowSeparator();
         }
-        foreach ($this->rows as $row) {
+        foreach ($this->rows as $key => $row) {
             $this->renderRow($row, $this->cellRowFormat);
+            if (in_array($key, $this->dividersAt)) {
+                $this->renderDivider();
+            }
         }
         if (!empty($this->rows)) {
             $this->renderRowSeparator();
@@ -375,6 +426,29 @@ class TableHelper extends Helper
         $markup = $this->crossingChar;
         for ($column = 0; $column < $count; $column++) {
             $markup .= str_repeat($this->horizontalBorderChar, $this->getColumnWidth($column)).$this->crossingChar;
+        }
+
+        $this->output->writeln(sprintf($this->borderFormat, $markup));
+    }
+
+    /**
+     * Renders horizontal row divider.
+     *
+     * Example: |     |           |       |
+     */
+    private function renderDivider()
+    {
+        if (0 === $count = $this->getNumberOfColumns()) {
+            return;
+        }
+
+        if (!$this->horizontalDividerChar && !$this->crossingDividerChar) {
+            return;
+        }
+
+        $markup = $this->crossingDividerChar;
+        for ($column = 0; $column < $count; $column++) {
+            $markup .= str_repeat($this->horizontalDividerChar, $this->getColumnWidth($column)).$this->crossingDividerChar;
         }
 
         $this->output->writeln(sprintf($this->borderFormat, $markup));

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -32,13 +32,14 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRender($headers, $rows, $layout, $expected)
+    public function testRender($headers, $rows, $layout, $dividersAt, $expected)
     {
         $table = new TableHelper();
         $table
             ->setHeaders($headers)
             ->setRows($rows)
             ->setLayout($layout)
+            ->setDividersAt($dividersAt)
         ;
         $table->render($output = $this->getOutputStream());
 
@@ -48,13 +49,14 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRenderAddRows($headers, $rows, $layout, $expected)
+    public function testRenderAddRows($headers, $rows, $layout, $dividersAt, $expected)
     {
         $table = new TableHelper();
         $table
             ->setHeaders($headers)
             ->addRows($rows)
             ->setLayout($layout)
+            ->setDividersAt($dividersAt)
         ;
         $table->render($output = $this->getOutputStream());
 
@@ -64,12 +66,13 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRenderAddRowsOneByOne($headers, $rows, $layout, $expected)
+    public function testRenderAddRowsOneByOne($headers, $rows, $layout, $dividersAt, $expected)
     {
         $table = new TableHelper();
         $table
             ->setHeaders($headers)
             ->setLayout($layout)
+            ->setDividersAt($dividersAt)
         ;
         foreach ($rows as $row) {
             $table->addRow($row);
@@ -93,6 +96,7 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
                 array('ISBN', 'Title', 'Author'),
                 $books,
                 TableHelper::LAYOUT_DEFAULT,
+                array(),
 <<<TABLE
 +---------------+--------------------------+------------------+
 | ISBN          | Title                    | Author           |
@@ -109,6 +113,7 @@ TABLE
                 array('ISBN', 'Title', 'Author'),
                 $books,
                 TableHelper::LAYOUT_COMPACT,
+                array(),
 <<<TABLE
  ISBN          Title                    Author           
  99921-58-10-7 Divine Comedy            Dante Alighieri  
@@ -122,6 +127,7 @@ TABLE
                 array('ISBN', 'Title', 'Author'),
                 $books,
                 TableHelper::LAYOUT_BORDERLESS,
+                array(),
 <<<TABLE
  =============== ========================== ================== 
   ISBN            Title                      Author            
@@ -143,6 +149,7 @@ TABLE
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
+                array(),
 <<<TABLE
 +---------------+--------------------------+------------------+
 | ISBN          | Title                    |                  |
@@ -164,6 +171,7 @@ TABLE
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
+                array(),
 <<<TABLE
 +---------------+--------------------------+------------------+
 | 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
@@ -183,6 +191,7 @@ TABLE
                     array("960-425-059-0", "The Lord of the Rings", "J. R. R.\nTolkien"),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
+                array(),
 <<<TABLE
 +---------------+----------------------------+-----------------+
 | ISBN          | Title                      | Author          |
@@ -200,9 +209,33 @@ TABLE
 TABLE
             ),
             array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
+                    array('9971-5-0210-0'),
+                    array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
+                    array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
+                ),
+                TableHelper::LAYOUT_DEFAULT,
+                array(2),
+                <<<TABLE
++---------------+--------------------------+------------------+
+| ISBN          | Title                    | Author           |
++---------------+--------------------------+------------------+
+| 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
+| 9971-5-0210-0 |                          |                  |
+| 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
+*               *                          *                  *
+| 80-902734-1-6 | And Then There Were None | Agatha Christie  |
++---------------+--------------------------+------------------+
+
+TABLE
+            ),
+            array(
                 array('ISBN', 'Title'),
                 array(),
                 TableHelper::LAYOUT_DEFAULT,
+                array(),
 <<<TABLE
 +------+-------+
 | ISBN | Title |
@@ -214,6 +247,7 @@ TABLE
                 array(),
                 array(),
                 TableHelper::LAYOUT_DEFAULT,
+                array(),
                 '',
             ),
             'Cell text with tags used for Output styling' => array(
@@ -223,6 +257,7 @@ TABLE
                     array('9971-5-0210-0', 'A Tale of Two Cities', '<info>Charles Dickens</>'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
+                array(),
 <<<TABLE
 +---------------+----------------------+-----------------+
 | ISBN          | Title                | Author          |
@@ -240,6 +275,7 @@ TABLE
                     array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
+                array(),
 <<<TABLE
 +----------------------------------+----------------------+-----------------+
 | ISBN                             | Title                | Author          |


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9325 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3269 |

This PR gives the ability to insert divider rows within a table.
