### PR TITLE
[Dependencyinjection] Fixed handling of inlined references in the AnalyzeServiceReferencesPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -103,7 +103,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
                     $this->getDefinition((string) $argument),
                     $argument
                 );
-            } elseif ($argument instanceof Definition) {
+            } elseif ($argument instanceof Definition && $this->currentDefinition !== $argument) {
                 $this->processArguments($argument->getArguments());
                 $this->processArguments($argument->getMethodCalls());
                 $this->processArguments($argument->getProperties());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
@@ -97,6 +97,22 @@ class AnalyzeServiceReferencesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $graph->getNode('a')->getInEdges());
     }
 
+    public function testProcessHandlesInlinedDefinitions()
+    {
+        $container = new ContainerBuilder();
+
+        $definitionA = $container->register('a');
+        $definitionA->addArgument(new Reference('b'));
+
+        $definitionB = $container->register('b');
+        // It can happen that a Reference is replaced with a service Definition by another compiler pass
+        $definitionB->addMethodCall('setFoo', array(array($definitionB, 'guessFoo')));
+
+        $graph = $this->process($container);
+
+        $this->assertCount(1, $graph->getNode('b')->getInEdges());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new RepeatedPass(array(new AnalyzeServiceReferencesPass()));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8299 |
| License | MIT |
| Doc PR |  |

In some cases `InlineServiceDefinitionsPass` replaces a Reference with a service Definition. In such scenarios `AnalyzeServiceReferencesPass` was falling into an infinite loop.
