### PR TITLE
[Validator] Removed duplicated test for IBAN in data provider

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -53,7 +53,6 @@ class IbanValidatorTest extends \PHPUnit_Framework_TestCase
     public function getValidIbans()
     {
         return array(
-            array('CH93 0076 2011 6238 5295 7'), //Switzerland
             array('CH9300762011623852957'), // Switzerland without spaces
 
             //Country list


### PR DESCRIPTION
Working on #9850, I spotted a duplicated value on `getValidIbans` data provider and I just removed the duplicated value.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
