### PR TITLE
[Config] fix #7243 allow 0 as arraynode name

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -200,7 +200,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     public function addChild(NodeInterface $node)
     {
         $name = $node->getName();
-        if (empty($name)) {
+        if (!strlen($name)) {
             throw new \InvalidArgumentException('Child nodes must be named.');
         }
         if (isset($this->children[$name])) {

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -117,10 +117,10 @@ class ArrayNodeTest extends \PHPUnit_Framework_TestCase
                     'string_key'  => 'just value',
                 ),
                 array(
-                    0 => Array (
+                    0 => array (
                         'name' => 'something',
                     ),
-                    5 => Array (
+                    5 => array (
                         0 => 'this won\'t work too',
                         'new_key' => 'some other value',
                     ),

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
+use Symfony\Component\Serializer\Tests\Fixtures\ScalarDummy;
 
 class ArrayNodeTest extends \PHPUnit_Framework_TestCase
 {
@@ -77,6 +79,55 @@ class ArrayNodeTest extends \PHPUnit_Framework_TestCase
                 array('foo-bar' => null, 'foo_bar' => 'foo'),
                 array('foo-bar' => null, 'foo_bar' => 'foo'),
             )
+        );
+    }
+
+    /**
+     * @group cordoval
+     * @dataProvider getZeroNamedNodeExamplesData
+     */
+    public function testNodeNameCanBeZero($denormalized, $normalized)
+    {
+        $zeroNode = new ArrayNode(0);
+        $zeroNode->addChild(new ScalarNode('name'));
+        $fiveNode = new ArrayNode(5);
+        $fiveNode->addChild(new ScalarNode(0));
+        $fiveNode->addChild(new ScalarNode('new_key'));
+        $rootNode = new ArrayNode('root');
+        $rootNode->addChild($zeroNode);
+        $rootNode->addChild($fiveNode);
+        $rootNode->addChild(new ScalarNode('string_key'));
+        $r = new \ReflectionMethod($rootNode, 'normalizeValue');
+        $r->setAccessible(true);
+
+        $this->assertSame($normalized, $r->invoke($rootNode, $denormalized));
+    }
+
+    public function getZeroNamedNodeExamplesData()
+    {
+        return array(
+            array(
+                array(
+                    0 => array(
+                        'name'    => 'something',
+                    ),
+                    5 => array(
+                        0         => 'this won\'t work too',
+                        'new_key' => 'some other value',
+                    ),
+                    'string_key'  => 'just value',
+                ),
+                array(
+                    0 => Array (
+                        'name' => 'something',
+                    ),
+                    5 => Array (
+                        0 => 'this won\'t work too',
+                        'new_key' => 'some other value',
+                    ),
+                    'string_key' => 'just value',
+                ),
+            ),
         );
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -83,7 +83,6 @@ class ArrayNodeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group cordoval
      * @dataProvider getZeroNamedNodeExamplesData
      */
     public function testNodeNameCanBeZero($denormalized, $normalized)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7243 |
| License | MIT |
| Doc PR | no need |
