### PR TITLE
[Routing][FrameworkBundle] Deprecated the apache dumper

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -271,6 +271,8 @@ UPGRADE FROM 2.x to 3.0
    <?php echo $view['form']->end($form) ?>
    ```
 
+ * The `RouterApacheDumperCommand` was removed.
+
 ### HttpKernel
 
  * The `Symfony\Component\HttpKernel\Log\LoggerInterface` has been removed in
@@ -380,6 +382,10 @@ UPGRADE FROM 2.x to 3.0
    $route->setMethods(array('POST', 'PUT'));
    $route->setSchemes('https');
    ```
+
+ * The `ApacheMatcherDumper` and `ApacheUrlMatcher` were removed since
+   the performance gains were minimal and it's hard to replicate the behaviour
+   of PHP implementation.
 
 ### Security
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 2.5.0
 -----
 
-* Added `yaml:lint` command
+ * Added `yaml:lint` command
+ * Deprecated the `RouterApacheDumperCommand` which will be removed in Symfony 3.0.
 
 2.4.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
@@ -21,6 +21,10 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * RouterApacheDumperCommand.
  *
+ * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+ *             The performance gains are minimal and it's very hard to replicate
+ *             the behavior of PHP implementation.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class RouterApacheDumperCommand extends ContainerAwareCommand

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+2.5.0
+-----
+
+ * [DEPRECATION] The `ApacheMatcherDumper` and `ApacheUrlMatcher` were deprecated and
+   will be removed in Symfony 3.0, since the performance gains were minimal and
+   it's hard to replicate the behaviour of PHP implementation.
+
 2.3.0
 -----
 

--- a/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
@@ -16,6 +16,10 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 /**
  * ApacheUrlMatcher matches URL based on Apache mod_rewrite matching (see ApacheMatcherDumper).
  *
+ * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+ *             The performance gains are minimal and it's very hard to replicate
+ *             the behavior of PHP implementation.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
  */

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -16,6 +16,10 @@ use Symfony\Component\Routing\Route;
 /**
  * Dumps a set of Apache mod_rewrite rules.
  *
+ * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+ *             The performance gains are minimal and it's very hard to replicate
+ *             the behavior of PHP implementation.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Kris Wallsmith <kris@symfony.com>
  */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #9652 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3446 |
