### PR TITLE
UniqueEntity failed to invalidate new collections with duplicate values

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationEntity.php
@@ -26,8 +26,8 @@ class AssociationEntity
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="SingleIntIdEntity")
-     * @var \Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity
+     * @ORM\ManyToOne(targetEntity="UniqueConstraintEntity")
+     * @var \Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueConstraintEntity
      */
     public $single;
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UniqueConstraintEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UniqueConstraintEntity.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
+
+/**
+ * @Entity
+ * @Table(uniqueConstraints={@UniqueConstraint(name="name", columns={"name"})})
+ */
+class UniqueConstraintEntity
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="string", nullable=true) */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -243,16 +243,24 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $validator = $this->createValidator($entityManagerName, $em);
 
         $entity1 = new UniqueConstraintEntity(1, 'foo');
-        $entity2 = new UniqueConstraintEntity(2, 'foo');
+        $entity2 = new UniqueConstraintEntity(2, 'bar');
+        $entity3 = new UniqueConstraintEntity(3, 'foo');
+        $entity4 = new UniqueConstraintEntity(4, 'bar');
 
         $em->persist($entity1);
         $em->persist($entity2);
         $em->flush();
 
         $violationsList = $validator->validate($entity1);
-        $this->assertEquals(1, $violationsList->count(), 'Violation found on entity with conflicting entity existing in the database.');
+        $this->assertEquals(0, $violationsList->count(), 'No violations found on entity after it was saved to the database.');
 
         $violationsList = $validator->validate($entity2);
+        $this->assertEquals(0, $violationsList->count(), 'No violations found on entity after it was saved to the database.');
+
+        $violationsList = $validator->validate($entity3);
+        $this->assertEquals(1, $violationsList->count(), 'Violation found on entity with conflicting entity existing in the database.');
+
+        $violationsList = $validator->validate($entity4);
         $this->assertEquals(1, $violationsList->count(), 'Violation found on entity with conflicting entity existing in the database.');
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity;
 use Symfony\Component\Validator\DefaultTranslator;
 use Symfony\Component\Validator\Tests\Fixtures\FakeMetadataFactory;
-use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueConstraintEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
@@ -96,7 +96,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
     public function createValidator($entityManagerName, $em, $validateClass = null, $uniqueFields = null, $errorPath = null, $repositoryMethod = 'findBy', $ignoreNull = true)
     {
         if (!$validateClass) {
-            $validateClass = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity';
+            $validateClass = 'Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueConstraintEntity';
         }
         if (!$uniqueFields) {
             $uniqueFields = array('name');
@@ -127,7 +127,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $schemaTool = new SchemaTool($em);
         $schemaTool->createSchema(array(
-            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity'),
+            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueConstraintEntity'),
             $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity'),
             $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity'),
             $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity'),
@@ -144,7 +144,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->createSchema($em);
         $validator = $this->createValidator($entityManagerName, $em);
 
-        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $entity1 = new UniqueConstraintEntity(1, 'Foo');
         $violationsList = $validator->validate($entity1);
         $this->assertEquals(0, $violationsList->count(), "No violations found on entity before it is saved to the database.");
 
@@ -154,7 +154,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $violationsList = $validator->validate($entity1);
         $this->assertEquals(0, $violationsList->count(), "No violations found on entity after it was saved to the database.");
 
-        $entity2 = new SingleIntIdEntity(2, 'Foo');
+        $entity2 = new UniqueConstraintEntity(2, 'Foo');
 
         $violationsList = $validator->validate($entity2);
         $this->assertEquals(1, $violationsList->count(), "Violation found on entity with conflicting entity existing in the database.");
@@ -172,12 +172,12 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->createSchema($em);
         $validator = $this->createValidator($entityManagerName, $em, null, null, 'bar');
 
-        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $entity1 = new UniqueConstraintEntity(1, 'Foo');
 
         $em->persist($entity1);
         $em->flush();
 
-        $entity2 = new SingleIntIdEntity(2, 'Foo');
+        $entity2 = new UniqueConstraintEntity(2, 'Foo');
 
         $violationsList = $validator->validate($entity2);
         $this->assertEquals(1, $violationsList->count(), "Violation found on entity with conflicting entity existing in the database.");
@@ -195,8 +195,8 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->createSchema($em);
         $validator = $this->createValidator($entityManagerName, $em);
 
-        $entity1 = new SingleIntIdEntity(1, null);
-        $entity2 = new SingleIntIdEntity(2, null);
+        $entity1 = new UniqueConstraintEntity(1, null);
+        $entity2 = new UniqueConstraintEntity(2, null);
 
         $em->persist($entity1);
         $em->persist($entity2);
@@ -242,8 +242,8 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->createSchema($em);
         $validator = $this->createValidator($entityManagerName, $em);
 
-        $entity1 = new SingleIntIdEntity(1, 'foo');
-        $entity2 = new SingleIntIdEntity(2, 'foo');
+        $entity1 = new UniqueConstraintEntity(1, 'foo');
+        $entity2 = new UniqueConstraintEntity(2, 'foo');
 
         $em->persist($entity1);
         $em->persist($entity2);
@@ -267,7 +267,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $em = $this->createEntityManagerMock($repository);
         $validator = $this->createValidator($entityManagerName, $em, null, array(), null, 'findByCustom');
 
-        $entity1 = new SingleIntIdEntity(1, 'foo');
+        $entity1 = new UniqueConstraintEntity(1, 'foo');
 
         $violationsList = $validator->validate($entity1);
         $this->assertEquals(0, $violationsList->count(), 'Violation is using custom repository method.');
@@ -275,7 +275,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidateUniquenessWithUnrewoundArray()
     {
-        $entity = new SingleIntIdEntity(1, 'foo');
+        $entity = new UniqueConstraintEntity(1, 'foo');
 
         $entityManagerName = 'foo';
         $repository = $this->createRepositoryMock();
@@ -309,7 +309,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->createSchema($em);
         $validator = $this->createValidator($entityManagerName, $em, 'Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity', array('single'));
 
-        $entity1 = new SingleIntIdEntity(1, 'foo');
+        $entity1 = new UniqueConstraintEntity(1, 'foo');
         $associated = new AssociationEntity();
         $associated->single = $entity1;
 
@@ -369,7 +369,7 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
 
         $uniqueValidator = new UniqueEntityValidator($registry);
 
-        $entity = new SingleIntIdEntity(1, null);
+        $entity = new UniqueConstraintEntity(1, null);
 
         $this->setExpectedException(
             'Symfony\Component\Validator\Exception\ConstraintDefinitionException',
@@ -391,11 +391,11 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
 
         $uniqueValidator = new UniqueEntityValidator($registry);
 
-        $entity = new SingleIntIdEntity(1, null);
+        $entity = new UniqueConstraintEntity(1, null);
 
         $this->setExpectedException(
             'Symfony\Component\Validator\Exception\ConstraintDefinitionException',
-            'Unable to find the object manager associated with an entity of class "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity"'
+            'Unable to find the object manager associated with an entity of class "Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueConstraintEntity"'
         );
 
         $uniqueValidator->validate($entity, $constraint);

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -30,6 +30,11 @@ class UniqueEntityValidator extends ConstraintValidator
     private $registry;
 
     /**
+     * @var array
+     */
+    protected $collection = array();
+
+    /**
      * @param ManagerRegistry $registry
      */
     public function __construct(ManagerRegistry $registry)
@@ -122,11 +127,17 @@ class UniqueEntityValidator extends ConstraintValidator
             reset($result);
         }
 
+        $class = get_class($entity);
+        $constraintKey = md5(serialize($fields));
+        $valuesKey = md5(serialize($criteria));
         /* If no entity matched the query criteria or a single entity matched,
          * which is the same as the entity being validated, the criteria is
          * unique.
          */
-        if (0 === count($result) || (1 === count($result) && $entity === ($result instanceof \Iterator ? $result->current() : current($result)))) {
+        if (0 === count($result) && !isset($this->collection[$class][$constraintKey][$valuesKey])) {
+            $this->collection[$class][$constraintKey][$valuesKey] = true;
+            return;
+        } elseif (1 === count($result) && $entity === ($result instanceof \Iterator ? $result->current() : current($result))) {
             return;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Basically I run over the same problem as described here:
http://stackoverflow.com/questions/11782056/how-to-validate-unique-entities-in-an-entity-collection-in-symfony2
In other words, if you have new entities collection and it contains at least two objects with same values on unique field then validator does nothing, allowing to proceed orm with inserting data which ends with "SQLSTATE[23000]: Integrity constraint violation".
The problem is that validator is unaware of collection as a whole, and it only validates against db.

So I thought I could try to fix even though problem is not trivial and solution I came with isn't great too (again, because validators are unaware of collection as a whole). But without it UniqueEntity is kinda useless right now.

The most important part is testValidateUniquenessForDuplicatesInCollection. However additionally I've changed tests to actually use entity with defined unique constraint, so test could be more reliable. Test testValidateUniquenessAfterConsideringMultipleQueryResults immediately failed after that change as it is broken by design. You can't persist record "foo" for field name twice if assumption was that field name is unique - so I fixed that test too.

Anyway, feel free to merge that as a whole, merge only some commits, change whatever need changes (or ask me to do that) or point me to completely different solution.

Todo:
- [ ] Tests passes on my dev env, but not in travis

``` sh
1) Symfony\Bridge\Doctrine\Tests\Validator\Constraints\UniqueValidatorTest::testValidateUniqueness

Doctrine\Common\Annotations\AnnotationException: [Semantical Error] The class "Table" is not annotated with @Annotation. Are you sure this class can be used as annotation? If so, then you need to add @Annotation to the _class_ doc comment of "Table". If it is indeed no annotation, then you need to add @IgnoreAnnotation("Table") to the _class_ doc comment of class Symfony\Bridge\Doctrine\Tests\Fixtures\UniqueConstraintEntity.
```
