### PR TITLE
Propel1 exception message

### DIFF
--- a/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
+++ b/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
@@ -17,6 +17,8 @@ use \Persistent;
 
 use Symfony\Component\Form\Exception\StringCastException;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
@@ -84,6 +86,13 @@ class ModelChoiceList extends ObjectChoiceList
         $this->class        = $class;
 
         $queryClass         = $this->class.'Query';
+        if (!class_exists($queryClass)) {
+            if (empty($this->class)) {
+                throw new MissingOptionsException('The "class" parameter is empty, you should provide the model class');
+            }
+            throw new InvalidOptionsException(sprintf('The query class "%s" is not found, you should provide the FQCN of the model class', $queryClass));
+        }
+
         $query              = new $queryClass();
 
         $this->query        = $queryObject ?: $query;

--- a/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/ModelChoiceListTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/ModelChoiceListTest.php
@@ -243,4 +243,20 @@ class ModelChoiceListTest extends Propel1TestCase
         $this->assertEquals(array(), $choiceList->getValuesForChoices(array(new Item(2, 'Bar'))));
         $this->assertEquals(array(), $choiceList->getChoicesForValues(array(2)));
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     */
+    public function testEmptyClass()
+    {
+        $choiceList = new ModelChoiceList('');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testInvalidClass()
+    {
+        $choiceList = new ModelChoiceList('Foo\Bar\DoesNotExistClass');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9932 |
| License | MIT |
| Doc PR | none |

This add exception message for `ModelChoiceList` and `ModelType` when `class` parameter is not provided or invalid
