### PR TITLE
[Form] Added delete_empty option to allow proper emptyData handling of collections

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -37,7 +37,8 @@ class CollectionType extends AbstractType
             $options['type'],
             $options['options'],
             $options['allow_add'],
-            $options['allow_delete']
+            $options['allow_delete'],
+            $options['delete_empty']
         );
 
         $builder->addEventSubscriber($resizeListener);
@@ -86,6 +87,7 @@ class CollectionType extends AbstractType
             'prototype_name' => '__name__',
             'type'           => 'text',
             'options'        => array(),
+            'delete_empty'   => false,
         ));
 
         $resolver->setNormalizers(array(

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -899,7 +899,9 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         if (isset($this->children[$name])) {
-            $this->children[$name]->setParent(null);
+            if (!$this->children[$name]->isSubmitted()) {
+                $this->children[$name]->setParent(null);
+            }
 
             unset($this->children[$name]);
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -90,7 +90,6 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertEquals(array('foo@foo.com'), $form->getData());
     }
 
-
     public function testResizedDownIfSubmittedWithEmptyDataAndDeleteEmpty()
     {
         $form = $this->factory->create('collection', null, array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\Tests\Fixtures\Author;
+use Symfony\Component\Form\Tests\Fixtures\AuthorType;
 
 class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
@@ -86,6 +88,79 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertFalse($form->has('1'));
         $this->assertEquals('foo@foo.com', $form[0]->getData());
         $this->assertEquals(array('foo@foo.com'), $form->getData());
+    }
+
+
+    public function testResizedDownIfSubmittedWithEmptyDataAndDeleteEmpty()
+    {
+        $form = $this->factory->create('collection', null, array(
+            'type' => 'text',
+            'allow_delete' => true,
+            'delete_empty' => true,
+        ));
+
+        $form->setData(array('foo@foo.com', 'bar@bar.com'));
+        $form->submit(array('foo@foo.com', ''));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertEquals('foo@foo.com', $form[0]->getData());
+        $this->assertEquals(array('foo@foo.com'), $form->getData());
+    }
+
+    public function testDontAddEmptyDataIfDeleteEmpty()
+    {
+        $form = $this->factory->create('collection', null, array(
+            'type' => 'text',
+            'allow_add' => true,
+            'delete_empty' => true,
+        ));
+
+        $form->setData(array('foo@foo.com'));
+        $form->submit(array('foo@foo.com', ''));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertEquals('foo@foo.com', $form[0]->getData());
+        $this->assertEquals(array('foo@foo.com'), $form->getData());
+    }
+
+    public function testNoDeleteEmptyIfDeleteNotAllowed()
+    {
+        $form = $this->factory->create('collection', null, array(
+            'type' => 'text',
+            'allow_delete' => false,
+            'delete_empty' => true,
+        ));
+
+        $form->setData(array('foo@foo.com'));
+        $form->submit(array(''));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertEquals('', $form[0]->getData());
+    }
+
+    public function testResizedDownIfSubmittedWithCompoundEmptyDataAndDeleteEmpty()
+    {
+        $form = $this->factory->create('collection', null, array(
+            'type' => new AuthorType(),
+            // If the field is not required, no new Author will be created if the
+            // form is completely empty
+            'options' => array('required' => false),
+            'allow_add' => true,
+            'delete_empty' => true,
+        ));
+
+        $form->setData(array(new Author('first', 'last')));
+        $form->submit(array(
+            array('firstName' => 's_first', 'lastName' => 's_last'),
+            array('firstName' => '', 'lastName' => ''),
+        ));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertEquals(new Author('s_first', 's_last'), $form[0]->getData());
+        $this->assertEquals(array(new Author('s_first', 's_last')), $form->getData());
     }
 
     public function testNotResizedIfSubmittedWithExtraData()

--- a/src/Symfony/Component/Form/Tests/Fixtures/Author.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Author.php
@@ -21,6 +21,12 @@ class Author
 
     private $privateProperty;
 
+    public function __construct($firstName = null, $lastName = null)
+    {
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+    }
+
     public function setLastName($lastName)
     {
         $this->lastName = $lastName;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes/no? |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9375 |
| License | MIT |
| Doc PR | symfony/symfony-docs#3338 |

This PR adresses the issue that if you have a form collection with the option required => false and you submit an empty collection so you will get a ArrayCollection that contains en element with the value null.

This behaviour was introduced with the following changes from symfony/symfony#3257

In addition to the above mentioned ticket there is also a description about the same issue here: http://stackoverflow.com/questions/19474872/symfony2-form-collection-allow-add-and-allow-delete-null-error-silex

With the changes of this PR the new option empty_data is introduced. With this option you will be able to ignore/delete such empty collections, so they will neither be validated nor appear as empty field in the result.

The option will remove/ignore such empty collections if you add them newly and if allow_add is enabled and
removes such empty collections only if allow_delete is enabled.

With setting required and empty_data accordingly it will be now flexible to customize to the outcome you want to achieve.

Thanks to @bschussek for the great work together - We have to discuss how to name this option so if delete
or ignore is the appropriate name.
