### PR TITLE
[Process] Redirect output without a shell

### DIFF
--- a/src/Symfony/Component/Process/NullProcessPipes.php
+++ b/src/Symfony/Component/Process/NullProcessPipes.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process;
+
+use Symfony\Component\Process\Exception\RuntimeException;
+
+/**
+ * NullProcessPipes allow redirecting output to dev/null without a subshell. Useful for processes that communicate
+ * over other means.
+ */
+class NullProcessPipes extends ProcessPipes
+{
+    /**
+     * Returns an array of descriptors for the use of proc_open.
+     *
+     * @return array
+     */
+    public function getDescriptors()
+    {
+        $nullfile = defined('PHP_WINDOWS_VERSION_BUILD') ? 'NUL' : '/dev/null';
+        return array(
+
+            array('pipe', 'r'), // stdin
+            array('file', $nullfile, 'a+'), // stdout
+            array('file', $nullfile, 'a+'), //stderr
+        );
+    }
+}
+

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -992,13 +992,24 @@ class Process
     }
 
     /**
+     * Sets the process pipes to use.
+     *
+     * @param ProcessPipes $pipes
+     */
+    public function setProcessPipes(ProcessPipes $pipes) {
+        $this->processPipes = $pipes;
+    }
+
+    /**
      * Creates the descriptors needed by the proc_open.
      *
      * @return array
      */
     private function getDescriptors()
     {
-        $this->processPipes = new ProcessPipes($this->useFileHandles);
+        if (!$this->processPipes) {
+            $this->processPipes = new ProcessPipes($this->useFileHandles);
+        }
         $descriptors = $this->processPipes->getDescriptors();
 
         if (!$this->useFileHandles && $this->enhanceSigchildCompatibility && $this->isSigchildEnabled()) {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -995,8 +995,13 @@ class Process
      * Sets the process pipes to use.
      *
      * @param ProcessPipes $pipes
+     * @throws LogicException If called after start()
      */
-    public function setProcessPipes(ProcessPipes $pipes) {
+    public function setProcessPipes(ProcessPipes $pipes)
+    {
+        if ($this->status !== self::STATUS_READY) {
+            throw new LogicException('ProcessPipes cannot be changed after the process has started');
+        }
         $this->processPipes = $pipes;
     }
 

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -29,6 +29,7 @@ class ProcessBuilder
     private $options = array();
     private $inheritEnv = true;
     private $prefix = array();
+    private $processPipes;
 
     public function __construct(array $arguments = array())
     {
@@ -118,6 +119,20 @@ class ProcessBuilder
     }
 
     /**
+     * Sets the process pipes to use for the new process
+     *
+     * @param ProcessPipes $pipes
+     *
+     * @return ProcessBuilder
+     */
+    public function setProcessPipes(ProcessPipes $pipes)
+    {
+        $this->processPipes = $pipes;
+
+        return $this;
+    }
+
+    /**
      * Sets the process timeout.
      *
      * To disable the timeout, set this value to null.
@@ -172,6 +187,11 @@ class ProcessBuilder
             $env = $this->env;
         }
 
-        return new Process($script, $this->cwd, $env, $this->stdin, $this->timeout, $options);
+        $process = new Process($script, $this->cwd, $env, $this->stdin, $this->timeout, $options);
+        if ($this->processPipes) {
+            $process->setProcessPipes($this->processPipes);
+        }
+
+        return $process;
     }
 }

--- a/src/Symfony/Component/Process/Tests/HeavyOutputtingProcess.php
+++ b/src/Symfony/Component/Process/Tests/HeavyOutputtingProcess.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Runs a php script that will dump a large amount of output and then quit.
+ */
+
+for ($i = 0; $i < 100000; $i++) {
+    echo "Lorem ipsum dolor sit amet\n";
+}

--- a/src/Symfony/Component/Process/Tests/NullProcessPipesTest.php
+++ b/src/Symfony/Component/Process/Tests/NullProcessPipesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Symfony\Component\Process\Tests;
+
+use Symfony\Component\Process\NullProcessPipes;
+use Symfony\Component\Process\Process;
+
+class NullProcessPipesTest extends \PHPUnit_Framework_TestCase {
+    public function testProcessCompletesWithNullPipes() {
+        // Without null pipes the pipe would fill and the process will never complete
+        $process = new Process('php ' . __DIR__ . '/HeavyOutputtingProcess.php');
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support NullProcessPipes');
+        }
+        $process->setProcessPipes(new NullProcessPipes());
+        $process->start();
+
+        while($process->isRunning()) {
+            usleep(100e3);
+        }
+
+        // No output!
+        $this->assertEquals('', $process->getOutput());
+    }
+}

--- a/src/Symfony/Component/Process/Tests/NullProcessPipesTest.php
+++ b/src/Symfony/Component/Process/Tests/NullProcessPipesTest.php
@@ -1,26 +1,47 @@
 <?php
 
-
 namespace Symfony\Component\Process\Tests;
 
 use Symfony\Component\Process\NullProcessPipes;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessPipes;
 
-class NullProcessPipesTest extends \PHPUnit_Framework_TestCase {
-    public function testProcessCompletesWithNullPipes() {
+class NullProcessPipesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessCompletesWithNullPipes()
+    {
         // Without null pipes the pipe would fill and the process will never complete
         $process = new Process('php ' . __DIR__ . '/HeavyOutputtingProcess.php');
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not support NullProcessPipes');
-        }
+
         $process->setProcessPipes(new NullProcessPipes());
         $process->start();
 
-        while($process->isRunning()) {
+        while ($process->isRunning()) {
             usleep(100e3);
         }
 
         // No output!
         $this->assertEquals('', $process->getOutput());
+    }
+
+    public function testReassigningPipesAfterStartIsNotAllowed()
+    {
+        $process = new Process('php -r "sleep(1);');
+
+        $process->setProcessPipes(new NullProcessPipes());
+        $process->start();
+
+        $this->setExpectedException('Symfony\Component\Process\Exception\LogicException');
+        $process->setProcessPipes(new ProcessPipes());
+    }
+
+    public function testRestartedProcesses() {
+        $process  = new Process('echo asdf');
+
+        $process->run();
+        $this->assertEquals("asdf\n", $process->getOutput());
+
+        $process->run();
+        $this->assertEquals("asdf\n", $process->getOutput());
     }
 }


### PR DESCRIPTION
Currently processes that output large amounts of data will block. If
the output is not important then this becomes an issue. It can be worked
around by redirecting the output to > /dev/null but this requires an
instance of /bin/sh to do the work.

This patch adds the ability to set the processPipes, and a new
processPipe that redirects to /dev/null.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9007 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3303 |
