### PR TITLE
[FrameworkBundle] avoid tables to have apparently long blank line breaks and be too far appart for long nested array params

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -198,7 +198,17 @@ abstract class Descriptor implements DescriptorInterface
     protected function formatParameter($value)
     {
         if (is_bool($value) || is_array($value) || (null === $value)) {
-            return json_encode($value);
+            $jsonString = json_encode($value);
+
+            if (!function_exists('mb_strlen')) {
+                return substr($jsonString, 0, 60).(strlen($jsonString) > 60 ? ' ...' : '');
+            }
+
+            if (mb_strlen($jsonString) > 60) {
+                return mb_substr($jsonString, 0, 60).' ...';
+            }
+
+            return $jsonString;
         }
 
         return (string) $value;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | na |

This PR fixes the uncomfortable long parameter array dumps on the tables, if one needs to see the details of a parameter they can do so by inspecting the specific parameter rather than having all the info in the table and render it out of whack.
