### PR TITLE
[HttpFoundation] BinaryFileResponse should also return 416 or 200 on some range-requets

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -218,7 +218,7 @@ class BinaryFileResponse extends Response
 
                 if ($start < 0 || $end > $fileSize - 1 || $start > $end) {
                     $this->setStatusCode(self::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE);
-                } else {
+                } elseif ($start !== 0 || $end !== $fileSize - 1) {
                     $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
                     $this->offset = $start;
 

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -216,15 +216,17 @@ class BinaryFileResponse extends Response
                     $start = (int) $start;
                 }
 
-                if ($start < 0 || $end > $fileSize - 1 || $start > $end) {
-                    $this->setStatusCode(self::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE);
-                } elseif ($start !== 0 || $end !== $fileSize - 1) {
-                    $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
-                    $this->offset = $start;
+                if ($start <= $end) {
+                    if ($start < 0 || $end > $fileSize - 1) {
+                        $this->setStatusCode(self::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE);
+                    } elseif ($start !== 0 || $end !== $fileSize - 1) {
+                        $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
+                        $this->offset = $start;
 
-                    $this->setStatusCode(self::HTTP_PARTIAL_CONTENT);
-                    $this->headers->set('Content-Range', sprintf('bytes %s-%s/%s', $start, $end, $fileSize));
-                    $this->headers->set('Content-Length', $end - $start + 1);
+                        $this->setStatusCode(self::HTTP_PARTIAL_CONTENT);
+                        $this->headers->set('Content-Range', sprintf('bytes %s-%s/%s', $start, $end, $fileSize));
+                        $this->headers->set('Content-Length', $end - $start + 1);
+                    }
                 }
             }
         }

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -216,15 +216,16 @@ class BinaryFileResponse extends Response
                     $start = (int) $start;
                 }
 
-                $start = max($start, 0);
-                $end = min($end, $fileSize - 1);
+                if ($start < 0 || $end > $fileSize - 1 || $start > $end) {
+                    $this->setStatusCode(self::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE);
+                } else {
+                    $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
+                    $this->offset = $start;
 
-                $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
-                $this->offset = $start;
-
-                $this->setStatusCode(206);
-                $this->headers->set('Content-Range', sprintf('bytes %s-%s/%s', $start, $end, $fileSize));
-                $this->headers->set('Content-Length', $end - $start + 1);
+                    $this->setStatusCode(self::HTTP_PARTIAL_CONTENT);
+                    $this->headers->set('Content-Range', sprintf('bytes %s-%s/%s', $start, $end, $fileSize));
+                    $this->headers->set('Content-Length', $end - $start + 1);
+                }
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -121,6 +121,9 @@ class BinaryFileResponseTest extends ResponseTestCase
             array('bytes=0-'),
             array('bytes=0-34'),
             array('bytes=-35'),
+            // Syntactical invalid range-request should also return the full resource
+            array('bytes=20-10'),
+            array('bytes=50-40'),
         );
     }
 
@@ -147,7 +150,6 @@ class BinaryFileResponseTest extends ResponseTestCase
     public function provideInvalidRanges()
     {
         return array(
-            array('bytes=20-10'),
             array('bytes=-40'),
             array('bytes=30-40')
         );

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -90,7 +90,6 @@ class BinaryFileResponseTest extends ResponseTestCase
         );
     }
 
-
     /**
      * @dataProvider provideFullFileRanges
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I read around in the docs and tried something with BinaryFileResponse ... There are two things I missed in the implementation here:
- If the range, provided in the query, does exceed the file-position, return an 416 (or 200 - I decided to take 416 here)
- If the range is logical invalid (f.e. to request from byte 50 to byte 30 ..) return 200 - OK

One decision I took in addition, is to provide a 200 code if the full file is requested. For me, it doesn't make sense here to return a 206 for just the complete file.

What I'm quite unsure about: Do we need some additional fields for these two options? I can remember reading something about a Content-Range for 416 but I was quite unsure what it should be ...
