### PR TITLE
[Form] use the property path to check for equality when a value path is given i...

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -96,6 +96,38 @@ class ObjectChoiceList extends ChoiceList
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getValuesForChoices(array $choices)
+    {
+        if ($this->valuePath) {
+            $choices = $this->fixChoices($choices);
+            $values = array();
+
+            $availableValues = $this->getValues();
+            foreach ($this->getChoices() as $i => $choice) {
+                foreach ($choices as $j => $givenChoice) {
+                    if (
+                        (is_array($givenChoice) || is_object($givenChoice))
+                        && $this->createValue($choice) === $this->createValue($givenChoice)
+                    ) {
+                        $values[] = $availableValues[$i];
+                        unset($choices[$j]);
+
+                        if (0 === count($choices)) {
+                            break 2;
+                        }
+                    }
+                }
+            }
+
+            return $values;
+        }
+
+        return parent::getValuesForChoices($choices);
+    }
+
+    /**
      * Initializes the list with choices.
      *
      * Safe to be called multiple times. The list is cleared on every call.

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
@@ -185,6 +185,58 @@ class ObjectChoiceListTest extends AbstractChoiceListTest
         );
     }
 
+    public function testGetValuesForChoicesWithIdenticalObjects()
+    {
+        $foo = new \stdClass();
+        $foo->id = 11;
+        $foo->name = 'Foo';
+
+        $bar = new \stdClass();
+        $bar->id = 12;
+        $bar->name = 'Bar';
+
+        $baz = new \stdClass();
+        $baz->id = 13;
+        $baz->name = 'Baz';
+
+        $list = new ObjectChoiceList(
+            array($foo, $bar, $baz),
+            'name',
+            array(),
+            null,
+            'id'
+        );
+        $this->assertEquals(array(12), $list->getValuesForChoices(array($bar)));
+    }
+
+    public function testGetValuesForChoicesWithEqualObjects()
+    {
+        $foo = new \stdClass();
+        $foo->id = 11;
+        $foo->name = 'Foo';
+
+        $bar = new \stdClass();
+        $bar->id = 12;
+        $bar->name = 'Bar';
+
+        $baz = new \stdClass();
+        $baz->id = 13;
+        $baz->name = 'Baz';
+
+        $anotherBar = new \stdClass();
+        $anotherBar->id = 12;
+        $anotherBar->name = 'Bar';
+
+        $list = new ObjectChoiceList(
+            array($foo, $bar, $baz),
+            'name',
+            array(),
+            null,
+            'id'
+        );
+        $this->assertEquals(array(12), $list->getValuesForChoices(array($anotherBar)));
+    }
+
     /**
      * @return \Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface
      */


### PR DESCRIPTION
...nstead of comparing for object identiy

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8825 |
| License | MIT |
| Doc PR |  |
