### PR TITLE
added feedback to the cache:clear command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -66,7 +66,8 @@ EOF
         }
 
         $kernel = $this->getContainer()->get('kernel');
-        $output->writeln(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+        $output->writeln($this->getClearingCacheMessage($output, $kernel));
+
         $this->getContainer()->get('cache_clearer')->clear($realCacheDir);
 
         if ($input->getOption('no-warmup')) {
@@ -77,9 +78,11 @@ EOF
             $warmupDir = substr($realCacheDir, 0, -1).'_';
 
             if ($filesystem->exists($warmupDir)) {
+                $this->writelnIfVerbose($output, 'Clearing outdated warmup directory...');
                 $filesystem->remove($warmupDir);
             }
 
+            $this->writelnIfVerbose($output, 'Warming up cache...');
             $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
 
             $filesystem->rename($realCacheDir, $oldCacheDir);
@@ -87,9 +90,41 @@ EOF
                 sleep(1);  // workaround for Windows PHP rename bug
             }
             $filesystem->rename($warmupDir, $realCacheDir);
+            $this->writelnIfVerbose($output, 'Warm up completed...');
         }
 
+        $this->writelnIfVerbose($output, 'Removing old cache directory...');
         $filesystem->remove($oldCacheDir);
+        $this->writelnIfVerbose($output, 'Completed clearing cache' . ($input->getOption('no-warmup') ? "!" : " and warmup!"));
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param KernelInterface $kernel
+     * @return string
+     */
+    protected function getClearingCacheMessage(OutputInterface $output, KernelInterface $kernel){
+        $message = 'Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>';
+        $message .= $this->isVerbose($output) ? ":" : "";
+        return sprintf($message, $kernel->getEnvironment(), var_export($kernel->isDebug(), true));
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param string $message
+     */
+    protected function writelnIfVerbose(OutputInterface $output, $message){
+        if ($this->isVerbose($output)){
+            $output->writeln($message);
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @return bool
+     */
+    protected function isVerbose(OutputInterface $output){
+        return OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity();
     }
 
     /**


### PR DESCRIPTION
simplified version of #9463

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9463 |
| License | MIT |
| Doc PR | n/a |

"Especially in production it is sometimes critical to know exactly when your cache is cleared or warmed up. Currently cache:clear provides no feedback whats however. As sites get bigger, so become their cache files. Removing old cache files may sometimes even take minutes. Without any feedback from the cache:clear you do not know the current status.

That's why i added more feedback to the cache:clear command that it makes it possible to see when your cache is warmed up and ready to go."
