### PR TITLE
[Dependencyinjection] Fixed handling of inlined references in the AnalyzeServiceReferencesPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -125,6 +125,10 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             return true;
         }
 
+        if ($this->currentId == $id) {
+            return false;
+        }
+
         $ids = array();
         foreach ($this->graph->getNode($id)->getInEdges() as $edge) {
             $ids[] = $edge->getSourceNode()->getId();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -144,6 +144,21 @@ class InlineServiceDefinitionsPassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($ref, $arguments[0]);
     }
 
+    public function testProcessDoesNotInlineWhenServiceReferencesItself()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setPublic(false)
+            ->addMethodCall('foo', array($ref = new Reference('foo')))
+        ;
+
+        $this->process($container);
+
+        $calls = $container->getDefinition('foo')->getMethodCalls();
+        $this->assertSame($ref, $calls[0][1][0]);
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $repeatedPass = new RepeatedPass(array(new AnalyzeServiceReferencesPass(), new InlineServiceDefinitionsPass()));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8299, #9829 |
| License | MIT |
| Doc PR | n/a |

Hopefully a better fix for #9829 (ping @jakzal). Unit tests coming soon.

In some cases `InlineServiceDefinitionsPass` replaces a Reference with a service Definition. In such scenarios `AnalyzeServiceReferencesPass` was falling into an infinite loop.
