### PR TITLE
[Translator] Fix Empty translations with Qt files

### DIFF
--- a/src/Symfony/Component/Translation/Loader/QtFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/QtFileLoader.php
@@ -53,11 +53,15 @@ class QtFileLoader implements LoaderInterface
         if ($nodes->length == 1) {
             $translations = $nodes->item(0)->nextSibling->parentNode->parentNode->getElementsByTagName('message');
             foreach ($translations as $translation) {
-                $catalogue->set(
-                    (string) $translation->getElementsByTagName('source')->item(0)->nodeValue,
-                    (string) $translation->getElementsByTagName('translation')->item(0)->nodeValue,
-                    $domain
-                );
+                $translationValue = (string) $translation->getElementsByTagName('translation')->item(0)->nodeValue;
+
+                if (!empty($translationValue)) {
+                    $catalogue->set(
+                        (string) $translation->getElementsByTagName('source')->item(0)->nodeValue,
+                        $translationValue,
+                        $domain
+                    );
+                }
                 $translation = $translation->nextSibling;
             }
             $catalogue->addResource(new FileResource($resource));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | n/a |
| Fixed tickets | no |
| License | MIT |
| Doc PR |  |

When you use ts files, QtLinguist, generate empty string for all translations, even if there are not translated yet.

It could be a good idea to generate an entry in the MessageCatalogue only if translation value is not empty.
