### PR TITLE
[WIP][FrameworkBundle][Command][Routing] Improve extensibility of router related command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
@@ -41,6 +41,11 @@ class RouterApacheDumperCommand extends ContainerAwareCommand
         return parent::isEnabled();
     }
 
+    protected function getRouter(InputInterface $input)
+    {
+        return $this->getContainer()->get('router');
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -69,7 +74,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $router = $this->getContainer()->get('router');
+        $router = $this->getRouter($input);
 
         $dumpOptions = array();
         if ($input->getArgument('script_name')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -43,6 +43,11 @@ class RouterDebugCommand extends ContainerAwareCommand
         return parent::isEnabled();
     }
 
+    protected function getRouter(InputInterface $input)
+    {
+        return $this->getContainer()->get('router');
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -77,7 +82,7 @@ EOF
         $helper = new DescriptorHelper();
 
         if ($name) {
-            $route = $this->getContainer()->get('router')->getRouteCollection()->get($name);
+            $route = $this->getRouter($input)->getRouteCollection()->get($name);
             if (!$route) {
                 throw new \InvalidArgumentException(sprintf('The route "%s" does not exist.', $name));
             }
@@ -88,7 +93,7 @@ EOF
                 'name'     => $name,
             ));
         } else {
-            $routes = $this->getContainer()->get('router')->getRouteCollection();
+            $routes = $this->getRouter($input)->getRouteCollection();
 
             foreach ($routes as $route) {
                 $this->convertController($route);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -41,6 +41,11 @@ class RouterMatchCommand extends ContainerAwareCommand
         return parent::isEnabled();
     }
 
+    protected function getRouter(InputInterface $input)
+    {
+        return $this->getContainer()->get('router');
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -66,7 +71,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $router = $this->getContainer()->get('router');
+        $router = $this->getRouter($input);
         $matcher = new TraceableUrlMatcher($router->getRouteCollection(), $router->getContext());
 
         $traces = $matcher->getTraces($input->getArgument('path_info'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

This is a very light and simple patch (I even thought about using the shorter checklist, but it still doesn't fit the description in the doc). Its point is simply to make Router-related commands easier to extend without having to copy-paste them.

Motivation: I am currently developing an app using several routers at once (using a cascading system, please tell me if you think it might be useful to make a PR for this and I shall prepare one, with doc and everything), and it would be nice to be able to debug each of them and not only the main/master one.
