### PR TITLE
[DomCrawler] xml not being filtered correctly (added failing test)

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -696,6 +696,28 @@ EOF
         $this->assertEquals('https://domain.com/path/link', $crawler->filterXPath('//a')->link()->getUri(), '<base> tag can set a path');
     }
 
+    public function testSitemapXml()
+    {
+        $crawler = new Crawler('<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url>
+                <loc>http://localhost/foo</loc>
+                <changefreq>weekly</changefreq>
+                <priority>0.5</priority>
+                <lastmod>2012-11-16</lastmod>
+            </url>
+            <url>
+                <loc>http://localhost/bar</loc>
+                <changefreq>weekly</changefreq>
+                <priority>0.5</priority>
+                <lastmod>2012-11-16</lastmod>
+            </url>
+        </urlset>
+        ');
+
+        $this->assertEquals(2, $crawler->filter('url')->count());
+    }
+
     public function createTestCrawler($uri = null)
     {
         $dom = new \DOMDocument();


### PR DESCRIPTION
I noticed after upgrading a project to 2.4, a bunch of functionality tied to the DomCrawler was not working anymore.  Specifically with regards to filtering XML.

This test passes in v2.3.7.
