### PR TITLE
Reset the box model to content-box in the web debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -18,6 +18,12 @@
     z-index: 6000000;
 }
 
+.sf-toolbarreset * {
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+}
+
 .sf-toolbarreset {
     position: fixed;
     background-color: #f7f7f7;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This makes the styles compatible with CSS frameworks changing the box model to box-sizing using a universal selector (Bootstrap 3 for instance).
