### PR TITLE
[Form] fix ORMQueryBuilderLoader (Issue #7156)

### DIFF
--- a/phpunit-postgresql.xml.dist
+++ b/phpunit-postgresql.xml.dist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="autoload.php.dist"
+>
+    <php>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
+        <const name="SYMFONY_TEST_PDO_DSN" value="pgsql:dbname=symfony;user=postgres;password=1234" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Test Suite">
+            <directory>./src/Symfony/Bridge/*/Tests/</directory>
+            <directory>./src/Symfony/Component/*/Tests/</directory>
+            <directory>./src/Symfony/Bundle/*/Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <groups>
+        <exclude>
+            <group>benchmark</group>
+        </exclude>
+    </groups>
+
+    <filter>
+        <whitelist>
+            <directory>./src/Symfony/</directory>
+            <exclude>
+                <directory>./src/Symfony/Bridge/*/Tests</directory>
+                <directory>./src/Symfony/Component/*/Tests</directory>
+                <directory>./src/Symfony/Bundle/*/Tests</directory>
+                <directory>./src/Symfony/Bundle/*/Resources</directory>
+                <directory>./src/Symfony/Component/*/Resources</directory>
+                <directory>./src/Symfony/Component/*/*/Resources</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -88,27 +88,27 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
                   ->setParameter($parameter, $values, Connection::PARAM_STR_ARRAY)
                   ->getResult();
     }
-    
+
     private function castValuesToProperType(array $values, $field)
     {
         $em = $this->queryBuilder->getEntityManager();
-        $entities = $this->queryBuilder->getRootEntities();  
+        $entities = $this->queryBuilder->getRootEntities();
 
-        if(!$entities) {
+        if (!$entities) {
             // root entities not found, so $field type can not be determine
             return $values;
         }
-        
+
         $class = $em->getClassMetadata($entities[0]);
 
         $type = $class->getTypeOfField($field);
 
-        if(in_array($type, array('integer', 'smallint', 'bigint'))) {
-            array_walk($values, function(&$value) {
+        if (in_array($type, array('integer', 'smallint', 'bigint'))) {
+            array_walk($values, function (&$value) {
                 $value = (int) $value;
             });
         }
-        
+
         return $values;
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
+++ b/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
@@ -22,6 +22,8 @@ use Doctrine\ORM\EntityManager;
  */
 class DoctrineTestHelper
 {
+    private static $pdo = array();
+    
     /**
      * Returns an entity manager for testing.
      *
@@ -42,10 +44,20 @@ class DoctrineTestHelper
         $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
         $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
 
-        $params = array(
-            'driver' => 'pdo_sqlite',
-            'memory' => true,
-        );
+        $dsn = defined('SYMFONY_TEST_PDO_DSN') ? SYMFONY_TEST_PDO_DSN : null;
+        
+        if($dsn) {
+            //share single connection through all tests to prevent exceed max connections limit
+            $pdo = isset(self::$pdo[$dsn]) ? self::$pdo[$dsn] : (self::$pdo[$dsn] = new \PDO($dsn));
+            $params = array(
+                'pdo' => $pdo,
+            );
+        } else {
+            $params = array(
+                'driver' => 'pdo_sqlite',
+                'memory' => true,
+            );
+        }
 
         return EntityManager::create($params, $config);
     }

--- a/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
+++ b/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
@@ -23,7 +23,7 @@ use Doctrine\ORM\EntityManager;
 class DoctrineTestHelper
 {
     private static $pdo = array();
-    
+
     /**
      * Returns an entity manager for testing.
      *
@@ -45,8 +45,8 @@ class DoctrineTestHelper
         $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
 
         $dsn = defined('SYMFONY_TEST_PDO_DSN') ? SYMFONY_TEST_PDO_DSN : null;
-        
-        if($dsn) {
+
+        if ($dsn) {
             //share single connection through all tests to prevent exceed max connections limit
             $pdo = isset(self::$pdo[$dsn]) ? self::$pdo[$dsn] : (self::$pdo[$dsn] = new \PDO($dsn));
             $params = array(

--- a/src/Symfony/Bridge/Doctrine/Test/EntityManagerTestLifecycle.php
+++ b/src/Symfony/Bridge/Doctrine/Test/EntityManagerTestLifecycle.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Test;
+
+use Doctrine\ORM\EntityManager;
+
+/**
+ * Enclose single test into transaction
+ *
+ * @author Piotr Śliwa <peter.pl7@gmail.com>
+ */
+class EntityManagerTestLifecycle
+{
+    private $em;
+    
+    public function __construct(EntityManager $em)
+    {
+        $this->em = $em;
+    }
+    
+    public function setUp() {
+        $this->em->beginTransaction();
+    }
+    
+    public function tearDown() {
+        $this->em->rollback();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Test/EntityManagerTestLifecycle.php
+++ b/src/Symfony/Bridge/Doctrine/Test/EntityManagerTestLifecycle.php
@@ -21,17 +21,19 @@ use Doctrine\ORM\EntityManager;
 class EntityManagerTestLifecycle
 {
     private $em;
-    
+
     public function __construct(EntityManager $em)
     {
         $this->em = $em;
     }
-    
-    public function setUp() {
+
+    public function setUp()
+    {
         $this->em->beginTransaction();
     }
-    
-    public function tearDown() {
+
+    public function tearDown()
+    {
         $this->em->rollback();
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
@@ -14,9 +14,9 @@ namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/** 
- * @ORM\Entity() 
- * @ORM\Table(name="Users") 
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="Users")
  */
 class User implements UserInterface
 {

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
@@ -11,21 +11,22 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
 
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/** @Entity */
+/** 
+ * @ORM\Entity() 
+ * @ORM\Table(name="Users") 
+ */
 class User implements UserInterface
 {
-    /** @Id @Column(type="integer") */
+    /** @ORM\Id @ORM\Column(type="integer") */
     protected $id1;
 
-    /** @Id @Column(type="integer") */
+    /** @ORM\Id @ORM\Column(type="integer") */
     protected $id2;
 
-    /** @Column(type="string") */
+    /** @ORM\Column(type="string") */
     public $name;
 
     public function __construct($id1, $id2, $name)

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/AbstractEntityChoiceListTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/AbstractEntityChoiceListTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Form\ChoiceList;
 
+use Symfony\Bridge\Doctrine\Test\EntityManagerTestLifecycle;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -33,6 +34,8 @@ abstract class AbstractEntityChoiceListTest extends AbstractChoiceListTest
     protected $obj3;
 
     protected $obj4;
+    
+    private $emLifecycle;
 
     protected function setUp()
     {
@@ -52,7 +55,9 @@ abstract class AbstractEntityChoiceListTest extends AbstractChoiceListTest
             $this->markTestSkipped('Doctrine ORM is not available.');
         }
 
-        $this->em = DoctrineTestHelper::createTestEntityManager();
+        $this->em = DoctrineTestHelper::createTestEntityManager();        
+        $this->emLifecycle = new EntityManagerTestLifecycle($this->em);
+        $this->emLifecycle->setUp();
 
         $schemaTool = new SchemaTool($this->em);
         $classes = array($this->em->getClassMetadata($this->getEntityClass()));
@@ -82,7 +87,11 @@ abstract class AbstractEntityChoiceListTest extends AbstractChoiceListTest
     {
         parent::tearDown();
 
+        if($this->emLifecycle !== null) {
+            $this->emLifecycle->tearDown();
+        }
         $this->em = null;
+        $this->emLifecycle = null;
     }
 
     abstract protected function getEntityClass();

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/AbstractEntityChoiceListTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/AbstractEntityChoiceListTest.php
@@ -34,7 +34,7 @@ abstract class AbstractEntityChoiceListTest extends AbstractChoiceListTest
     protected $obj3;
 
     protected $obj4;
-    
+
     private $emLifecycle;
 
     protected function setUp()
@@ -55,7 +55,7 @@ abstract class AbstractEntityChoiceListTest extends AbstractChoiceListTest
             $this->markTestSkipped('Doctrine ORM is not available.');
         }
 
-        $this->em = DoctrineTestHelper::createTestEntityManager();        
+        $this->em = DoctrineTestHelper::createTestEntityManager();
         $this->emLifecycle = new EntityManagerTestLifecycle($this->em);
         $this->emLifecycle->setUp();
 
@@ -87,7 +87,7 @@ abstract class AbstractEntityChoiceListTest extends AbstractChoiceListTest
     {
         parent::tearDown();
 
-        if($this->emLifecycle !== null) {
+        if ($this->emLifecycle !== null) {
             $this->emLifecycle->tearDown();
         }
         $this->em = null;

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/GenericEntityChoiceListTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/GenericEntityChoiceListTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Form\ChoiceList;
 
+use Symfony\Bridge\Doctrine\Test\EntityManagerTestLifecycle;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\GroupableEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
@@ -33,6 +34,8 @@ class GenericEntityChoiceListTest extends \PHPUnit_Framework_TestCase
      * @var \Doctrine\ORM\EntityManager
      */
     private $em;
+    
+    private $emLifecycle;
 
     protected function setUp()
     {
@@ -53,6 +56,8 @@ class GenericEntityChoiceListTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->em = DoctrineTestHelper::createTestEntityManager();
+        $this->emLifecycle = new EntityManagerTestLifecycle($this->em);
+        $this->emLifecycle->setUp();
 
         $schemaTool = new SchemaTool($this->em);
         $classes = array(
@@ -79,7 +84,9 @@ class GenericEntityChoiceListTest extends \PHPUnit_Framework_TestCase
     {
         parent::tearDown();
 
+        $this->emLifecycle->tearDown();
         $this->em = null;
+        $this->emLifecycle = null;
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/GenericEntityChoiceListTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/GenericEntityChoiceListTest.php
@@ -34,7 +34,7 @@ class GenericEntityChoiceListTest extends \PHPUnit_Framework_TestCase
      * @var \Doctrine\ORM\EntityManager
      */
     private $em;
-    
+
     private $emLifecycle;
 
     protected function setUp()

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -30,7 +30,7 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
      * @var \Doctrine\ORM\EntityManager
      */
     private $em;
-    
+
     private $emLifecycle;
 
     protected function getExtensions()
@@ -99,11 +99,11 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
 
         $this->em->flush();
     }
-    
+
     protected function tearDown()
     {
         parent::tearDown();
-        
+
         $this->emLifecycle->tearDown();
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Form\Type;
 
+use Symfony\Bridge\Doctrine\Test\EntityManagerTestLifecycle;
 use Symfony\Component\Form\Tests\FormPerformanceTestCase;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -29,6 +30,8 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
      * @var \Doctrine\ORM\EntityManager
      */
     private $em;
+    
+    private $emLifecycle;
 
     protected function getExtensions()
     {
@@ -67,6 +70,8 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
         }
 
         $this->em = DoctrineOrmTestCase::createTestEntityManager();
+        $this->emLifecycle = new EntityManagerTestLifecycle($this->em);
+        $this->emLifecycle->setUp();
 
         parent::setUp();
 
@@ -93,6 +98,13 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
         }
 
         $this->em->flush();
+    }
+    
+    protected function tearDown()
+    {
+        parent::tearDown();
+        
+        $this->emLifecycle->tearDown();
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Form\Type;
 
+use Symfony\Bridge\Doctrine\Test\EntityManagerTestLifecycle;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -41,6 +42,8 @@ class EntityTypeTest extends TypeTestCase
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $emRegistry;
+    
+    private $emLifecycle;
 
     protected function setUp()
     {
@@ -61,6 +64,8 @@ class EntityTypeTest extends TypeTestCase
         }
 
         $this->em = DoctrineTestHelper::createTestEntityManager();
+        $this->emLifecycle = new EntityManagerTestLifecycle($this->em);
+        $this->emLifecycle->setUp();
         $this->emRegistry = $this->createRegistryMock('default', $this->em);
 
         parent::setUp();
@@ -89,8 +94,13 @@ class EntityTypeTest extends TypeTestCase
     {
         parent::tearDown();
 
+        if($this->emLifecycle !== null) {
+            $this->emLifecycle->tearDown();
+        }
+        
         $this->em = null;
         $this->emRegistry = null;
+        $this->emLifecycle = null;
     }
 
     protected function getExtensions()

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -42,7 +42,7 @@ class EntityTypeTest extends TypeTestCase
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $emRegistry;
-    
+
     private $emLifecycle;
 
     protected function setUp()
@@ -94,10 +94,10 @@ class EntityTypeTest extends TypeTestCase
     {
         parent::tearDown();
 
-        if($this->emLifecycle !== null) {
+        if ($this->emLifecycle !== null) {
             $this->emLifecycle->tearDown();
         }
-        
+
         $this->em = null;
         $this->emRegistry = null;
         $this->emLifecycle = null;

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -21,7 +21,7 @@ class EntityUserProviderTest extends \PHPUnit_Framework_TestCase
 {
     private $em;
     private $emLifecycle;
-    
+
     protected function setUp()
     {
         if (!class_exists('Symfony\Component\Security\Core\SecurityContext')) {
@@ -29,15 +29,16 @@ class EntityUserProviderTest extends \PHPUnit_Framework_TestCase
         }
 
         parent::setUp();
-        
+
         $this->em = DoctrineTestHelper::createTestEntityManager();
         $this->emLifecycle = new EntityManagerTestLifecycle($this->em);
         $this->emLifecycle->setUp();
     }
-    
-    protected function tearDown() {
+
+    protected function tearDown()
+    {
         parent::tearDown();
-        
+
         $this->emLifecycle->tearDown();
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -30,7 +30,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
 {
     private $em;
     private $emLifecycle;
-    
+
     protected function setUp()
     {
         parent::setUp();
@@ -42,17 +42,17 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         if (!class_exists('Symfony\Component\Validator\Constraint')) {
             $this->markTestSkipped('The "Validator" component is not available');
         }
-        
+
         $this->em = DoctrineTestHelper::createTestEntityManager();
         $this->emLifecycle = new EntityManagerTestLifecycle($this->em);
         $this->emLifecycle->setUp();
     }
-    
+
     protected function tearDown()
     {
         parent::tearDown();
-        
-        if($this->emLifecycle !== null) {
+
+        if ($this->emLifecycle !== null) {
             $this->emLifecycle->tearDown();
         }
         $this->em = null;
@@ -310,7 +310,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $repository->expects($this->once())
             ->method('findByCustom')
             ->will(
-                $this->returnCallback(function() use ($entity) {
+                $this->returnCallback(function () use ($entity) {
                     $returnValue = array(
                         $entity,
                     );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7156 |
| License | MIT |
| Doc PR | - |

Fixed bug occured e.g. on postgresql db, on sqlite everything was ok. I have no provide any new tests because this issue has been covered by tests already, but when sqlite db was used, tests passed. In first commit I added ability to run tests using different database driver.

To run tests using postgresql you should use command:

```
phpunit -c phpunit-postgresql.xml.dist src/Symfony/Bridge/Doctrine/Tests
```

Default dsn: pgsql:dbname=symfony;user=postgres;password=1234

In order to ensure postgresql tests isolation I have provide transaction rollback teardown.
