### PR TITLE
ErrorHandlerTest: restore_error_handler() on assertion failure

### DIFF
--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -90,6 +90,11 @@ PHP
             );
         } catch (DummyException $e) {
             // if an exception is thrown, the test passed
+        } catch (\Exception $e) {
+            restore_error_handler();
+            restore_exception_handler();
+
+            throw $e;
         }
 
         restore_error_handler();
@@ -135,6 +140,10 @@ PHP
             self::triggerNotice($this);
         } catch (DummyException $e) {
             // if an exception is thrown, the test passed
+        } catch (\Exception $e) {
+            restore_error_handler();
+
+            throw $e;
         }
 
         restore_error_handler();
@@ -150,72 +159,84 @@ PHP
 
     public function testConstruct()
     {
-        $handler = ErrorHandler::register(3);
+        try {
+            $handler = ErrorHandler::register(3);
 
-        $level = new \ReflectionProperty($handler, 'level');
-        $level->setAccessible(true);
+            $level = new \ReflectionProperty($handler, 'level');
+            $level->setAccessible(true);
 
-        $this->assertEquals(3, $level->getValue($handler));
+            $this->assertEquals(3, $level->getValue($handler));
 
-        restore_error_handler();
+            restore_error_handler();
+        } catch (\Exception $e) {
+            restore_error_handler();
+
+            throw $e;
+        }
     }
 
     public function testHandle()
     {
-        $handler = ErrorHandler::register(0);
-        $this->assertFalse($handler->handle(0, 'foo', 'foo.php', 12, 'foo'));
-
-        restore_error_handler();
-
-        $handler = ErrorHandler::register(3);
-        $this->assertFalse($handler->handle(4, 'foo', 'foo.php', 12, 'foo'));
-
-        restore_error_handler();
-
-        $handler = ErrorHandler::register(3);
         try {
-            $handler->handle(111, 'foo', 'foo.php', 12, 'foo');
-        } catch (\ErrorException $e) {
-            $this->assertSame('111: foo in foo.php line 12', $e->getMessage());
-            $this->assertSame(111, $e->getSeverity());
-            $this->assertSame('foo.php', $e->getFile());
-            $this->assertSame(12, $e->getLine());
+            $handler = ErrorHandler::register(0);
+            $this->assertFalse($handler->handle(0, 'foo', 'foo.php', 12, 'foo'));
+
+            restore_error_handler();
+
+            $handler = ErrorHandler::register(3);
+            $this->assertFalse($handler->handle(4, 'foo', 'foo.php', 12, 'foo'));
+
+            restore_error_handler();
+
+            $handler = ErrorHandler::register(3);
+            try {
+                $handler->handle(111, 'foo', 'foo.php', 12, 'foo');
+            } catch (\ErrorException $e) {
+                $this->assertSame('111: foo in foo.php line 12', $e->getMessage());
+                $this->assertSame(111, $e->getSeverity());
+                $this->assertSame('foo.php', $e->getFile());
+                $this->assertSame(12, $e->getLine());
+            }
+
+            restore_error_handler();
+
+            $handler = ErrorHandler::register(E_USER_DEPRECATED);
+            $this->assertTrue($handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, 'foo'));
+
+            restore_error_handler();
+
+            $handler = ErrorHandler::register(E_DEPRECATED);
+            $this->assertTrue($handler->handle(E_DEPRECATED, 'foo', 'foo.php', 12, 'foo'));
+
+            restore_error_handler();
+
+            $logger = $this->getMock('Psr\Log\LoggerInterface');
+
+            $that = $this;
+            $warnArgCheck = function($message, $context) use ($that) {
+                $that->assertEquals('foo', $message);
+                $that->assertArrayHasKey('type', $context);
+                $that->assertEquals($context['type'], ErrorHandler::TYPE_DEPRECATION);
+                $that->assertArrayHasKey('stack', $context);
+                $that->assertInternalType('array', $context['stack']);
+            };
+
+            $logger
+                ->expects($this->once())
+                ->method('warning')
+                ->will($this->returnCallback($warnArgCheck))
+            ;
+
+            $handler = ErrorHandler::register(E_USER_DEPRECATED);
+            $handler->setLogger($logger);
+            $handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, 'foo');
+
+            restore_error_handler();
+        } catch (\Exception $e) {
+            restore_error_handler();
+
+            throw $e;
         }
-
-        restore_error_handler();
-
-        $handler = ErrorHandler::register(E_USER_DEPRECATED);
-        $this->assertTrue($handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, 'foo'));
-
-        restore_error_handler();
-
-        $handler = ErrorHandler::register(E_DEPRECATED);
-        $this->assertTrue($handler->handle(E_DEPRECATED, 'foo', 'foo.php', 12, 'foo'));
-
-        restore_error_handler();
-
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
-
-        $that = $this;
-        $warnArgCheck = function($message, $context) use ($that) {
-            $that->assertEquals('foo', $message);
-            $that->assertArrayHasKey('type', $context);
-            $that->assertEquals($context['type'], ErrorHandler::TYPE_DEPRECATION);
-            $that->assertArrayHasKey('stack', $context);
-            $that->assertInternalType('array', $context['stack']);
-        };
-
-        $logger
-            ->expects($this->once())
-            ->method('warning')
-            ->will($this->returnCallback($warnArgCheck))
-        ;
-
-        $handler = ErrorHandler::register(E_USER_DEPRECATED);
-        $handler->setLogger($logger);
-        $handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, 'foo');
-
-        restore_error_handler();
     }
 
     /**


### PR DESCRIPTION
Before the patch, if any test fail in src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php,
phpunit's error handler is not correctly restored.
When running a test batch, this breaks other tests that rely on its behavior (@expectedException PHPUnit_Framework_Error)
