### PR TITLE
Added tests for #8930

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -63,11 +63,10 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
             array('[root][%!@$§.]', 'Bernhard', array('root' => array('%!@$§.' => 'Bernhard'))),
             array('[child][index][firstName]', 'Bernhard', array('child' => array('index' => array('firstName' => 'Bernhard')))),
 
-            // additional tests for #8930
             array('[@name]', 'Thunderer', array('@name' => 'Thunderer')),
             array('@name', 'Thunderer', (object) array('@name' => 'Thunderer')),
             array('_name', 'Thunderer', (object) array('_name' => 'Thunderer')),
-            );
+        );
     }
 
     public function testGetValueReadsArrayWithMissingIndexForCustomPropertyPath()

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -45,32 +45,29 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->propertyAccessor->getValue($array, 'firstName');
     }
 
-    public function testGetValueReadsZeroIndex()
+    /**
+     * @dataProvider provideValueReads
+     */
+    public function testGetValueReads($propertyPath, $expectedValue, $testedData)
     {
-        $array = array('Bernhard');
-
-        $this->assertEquals('Bernhard', $this->propertyAccessor->getValue($array, '[0]'));
+        $this->assertEquals($expectedValue, $this->propertyAccessor->getValue($testedData, $propertyPath));
     }
 
-    public function testGetValueReadsIndexWithSpecialChars()
+    public function provideValueReads()
     {
-        $array = array('%!@$§.' => 'Bernhard');
+        return array(
+            array('%!@$§', 'Bernhard', (object) array('%!@$§' => 'Bernhard')),
+            array('[0]', 'Bernhard', array('Bernhard')),
+            array('[%!@$§.]', 'Bernhard', array('%!@$§.' => 'Bernhard')),
 
-        $this->assertEquals('Bernhard', $this->propertyAccessor->getValue($array, '[%!@$§.]'));
-    }
+            array('[root][%!@$§.]', 'Bernhard', array('root' => array('%!@$§.' => 'Bernhard'))),
+            array('[child][index][firstName]', 'Bernhard', array('child' => array('index' => array('firstName' => 'Bernhard')))),
 
-    public function testGetValueReadsNestedIndexWithSpecialChars()
-    {
-        $array = array('root' => array('%!@$§.' => 'Bernhard'));
-
-        $this->assertEquals('Bernhard', $this->propertyAccessor->getValue($array, '[root][%!@$§.]'));
-    }
-
-    public function testGetValueReadsArrayWithCustomPropertyPath()
-    {
-        $array = array('child' => array('index' => array('firstName' => 'Bernhard')));
-
-        $this->assertEquals('Bernhard', $this->propertyAccessor->getValue($array, '[child][index][firstName]'));
+            // additional tests for #8930
+            array('[@name]', 'Thunderer', array('@name' => 'Thunderer')),
+            array('@name', 'Thunderer', (object) array('@name' => 'Thunderer')),
+            array('_name', 'Thunderer', (object) array('_name' => 'Thunderer')),
+            );
     }
 
     public function testGetValueReadsArrayWithMissingIndexForCustomPropertyPath()
@@ -95,13 +92,6 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $object = (object) array('children' => 'Many');
 
         $this->assertEquals('Many', $this->propertyAccessor->getValue($object, 'children|child'));
-    }
-
-    public function testGetValueReadsPropertyWithSpecialCharsExceptDot()
-    {
-        $array = (object) array('%!@$§' => 'Bernhard');
-
-        $this->assertEquals('Bernhard', $this->propertyAccessor->getValue($array, '%!@$§'));
     }
 
     public function testGetValueReadsPropertyWithCustomPropertyPath()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8930 |
| License | MIT |
| Doc PR | - |

These tests are for #8930 - I've refactored tests so that similar ones use @dataProvider annotation. From my experience with the subject this issue happens neither in 2.3 nor in master.
