### PR TITLE
[Security] Fix parent serialization of user object

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -146,7 +146,14 @@ abstract class AbstractToken implements TokenInterface
      */
     public function serialize()
     {
-        return serialize(array($this->user, $this->authenticated, $this->roles, $this->attributes));
+        return serialize(
+            array(
+                \is_object($this->user) ? clone $this->user : $this->user,
+                $this->authenticated,
+                $this->roles,
+                $this->attributes
+            )
+        );
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -148,7 +148,7 @@ abstract class AbstractToken implements TokenInterface
     {
         return serialize(
             array(
-                \is_object($this->user) ? clone $this->user : $this->user,
+                is_object($this->user) ? clone $this->user : $this->user,
                 $this->authenticated,
                 $this->roles,
                 $this->attributes

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Token/AbstractTokenTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Security\Tests\Core\Authentication\Token;
 
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\SwitchUserRole;
 
 class TestUser
 {
@@ -26,6 +28,31 @@ class TestUser
     {
         return $this->name;
     }
+}
+
+class ConcreteToken extends AbstractToken
+{
+    private $credentials = 'credentials_value';
+
+    public function __construct($user, array $roles = array())
+    {
+        parent::__construct($roles);
+
+        $this->setUser($user);
+    }
+
+    public function serialize()
+    {
+        return serialize(array($this->credentials, parent::serialize()));
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->credentials, $parentStr) = unserialize($serialized);
+        parent::unserialize($parentStr);
+    }
+
+    public function getCredentials() {}
 }
 
 class AbstractTokenTest extends \PHPUnit_Framework_TestCase
@@ -69,6 +96,20 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($token->getRoles(), $uToken->getRoles());
         $this->assertEquals($token->getAttributes(), $uToken->getAttributes());
+    }
+
+    public function testSerializeParent()
+    {
+        $user = new TestUser('fabien');
+        $token = new ConcreteToken($user, array('ROLE_FOO'));
+
+        $parentToken = new ConcreteToken($user, array(new SwitchUserRole('ROLE_PREVIOUS', $token)));
+        $uToken = unserialize(serialize($parentToken));
+
+        $this->assertEquals(
+            \current($parentToken->getRoles())->getSource()->getUser(),
+            \current($uToken->getRoles())->getSource()->getUser()
+        );
     }
 
     /**

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Token/AbstractTokenTest.php
@@ -107,8 +107,8 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
         $uToken = unserialize(serialize($parentToken));
 
         $this->assertEquals(
-            \current($parentToken->getRoles())->getSource()->getUser(),
-            \current($uToken->getRoles())->getSource()->getUser()
+            current($parentToken->getRoles())->getSource()->getUser(),
+            current($uToken->getRoles())->getSource()->getUser()
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

`parent::serialize()` and `parent::unserialize()`, which are used in the `AbstractToken` are [problematic](https://bugs.php.net/bug.php?id=62836) in PHP >= 5.4. [Cloning the object](https://gist.github.com/aurelijus/4713758) before serialization seems to fix this.
