### PR TITLE
[Console] hide output of ProgressHelper when isDecorated is false

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Helper;
 
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -185,7 +186,9 @@ class ProgressHelper extends Helper
         $this->startTime = time();
         $this->current   = 0;
         $this->max       = (int) $max;
-        $this->output    = $output;
+
+        // Disabling output when it does not support ANSI codes as it would result in a broken display anyway.
+        $this->output    = $output->isDecorated() ? $output : new NullOutput();
         $this->lastMessagesLength = 0;
         $this->barCharOriginal = '';
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
@@ -192,9 +192,19 @@ class ProgressHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->generateOutput('   0/200 [>---------------------------]   0%').$this->generateOutput(' 199/200 [===========================>]  99%').$this->generateOutput(' 200/200 [============================] 100%'), stream_get_contents($output->getStream()));
     }
 
-    protected function getOutputStream()
+    public function testNonDecoratedOutput()
     {
-        return new StreamOutput(fopen('php://memory', 'r+', false));
+        $progress = new ProgressHelper();
+        $progress->start($output = $this->getOutputStream(false));
+        $progress->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals('', stream_get_contents($output->getStream()));
+    }
+
+    protected function getOutputStream($decorated = true)
+    {
+        return new StreamOutput(fopen('php://memory', 'r+', false), StreamOutput::VERBOSITY_NORMAL, $decorated);
     }
 
     protected $lastMessagesLength;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9511 |
| License | MIT |
| Doc PR | n/a |
