### PR TITLE
[TwigBridge] Update min. version of Twig

### DIFF
--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "twig/twig": "~1.11"
+        "twig/twig": "~1.12"
     },
     "require-dev": {
         "symfony/form": "~2.2",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kinda |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| License | MIT |

The minimal version of Twig must be 1.12 because of usage the method `Twig_SimpleFunction` that was added in that version.
