### PR TITLE
[BrowserKit] Throw exception on invalid cookie expiration timestamp

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -80,6 +80,8 @@ class Cookie
      * Returns the HTTP representation of the Cookie.
      *
      * @return string The HTTP representation of the Cookie
+     * 
+     * @throws \UnexpectedValueException
      *
      * @api
      */
@@ -88,7 +90,13 @@ class Cookie
         $cookie = sprintf('%s=%s', $this->name, $this->rawValue);
 
         if (null !== $this->expires) {
-            $cookie .= '; expires='.substr(\DateTime::createFromFormat('U', $this->expires, new \DateTimeZone('GMT'))->format(self::$dateFormats[0]), 0, -5);
+            $dateTime = \DateTime::createFromFormat('U', $this->expires, new \DateTimeZone('GMT'));
+
+            if ($dateTime === false) {
+                throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.'), $this->expires);
+            }
+
+            $cookie .= '; expires='.substr($dateTime->format(self::$dateFormats[0]), 0, -5);
         }
 
         if ('' !== $this->domain) {

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -80,7 +80,7 @@ class Cookie
      * Returns the HTTP representation of the Cookie.
      *
      * @return string The HTTP representation of the Cookie
-     * 
+     *
      * @throws \UnexpectedValueException
      *
      * @api


### PR DESCRIPTION
Currently, if an invalid timestamp is provided, a fatal error with no stack trace will occur, making it difficult to trace the problem.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
