### PR TITLE
[Tests|WCM] add memcache, memcached, and mongodb extensions to run skipped tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,15 @@ php:
   - 5.4
   - 5.5
 
+services: mongodb
+
 before_script:
     - sudo apt-get install parallel
     - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+    - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - sh -c 'if [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
+    - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
 
 script:

--- a/src/Symfony/Component/Intl/Util/SvnRepository.php
+++ b/src/Symfony/Component/Intl/Util/SvnRepository.php
@@ -137,5 +137,4 @@ class SvnRepository
 
         return $this->svnInfo;
     }
-
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | na |
| License | MIT |
| Doc PR | na |
- [x] go over all skipped tests, take note and check they are reasonable
- [x] reenable memcache, mongodb, and memcached

We are keeping the icu intl related tests skipped because setting up icu 51.2 is totally time consuming in travis and it would require a custom distro box on travis because there are no ppa's available for the ubuntu version. I tried hard but it does not seem worth it. Same for plugging beta of memcached with pecl, it is just not reasonable to be running beta versions on travis. This then does not address #9797 but at least now we are aware.

This PR now can be merged as is as it improves tests that before were not ran. Not all but more than before. :baby: 
