### PR TITLE
[Validator] Moved DoctrineCache to Doctrine Bridge

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -444,7 +444,7 @@ UPGRADE FROM 2.x to 3.0
 ### Validator
 
  * The class `Symfony\Component\Validator\Mapping\Cache\ApcCache` has been removed in favor
-   of `Symfony\Component\Validator\Mapping\Cache\DoctrineCache`.
+   of `Symfony\Bridge\Doctrine\Validator\Mapping\DoctrineCache`.
 
    Before:
 
@@ -457,7 +457,7 @@ UPGRADE FROM 2.x to 3.0
    After:
 
    ```
-   use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
+   use Symfony\Bridge\Doctrine\Validator\Mapping\DoctrineCache;
    use Doctrine\Common\Cache\ApcCache;
 
    $apcCache = new ApcCache();

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.5.0
+-----
+
+ * added Validator\Mapping\DoctrineCache class
+
 2.2.0
 -----
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Mapping/DoctrineCacheTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Mapping/DoctrineCacheTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Validator\Tests\Mapping\Cache;
+namespace Symfony\Bridge\Doctrine\Tests\Validator\Mapping;
 
-use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
+use Symfony\Bridge\Doctrine\Validator\Mapping\DoctrineCache;
 use Doctrine\Common\Cache\ArrayCache;
 
 class DoctrineCacheTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Bridge/Doctrine/Validator/Mapping/DoctrineCache.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Mapping/DoctrineCache.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Validator\Mapping\Cache;
+namespace Symfony\Bridge\Doctrine\Validator\Mapping;
 
+use Symfony\Component\Validator\Mapping\Cache\CacheInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Doctrine\Common\Cache\Cache;
 

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,8 +4,7 @@ CHANGELOG
 2.5.0
 -----
 
- * deprecated `ApcCache` in favor of `DoctrineCache`
- * added `DoctrineCache` to adapt any Doctrine cache
+ * deprecated `ApcCache` in favor of `Symfony\Bridge\Doctrine\Validator\Mapping\DoctrineCache`
 
 2.4.0
 -----

--- a/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
+++ b/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
@@ -15,7 +15,8 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
  * @deprecated Deprecated since version 2.5, to be removed in 3.0.
- *             Use DoctrineCache with Doctrine\Common\Cache\ApcCache instead.
+ *             Use Symfony\Bridge\Doctrine\Validator\Mapping\DoctrineCache
+ *             with Doctrine\Common\Cache\ApcCache instead.
  */
 class ApcCache implements CacheInterface
 {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -30,7 +30,7 @@
     },
     "suggest": {
         "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
-        "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+        "doctrine/cache": "For using the default cached annotation reader.",
         "symfony/http-foundation": "",
         "symfony/intl": "",
         "symfony/yaml": "",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

As per @stof remark on https://github.com/symfony/symfony/pull/9892 the `DoctrineCache` class should be located in the Doctrine Bridge.
