### PR TITLE
Bug Fixed!

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -117,7 +117,7 @@ class ExceptionListener implements EventSubscriberInterface
             // keep for BC -- as $format can be an argument of the controller callable
             // see src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
             // @deprecated in 2.4, to be removed in 3.0
-            'format' => $request->getRequestFormat(),
+            '_format' => $request->getRequestFormat(),
         );
         $request = $request->duplicate(null, null, $attributes);
         $request->setMethod('GET');


### PR DESCRIPTION
Change 'format' key of $attributes to '_format' to correct with: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php#L48
