### PR TITLE
[EventDispatcher] Fix hardcoded listenerTag name in error message

### DIFF
--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -70,7 +70,7 @@ class RegisterListenersPass implements CompilerPassInterface
                 $priority = isset($event['priority']) ? $event['priority'] : 0;
 
                 if (!isset($event['event'])) {
-                    throw new \InvalidArgumentException(sprintf('Service "%s" must define the "event" attribute on "kernel.event_listener" tags.', $id));
+                    throw new \InvalidArgumentException(sprintf('Service "%s" must define the "event" attribute on "%s" tags.', $id, $this->listenerTag));
                 }
 
                 if (!isset($event['method'])) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | N/A |
| License | MIT |

Just as the title say, there was a kernel.event_listener string hardcoded in an error message although everywhere else in this class it is stored in the `$listenerTag` property.
