### PR TITLE
[WIP][Yaml] reproducing bug #8077 yaml sample should be equivalent

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -635,5 +635,4 @@ class Parser
     {
         return (0 === strpos($this->currentLine, '- '));
     }
-
 }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -385,6 +385,27 @@ EOF;
         );
         $tests['Folded block chomping keep without trailing newline'] = array($expected, $yaml);
 
+        $yaml = <<<'EOF'
+---
+a:
+-
+  b: c
+EOF;
+        $expected = array(
+            'a' => array(0 => array('b' => 'c')),
+        );
+        $tests['Check for an keyless array with nested items on new line'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+---
+a:
+- b: c
+EOF;
+        $expected = array(
+            'a' => array(0 => array('b' => 'c')),
+        );
+        $tests['Check for an keyless array with nested items inline'] = array($expected, $yaml);
+
         return $tests;
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8077 |
| License | MIT |
| Doc PR | no |

The parsing should be identical according to results from http://yamllint.com/ :baby: 
