### PR TITLE
[CssSelector] fixed numeric attribute issue

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -378,6 +378,11 @@ class Parser implements ParserInterface
         $stream->skipWhitespace();
         $value = $stream->getNext();
 
+        if ($value->isNumber()) {
+            // if the value is a number, it's casted into a string
+            $value = new Token(Token::TYPE_STRING, (string) $value->getValue(), $value->getPosition());
+        }
+
         if (!($value->isIdentifier() || $value->isString())) {
             throw SyntaxErrorException::unexpectedToken('string or identifier', $value);
         }

--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -133,6 +133,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             array('div#foobar', array('Hash[Element[div]#foobar]')),
             array('div:not(div.foo)', array('Negation[Element[div]:not(Class[Element[div].foo])]')),
             array('td ~ th', array('CombinedSelector[Element[td] ~ Element[th]]')),
+            array('.foo[data-bar][data-baz=0]', array("Attribute[Attribute[Class[Element[*].foo][data-bar]][data-baz = '0']]")),
         );
     }
 


### PR DESCRIPTION
This PR adds a cast from number to string when parsing a numeric attribute value.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9968 |
