### PR TITLE
[Security] Fix ExceptionListener to catch correctly AccessDeniedException if is not first exception

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -83,79 +83,79 @@ class ExceptionListener
         $exception = $event->getException();
         $request = $event->getRequest();
 
-        // determine the actual cause for the exception
-        while (null !== $previous = $exception->getPrevious()) {
-            $exception = $previous;
-        }
-
-        if ($exception instanceof AuthenticationException) {
-            if (null !== $this->logger) {
-                $this->logger->info(sprintf('Authentication exception occurred; redirecting to authentication entry point (%s)', $exception->getMessage()));
-            }
-
-            try {
-                $response = $this->startAuthentication($request, $exception);
-            } catch (\Exception $e) {
-                $event->setException($e);
-
-                return;
-            }
-        } elseif ($exception instanceof AccessDeniedException) {
-            $event->setException(new AccessDeniedHttpException($exception->getMessage(), $exception));
-
-            $token = $this->context->getToken();
-            if (!$this->authenticationTrustResolver->isFullFledged($token)) {
+        while (null !== $exception) {
+            if ($exception instanceof AuthenticationException) {
                 if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Access is denied (user is not fully authenticated) by "%s" at line %s; redirecting to authentication entry point', $exception->getFile(), $exception->getLine()));
+                    $this->logger->info(sprintf('Authentication exception occurred; redirecting to authentication entry point (%s)', $exception->getMessage()));
                 }
-
+    
                 try {
-                    $insufficientAuthenticationException = new InsufficientAuthenticationException('Full authentication is required to access this resource.', 0, $exception);
-                    $insufficientAuthenticationException->setToken($token);
-                    $response = $this->startAuthentication($request, $insufficientAuthenticationException);
+                    $response = $this->startAuthentication($request, $exception);
                 } catch (\Exception $e) {
                     $event->setException($e);
-
+    
                     return;
                 }
-            } else {
-                if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Access is denied (and user is neither anonymous, nor remember-me) by "%s" at line %s', $exception->getFile(), $exception->getLine()));
-                }
-
-                try {
-                    if (null !== $this->accessDeniedHandler) {
-                        $response = $this->accessDeniedHandler->handle($request, $exception);
-
-                        if (!$response instanceof Response) {
-                            return;
-                        }
-                    } elseif (null !== $this->errorPage) {
-                        $subRequest = $this->httpUtils->createRequest($request, $this->errorPage);
-                        $subRequest->attributes->set(SecurityContextInterface::ACCESS_DENIED_ERROR, $exception);
-
-                        $response = $event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
-                    } else {
+            } elseif ($exception instanceof AccessDeniedException) {
+                $event->setException(new AccessDeniedHttpException($exception->getMessage(), $exception));
+    
+                $token = $this->context->getToken();
+                if (!$this->authenticationTrustResolver->isFullFledged($token)) {
+                    if (null !== $this->logger) {
+                        $this->logger->debug(sprintf('Access is denied (user is not fully authenticated) by "%s" at line %s; redirecting to authentication entry point', $exception->getFile(), $exception->getLine()));
+                    }
+    
+                    try {
+                        $insufficientAuthenticationException = new InsufficientAuthenticationException('Full authentication is required to access this resource.', 0, $exception);
+                        $insufficientAuthenticationException->setToken($token);
+                        $response = $this->startAuthentication($request, $insufficientAuthenticationException);
+                    } catch (\Exception $e) {
+                        $event->setException($e);
+    
                         return;
                     }
-                } catch (\Exception $e) {
+                } else {
                     if (null !== $this->logger) {
-                        $this->logger->error(sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage()));
+                        $this->logger->debug(sprintf('Access is denied (and user is neither anonymous, nor remember-me) by "%s" at line %s', $exception->getFile(), $exception->getLine()));
                     }
-
-                    $event->setException(new \RuntimeException('Exception thrown when handling an exception.', 0, $e));
-
+    
+                    try {
+                        if (null !== $this->accessDeniedHandler) {
+                            $response = $this->accessDeniedHandler->handle($request, $exception);
+    
+                            if (!$response instanceof Response) {
+                                return;
+                            }
+                        } elseif (null !== $this->errorPage) {
+                            $subRequest = $this->httpUtils->createRequest($request, $this->errorPage);
+                            $subRequest->attributes->set(SecurityContextInterface::ACCESS_DENIED_ERROR, $exception);
+    
+                            $response = $event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
+                        } else {
+                            return;
+                        }
+                    } catch (\Exception $e) {
+                        if (null !== $this->logger) {
+                            $this->logger->error(sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage()));
+                        }
+    
+                        $event->setException(new \RuntimeException('Exception thrown when handling an exception.', 0, $e));
+    
+                        return;
+                    }
+                }
+            } elseif ($exception instanceof LogoutException) {
+                if (null !== $this->logger) {
+                    $this->logger->info(sprintf('Logout exception occurred; wrapping with AccessDeniedHttpException (%s)', $exception->getMessage()));
+                }
+    
+                return;
+            } else {
+                if (null === $exception->getPrevious()){
                     return;
                 }
             }
-        } elseif ($exception instanceof LogoutException) {
-            if (null !== $this->logger) {
-                $this->logger->info(sprintf('Logout exception occurred; wrapping with AccessDeniedHttpException (%s)', $exception->getMessage()));
-            }
-
-            return;
-        } else {
-            return;
+            $exception = $exception->getPrevious();
         }
 
         $event->setResponse($response);

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -96,6 +96,7 @@ class ExceptionListener
 
                     return;
                 }
+                break;
             } elseif ($exception instanceof AccessDeniedException) {
                 $event->setException(new AccessDeniedHttpException($exception->getMessage(), $exception));
 
@@ -144,16 +145,15 @@ class ExceptionListener
                         return;
                     }
                 }
+                break;
             } elseif ($exception instanceof LogoutException) {
                 if (null !== $this->logger) {
                     $this->logger->info(sprintf('Logout exception occurred; wrapping with AccessDeniedHttpException (%s)', $exception->getMessage()));
                 }
 
                 return;
-            } else {
-                if (null === $exception->getPrevious()) {
-                    return;
-                }
+            } elseif (null === $exception->getPrevious()) {
+                return;
             }
             $exception = $exception->getPrevious();
         }

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -88,48 +88,48 @@ class ExceptionListener
                 if (null !== $this->logger) {
                     $this->logger->info(sprintf('Authentication exception occurred; redirecting to authentication entry point (%s)', $exception->getMessage()));
                 }
-    
+
                 try {
                     $response = $this->startAuthentication($request, $exception);
                 } catch (\Exception $e) {
                     $event->setException($e);
-    
+
                     return;
                 }
             } elseif ($exception instanceof AccessDeniedException) {
                 $event->setException(new AccessDeniedHttpException($exception->getMessage(), $exception));
-    
+
                 $token = $this->context->getToken();
                 if (!$this->authenticationTrustResolver->isFullFledged($token)) {
                     if (null !== $this->logger) {
                         $this->logger->debug(sprintf('Access is denied (user is not fully authenticated) by "%s" at line %s; redirecting to authentication entry point', $exception->getFile(), $exception->getLine()));
                     }
-    
+
                     try {
                         $insufficientAuthenticationException = new InsufficientAuthenticationException('Full authentication is required to access this resource.', 0, $exception);
                         $insufficientAuthenticationException->setToken($token);
                         $response = $this->startAuthentication($request, $insufficientAuthenticationException);
                     } catch (\Exception $e) {
                         $event->setException($e);
-    
+
                         return;
                     }
                 } else {
                     if (null !== $this->logger) {
                         $this->logger->debug(sprintf('Access is denied (and user is neither anonymous, nor remember-me) by "%s" at line %s', $exception->getFile(), $exception->getLine()));
                     }
-    
+
                     try {
                         if (null !== $this->accessDeniedHandler) {
                             $response = $this->accessDeniedHandler->handle($request, $exception);
-    
+
                             if (!$response instanceof Response) {
                                 return;
                             }
                         } elseif (null !== $this->errorPage) {
                             $subRequest = $this->httpUtils->createRequest($request, $this->errorPage);
                             $subRequest->attributes->set(SecurityContextInterface::ACCESS_DENIED_ERROR, $exception);
-    
+
                             $response = $event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
                         } else {
                             return;
@@ -138,9 +138,9 @@ class ExceptionListener
                         if (null !== $this->logger) {
                             $this->logger->error(sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage()));
                         }
-    
+
                         $event->setException(new \RuntimeException('Exception thrown when handling an exception.', 0, $e));
-    
+
                         return;
                     }
                 }
@@ -148,10 +148,10 @@ class ExceptionListener
                 if (null !== $this->logger) {
                     $this->logger->info(sprintf('Logout exception occurred; wrapping with AccessDeniedHttpException (%s)', $exception->getMessage()));
                 }
-    
+
                 return;
             } else {
-                if (null === $exception->getPrevious()){
+                if (null === $exception->getPrevious()) {
                     return;
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9544 |
| License | MIT |
| Doc PR |  |

My after HackingDay contribution :) @jakzal.
The problem was with "while" loop which extracts only the first exception.
Now the Listener walks through all exceptions and checks if there are any security exceptions
