### PR TITLE
[HttpFoundation] JsonResponse::setEncodingOptions accepts also integer

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -117,18 +117,13 @@ class JsonResponse extends Response
     /**
      * Sets options used while encoding data to JSON.
      *
-     * @param array $encodingOptions
+     * @param integer $encodingOptions
      *
      * @return JsonResponse
      */
-    public function setEncodingOptions(array $encodingOptions)
+    public function setEncodingOptions($encodingOptions)
     {
-        $this->encodingOptions = 0;
-        foreach ($encodingOptions as $encodingOption) {
-            if (($this->encodingOptions & $encodingOption) != $encodingOption) {
-                $this->encodingOptions |= $encodingOption;
-            }
-        }
+        $this->encodingOptions = (integer) $encodingOptions;
 
         return $this->setData(json_decode($this->data));
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -180,7 +180,7 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('[[1,2,3]]', $response->getContent());
 
-        $response->setEncodingOptions(array(JSON_FORCE_OBJECT));
+        $response->setEncodingOptions(JSON_FORCE_OBJECT);
 
         $this->assertEquals('{"0":{"0":1,"1":2,"2":3}}', $response->getContent());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Tests pass? | yes |
| License | MIT |

Now you can also set encoding options like:

``` php
$response->setEncodingOptions(JSON_UNESCAPED_UNICODE | $response->getEncodingOptions());
```
