### PR TITLE
[WIP][RFC]  php-cs-fixer.phar to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
   - 5.4
   - 5.5
 
+before_install:
+ - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
+
 before_script:
     - sudo apt-get install parallel
     - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
@@ -15,3 +18,4 @@ before_script:
 script:
     - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || exit 1
     - echo "Running tests requiring tty"; phpunit --group tty
+    - output=$(php php-cs-fixer.phar fix -v --dry-run .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;


### PR DESCRIPTION
This add to .travis.yml the execution of the CS fixer.

Adding the CS fixer will introduce a little bit of overhead in the travis job
 but I'm sure it will speed up the Pull Requests life-cycle of this repo.
Usually a PR get a lot of comments about CS.

To-do:
- [ ] PR header.
- [ ] improve the result adding a configuration file with an exclusion list.
- [ ] gather feedback about continue or not.
- [ ] fix old issues.

waiting feedback
