### PR TITLE
Add support for HHVM in the getting of the PHP executable

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -33,6 +33,11 @@ class PhpExecutableFinder
      */
     public function find()
     {
+        // HHVM support
+        if (($hhvm = getenv("PHP_BINARY")) !== false) {
+            return $hhvm;
+        }
+        
         // PHP_BINARY return the current sapi executable
         if (defined('PHP_BINARY') && PHP_BINARY && ('cli' === PHP_SAPI) && is_file(PHP_BINARY)) {
             return PHP_BINARY;

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -34,10 +34,10 @@ class PhpExecutableFinder
     public function find()
     {
         // HHVM support
-        if (($hhvm = getenv("PHP_BINARY")) !== false) {
+        if (defined('HHVM_VERSION') && false !== $hhvm = getenv('PHP_BINARY')) {
             return $hhvm;
         }
-        
+
         // PHP_BINARY return the current sapi executable
         if (defined('PHP_BINARY') && PHP_BINARY && ('cli' === PHP_SAPI) && is_file(PHP_BINARY)) {
             return PHP_BINARY;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Same as #9583 but with CS fixed, on 2.3, and with an added safeguard to only change the current behavior for HHVM.

Check for a PHP_BINARY environment variable before using the pre-defined PHP_BINARY constant.

HHVM has an explicit hhvm binary and a wrapper to mimic php functionality. We were running into issues with tests that ran in their own process where using the hhvm binary does not handle php code sent to it via stdin very well. We get "Nothing to do...pass file" exceptions. Unfortunately, the PHP_BINARY is always set to the explicit binary (the php wrapper is basically a symlink to the explicit binary). So, we thought about adding a check for a PHP_BINARY environment variable as the first choice when getting the PHP binary.
