### PR TITLE
[DoctrineBridge] Fixed an issue with DoctrineParserCache

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ExpressionLanguage/DoctrineParserCache.php
+++ b/src/Symfony/Bridge/Doctrine/ExpressionLanguage/DoctrineParserCache.php
@@ -35,7 +35,11 @@ class DoctrineParserCache implements ParserCacheInterface
      */
     public function fetch($key)
     {
-        return $this->cache->fetch($key);
+        if (false === $value = $this->cache->fetch($key)) {
+            return null;
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/ExpressionLanguage/DoctrineParserCacheTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ExpressionLanguage/DoctrineParserCacheTest.php
@@ -29,6 +29,19 @@ class DoctrineParserCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $result);
     }
 
+    public function testFetchUnexisting()
+    {
+        $doctrineCacheMock = $this->getMock('Doctrine\Common\Cache\Cache');
+        $parserCache = new DoctrineParserCache($doctrineCacheMock);
+
+        $doctrineCacheMock
+            ->expects($this->once())
+            ->method('fetch')
+            ->will($this->returnValue(false));
+
+        $this->assertNull($parserCache->fetch(''));
+    }
+
     public function testSave()
     {
         $doctrineCacheMock = $this->getMock('Doctrine\Common\Cache\Cache');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `DoctrineParserCache` returns `false` when there is no entry (https://github.com/doctrine/cache/blob/master/lib/Doctrine/Common/Cache/Cache.php#L52).
But the `ExpressionLanguage` class expects `null` to be returned by the `ParserCacheInterface`, which causes the expressions to not be parsed when using a `DoctrineParserCache`.
