### PR TITLE
[Config] fix 5528 let ArrayNode::normalizeValue respect order of value array provided

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -294,7 +294,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
         $normalized = array();
         foreach ($value as $name => $val) {
-            if (array_key_exists($name, $this->children)) {
+            if (isset($this->children[$name])) {
                 $normalized[$name] = $this->children[$name]->normalize($val);
                 unset($value[$name]);
             }

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -293,9 +293,9 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         $value = $this->remapXml($value);
 
         $normalized = array();
-        foreach ($this->children as $name => $child) {
-            if (array_key_exists($name, $value)) {
-                $normalized[$name] = $child->normalize($value[$name]);
+        foreach ($value as $name => $val) {
+            if (array_key_exists($name, $this->children)) {
+                $normalized[$name] = $this->children[$name]->normalize($val);
                 unset($value[$name]);
             }
         }

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
 
 class ArrayNodeTest extends \PHPUnit_Framework_TestCase
 {
@@ -77,6 +78,35 @@ class ArrayNodeTest extends \PHPUnit_Framework_TestCase
                 array('foo-bar' => null, 'foo_bar' => 'foo'),
                 array('foo-bar' => null, 'foo_bar' => 'foo'),
             )
+        );
+    }
+
+    /**
+     * @dataProvider getPreNormalizedNormalizedOrderedData
+     */
+    public function testChildrenOrderIsMaintainedOnNormalizeValue($prenormalized, $normalized)
+    {
+        $scalar1 = new ScalarNode('1');
+        $scalar2 = new ScalarNode('2');
+        $scalar3 = new ScalarNode('3');
+        $node = new ArrayNode('foo');
+        $node->addChild($scalar1);
+        $node->addChild($scalar3);
+        $node->addChild($scalar2);
+
+        $r = new \ReflectionMethod($node, 'normalizeValue');
+        $r->setAccessible(true);
+
+        $this->assertSame($normalized, $r->invoke($node, $prenormalized));
+    }
+
+    public function getPreNormalizedNormalizedOrderedData()
+    {
+        return array(
+            array(
+                array('2' => 'two', '1' => 'one', '3' => 'three'),
+                array('2' => 'two', '1' => 'one', '3' => 'three'),
+            ),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5528 |
| License | MIT |
| Doc PR | maybe a note @WouterJ ? |
