### PR TITLE
[DependencyInjection] fixes #9815 Syntax error in PHP dumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -490,7 +490,7 @@ class PhpDumper extends Dumper
             $class = $this->dumpValue($callable[0]);
             // If the class is a string we can optimize call_user_func away
             if (strpos($class, "'") === 0) {
-                return sprintf("        \%s::%s(\$%s);\n", substr($class, 1, -1), $callable[1], $variableName);
+                return sprintf("        %s::%s(\$%s);\n", $this->dumpLiteralClass($class), $callable[1], $variableName);
             }
 
             return sprintf("        call_user_func(array(%s, '%s'), \$%s);\n", $this->dumpValue($callable[0]), $callable[1], $variableName);
@@ -701,7 +701,7 @@ EOF;
 
                 // If the class is a string we can optimize call_user_func away
                 if (strpos($class, "'") === 0) {
-                    return sprintf("        $return{$instantiation}\%s::%s(%s);\n", substr($class, 1, -1), $definition->getFactoryMethod(), $arguments ? implode(', ', $arguments) : '');
+                    return sprintf("        $return{$instantiation}%s::%s(%s);\n", $this->dumpLiteralClass($class), $definition->getFactoryMethod(), $arguments ? implode(', ', $arguments) : '');
                 }
 
                 return sprintf("        $return{$instantiation}call_user_func(array(%s, '%s')%s);\n", $this->dumpValue($definition->getFactoryClass()), $definition->getFactoryMethod(), $arguments ? ', '.implode(', ', $arguments) : '');
@@ -718,7 +718,7 @@ EOF;
             return sprintf("        \$class = %s;\n\n        $return{$instantiation}new \$class(%s);\n", $class, implode(', ', $arguments));
         }
 
-        return sprintf("        $return{$instantiation}new \\%s(%s);\n", substr(str_replace('\\\\', '\\', $class), 1, -1), implode(', ', $arguments));
+        return sprintf("        $return{$instantiation}new %s(%s);\n", $this->dumpLiteralClass($class), implode(', ', $arguments));
     }
 
     /**
@@ -1246,6 +1246,18 @@ EOF;
         } else {
             return var_export($value, true);
         }
+    }
+
+    /**
+     * Dumps a string to a literal (aka PHP Code) class value.
+     *
+     * @param string $class
+     *
+     * @return string
+     */
+    private function dumpLiteralClass($class)
+    {
+         return '\\'.substr(str_replace('\\\\', '\\', $class), 1, -1);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -40,7 +40,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $definitions = array(
-            'foo' => new Definition('FooClass'),
+            'foo' => new Definition('Bar\FooClass'),
             'bar' => new Definition('BarClass'),
         );
         $builder->setDefinitions($definitions);
@@ -69,7 +69,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testRegister()
     {
         $builder = new ContainerBuilder();
-        $builder->register('foo', 'FooClass');
+        $builder->register('foo', 'Bar\FooClass');
         $this->assertTrue($builder->hasDefinition('foo'), '->register() registers a new service definition');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Definition', $builder->getDefinition('foo'), '->register() returns the newly created Definition instance');
     }
@@ -81,7 +81,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $this->assertFalse($builder->has('foo'), '->has() returns false if the service does not exist');
-        $builder->register('foo', 'FooClass');
+        $builder->register('foo', 'Bar\FooClass');
         $this->assertTrue($builder->has('foo'), '->has() returns true if a service definition exists');
         $builder->set('bar', new \stdClass());
         $this->assertTrue($builder->has('bar'), '->has() returns true if a service exists');
@@ -259,11 +259,11 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testCreateService()
     {
         $builder = new ContainerBuilder();
-        $builder->register('foo1', 'FooClass')->setFile(__DIR__.'/Fixtures/includes/foo.php');
-        $this->assertInstanceOf('\FooClass', $builder->get('foo1'), '->createService() requires the file defined by the service definition');
-        $builder->register('foo2', 'FooClass')->setFile(__DIR__.'/Fixtures/includes/%file%.php');
+        $builder->register('foo1', 'Bar\FooClass')->setFile(__DIR__.'/Fixtures/includes/foo.php');
+        $this->assertInstanceOf('\Bar\FooClass', $builder->get('foo1'), '->createService() requires the file defined by the service definition');
+        $builder->register('foo2', 'Bar\FooClass')->setFile(__DIR__.'/Fixtures/includes/%file%.php');
         $builder->setParameter('file', 'foo');
-        $this->assertInstanceOf('\FooClass', $builder->get('foo2'), '->createService() replaces parameters in the file provided by the service definition');
+        $this->assertInstanceOf('\Bar\FooClass', $builder->get('foo2'), '->createService() replaces parameters in the file provided by the service definition');
     }
 
     /**
@@ -273,13 +273,13 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
 
-        $builder->register('foo1', 'FooClass')->setFile(__DIR__.'/Fixtures/includes/foo.php');
+        $builder->register('foo1', 'Bar\FooClass')->setFile(__DIR__.'/Fixtures/includes/foo.php');
         $builder->getDefinition('foo1')->setLazy(true);
 
         $foo1 = $builder->get('foo1');
 
         $this->assertSame($foo1, $builder->get('foo1'), 'The same proxy is retrieved on multiple subsequent calls');
-        $this->assertSame('FooClass', get_class($foo1));
+        $this->assertSame('Bar\FooClass', get_class($foo1));
     }
 
     /**
@@ -300,7 +300,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $builder->register('bar', 'stdClass');
-        $builder->register('foo1', 'FooClass')->addArgument(array('foo' => '%value%', '%value%' => 'foo', new Reference('bar'), '%%unescape_it%%'));
+        $builder->register('foo1', 'Bar\FooClass')->addArgument(array('foo' => '%value%', '%value%' => 'foo', new Reference('bar'), '%%unescape_it%%'));
         $builder->setParameter('value', 'bar');
         $this->assertEquals(array('foo' => 'bar', 'bar' => 'foo', $builder->get('bar'), '%unescape_it%'), $builder->get('foo1')->arguments, '->createService() replaces parameters and service references in the arguments provided by the service definition');
     }
@@ -312,7 +312,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $builder->register('bar', 'stdClass');
-        $builder->register('foo1', 'FooClass')->setFactoryClass('FooClass')->setFactoryMethod('getInstance')->addArgument(array('foo' => '%value%', '%value%' => 'foo', new Reference('bar')));
+        $builder->register('foo1', 'Bar\FooClass')->setFactoryClass('Bar\FooClass')->setFactoryMethod('getInstance')->addArgument(array('foo' => '%value%', '%value%' => 'foo', new Reference('bar')));
         $builder->setParameter('value', 'bar');
         $this->assertTrue($builder->get('foo1')->called, '->createService() calls the factory method to create the service instance');
         $this->assertEquals(array('foo' => 'bar', 'bar' => 'foo', $builder->get('bar')), $builder->get('foo1')->arguments, '->createService() passes the arguments to the factory method');
@@ -337,7 +337,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $builder->register('bar', 'stdClass');
-        $builder->register('foo1', 'FooClass')->addMethodCall('setBar', array(array('%value%', new Reference('bar'))));
+        $builder->register('foo1', 'Bar\FooClass')->addMethodCall('setBar', array(array('%value%', new Reference('bar'))));
         $builder->setParameter('value', 'bar');
         $this->assertEquals(array('bar', $builder->get('bar')), $builder->get('foo1')->bar, '->createService() replaces the values in the method calls arguments');
     }
@@ -348,23 +348,23 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testCreateServiceConfigurator()
     {
         $builder = new ContainerBuilder();
-        $builder->register('foo1', 'FooClass')->setConfigurator('sc_configure');
+        $builder->register('foo1', 'Bar\FooClass')->setConfigurator('sc_configure');
         $this->assertTrue($builder->get('foo1')->configured, '->createService() calls the configurator');
 
-        $builder->register('foo2', 'FooClass')->setConfigurator(array('%class%', 'configureStatic'));
+        $builder->register('foo2', 'Bar\FooClass')->setConfigurator(array('%class%', 'configureStatic'));
         $builder->setParameter('class', 'BazClass');
         $this->assertTrue($builder->get('foo2')->configured, '->createService() calls the configurator');
 
         $builder->register('baz', 'BazClass');
-        $builder->register('foo3', 'FooClass')->setConfigurator(array(new Reference('baz'), 'configure'));
+        $builder->register('foo3', 'Bar\FooClass')->setConfigurator(array(new Reference('baz'), 'configure'));
         $this->assertTrue($builder->get('foo3')->configured, '->createService() calls the configurator');
 
-        $builder->register('foo4', 'FooClass')->setConfigurator('foo');
+        $builder->register('foo4', 'Bar\FooClass')->setConfigurator('foo');
         try {
             $builder->get('foo4');
             $this->fail('->createService() throws an InvalidArgumentException if the configure callable is not a valid callable');
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals('The configure callable for class "FooClass" is not a callable.', $e->getMessage(), '->createService() throws an InvalidArgumentException if the configure callable is not a valid callable');
+            $this->assertEquals('The configure callable for class "Bar\FooClass" is not a callable.', $e->getMessage(), '->createService() throws an InvalidArgumentException if the configure callable is not a valid callable');
         }
     }
 
@@ -375,7 +375,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testCreateSyntheticService()
     {
         $builder = new ContainerBuilder();
-        $builder->register('foo', 'FooClass')->setSynthetic(true);
+        $builder->register('foo', 'Bar\FooClass')->setSynthetic(true);
         $builder->get('foo');
     }
 
@@ -384,7 +384,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $builder = new ContainerBuilder();
         $builder->setParameter('bar', 'bar');
         $builder->register('bar', 'BarClass');
-        $builder->register('foo', 'FooClass')->addArgument(array('foo' => new Expression('service("bar").foo ~ parameter("bar")')));
+        $builder->register('foo', 'Bar\FooClass')->addArgument(array('foo' => new Expression('service("bar").foo ~ parameter("bar")')));
         $this->assertEquals('foobar', $builder->get('foo')->arguments['foo']);
     }
 
@@ -394,7 +394,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testResolveServices()
     {
         $builder = new ContainerBuilder();
-        $builder->register('foo', 'FooClass');
+        $builder->register('foo', 'Bar\FooClass');
         $this->assertEquals($builder->get('foo'), $builder->resolveServices(new Reference('foo')), '->resolveServices() resolves service references to service instances');
         $this->assertEquals(array('foo' => array('foo', $builder->get('foo'))), $builder->resolveServices(array('foo' => array('foo', new Reference('foo')))), '->resolveServices() resolves service references to service instances in nested arrays');
         $this->assertEquals($builder->get('foo'), $builder->resolveServices(new Expression('service("foo")')), '->resolveServices() resolves expressions');
@@ -427,7 +427,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
-        $container->register('foo', 'FooClass');
+        $container->register('foo', 'Bar\FooClass');
         $container->register('bar', 'BarClass');
         $config = new ContainerBuilder();
         $config->setDefinition('baz', new Definition('BazClass'));
@@ -441,7 +441,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
-        $container->register('foo', 'FooClass');
+        $container->register('foo', 'Bar\FooClass');
         $config->setDefinition('foo', new Definition('BazClass'));
         $container->merge($config);
         $this->assertEquals('BazClass', $container->getDefinition('foo')->getClass(), '->merge() overrides already defined services');
@@ -466,7 +466,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $builder
-            ->register('foo', 'FooClass')
+            ->register('foo', 'Bar\FooClass')
             ->addTag('foo', array('foo' => 'foo'))
             ->addTag('bar', array('bar' => 'bar'))
             ->addTag('foo', array('foofoo' => 'foofoo'))
@@ -486,7 +486,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testFindDefinition()
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('foo', $definition = new Definition('FooClass'));
+        $container->setDefinition('foo', $definition = new Definition('Bar\FooClass'));
         $container->setAlias('bar', 'foo');
         $container->setAlias('foobar', 'bar');
         $this->assertEquals($definition, $container->findDefinition('foobar'), '->findDefinition() returns a Definition');

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -10,10 +10,10 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 $container = new ContainerBuilder();
 $container->
-    register('foo', 'FooClass')->
+    register('foo', 'Bar\FooClass')->
     addTag('foo', array('foo' => 'foo'))->
     addTag('foo', array('bar' => 'bar'))->
-    setFactoryClass('FooClass')->
+    setFactoryClass('Bar\\FooClass')->
     setFactoryMethod('getInstance')->
     setArguments(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))->
     setProperties(array('foo' => 'bar', 'moo' => new Reference('foo.baz')))->
@@ -22,7 +22,7 @@ $container->
     setConfigurator('sc_configure')
 ;
 $container->
-    register('bar', 'FooClass')->
+    register('bar', 'Bar\FooClass')->
     setArguments(array('foo', new Reference('foo.baz'), new Parameter('foo_bar')))->
     setScope('container')->
     setConfigurator(array(new Reference('foo.baz'), 'configure'))
@@ -40,13 +40,13 @@ $container->
 $container->getParameterBag()->clear();
 $container->getParameterBag()->add(array(
     'baz_class' => 'BazClass',
-    'foo_class' => 'FooClass',
+    'foo_class' => 'Bar\FooClass',
     'foo' => 'bar',
 ));
 $container->setAlias('alias_for_foo', 'foo');
 $container->setAlias('alias_for_alias', 'alias_for_foo');
 $container->
-    register('method_call1', 'FooClass')->
+    register('method_call1', 'Bar\FooClass')->
     setFile(realpath(__DIR__.'/../includes/foo.php'))->
     addMethodCall('setBar', array(new Reference('foo')))->
     addMethodCall('setBar', array(new Reference('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE)))->

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
@@ -3,11 +3,11 @@ digraph sc {
   node [fontsize="11" fontname="Arial" shape="record"];
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
-  node_foo [label="foo (alias_for_foo)\nFooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
-  node_bar [label="bar\nFooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_foo [label="foo (alias_for_foo)\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_bar [label="bar\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo_baz [label="foo.baz\nBazClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
-  node_foo_bar [label="foo_bar\nFooClass\n", shape=record, fillcolor="#eeeeee", style="dotted"];
-  node_method_call1 [label="method_call1\nFooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_foo_bar [label="foo_bar\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="dotted"];
+  node_method_call1 [label="method_call1\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_factory_service [label="factory_service\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo_with_inline [label="foo_with_inline\nFoo\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_inlined [label="inlined\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/foo.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Bar;
+
 class FooClass
 {
     public $foo, $moo;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -49,13 +49,13 @@ class ProjectServiceContainer extends Container
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return FooClass A FooClass instance.
+     * @return Bar\FooClass A Bar\FooClass instance.
      */
     protected function getBarService()
     {
         $a = $this->get('foo.baz');
 
-        $this->services['bar'] = $instance = new \FooClass('foo', $a, $this->getParameter('foo_bar'));
+        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
 
         $a->configure($instance);
 
@@ -132,13 +132,13 @@ class ProjectServiceContainer extends Container
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return FooClass A FooClass instance.
+     * @return Bar\FooClass A Bar\FooClass instance.
      */
     protected function getFooService()
     {
         $a = $this->get('foo.baz');
 
-        $this->services['foo'] = $instance = \FooClass::getInstance('foo', $a, array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo')), true, $this);
+        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo')), true, $this);
 
         $instance->setBar($this->get('bar'));
         $instance->initialize();
@@ -201,13 +201,13 @@ class ProjectServiceContainer extends Container
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return FooClass A FooClass instance.
+     * @return Bar\FooClass A Bar\FooClass instance.
      */
     protected function getMethodCall1Service()
     {
         require_once '%path%foo.php';
 
-        $this->services['method_call1'] = $instance = new \FooClass();
+        $this->services['method_call1'] = $instance = new \Bar\FooClass();
 
         $instance->setBar($this->get('foo'));
         $instance->setBar($this->get('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE));
@@ -297,7 +297,7 @@ class ProjectServiceContainer extends Container
     {
         return array(
             'baz_class' => 'BazClass',
-            'foo_class' => 'FooClass',
+            'foo_class' => 'Bar\\FooClass',
             'foo' => 'bar',
         );
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -58,13 +58,13 @@ class ProjectServiceContainer extends Container
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return FooClass A FooClass instance.
+     * @return Bar\FooClass A Bar\FooClass instance.
      */
     protected function getBarService()
     {
         $a = $this->get('foo.baz');
 
-        $this->services['bar'] = $instance = new \FooClass('foo', $a, $this->getParameter('foo_bar'));
+        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
 
         $a->configure($instance);
 
@@ -144,13 +144,13 @@ class ProjectServiceContainer extends Container
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return FooClass A FooClass instance.
+     * @return Bar\FooClass A Bar\FooClass instance.
      */
     protected function getFooService()
     {
         $a = $this->get('foo.baz');
 
-        $this->services['foo'] = $instance = \FooClass::getInstance('foo', $a, array('bar' => 'foo is bar', 'foobar' => 'bar'), true, $this);
+        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array('bar' => 'foo is bar', 'foobar' => 'bar'), true, $this);
 
         $instance->setBar($this->get('bar'));
         $instance->initialize();
@@ -181,11 +181,11 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the 'foo_bar' service.
      *
-     * @return FooClass A FooClass instance.
+     * @return Bar\FooClass A Bar\FooClass instance.
      */
     protected function getFooBarService()
     {
-        return new \FooClass();
+        return new \Bar\FooClass();
     }
 
     /**
@@ -216,13 +216,13 @@ class ProjectServiceContainer extends Container
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return FooClass A FooClass instance.
+     * @return Bar\FooClass A Bar\FooClass instance.
      */
     protected function getMethodCall1Service()
     {
         require_once '%path%foo.php';
 
-        $this->services['method_call1'] = $instance = new \FooClass();
+        $this->services['method_call1'] = $instance = new \Bar\FooClass();
 
         $instance->setBar($this->get('foo'));
         $instance->setBar(NULL);
@@ -306,7 +306,7 @@ class ProjectServiceContainer extends Container
     {
         return array(
             'baz_class' => 'BazClass',
-            'foo_class' => 'FooClass',
+            'foo_class' => 'Bar\\FooClass',
             'foo' => 'bar',
         );
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -2,11 +2,11 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <parameters>
     <parameter key="baz_class">BazClass</parameter>
-    <parameter key="foo_class">FooClass</parameter>
+    <parameter key="foo_class">Bar\FooClass</parameter>
     <parameter key="foo">bar</parameter>
   </parameters>
   <services>
-    <service id="foo" class="FooClass" factory-method="getInstance">
+    <service id="foo" class="Bar\FooClass" factory-method="getInstance">
       <tag name="foo" foo="foo"/>
       <tag name="foo" bar="bar"/>
       <argument>foo</argument>
@@ -25,7 +25,7 @@
       <call method="initialize"/>
       <configurator function="sc_configure"/>
     </service>
-    <service id="bar" class="FooClass">
+    <service id="bar" class="Bar\FooClass">
       <argument>foo</argument>
       <argument type="service" id="foo.baz"/>
       <argument>%foo_bar%</argument>
@@ -35,7 +35,7 @@
       <configurator class="%baz_class%" method="configureStatic1"/>
     </service>
     <service id="foo_bar" class="%foo_class%" scope="prototype"/>
-    <service id="method_call1" class="FooClass">
+    <service id="method_call1" class="Bar\FooClass">
       <file>%path%foo.php</file>
       <call method="setBar">
         <argument type="service" id="foo"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -1,15 +1,15 @@
 parameters:
     baz_class: BazClass
-    foo_class: FooClass
+    foo_class: Bar\FooClass
     foo: bar
 
 services:
     foo:
-        class: FooClass
+        class: Bar\FooClass
         tags:
             - { name: foo, foo: foo }
             - { name: foo, bar: bar }
-        factory_class: FooClass
+        factory_class: Bar\FooClass
         factory_method: getInstance
         arguments: [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%' }, true, '@service_container']
         properties: { foo: bar, moo: '@foo.baz' }
@@ -19,7 +19,7 @@ services:
 
         configurator: sc_configure
     bar:
-        class: FooClass
+        class: Bar\FooClass
         arguments: [foo, '@foo.baz', '%foo_bar%']
         configurator: ['@foo.baz', configure]
     foo.baz:
@@ -31,7 +31,7 @@ services:
         class: %foo_class%
         scope: prototype
     method_call1:
-        class: FooClass
+        class: Bar\FooClass
         file: %path%foo.php
         calls:
             - [setBar, ['@foo']]


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9815 |
| License | MIT |
| Doc PR | - |

I also updated the unit tests to test a namespaces class to prevent future issues like this one.
