### PR TITLE
[Security] Add ExpressionLanguage to require-dev.

### DIFF
--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "symfony/event-dispatcher": "~2.1",
+        "symfony/expression-language": "~2.4",
         "symfony/http-foundation": "~2.4",
         "symfony/validator": "~2.2",
         "psr/log": "~1.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Running the tests for Security-Core fails because ExpressionLanguage is missing.
