### PR TITLE
[Validator] Added Doctrine cache

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -443,6 +443,29 @@ UPGRADE FROM 2.x to 3.0
 
 ### Validator
 
+ * The class `Symfony\Component\Validator\Mapping\Cache\ApcCache` has been removed in favor
+   of `Symfony\Component\Validator\Mapping\Cache\DoctrineCache`.
+
+   Before:
+
+   ```
+   use Symfony\Component\Validator\Mapping\Cache\ApcCache;
+
+   $cache = new ApcCache('symfony.validator');
+   ```
+
+   After:
+
+   ```
+   use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
+   use Doctrine\Common\Cache\ApcCache;
+
+   $apcCache = new ApcCache();
+   $apcCache->setNamespace('symfony.validator');
+
+   $cache = new DoctrineCache($apcCache);
+   ```
+
  * The constraints `Optional` and `Required` were moved to the
    `Symfony\Component\Validator\Constraints\` namespace. You should adapt
    the path wherever you used them.

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.5.0
+-----
+
+ * deprecated `ApcCache` in favor of `DoctrineCache`
+ * added `DoctrineCache` to adapt any Doctrine cache
+
 2.4.0
 -----
 

--- a/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
+++ b/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
@@ -13,6 +13,10 @@ namespace Symfony\Component\Validator\Mapping\Cache;
 
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
+/**
+ * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+ *             Use DoctrineCache with Doctrine\Common\Cache\ApcCache instead.
+ */
 class ApcCache implements CacheInterface
 {
     private $prefix;

--- a/src/Symfony/Component/Validator/Mapping/Cache/DoctrineCache.php
+++ b/src/Symfony/Component/Validator/Mapping/Cache/DoctrineCache.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Mapping\Cache;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Doctrine\Common\Cache\Cache;
+
+/**
+ * Adapts a Doctrine cache to a CacheInterface.
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+final class DoctrineCache implements CacheInterface
+{
+    private $cache;
+
+    /**
+     * Creates a new Doctrine cache.
+     *
+     * @param Cache $cache The cache to adapt
+     */
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Sets the cache to adapt.
+     *
+     * @param Cache $cache The cache to adapt
+     */
+    public function setCache(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($class)
+    {
+        return $this->cache->contains($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($class)
+    {
+        return $this->cache->fetch($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write(ClassMetadata $metadata)
+    {
+        $this->cache->save($metadata->getClassName(), $metadata);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Mapping\Cache;
+
+use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
+use Doctrine\Common\Cache\ArrayCache;
+
+class DoctrineCacheTest extends \PHPUnit_Framework_TestCase
+{
+    private $cache;
+
+    public function testWrite()
+    {
+        $meta = $this->getMockBuilder('Symfony\\Component\\Validator\\Mapping\\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getClassName'))
+            ->getMock();
+
+        $meta->expects($this->once())
+            ->method('getClassName')
+            ->will($this->returnValue('bar'));
+
+        $this->cache->write($meta);
+
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Validator\\Mapping\\ClassMetadata',
+            $this->cache->read('bar'),
+            'write() stores metadata'
+        );
+    }
+
+    public function testHas()
+    {
+        $meta = $this->getMockBuilder('Symfony\\Component\\Validator\\Mapping\\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getClassName'))
+            ->getMock();
+
+        $meta->expects($this->once())
+            ->method('getClassName')
+            ->will($this->returnValue('bar'));
+
+        $this->assertFalse($this->cache->has('bar'), 'has() returns false when there is no entry');
+
+        $this->cache->write($meta);
+        $this->assertTrue($this->cache->has('bar'), 'has() returns true when the is an entry');
+    }
+
+    public function testRead()
+    {
+        $meta = $this->getMockBuilder('Symfony\\Component\\Validator\\Mapping\\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getClassName'))
+            ->getMock();
+
+        $meta->expects($this->once())
+            ->method('getClassName')
+            ->will($this->returnValue('bar'));
+
+        $this->assertFalse($this->cache->read('bar'), 'read() returns false when there is no entry');
+
+        $this->cache->write($meta);
+
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Validator\\Mapping\\ClassMetadata',
+            $this->cache->read('bar'),
+            'read() returns metadata'
+        );
+    }
+
+    protected function setUp()
+    {
+        $this->cache = new DoctrineCache(new ArrayCache);
+    }
+}

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -30,7 +30,7 @@
     },
     "suggest": {
         "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
-        "doctrine/cache": "For using the default cached annotation reader",
+        "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
         "symfony/http-foundation": "",
         "symfony/intl": "",
         "symfony/yaml": "",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/9887 |
| License | MIT |
| Doc PR |  |

I propose to keep the `CacheInterface` and deprecate only the `ApcCache`. 
It will leave the classes depending on a `CacheInterface` unchanged and will allow to adapt new cache providers in the future.
