### PR TITLE
[PropertyAccess] Allowed non alphanumeric chars in object properties

### DIFF
--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.5.0
+------
+
+ * allowed non alpha numeric characters in second level and deeper object properties names
+
 2.3.0
 ------
 

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -118,7 +118,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
 
             $position += strlen($matches[1]);
             $remaining = $matches[4];
-            $pattern = '/^(\.(\w+)|\[([^\]]+)\])(.*)/';
+            $pattern = '/^(\.([^\.|\[]+)|\[([^\]]+)\])(.*)/';
         }
 
         if ('' !== $remaining) {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -137,6 +137,13 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Bernhard', $this->getPropertyAccessor()->getValue($array, '%!@$§'));
     }
 
+    public function testGetValueReadsPropertyWithSpecialCharsExceptDotNested()
+    {
+        $object = (object) array('nested' => (object) array('@child' => 'foo'));
+
+        $this->assertEquals('foo', $this->getPropertyAccessor()->getValue($object, 'nested.@child'));
+    }
+
     public function testGetValueReadsPropertyWithCustomPropertyPath()
     {
         $object = new Author();
@@ -326,6 +333,17 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->getPropertyAccessor()->setValue($object, 'last_name', 'Schussek');
 
         $this->assertEquals('Schussek', $object->getLastName());
+    }
+
+    public function testSetValueWithSpecialCharsNested()
+    {
+        $object = new \stdClass();
+        $person = new \stdClass();
+        $person->{'@email'} = null;
+        $object->person = $person;
+
+        $this->getPropertyAccessor()->setValue($object, 'person.@email', 'bar');
+        $this->assertEquals('bar', $object->person->{'@email'});
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
@@ -38,12 +38,26 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
         new PropertyPath('.property');
     }
 
+    public function providePathsContainingUnexpectedCharacters()
+    {
+        return array(
+            array('property.'),
+            array('property.['),
+            array('property..'),
+            array('property['),
+            array('property[['),
+            array('property[.'),
+            array('property[]'),
+        );
+    }
+
     /**
+     * @dataProvider providePathsContainingUnexpectedCharacters
      * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException
      */
-    public function testUnexpectedCharacters()
+    public function testUnexpectedCharacters($path)
     {
-        new PropertyPath('property.$foo');
+        new PropertyPath($path);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/8930 |
| License | MIT |
| Doc PR |  |
