### PR TITLE
[Console] fixed column width when using the Table helper with some decoration in cells

### DIFF
--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -389,6 +389,8 @@ class TableHelper extends Helper
             $width += strlen($cell) - mb_strlen($cell, $encoding);
         }
 
+        $width += $this->strlen($cell) - $this->computeLengthWithoutDecoration($cell);
+
         $this->output->write(sprintf(
             $cellFormat,
             str_pad(
@@ -452,15 +454,7 @@ class TableHelper extends Helper
      */
     private function getCellWidth(array $row, $column)
     {
-        if ($column < 0) {
-            return 0;
-        }
-
-        if (isset($row[$column])) {
-            return $this->strlen($row[$column]);
-        }
-
-        return $this->getCellWidth($row, $column - 1);
+        return isset($row[$column]) ? $this->computeLengthWithoutDecoration($row[$column]) : 0;
     }
 
     /**
@@ -470,6 +464,18 @@ class TableHelper extends Helper
     {
         $this->columnWidths = array();
         $this->numberOfColumns = null;
+    }
+
+    private function computeLengthWithoutDecoration($string)
+    {
+        $formatter = $this->output->getFormatter();
+        $isDecorated = $formatter->isDecorated();
+        $formatter->setDecorated(false);
+
+        $string = $formatter->format($string);
+        $formatter->setDecorated($isDecorated);
+
+        return $this->strlen($string);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -196,6 +196,40 @@ TABLE
                 TableHelper::LAYOUT_DEFAULT,
                 '',
             ),
+            'Cell text with tags used for Output styling' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array('<info>99921-58-10-7</info>', '<error>Divine Comedy</error>', '<fg=blue;bg=white>Dante Alighieri</fg=blue;bg=white>'),
+                    array('9971-5-0210-0', 'A Tale of Two Cities', '<info>Charles Dickens</>'),
+                ),
+                TableHelper::LAYOUT_DEFAULT,
+<<<TABLE
++---------------+----------------------+-----------------+
+| ISBN          | Title                | Author          |
++---------------+----------------------+-----------------+
+| 99921-58-10-7 | Divine Comedy        | Dante Alighieri |
+| 9971-5-0210-0 | A Tale of Two Cities | Charles Dickens |
++---------------+----------------------+-----------------+
+
+TABLE
+            ),
+            'Cell text with tags not used for Output styling' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array('<strong>99921-58-10-700</strong>', '<f>Divine Com</f>', 'Dante Alighieri'),
+                    array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
+                ),
+                TableHelper::LAYOUT_DEFAULT,
+<<<TABLE
++----------------------------------+----------------------+-----------------+
+| ISBN                             | Title                | Author          |
++----------------------------------+----------------------+-----------------+
+| <strong>99921-58-10-700</strong> | <f>Divine Com</f>    | Dante Alighieri |
+| 9971-5-0210-0                    | A Tale of Two Cities | Charles Dickens |
++----------------------------------+----------------------+-----------------+
+
+TABLE
+            ),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8152, #9366 |
| License | MIT |
| Doc PR | n/a |

This PR fixes the same issue as #9366 but works in all situations (all kind of styles, when the string is shorter than any other one or larger than any other ones, ...).

I'm not very satisfied with the fix and especially the `computeLengthWithoutDecoration` method, but the whole helper should be rethought to make it stateless (out of the scope of this PR).
