### PR TITLE
[OptionsResolver] Choose policy on unknown options

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -17,6 +17,18 @@ namespace Symfony\Component\OptionsResolver;
 interface OptionsResolverInterface
 {
     /**
+     * Remove unknown options passed to the resolve() method
+     * Is mutually exclusive with IGNORE_UNKNOWN
+     */
+    const REMOVE_UNKNOWN = 1;
+
+    /**
+     * Ignore unknown options passed to the resolve() method
+     * Is mutually exclusive with REMOVE_UNKNOWN
+     */
+    const IGNORE_UNKNOWN = 2;
+
+    /**
      * Sets default option values.
      *
      * The options can either be values of any types or closures that
@@ -196,6 +208,7 @@ interface OptionsResolverInterface
      * Returns the combination of the default and the passed options.
      *
      * @param array $options The custom option values.
+     * @param int   $flags   Can be REMOVE_UNKNOWN or IGNORE_UNKNOWN
      *
      * @return array A list of options and their values.
      *
@@ -206,5 +219,5 @@ interface OptionsResolverInterface
      * @throws Exception\OptionDefinitionException If a cyclic dependency is detected
      *                                             between two lazy options.
      */
-    public function resolve(array $options = array());
+    public function resolve(array $options = array(), $flags = 0);
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\OptionsResolver\Tests;
 
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
 
@@ -677,5 +678,53 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
             'one' => '1',
             'three' => '3',
         ), $clone->resolve());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRemoveUnknownAndIgnoreUnknownAreMutuallyExclusive()
+    {
+        $this->resolver->resolve(array(
+            'one' => 'one',
+            'two' => 'two'
+        ), OptionsResolverInterface::REMOVE_UNKNOWN | OptionsResolverInterface::IGNORE_UNKNOWN);
+    }
+
+    public function testRemoveUnknownOption()
+    {
+        $this->resolver->setDefaults(array(
+            'one' => 'default',
+            'two' => 'default'
+        ));
+
+        $options = $this->resolver->resolve(array(
+            'one' => 'keep',
+            'three' => 'remove'
+        ), OptionsResolverInterface::REMOVE_UNKNOWN);
+
+        $this->assertEquals($options, array(
+            'one' => 'keep',
+            'two' => 'default'
+        ));
+    }
+
+    public function testIgnoreUnknownOption()
+    {
+        $this->resolver->setDefaults(array(
+            'one' => 'default',
+            'two' => 'default'
+        ));
+
+        $options = $this->resolver->resolve(array(
+            'one' => 'keep',
+            'three' => 'ignored'
+        ), OptionsResolverInterface::IGNORE_UNKNOWN);
+
+        $this->assertEquals($options, array(
+            'one' => 'keep',
+            'two' => 'default',
+            'three' => 'ignored'
+        ));
     }
 }


### PR DESCRIPTION
Hi,

This commit adds the possibility to choose a policy on unknown options :
- required : like before, throw exception (default to keep BC)
- remove : remove options and do not throw exception
- ignore : keep options and do not throw exception

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7979 |
| License | MIT |
| Doc PR |  |
