### PR TITLE
[Filesystem] Changed the mode for a target file in copy() to be write only

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -50,7 +50,7 @@ class Filesystem
         if ($doCopy) {
             // https://bugs.php.net/bug.php?id=64634
             $source = fopen($originFile, 'r');
-            $target = fopen($targetFile, 'w+');
+            $target = fopen($targetFile, 'w');
             stream_copy_to_stream($source, $target);
             fclose($source);
             fclose($target);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9789 |
| License | MIT |
| Doc PR | - |

Stream wrappers like S3 [do not support w+](http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.StreamWrapper.html) and we don't read here anyway (as pointed out in #9789).
