### PR TITLE
[FrameworkBundle] Update composer.json to account for #9792

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/dependency-injection" : "~2.2",
         "symfony/config" : "~2.4",
-        "symfony/event-dispatcher": "~2.1",
+        "symfony/event-dispatcher": "~2.5",
         "symfony/http-foundation": "~2.4",
         "symfony/http-kernel": "~2.4",
         "symfony/filesystem": "~2.3",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In #9792 RegisterListenersPass was moved from HttpKernel to EventDispatcher. Since FrameworkBundle uses that class the dependency needs to be rises to 2.5.
