### PR TITLE
[Routing] Fix router matching pattern against multiple hosts

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -75,7 +75,7 @@ class TraceableUrlMatcher extends UrlMatcher
             if ($compiledRoute->getHostRegex() && !preg_match($compiledRoute->getHostRegex(), $this->context->getHost(), $hostMatches)) {
                 $this->addTrace(sprintf('Host "%s" does not match the requirement ("%s")', $this->context->getHost(), $route->getHost()), self::ROUTE_ALMOST_MATCHES, $name, $route);
 
-                return true;
+                continue;
             }
 
             // check HTTP method requirement

--- a/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
@@ -54,6 +54,37 @@ class TraceableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(0, 1, 2), $this->getLevels($traces));
     }
 
+    public function testMatchRouteOnMultipleHosts()
+    {
+        $routes = new RouteCollection();
+        $routes->add('first', new Route(
+            '/mypath/',
+            array('_controller' => 'MainBundle:Info:first'),
+            array(),
+            array(),
+            'some.example.com'
+        ));
+
+        $routes->add('second', new Route(
+            '/mypath/',
+            array('_controller' => 'MainBundle:Info:second'),
+            array(),
+            array(),
+            'another.example.com'
+        ));
+
+        $context = new RequestContext();
+        $context->setHost('baz');
+
+        $matcher = new TraceableUrlMatcher($routes, $context);
+
+        $traces = $matcher->getTraces('/mypath/');
+        $this->assertEquals(
+            array(TraceableUrlMatcher::ROUTE_ALMOST_MATCHES, TraceableUrlMatcher::ROUTE_ALMOST_MATCHES),
+            $this->getLevels($traces)
+        );
+    }
+
     public function getLevels($traces)
     {
         $levels = array();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8811, #6744 |
| License | MIT |
| Doc PR |  |

When you had a pattern that matched on multiple host then only the first one was displayed as "almost matching". Fixed router matching against the same pattern on multiple hosts so now it shows every "almost match" on different hosts.
