### PR TITLE
[Form] Switched to correct gender of "Token"

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.de.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>Das CSRF-Token ist ungültig. Versuchen Sie bitte das Formular erneut zu senden.</target>
+                <target>Der CSRF-Token ist ungültig. Versuchen Sie bitte das Formular erneut zu senden.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
The neutral gender "das Token" is used in science to describe an array of bits or chars, where as the masculin "der Token" is commenly used for keys in communications and authentication in the network.

I guess the a CSRF-Token is more a key for authentication then a bit array.

Cheers,

Christian

| Q | A |
| --- | --- |
| Bug fix? | yes/kinda |
| New feature? | not really |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| Doc PR | none |
