### PR TITLE
[Validator] Updated lithuanian validator translation.

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -176,7 +176,7 @@
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user current password.</source>
-                <target>Ši reikšmė turi sutapti su dabartiniu vartotojo slaptažodžiu.</target>
+                <target>Ši reikšmė turi sutapti su dabartiniu naudotojo slaptažodžiu.</target>
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>


### PR DESCRIPTION
Updated lithuanian validator translation: changed 'vartotojas' to 'naudotojas' as it is more proper term.

| Q | A |
| --- | --- |
| Bug fix? | no |
| License | MIT |
