### PR TITLE
[Security] [Acl] [AclVoter] Refactor and reduce complexity

### DIFF
--- a/src/Symfony/Component/Security/Acl/Tests/Voter/AclVoterTest.php
+++ b/src/Symfony/Component/Security/Acl/Tests/Voter/AclVoterTest.php
@@ -126,6 +126,24 @@ class AclVoterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($vote, $voter->vote($this->getToken(), new \stdClass(), array('VIEW')));
     }
 
+    public function testVoteWhenAttributesIsEmpty()
+    {
+        list($voter,, $permissionMap,,) = $this->getVoter();
+        $permissionMap
+            ->expects($this->any())
+            ->method('getMasks')
+            ->will($this->returnValue(null));
+
+        $object = $this->getMock('Symfony\Component\Security\Acl\Model\ObjectIdentityInterface');
+
+        $object
+            ->expects($this->any())
+            ->method('getType')
+            ->will($this->returnValue(null));
+
+        $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $voter->vote($this->getToken(), $object, array()));
+    }
+
     public function getTrueFalseTests()
     {
         return array(array(true), array(false));

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -70,7 +70,9 @@ class AclVoter implements VoterInterface
                 $this->logDebug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
 
                 return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
-            } elseif ($object instanceof FieldVote) {
+            }
+
+            if ($object instanceof FieldVote) {
                 $field = $object->getField();
                 $object = $object->getDomainObject();
             } else {
@@ -98,7 +100,9 @@ class AclVoter implements VoterInterface
                     $this->logDebug('ACL found, permission granted. Voting to grant access');
 
                     return self::ACCESS_GRANTED;
-                } elseif (null !== $field && $acl->isFieldGranted($field, $masks, $sids, false)) {
+                }
+
+                if (null !== $field && $acl->isFieldGranted($field, $masks, $sids, false)) {
                     $this->logDebug('ACL found, permission granted. Voting to grant access');
 
                     return self::ACCESS_GRANTED;

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -61,13 +61,13 @@ class AclVoter implements VoterInterface
 
     public function vote(TokenInterface $token, $object, array $attributes)
     {
+        if (null === $object) {
+            return $this->voteObjectIdentityUnavailable();
+        }
+
         foreach ($attributes as $attribute) {
             if (null === $masks = $this->permissionMap->getMasks($attribute, $object)) {
                 continue;
-            }
-
-            if (null === $object) {
-                return $this->voteObjectIdentityUnavailable();
             }
 
             if ($object instanceof FieldVote) {

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -36,6 +36,14 @@ class AclVoter implements VoterInterface
     private $allowIfObjectIdentityUnavailable;
     private $logger;
 
+    /**
+     * @param AclProviderInterface                       $aclProvider
+     * @param ObjectIdentityRetrievalStrategyInterface   $oidRetrievalStrategy
+     * @param SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy
+     * @param PermissionMapInterface                     $permissionMap
+     * @param LoggerInterface|null                       $logger
+     * @param Boolean                                    $allowIfObjectIdentityUnavailable
+     */
     public function __construct(AclProviderInterface $aclProvider, ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy, SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy, PermissionMapInterface $permissionMap, LoggerInterface $logger = null, $allowIfObjectIdentityUnavailable = true)
     {
         $this->aclProvider = $aclProvider;

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -65,29 +65,29 @@ class AclVoter implements VoterInterface
             return $this->voteObjectIdentityUnavailable();
         }
 
+        if ($object instanceof FieldVote) {
+            $field = $object->getField();
+            $object = $object->getDomainObject();
+        } else {
+            $field = null;
+        }
+
+        if ($object instanceof ObjectIdentityInterface) {
+            $oid = $object;
+        } elseif (null === $oid = $this->objectIdentityRetrievalStrategy->getObjectIdentity($object)) {
+            return $this->voteObjectIdentityUnavailable();
+        }
+
+        if (!$this->supportsClass($oid->getType())) {
+            return self::ACCESS_ABSTAIN;
+        }
+
+        $sids = $this->securityIdentityRetrievalStrategy->getSecurityIdentities($token);
+
         foreach ($attributes as $attribute) {
             if (null === $masks = $this->permissionMap->getMasks($attribute, $object)) {
                 continue;
             }
-
-            if ($object instanceof FieldVote) {
-                $field = $object->getField();
-                $object = $object->getDomainObject();
-            } else {
-                $field = null;
-            }
-
-            if ($object instanceof ObjectIdentityInterface) {
-                $oid = $object;
-            } elseif (null === $oid = $this->objectIdentityRetrievalStrategy->getObjectIdentity($object)) {
-                return $this->voteObjectIdentityUnavailable();
-            }
-
-            if (!$this->supportsClass($oid->getType())) {
-                return self::ACCESS_ABSTAIN;
-            }
-
-            $sids = $this->securityIdentityRetrievalStrategy->getSecurityIdentities($token);
 
             try {
                 $acl = $this->aclProvider->findAcl($oid, $sids);

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -67,9 +67,7 @@ class AclVoter implements VoterInterface
             }
 
             if (null === $object) {
-                if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
-                }
+                $this->logDebug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
 
                 return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
             } elseif ($object instanceof FieldVote) {
@@ -82,9 +80,7 @@ class AclVoter implements VoterInterface
             if ($object instanceof ObjectIdentityInterface) {
                 $oid = $object;
             } elseif (null === $oid = $this->objectIdentityRetrievalStrategy->getObjectIdentity($object)) {
-                if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
-                }
+                $this->logDebug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
 
                 return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
             }
@@ -99,34 +95,24 @@ class AclVoter implements VoterInterface
                 $acl = $this->aclProvider->findAcl($oid, $sids);
 
                 if (null === $field && $acl->isGranted($masks, $sids, false)) {
-                    if (null !== $this->logger) {
-                        $this->logger->debug('ACL found, permission granted. Voting to grant access');
-                    }
+                    $this->logDebug('ACL found, permission granted. Voting to grant access');
 
                     return self::ACCESS_GRANTED;
                 } elseif (null !== $field && $acl->isFieldGranted($field, $masks, $sids, false)) {
-                    if (null !== $this->logger) {
-                        $this->logger->debug('ACL found, permission granted. Voting to grant access');
-                    }
+                    $this->logDebug('ACL found, permission granted. Voting to grant access');
 
                     return self::ACCESS_GRANTED;
                 }
 
-                if (null !== $this->logger) {
-                    $this->logger->debug('ACL found, insufficient permissions. Voting to deny access.');
-                }
+                $this->logDebug('ACL found, insufficient permissions. Voting to deny access.');
 
                 return self::ACCESS_DENIED;
             } catch (AclNotFoundException $noAcl) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('No ACL found for the object identity. Voting to deny access.');
-                }
+                $this->logDebug('No ACL found for the object identity. Voting to deny access.');
 
                 return self::ACCESS_DENIED;
             } catch (NoAceFoundException $noAce) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('ACL found, no ACE applicable. Voting to deny access.');
-                }
+                $this->logDebug('ACL found, no ACE applicable. Voting to deny access.');
 
                 return self::ACCESS_DENIED;
             }
@@ -147,5 +133,18 @@ class AclVoter implements VoterInterface
     public function supportsClass($class)
     {
         return true;
+    }
+
+    /**
+     * Log debug message if logger defined
+     *
+     * @param string $message
+     * @param array  $context
+     */
+    private function logDebug($message, array $context = array())
+    {
+        if (null !== $this->logger) {
+            $this->logger->debug($message, $context);
+        }
     }
 }

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -67,9 +67,7 @@ class AclVoter implements VoterInterface
             }
 
             if (null === $object) {
-                $this->logDebug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
-
-                return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
+                return $this->voteObjectIdentityUnavailable();
             }
 
             if ($object instanceof FieldVote) {
@@ -82,9 +80,7 @@ class AclVoter implements VoterInterface
             if ($object instanceof ObjectIdentityInterface) {
                 $oid = $object;
             } elseif (null === $oid = $this->objectIdentityRetrievalStrategy->getObjectIdentity($object)) {
-                $this->logDebug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
-
-                return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
+                return $this->voteObjectIdentityUnavailable();
             }
 
             if (!$this->supportsClass($oid->getType())) {
@@ -150,5 +146,17 @@ class AclVoter implements VoterInterface
         if (null !== $this->logger) {
             $this->logger->debug($message, $context);
         }
+    }
+
+    /**
+     * Get vote for object with no identity
+     *
+     * @return integer
+     */
+    private function voteObjectIdentityUnavailable()
+    {
+        $this->logDebug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable ? 'grant access' : 'abstain'));
+
+        return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

While working through understanding the internals of the Security component and extending some of the classes for my own implementation it seemed there was room to optimize the existing code. I started with the AclVoter class. If these changes are useful I can tackle additional classes.

The one thing that jumped out at me was the amount of code in the main `foreach` loop of the `vote()` method used to setup variables whose value would not change within the block. Additionally there were reoccurring statement blocks adding noise to the actual logic of the method. After refactoring and moving code out of the `foreach` loop PHPMD reports a reduction of cyclomatic complexity from 25 to 14 and NPath complexity from 73729 to 360.

I modified the few tests which were expecting calls to the `PermissionMap` object and added an additional test for the case of the voter abstaining when no attributes match in the `PermissionMap`.
