### PR TITLE
[Doctrine Bridge][Validator] Fix for null values in assosiated properties when using UniqueEntityValidator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -330,9 +330,6 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $violationsList->count());
     }
 
-    /**
-     * @group GH-7382
-     */
     public function testAssociatedEntityWithNull()
     {
         $entityManagerName = "foo";

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -331,6 +331,26 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group GH-7382
+     */
+    public function testAssociatedEntityWithNull()
+    {
+        $entityManagerName = "foo";
+        $em = DoctrineTestHelper::createTestEntityManager();
+        $this->createSchema($em);
+        $validator = $this->createValidator($entityManagerName, $em, 'Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity', array('single'), null, 'findBy', false);
+
+        $associated = new AssociationEntity();
+        $associated->single = null;
+
+        $em->persist($associated);
+        $em->flush();
+
+        $violationsList = $validator->validate($associated);
+        $this->assertEquals(0, $violationsList->count());
+    }
+
+    /**
      * @group GH-1635
      */
     public function testAssociatedCompositeEntity()

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -89,7 +89,7 @@ class UniqueEntityValidator extends ConstraintValidator
                 return;
             }
 
-            if ($class->hasAssociation($fieldName)) {
+            if ($class->hasAssociation($fieldName) && null !== $criteria[$fieldName]) {
                 /* Ensure the Proxy is initialized before using reflection to
                  * read its identifiers. This is necessary because the wrapped
                  * getter methods in the Proxy are being bypassed.

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -89,7 +89,7 @@ class UniqueEntityValidator extends ConstraintValidator
                 return;
             }
 
-            if ($class->hasAssociation($fieldName) && null !== $criteria[$fieldName]) {
+            if (null !== $criteria[$fieldName] && $class->hasAssociation($fieldName)) {
                 /* Ensure the Proxy is initialized before using reflection to
                  * read its identifiers. This is necessary because the wrapped
                  * getter methods in the Proxy are being bypassed.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7382 |
| License | MIT |
| Doc PR |  |

This fixes issue with UniqueEntityValidator when ignoreNull = false and associated property contains null value:

```
Warning: ReflectionProperty::getValue() expects parameter 1 to be object, null given in [...]/symfony2/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php line 670 
```

Here's what docs say about ignoreNull:

> If this option is set to true, then the constraint will allow multiple entities to have a null value for a field without failing validation. If set to false, only one null value is allowed - if a second entity also has a null value, validation would fail.
