### PR TITLE
[Form] Adding attributes to ChoiceView

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -96,7 +96,7 @@
                 {{ block('choice_widget_options') }}
             </optgroup>
         {% else %}
-            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
+            <option {{ block('option_data_attributes') }} value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
         {% endif %}
     {% endfor %}
 {% endspaceless %}
@@ -423,3 +423,16 @@
     {%- endfor -%}
 {% endspaceless %}
 {% endblock button_attributes %}
+
+{% block option_data_attributes %}
+{% spaceless %}
+    {%- for attrname, attrvalue in choice.attr -%}
+        {{- " " -}}
+        data-{{attrname}}="{{attrvalue}}"
+    {%- endfor -%}
+
+    {% if choice.prototype %}
+        data-prototype="{{ form_row(choice.prototype)|e }}"
+    {% endif %}
+{% endspaceless %}
+{% endblock option_data_attributes %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_options.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_options.html.php
@@ -6,6 +6,6 @@
             <?php echo $formHelper->block($form, 'choice_widget_options', array('choices' => $choice)) ?>
         </optgroup>
     <?php else: ?>
-        <option value="<?php echo $view->escape($choice->value) ?>"<?php if ($is_selected($choice->value, $value)): ?> selected="selected"<?php endif?>><?php echo $view->escape($translatorHelper->trans($choice->label, array(), $translation_domain)) ?></option>
+        <option <?php echo $formHelper->block($form, 'option_data_attributes', array('choice' => $choice, 'formHelper' => $formHelper)) ?>value="<?php echo $view->escape($choice->value) ?>"<?php if ($is_selected($choice->value, $value)): ?> selected="selected"<?php endif?>><?php echo $view->escape($translatorHelper->trans($choice->label, array(), $translation_domain)) ?></option>
     <?php endif ?>
 <?php endforeach ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/option_data_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/option_data_attributes.html.php
@@ -1,0 +1,6 @@
+<?php foreach ($choice->attr as $k => $v): ?>
+data-<?php echo $k ?>="<?php echo $v ?>"
+<?php endforeach ?>
+<?php if ($choice->prototype): ?>
+    data-prototype="<?php echo $view->escape($formHelper->block($choice->prototype, 'form_row')) ?>"
+<?php endif ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Exception\LogicException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\Form\Extension\Core\EventListener\FixRadioInputListener;
 use Symfony\Component\Form\Extension\Core\EventListener\FixCheckboxInputListener;
@@ -26,9 +27,8 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToBooleanArrayTr
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToValuesTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToBooleanArrayTransformer;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class ChoiceType extends AbstractType
 {
@@ -157,9 +157,8 @@ class ChoiceType extends AbstractType
             $view->vars['full_name'] = $view->vars['full_name'].'[]';
         }
 
-        $choicesAttributes = $options['choices_attributes'];
-        $choicesPrototypes = $options['choices_prototypes'];
-        if (count($choicesAttributes) || count($choicesPrototypes)) {
+        if (!empty($options['choices_attributes']) || !empty($options['choices_prototypes'])) {
+            $choicesAttributes = $options['choices_attributes'];
             foreach ($view->vars['choices'] as $key => $choiceView) {
                 if (array_key_exists($key, $choicesAttributes)) {
                     $choiceView->attr = $choicesAttributes[$key];
@@ -242,7 +241,7 @@ class ChoiceType extends AbstractType
         };
 
         $choicesClosureNormalizer = function (Options $options, $values) {
-            if ($values instanceof \Closure && false === is_array($values = $values($options['choice_list']))) {
+            if ($values instanceof \Closure && !is_array($values = $values($options['choice_list']))) {
                 throw new UnexpectedTypeException($values, 'array');
             }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -158,10 +158,9 @@ class ChoiceType extends AbstractType
         }
 
         if (!empty($options['choices_attributes']) || !empty($options['choices_prototypes'])) {
-            $choicesAttributes = $options['choices_attributes'];
             foreach ($view->vars['choices'] as $key => $choiceView) {
-                if (array_key_exists($key, $choicesAttributes)) {
-                    $choiceView->attr = $choicesAttributes[$key];
+                if (array_key_exists($key, $options['choices_attributes'])) {
+                    $choiceView->attr = $options['choices_attributes'][$key];
                 }
 
                 if (array_key_exists($key, $this->choicesPrototypeForm) && $this->choicesPrototypeForm[$key] instanceof FormInterface) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -12,23 +12,23 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Exception\LogicException;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
-use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
-use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToBooleanArrayTransformer;
-use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToValueTransformer;
-use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToBooleanArrayTransformer;
-use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToValuesTransformer;
-use Symfony\Component\Form\Extension\Core\EventListener\FixCheckboxInputListener;
-use Symfony\Component\Form\Extension\Core\EventListener\FixRadioInputListener;
-use Symfony\Component\Form\Extension\Core\EventListener\MergeCollectionListener;
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Exception\LogicException;
+use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
+use Symfony\Component\Form\Extension\Core\EventListener\FixRadioInputListener;
+use Symfony\Component\Form\Extension\Core\EventListener\FixCheckboxInputListener;
+use Symfony\Component\Form\Extension\Core\EventListener\MergeCollectionListener;
+use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToValueTransformer;
+use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToBooleanArrayTransformer;
+use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToValuesTransformer;
+use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToBooleanArrayTransformer;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class ChoiceType extends AbstractType
 {

--- a/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
@@ -19,6 +19,20 @@ namespace Symfony\Component\Form\Extension\Core\View;
 class ChoiceView
 {
     /**
+     * Attributes which can be used in view.
+     *
+     * @var array
+     */
+    public $attr = array();
+
+    /**
+     * A prototype who can be used in view.
+     *
+     * @var FormView
+     */
+    public $prototype;
+
+    /**
      * The original choice value.
      *
      * @var mixed


### PR DESCRIPTION
Description:
Because some times is usefull to add some attributes to select's options. Exemple when using, select2, chosen, or juste by adding some prototypes.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5286 |
| License | MIT |

Example : 

``` php
    $builder->add('test2', 'choice', array(
            'choices' => array(
                'male' => 'MALE',
                'female' => 'FEMALE'
            ),
            'choices_attributes' => array(
                 array('titi' => 'toto'),
                 array('foo' => 'bar')
            ),
            // OR
            'choices_attributes' => function(ChoiceListInterface $choices) {
                $att = array();
                foreach ($choices->getChoices() as $choice) {
                    $attr[] = array('foo' => 'data from another place' . $choice);
                }

                return $attr;
            },
            'choices_prototypes' => array(
               array('name' => 'toto', 'form' => new ContactType(), 'options' => array())
            )
            // OR
            'choices_prototypes' => function(ChoiceListInterface $choices) {
                $protos = array();
                foreach ($choices->getChoices() as $choice) {
                    $protos[] = array('name' => 'advanced', 'type' => new ContactType($choice));
                }

                return $protos;
            }
        ));
```
