### PR TITLE
[HttpFoundation] added a getter for statusText in Response

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -516,6 +516,18 @@ class Response
     }
 
     /**
+     * Retrieves the status text for the current web response.
+     *
+     * @return string Status text
+     *
+     * @api
+     */
+    public function getStatusText()
+    {
+        return $this->statusText;
+    }
+
+    /**
      * Sets the response charset.
      *
      * @param string $charset Character set

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -519,8 +519,6 @@ class Response
      * Retrieves the status text for the current web response.
      *
      * @return string Status text
-     *
-     * @api
      */
     public function getStatusText()
     {


### PR DESCRIPTION
This getter is needed in order to add a `Status` header as defined in CGI specification.

```
<?php

$response->headers->set('Status', sprintf('%s %s', $response->getStatusCode(), $response->getStatusText()));
```
