### PR TITLE
[WCM][Tests] Improve tests running with specific requirements (except intl icu)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/JsonDescriptorTest.php
@@ -17,7 +17,9 @@ class JsonDescriptorTest extends AbstractDescriptorTest
 {
     protected function setUp()
     {
-        $this->markTestSkipped('Test skipped on PHP 5.3 as JSON_PRETTY_PRINT does not exist.');
+        if (version_compare(phpversion(), '5.4.0', '<')) {
+            $this->markTestSkipped('Test skipped on PHP 5.3 as JSON_PRETTY_PRINT does not exist.');
+        }
     }
 
     protected function getDescriptor()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | na |
| License | MIT |
| Doc PR | na |
- [x] go over all skipped tests, take note and check they are reasonable
- [x] reenable memcache, mongodb, and memcached

We are keeping the icu intl related tests skipped because setting up icu 51.2 is totally time consuming in travis and it would require a custom distro box on travis because there are no ppa's available for the ubuntu version. I tried hard but it does not seem worth it. Same for plugging beta of memcached with pecl, it is just not reasonable to be running beta versions on travis. This then does not address #9797 but at least now we are aware.

This PR now can be merged as is as it improves tests that before were not ran. Not all but more than before. :baby: 
