### PR TITLE
[Security] added string representation for core Users

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/User/UserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/UserTest.php
@@ -123,4 +123,13 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $user->eraseCredentials();
         $this->assertEquals('superpass', $user->getPassword());
     }
+
+    /**
+     * @covers Symfony\Component\Security\Core\User\User::__toString
+     */
+    public function testToString()
+    {
+        $user = new User('fabien', 'superpass');
+        $this->assertEquals('fabien', (string) $user);
+    }
 }

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -43,6 +43,11 @@ final class User implements AdvancedUserInterface
         $this->roles = $roles;
     }
 
+    public function __toString()
+    {
+        return $this->getUsername();
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I often use type casting and `__toString()` to print my users as this lets me very easily keep one canonical format for their representation. In functional tests however, it is easier to use in-memory users but this defaults to instances of the core `User` object. Because these don't have a string representation all the nice type casting crashes.

Hence I propose to represent the core Users by their username string by default. It would be useful in a lot of cases and I can't see any harm in it?
