### PR TITLE
[Intl] Added round support for ROUND_CEILING, ROUND_FLOOR, ROUND_DOWN, ROUND_UP

### DIFF
--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -154,7 +154,7 @@ class NumberFormatter
     private $attributes = array(
         self::FRACTION_DIGITS => 0,
         self::GROUPING_USED   => 1,
-        self::ROUNDING_MODE   => self::ROUND_HALFEVEN
+        self::ROUNDING_MODE   => self::ROUND_HALFEVEN,
     );
 
     /**
@@ -171,7 +171,7 @@ class NumberFormatter
      */
     private static $supportedStyles = array(
         'CURRENCY' => self::CURRENCY,
-        'DECIMAL'  => self::DECIMAL
+        'DECIMAL'  => self::DECIMAL,
     );
 
     /**
@@ -182,7 +182,7 @@ class NumberFormatter
     private static $supportedAttributes = array(
         'FRACTION_DIGITS' => self::FRACTION_DIGITS,
         'GROUPING_USED'   => self::GROUPING_USED,
-        'ROUNDING_MODE'   => self::ROUNDING_MODE
+        'ROUNDING_MODE'   => self::ROUNDING_MODE,
     );
 
     /**
@@ -199,7 +199,7 @@ class NumberFormatter
         'ROUND_CEILING'  => self::ROUND_CEILING,
         'ROUND_FLOOR'    => self::ROUND_FLOOR,
         'ROUND_DOWN'     => self::ROUND_DOWN,
-        'ROUND_UP'       => self::ROUND_UP
+        'ROUND_UP'       => self::ROUND_UP,
     );
 
     /**
@@ -227,7 +227,7 @@ class NumberFormatter
         self::ROUND_CEILING => true,
         self::ROUND_FLOOR   => true,
         self::ROUND_DOWN    => true,
-        self::ROUND_UP      => true
+        self::ROUND_UP      => true,
     );
 
     /**
@@ -237,7 +237,7 @@ class NumberFormatter
      */
     private static $int32Range = array(
         'positive' => 2147483647,
-        'negative' => -2147483648
+        'negative' => -2147483648,
     );
 
     /**
@@ -247,7 +247,7 @@ class NumberFormatter
      */
     private static $int64Range = array(
         'positive' => 9223372036854775807,
-        'negative' => -9223372036854775808
+        'negative' => -9223372036854775808,
     );
 
     private static $enSymbols = array(

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -720,8 +720,7 @@ class NumberFormatter
 
         $roundingModeAttribute = $this->getAttribute(self::ROUNDING_MODE);
         if (isset(self::$phpRoundingMap[$roundingModeAttribute])) {
-            $roundingMode = self::$phpRoundingMap[$this->getAttribute(self::ROUNDING_MODE)];
-            $value = round($value, $precision, $roundingMode);
+            $value = round($value, $precision, self::$phpRoundingMap[$roundingModeAttribute]);
         } elseif (isset(self::$customRoundingList[$roundingModeAttribute])) {
             $roundingCoef = pow(10, $precision);
             $value *= $roundingCoef;

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -716,7 +716,7 @@ class NumberFormatter
      */
     private function round($value, $precision)
     {
-        $precision = $this->getUnitializedPrecision($value, $precision);
+        $precision = $this->getUninitializedPrecision($value, $precision);
 
         $roundingModeAttribute = $this->getAttribute(self::ROUNDING_MODE);
         if (isset(self::$phpRoundingMap[$roundingModeAttribute])) {
@@ -756,20 +756,20 @@ class NumberFormatter
      */
     private function formatNumber($value, $precision)
     {
-        $precision = $this->getUnitializedPrecision($value, $precision);
+        $precision = $this->getUninitializedPrecision($value, $precision);
 
         return number_format($value, $precision, '.', $this->getAttribute(self::GROUPING_USED) ? ',' : '');
     }
 
     /**
-     * Returns the precision value if the DECIMAL style is being used and the FRACTION_DIGITS attribute is unitialized.
+     * Returns the precision value if the DECIMAL style is being used and the FRACTION_DIGITS attribute is uninitialized.
      *
-     * @param integer|float $value     The value to get the precision from if the FRACTION_DIGITS attribute is unitialized
+     * @param integer|float $value     The value to get the precision from if the FRACTION_DIGITS attribute is uninitialized
      * @param int           $precision The precision value to returns if the FRACTION_DIGITS attribute is initialized
      *
      * @return int The precision value
      */
-    private function getUnitializedPrecision($value, $precision)
+    private function getUninitializedPrecision($value, $precision)
     {
         if ($this->style == self::CURRENCY) {
             return $precision;

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -466,6 +466,102 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @dataProvider formatRoundingModeRoundCeilingProvider
+     */
+    public function testFormatRoundingModeCeiling($value, $expected)
+    {
+        $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
+
+        $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_CEILING);
+        $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_CEILING rounding mode.');
+    }
+
+    public function formatRoundingModeRoundCeilingProvider()
+    {
+        return array(
+            array(1.123, '1.13'),
+            array(1.125, '1.13'),
+            array(1.127, '1.13'),
+            array(-1.123, '-1.12'),
+            array(-1.125, '-1.12'),
+            array(-1.127, '-1.12')
+        );
+    }
+
+    /**
+     * @dataProvider formatRoundingModeRoundFloorProvider
+     */
+    public function testFormatRoundingModeFloor($value, $expected)
+    {
+        $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
+
+        $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_FLOOR);
+        $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_FLOOR rounding mode.');
+    }
+
+    public function formatRoundingModeRoundFloorProvider()
+    {
+        return array(
+            array(1.123, '1.12'),
+            array(1.125, '1.12'),
+            array(1.127, '1.12'),
+            array(-1.123, '-1.13'),
+            array(-1.125, '-1.13'),
+            array(-1.127, '-1.13')
+        );
+    }
+
+    /**
+     * @dataProvider formatRoundingModeRoundDownProvider
+     */
+    public function testFormatRoundingModeDown($value, $expected)
+    {
+        $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
+
+        $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
+        $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_DOWN rounding mode.');
+    }
+
+    public function formatRoundingModeRoundDownProvider()
+    {
+        return array(
+            array(1.123, '1.12'),
+            array(1.125, '1.12'),
+            array(1.127, '1.12'),
+            array(-1.123, '-1.12'),
+            array(-1.125, '-1.12'),
+            array(-1.127, '-1.12')
+        );
+    }
+
+    /**
+     * @dataProvider formatRoundingModeRoundUpProvider
+     */
+    public function testFormatRoundingModeUp($value, $expected)
+    {
+        $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
+
+        $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_UP);
+        $this->assertSame($expected, $formatter->format($value), '->format() with ROUND_UP rounding mode.');
+    }
+
+    public function formatRoundingModeRoundUpProvider()
+    {
+        return array(
+            array(1.123, '1.13'),
+            array(1.125, '1.13'),
+            array(1.127, '1.13'),
+            array(-1.123, '-1.13'),
+            array(-1.125, '-1.13'),
+            array(-1.127, '-1.13')
+        );
+    }
+
     public function testGetLocale()
     {
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -486,7 +486,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
             array(1.127, '1.13'),
             array(-1.123, '-1.12'),
             array(-1.125, '-1.12'),
-            array(-1.127, '-1.12')
+            array(-1.127, '-1.12'),
         );
     }
 
@@ -510,7 +510,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
             array(1.127, '1.12'),
             array(-1.123, '-1.13'),
             array(-1.125, '-1.13'),
-            array(-1.127, '-1.13')
+            array(-1.127, '-1.13'),
         );
     }
 
@@ -534,7 +534,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
             array(1.127, '1.12'),
             array(-1.123, '-1.12'),
             array(-1.125, '-1.12'),
-            array(-1.127, '-1.12')
+            array(-1.127, '-1.12'),
         );
     }
 
@@ -558,7 +558,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
             array(1.127, '1.13'),
             array(-1.123, '-1.13'),
             array(-1.125, '-1.13'),
-            array(-1.127, '-1.13')
+            array(-1.127, '-1.13'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no, actually it fixes some |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9838 |
| License | MIT |
| Doc PR |  |

Adds support for 4 unsupported rounding modes (ROUND_CEILING, ROUND_FLOOR, ROUND_DOWN, ROUND_UP) in `NumberFormatter` from `Intl` component, so that `Symfony\Component\Form\Extension\Core\DataTransformer\IntegerToLocalizedStringTransformer` won't throw exception if `lib-intl` is not installed.
