### PR TITLE
[SecurityComponent] Added a "target_forward" option

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -38,6 +38,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
         'login_path'                     => '/login',
         'target_path_parameter'          => '_target_path',
         'use_referer'                    => false,
+        'target_forward'                 => false
     );
 
     protected $defaultFailureHandlerOptions = array(

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -123,6 +123,7 @@
         <service id="security.authentication.success_handler" class="%security.authentication.success_handler.class%" abstract="true" public="false">
             <argument type="service" id="security.http_utils" />
             <argument type="collection" /> <!-- Options -->
+            <argument type="service" id="http_kernel" />
         </service>
 
         <service id="security.authentication.failure_handler" class="%security.authentication.failure_handler.class%" abstract="true" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | None |
| License | MIT |
| Doc PR | symfony/symfony-docs#3364 |

This PR add an `target_forward` option that makes the `DefaultAuthenticationSuccessHandler` to forward instead of redirect if login is successful.

A use case is using `XmlHttpRequest`s, `302 Found` redirects might not works with CORS.
