### PR TITLE
[ExpressionLanguage] way to use getters for private attributes

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -39,7 +39,7 @@ class GetAttrNode extends Node
                 $obj = $compiler->getFunction($objName);
 
                 // scope may be injected in compiler
-                if(is_array($obj) && isset($obj['compiler'])) {
+                if(is_array($obj)) {
                     if(isset($obj['compiler']) && $obj['compiler'] instanceof Compiler) {
                         $obj = $obj['compiler']->getFunction($objName);
                     }

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ExpressionLanguage\Node;
 
 use Symfony\Component\ExpressionLanguage\Compiler;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class GetAttrNode extends Node
 {
@@ -69,8 +70,9 @@ class GetAttrNode extends Node
                 }
 
                 $property = $this->nodes['attribute']->attributes['value'];
+                $accessor = PropertyAccess::createPropertyAccessor();
 
-                return $obj->$property;
+                return $accessor->getValue($obj, $property);
 
             case self::METHOD_CALL:
                 $obj = $this->nodes['node']->evaluate($functions, $values);

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -38,6 +38,13 @@ class GetAttrNode extends Node
                 $objName = $this->nodes['node']->attributes['name'];
                 $obj = $compiler->getFunction($objName);
 
+                // scope may be injected in compiler
+                if(is_array($obj) && isset($obj['compiler'])) {
+                    if(isset($obj['compiler']) && $obj['compiler'] instanceof Compiler) {
+                        $obj = $obj['compiler']->getFunction($objName);
+                    }
+                }
+
                 $compiler
                     ->compile($this->nodes['node'])
                     ->raw($accessor->getAccessorPath($obj, $property));

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -32,10 +32,15 @@ class GetAttrNode extends Node
     {
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
+
+                $property = $this->nodes['attribute']->attributes['value'];
+                $accessor = PropertyAccess::createPropertyAccessor();
+                $objName = $this->nodes['node']->attributes['name'];
+                $obj = $compiler->getFunction($objName);
+
                 $compiler
                     ->compile($this->nodes['node'])
-                    ->raw('->')
-                    ->raw($this->nodes['attribute']->attributes['value'])
+                    ->raw($accessor->getAccessorPath($obj, $property));
                 ;
                 break;
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -39,6 +39,8 @@ class GetAttrNodeTest extends AbstractNodeTest
 
             array('$foo->foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
 
+            array('$foo->getBar()', new GetAttrNode(new NameNode('foo'), new ConstantNode('bar'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
+
             array('$foo->foo(array("b" => "a", 0 => "b"))', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
         );
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -25,6 +25,7 @@ class GetAttrNodeTest extends AbstractNodeTest
             array('a', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), array('foo' => array('b' => 'a', 'b'))),
 
             array('bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
+            array('foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('bar'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
 
             array('baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
         );
@@ -55,9 +56,15 @@ class GetAttrNodeTest extends AbstractNodeTest
 class Obj
 {
     public $foo = 'bar';
+    private $bar = 'foo';
 
     public function foo()
     {
         return 'baz';
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "symfony/property-access": "2.4"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\ExpressionLanguage\\": "" }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -78,4 +78,24 @@ interface PropertyAccessorInterface
      * @throws Exception\NoSuchPropertyException If a property does not exist or is not public.
      */
     public function getValue($objectOrArray, $propertyPath);
+
+    /**
+     * Returns the accessor to use to access to property
+     *
+     * Example:
+     *
+     *     use Symfony\Component\PropertyAccess\PropertyAccess;
+     *
+     *     $propertyAccessor = PropertyAccess::getPropertyAccessor();
+     *
+     *     return $propertyAccessor->getRepresentation($object, 'child.name);
+     *     // returns '->getChild()->getName()'
+     *
+     * @param object|array                 $objectOrArray The object or array to traverse
+     * @param string|PropertyPathInterface $propertyPath  The property path to read
+     *
+     * @return string accessor of the attributes
+     *
+     */
+    public function getAccessorPath($objectOrArray, $propertyPath);
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -413,4 +413,28 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foobar', $object->getMagicProperty());
     }
 
+    public function testGetAccessorPathGivesUsablePathForPublicAttributes()
+    {
+        $object = new Author();
+        $object->firstName = 'Jean-François';
+        $this->assertEquals('->firstName', $this->getPropertyAccessor()->getAccessorPath($object, 'firstName'));
+    }
+
+    public function testGetAccessorPathGivesUsablePathForPrivateAttributes()
+    {
+        $object = new Author();
+        $object->setLastName('Lépine');
+        $this->assertEquals('->getLastName()', $this->getPropertyAccessor()->getAccessorPath($object, 'lastName'));
+    }
+
+    public function testGetAccessorPathGivesUsablePatRecursively()
+    {
+        $object = new Author();
+        $object->child = array();
+        $object->child['index'] = new Author();
+        $object->child['index']->setLastName('Lépine');
+        $this->assertEquals('->child->index->getLastName()', $this->getPropertyAccessor()->getAccessorPath($object, 'child[index].lastName'));
+    }
+
+
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | No |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This patch uses the PropertyAccess component in order to use getter strategy when private attribute is read:

``` php
class User {
    private $age = 27;

    public function getAge()
    {
        return $this->age;
    }
}

$language = new \Symfony\Component\ExpressionLanguage\ExpressionLanguage();
$language->evaluate('user.age > 10', ['user' => new User]); // true
```
