### PR TITLE
[Process] Add support SAPI cli-server

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -39,7 +39,7 @@ class PhpExecutableFinder
         }
 
         // PHP_BINARY return the current sapi executable
-        if (defined('PHP_BINARY') && PHP_BINARY && ('cli' === PHP_SAPI) && is_file(PHP_BINARY)) {
+        if (defined('PHP_BINARY') && PHP_BINARY && in_array(PHP_SAPI, array('cli', 'cli-server')) && is_file(PHP_BINARY)) {
             return PHP_BINARY;
         }
 


### PR DESCRIPTION
As of PHP 5.4.0, the CLI SAPI provides a built-in web server.

``` php
PHP_SAPI == 'cli-server'
```

PHP can be used portable without installation on PC. For example, the [assembly](http://windows.php.net/download/) does not require installation in the system on Windows. In this case `PHP_BINARY` contains the path to the PHP executor, and all the other search methods will not return result.
