### PR TITLE
[TwigBundle] Handle Exception during twig rendering

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error_fallback.html
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error_fallback.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>An Error Occurred: {{ status_text }}</title>
+    </head>
+    <body>
+        <h1>Oops! An Error Occurred</h1>
+        <h2>The server returned a "{{ status_code }} {{ status_text }}".</h2>
+
+        <div>
+            Something is broken. We will fix it as soon
+            as possible. Sorry for any inconvenience caused.
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
An Exception can be throw by twig during rendering an other exception (i.e. when using is_granted()).
This exception was not caught, and non-secure data were sent to the client.
With this commit, we fallback to a secure HTML file

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
