### PR TITLE
Add an easy way to force download on BinaryFileResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -287,4 +287,12 @@ class BinaryFileResponse extends Response
     {
         self::$trustXSendfileTypeHeader = true;
     }
+    
+    /**
+     * Enforces download 
+     */
+     public function forceDownload()
+     {
+         $this->headers->set('Content-type', 'application/force-download');
+     }
 }


### PR DESCRIPTION
Force download of a binary file is a common problem, which can be resolved by
 the correct content type 'application/force-download'.

I need it, so I share it.
I need little help to found a efficient way to test it, i will add documentation to.

| Q | A |
| --- | --- |
| Bug fix? | [yes |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [] |
