### PR TITLE
[Form] Fixed issue in BaseDateTimeTransformer when invalid timezone cause Trans...

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 abstract class BaseDateTimeTransformer implements DataTransformerInterface
@@ -35,6 +36,7 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
      * @param string $outputTimezone The name of the output timezone
      *
      * @throws UnexpectedTypeException if a timezone is not a string
+     * @throws InvalidArgumentException if a timezone is not valid
      */
     public function __construct($inputTimezone = null, $outputTimezone = null)
     {
@@ -48,5 +50,18 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
 
         $this->inputTimezone = $inputTimezone ?: date_default_timezone_get();
         $this->outputTimezone = $outputTimezone ?: date_default_timezone_get();
+
+        // Check if input and output timezones are valid
+        try {
+            new \DateTimeZone($this->inputTimezone);
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException(sprintf('Input timezone is invalid: %s.', $this->inputTimezone), $e->getCode(), $e);
+        }
+
+        try {
+            new \DateTimeZone($this->outputTimezone);
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException(sprintf('Output timezone is invalid: %s.', $this->outputTimezone), $e->getCode(), $e);
+        }
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BaseDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BaseDateTimeTransformerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
+
+class BaseDateTimeTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedExceptionMessage this_timezone_does_not_exist
+     */
+    public function testConstructFailsIfInputTimezoneIsInvalid()
+    {
+        $this->getMock(
+            'Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer',
+            array(),
+            array('this_timezone_does_not_exist')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedExceptionMessage that_timezone_does_not_exist
+     */
+    public function testConstructFailsIfOutputTimezoneIsInvalid()
+    {
+        $this->getMock(
+            'Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer',
+            array(),
+            array(null, 'that_timezone_does_not_exist')
+        );
+    }
+}


### PR DESCRIPTION
...formation filed exception (closes #9403).

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #9403 |
| License | MIT |
| Doc PR |  |

DateTimeZone object creation could rise an exception. So in BaseDateTimeTransformer constructor we need to check if timezone is valid. If this exception is catched and rethrowed as TransformationFailed exception we have an issue: user will see "Invalid value" error in form, but issue is actually with php configuration or form type configuration.

Replaces #9772.
