### PR TITLE
[Console] Added a way to set the process title

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.5.0
+-----
+
+* added a way to set the process name of a command
+
 2.4.0
 -----
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -33,6 +33,7 @@ class Command
 {
     private $application;
     private $name;
+    private $processName;
     private $aliases = array();
     private $definition;
     private $help;
@@ -212,6 +213,16 @@ class Command
      */
     public function run(InputInterface $input, OutputInterface $output)
     {
+        if (null !== $this->processName) {
+            if (function_exists('cli_set_process_title')) {
+                cli_set_process_title($this->processName);
+            } elseif (function_exists('setproctitle')) {
+                setproctitle($this->processName);
+            } elseif (OutputInterface::VERBOSITY_VERY_VERBOSE === $output->getVerbosity()) {
+                $output->writeln('<comment>Install the proctitle PECL to be able to change the process title.</comment>');
+            }
+        }
+
         // force the creation of the synopsis before the merge with the app definition
         $this->getSynopsis();
 
@@ -407,6 +418,25 @@ class Command
         $this->validateName($name);
 
         $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Sets the process name of the command.
+     *
+     * This feature should be used only when creating a long process command,
+     * like a daemon.
+     *
+     * PHP 5.5+ or the proctitle PECL library is required
+     *
+     * @param string $name The process name
+     *
+     * @return Command The current instance
+     */
+    public function setProcessName($name)
+    {
+        $this->processName = $name;
 
         return $this;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
- I did not write test, because I want to RFC the idea before
- Do we want the process update its name when a sub command is executed by a master command ?
