### PR TITLE
[Yaml][Bug] Fix #9105 - Remove white spaces from yml parameter with html

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -482,6 +482,7 @@ class Parser
         if ('>' === $separator) {
             preg_match('/(\n*)$/', $text, $matches);
             $text = preg_replace('/(?<!\n)\n(?!\n)/', ' ', rtrim($text, "\n"));
+            $text = preg_replace('/>\s+</', '><', $text);
             $text .= $matches[1];
         }
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -611,6 +611,42 @@ EOT
 EOF
         ));
     }
+
+    public function testHtmlStringWithWhiteSpaces()
+    {
+        $this->assertEquals(array('test' => <<<EOT
+<h2>A heading</h2><ul><li>a list</li><li>may be a good example</li></ul>
+EOT
+        ), Yaml::parse(<<<EOF
+test: >
+    <h2>A heading</h2>
+
+    <ul>
+        <li>a list</li>
+        <li>may be a good example</li>
+    </ul>
+EOF
+        ));
+
+        $this->assertEquals(array('test' => <<<EOT
+<h2> 3 < 4 </h2>
+EOT
+        ), Yaml::parse(<<<EOF
+test: >
+    <h2> 3 < 4 </h2>
+EOF
+        ));
+
+        $this->assertEquals(array('test' => <<<EOT
+<h2> 4 > 3 </h2>
+EOT
+        ), Yaml::parse(<<<EOF
+test: >
+    <h2> 4 > 3 </h2>
+EOF
+        ));
+
+    }
 }
 
 class B


### PR DESCRIPTION
There was reported a problem with yaml parser and line breaks in folded style blocks. I have confirmed it and also repaired by adding new regexp to parsing method. 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9105 Problem with yaml parser and line breaks in folded style blocks |
| License | MIT |
- [x] fixed a problem with yaml parser and line breaks in folded style blocks.
- [x] added tests for claimed issue
