### PR TITLE
[Form] Update UPGRADE-2.3.md to account for #9388

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -170,7 +170,7 @@ Form
    $form = $builder->getForm();
    ```
    
- * Even if it wasn't intended, it was possible to set a form type's `data`
+ * While it wasn't intended, it was possible to set a form type's `data`
    option to `null` if you wanted the form component to set the form's data
    to the data of the object bound to the form (if one was bound).
    This was used in some projects to pre-set a form field with optional
@@ -195,19 +195,6 @@ Form
       'data' => $options['default_data'] ?: null,
    ));
    $builder->get('field')->setDataLocked(false);
-   ```
-   
-   The cleanest solution would be to only set the `data` option if there's
-   actually data to pre-set.
-   
-   After (Alternative 1):
-   
-   ```
-   $fieldOptions = array();
-   if ($options['default_data']) {
-      $fieldOptions['data'] = $options['default_data'];
-   }
-   $builder->add('field', 'text', $fieldOptions);
    ```
 
 PropertyAccess

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -169,6 +169,45 @@ Form
    $builder->add('field', 'text');
    $form = $builder->getForm();
    ```
+   
+ * Even if it wasn't intended, it was possible to set a form type's `data`
+   option to `null` if you wanted the form component to set the form's data
+   to the data of the object bound to the form (if one was bound).
+   This was used in some projects to preset a form field with optional
+   initial data as long as there wasn't already data set through a bound object.
+   Altough this feature is intended, setting the `data` option for a form
+   by default also locks that form's data so that it can't be overriden by
+   a later bound object. To disable said lock you have to specifically call
+   `FormConfigBuilderInterface:setDataLocked()`:
+
+   Before:
+
+   ```
+   $builder->add('field', 'text', array(
+      'data' => $options['default_data'] ?: null,
+   ));
+   ```
+   
+   After:
+
+   ```
+   $builder->add('field', 'text', array(
+      'data' => $options['default_data'] ?: null,
+   ));
+   $builder->get('field')->setDataLocked(false);
+   ```
+   
+   The cleanest solution would be to only set the `data` option if there's
+   actually data so pre-set.
+   
+   After (Alternative 1):
+   
+   ```
+   $fieldOptions = array();
+   if ($options['default_data']) {
+      $fieldOptions['data'] = $options['default_data'];
+   }
+   $builder->add('field', 'text', $fieldOptions);
 
 PropertyAccess
 --------------
@@ -254,7 +293,7 @@ Console
 
    Before:
 
-   ```
+   ```a
    if (OutputInterface::VERBOSITY_VERBOSE === $output->getVerbosity()) { ... }
    ```
 

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -173,7 +173,7 @@ Form
  * Even if it wasn't intended, it was possible to set a form type's `data`
    option to `null` if you wanted the form component to set the form's data
    to the data of the object bound to the form (if one was bound).
-   This was used in some projects to preset a form field with optional
+   This was used in some projects to pre-set a form field with optional
    initial data as long as there wasn't already data set through a bound object.
    Altough this feature is intended, setting the `data` option for a form
    by default also locks that form's data so that it can't be overriden by
@@ -198,7 +198,7 @@ Form
    ```
    
    The cleanest solution would be to only set the `data` option if there's
-   actually data so pre-set.
+   actually data to pre-set.
    
    After (Alternative 1):
    
@@ -293,7 +293,7 @@ Console
 
    Before:
 
-   ```a
+   ```
    if (OutputInterface::VERBOSITY_VERBOSE === $output->getVerbosity()) { ... }
    ```
 

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -169,32 +169,31 @@ Form
    $builder->add('field', 'text');
    $form = $builder->getForm();
    ```
-   
- * While it wasn't intended, it was possible to set a form type's `data`
-   option to `null` if you wanted the form component to set the form's data
-   to the data of the object bound to the form (if one was bound).
-   This was used in some projects to pre-set a form field with optional
-   initial data as long as there wasn't already data set through a bound object.
-   Altough this feature is intended, setting the `data` option for a form
-   by default also locks that form's data so that it can't be overriden by
-   a later bound object. To disable said lock you have to specifically call
-   `FormConfigBuilderInterface:setDataLocked()`:
+
+ * Previously, when the "data" option of a field was set to `null` and the
+   containing form was mapped to an object, the field would receive the data
+   from the object as default value. This functionality was unintended and fixed
+   to use `null` as default value in Symfony 2.3.
+
+   In cases where you made use of the previous behavior, you should now remove
+   the "data" option altogether.
 
    Before:
 
    ```
    $builder->add('field', 'text', array(
-      'data' => $options['default_data'] ?: null,
+      'data' => $defaultData ?: null,
    ));
    ```
-   
+
    After:
 
    ```
-   $builder->add('field', 'text', array(
-      'data' => $options['default_data'] ?: null,
-   ));
-   $builder->get('field')->setDataLocked(false);
+   $options = array();
+   if ($defaultData) {
+       $options['data'] = $defaultData;
+   }
+   $builder->add('field', 'text', $options);
    ```
 
 PropertyAccess

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -208,6 +208,7 @@ Form
       $fieldOptions['data'] = $options['default_data'];
    }
    $builder->add('field', 'text', $fieldOptions);
+   ```
 
 PropertyAccess
 --------------


### PR DESCRIPTION
Added documentation for how to correctly pre-fill a form using the form's `data` option.
The "old" and also wrong way of doing it broke with Symfony 2.3.7 (with https://github.com/symfony/symfony/pull/9388 to be precise) and this short documentation should help others to fix the problem and do it right.
