### PR TITLE
[Routing] add missing unit tests for Route and RouteCollection classes

### DIFF
--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -259,13 +259,13 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $collection->add('a', new Route('/a'));
         $collection->add('b', new Route('/b', array('placeholder' => 'default'), array('placeholder' => '.+')));
 
-        $collectionBis = clone $collection;
+        $clonedCollection = clone $collection;
 
-        $this->assertEquals(2, count($collectionBis));
-        $this->assertEquals($collection->get('a'),$collectionBis->get('a'));
-        $this->assertNotSame($collection->get('a'),$collectionBis->get('a'));
-        $this->assertEquals($collection->get('b'),$collectionBis->get('b'));
-        $this->assertNotSame($collection->get('b'),$collectionBis->get('b'));
+        $this->assertCount(2, $clonedCollection);
+        $this->assertEquals($collection->get('a'), $clonedCollection->get('a'));
+        $this->assertNotSame($collection->get('a'), $clonedCollection->get('a'));
+        $this->assertEquals($collection->get('b'), $clonedCollection->get('b'));
+        $this->assertNotSame($collection->get('b'), $clonedCollection->get('b'));
     }
 
     public function testSetSchemes()

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -252,4 +252,47 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{locale}.example.com', $routea->getHost());
         $this->assertEquals('{locale}.example.com', $routeb->getHost());
     }
+
+    public function testClone()
+    {
+        $collection = new RouteCollection();
+        $collection->add('a', new Route('/a'));
+        $collection->add('b', new Route('/b', array('placeholder' => 'default'), array('placeholder' => '.+')));
+
+        $collectionBis = clone $collection;
+
+        $this->assertEquals(2, count($collectionBis));
+        $this->assertEquals($collection->get('a'),$collectionBis->get('a'));
+        $this->assertNotSame($collection->get('a'),$collectionBis->get('a'));
+        $this->assertEquals($collection->get('b'),$collectionBis->get('b'));
+        $this->assertNotSame($collection->get('b'),$collectionBis->get('b'));
+    }
+
+    public function testSetSchemes()
+    {
+        $collection = new RouteCollection();
+        $routea = new Route('/a', array(), array(), array(), '', 'http');
+        $routeb = new Route('/b');
+        $collection->add('a', $routea);
+        $collection->add('b', $routeb);
+
+        $collection->setSchemes(array('http', 'https'));
+
+        $this->assertEquals(array('http', 'https'), $routea->getSchemes());
+        $this->assertEquals(array('http', 'https'), $routeb->getSchemes());
+    }
+
+    public function testSetMethods()
+    {
+        $collection = new RouteCollection();
+        $routea = new Route('/a', array(), array(), array(), '', array(), array('GET', 'POST'));
+        $routeb = new Route('/b');
+        $collection->add('a', $routea);
+        $collection->add('b', $routeb);
+
+        $collection->setMethods('PUT');
+
+        $this->assertEquals(array('PUT'), $routea->getMethods());
+        $this->assertEquals(array('PUT'), $routeb->getMethods());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -62,6 +62,15 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'foo', 'bar' => 'bar', 'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler'), $route->getOptions(), '->addDefaults() keep previous defaults');
     }
 
+    public function testOption()
+    {
+        $route = new Route('/{foo}');
+        $this->assertFalse($route->hasOption('foo'), '->hasOption() return false if option is not setted');
+        $this->assertEquals($route, $route->setOption('foo', 'bar'), '->setOption() implements a fluent interface');
+        $this->assertEquals('bar', $route->getOption('foo'), '->setOption() sets the option');
+        $this->assertTrue($route->hasOption('foo'), '->hasOption() return true if option is setted');
+    }
+
     public function testDefaults()
     {
         $route = new Route('/{foo}');
@@ -105,8 +114,10 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     public function testRequirement()
     {
         $route = new Route('/{foo}');
+        $this->assertFalse($route->hasRequirement('foo'), '->hasRequirement() return false if requirement is not setted');
         $route->setRequirement('foo', '^\d+$');
         $this->assertEquals('\d+', $route->getRequirement('foo'), '->setRequirement() removes ^ and $ from the path');
+        $this->assertTrue($route->hasRequirement('foo'), '->hasRequirement() return true if requirement is setted');
     }
 
     /**
@@ -196,5 +207,25 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($compiled, $route->compile(), '->compile() only compiled the route once if unchanged');
         $route->setRequirement('foo', '.*');
         $this->assertNotSame($compiled, $route->compile(), '->compile() recompiles if the route was modified');
+    }
+
+    public function testPattern()
+    {
+        $route = new Route('/{foo}');
+        $this->assertEquals('/{foo}', $route->getPattern());
+
+        $route->setPattern('/bar');
+        $this->assertEquals('/bar', $route->getPattern());
+    }
+
+    public function testSerialize()
+    {
+        $route = new Route('/{foo}', array('foo' => 'default'), array('foo' => '\d+'));
+
+        $serialized = serialize($route);
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($route, $unserialized);
+        $this->assertNotSame($route, $unserialized);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -65,10 +65,10 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     public function testOption()
     {
         $route = new Route('/{foo}');
-        $this->assertFalse($route->hasOption('foo'), '->hasOption() return false if option is not setted');
+        $this->assertFalse($route->hasOption('foo'), '->hasOption() return false if option is not set');
         $this->assertEquals($route, $route->setOption('foo', 'bar'), '->setOption() implements a fluent interface');
         $this->assertEquals('bar', $route->getOption('foo'), '->setOption() sets the option');
-        $this->assertTrue($route->hasOption('foo'), '->hasOption() return true if option is setted');
+        $this->assertTrue($route->hasOption('foo'), '->hasOption() return true if option is set');
     }
 
     public function testDefaults()
@@ -83,7 +83,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 
         $route->setDefault('foo2', 'bar2');
         $this->assertEquals('bar2', $route->getDefault('foo2'), '->getDefault() return the default value');
-        $this->assertNull($route->getDefault('not_defined'), '->getDefault() return null if default value is not setted');
+        $this->assertNull($route->getDefault('not_defined'), '->getDefault() return null if default value is not set');
 
         $route->setDefault('_controller', $closure = function () { return 'Hello'; });
         $this->assertEquals($closure, $route->getDefault('_controller'), '->setDefault() sets a default value');
@@ -114,10 +114,10 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     public function testRequirement()
     {
         $route = new Route('/{foo}');
-        $this->assertFalse($route->hasRequirement('foo'), '->hasRequirement() return false if requirement is not setted');
+        $this->assertFalse($route->hasRequirement('foo'), '->hasRequirement() return false if requirement is not set');
         $route->setRequirement('foo', '^\d+$');
         $this->assertEquals('\d+', $route->getRequirement('foo'), '->setRequirement() removes ^ and $ from the path');
-        $this->assertTrue($route->hasRequirement('foo'), '->hasRequirement() return true if requirement is setted');
+        $this->assertTrue($route->hasRequirement('foo'), '->hasRequirement() return true if requirement is set');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Just add few unit tests in Route and RouteCollection classes to have a full coverage.
