### PR TITLE
[Form] Update minimal requirement in composer.json

### DIFF
--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -20,7 +20,7 @@
         "symfony/event-dispatcher": "~2.1",
         "symfony/intl": "~2.3",
         "symfony/options-resolver": "~2.1",
-        "symfony/property-access": "~2.2"
+        "symfony/property-access": "~2.3"
     },
     "require-dev": {
         "symfony/validator": "~2.2",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| Fixed tickets | #9959 |
| License | MIT |

Minimal requirement for PropertyAccess component needs to be `~2.3` as Form component depends on new method `PropertyAccess::createPropertyAccessor()`.
