### PR TITLE
[Form] Deprecated max_length and pattern options

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -377,8 +377,6 @@
     {%- if read_only %} readonly="readonly"{% endif -%}
     {%- if disabled %} disabled="disabled"{% endif -%}
     {%- if required %} required="required"{% endif -%}
-    {%- if max_length %} maxlength="{{ max_length }}"{% endif -%}
-    {%- if pattern %} pattern="{{ pattern }}"{% endif -%}
     {%- for attrname, attrvalue in attr -%}
         {{- " " -}}
         {%- if attrname in ['placeholder', 'title'] -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -1,8 +1,6 @@
 id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($read_only): ?>readonly="readonly" <?php endif ?>
 <?php if ($disabled): ?>disabled="disabled" <?php endif ?>
 <?php if ($required): ?>required="required" <?php endif ?>
-<?php if ($max_length): ?>maxlength="<?php echo $view->escape($max_length) ?>" <?php endif ?>
-<?php if ($pattern): ?>pattern="<?php echo $view->escape($pattern) ?>" <?php endif ?>
 <?php foreach ($attr as $k => $v): ?>
 <?php if (in_array($v, array('placeholder', 'title'), true)): ?>
 <?php printf('%s="%s" ', $view->escape($k), $view->escape($view['translator']->trans($v, array(), $translation_domain))) ?>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ------
 
  * added an option for multiple files upload
+ * deprecated options "max_length" and "pattern" in favor of putting these values in "attr" option
 
 2.4.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -92,8 +92,8 @@ class FormType extends BaseType
             'value'      => $form->getViewData(),
             'data'       => $form->getNormData(),
             'required'   => $form->isRequired(),
-            'max_length' => $options['max_length'],
-            'pattern'    => $options['pattern'],
+            'max_length' => isset($options['attr']['maxlength']) ? $options['attr']['maxlength'] : null, // Deprecated
+            'pattern'    => isset($options['attr']['pattern']) ? $options['attr']['pattern'] : null, // Deprecated
             'size'       => null,
             'label_attr' => $options['label_attr'],
             'compound'   => $form->getConfig()->getCompound(),
@@ -170,6 +170,22 @@ class FormType extends BaseType
             'data',
         ));
 
+        // BC clause for the "max_length" and "pattern" option
+        // Add these values to the "attr" option instead
+        $defaultAttr = function (Options $options) {
+            $attributes = array();
+
+            if (null !== $options['max_length']) {
+                $attributes['maxlength'] = $options['max_length'];
+            }
+
+            if (null !== $options['pattern']) {
+                $attributes['pattern'] = $options['pattern'];
+            }
+
+            return $attributes;
+        };
+
         $resolver->setDefaults(array(
             'data_class'         => $dataClass,
             'empty_data'         => $emptyData,
@@ -190,6 +206,7 @@ class FormType extends BaseType
             // According to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt)
             // section 4.2., empty URIs are considered same-document references
             'action'             => '',
+            'attr'               => $defaultAttr
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -113,11 +113,11 @@ class FormFactory implements FormFactoryInterface
         $pattern   = $patternGuess ? $patternGuess->getValue() : null;
 
         if (null !== $pattern) {
-            $options = array_merge(array('pattern' => $pattern), $options);
+            $options = array_merge(array('attr' => array('pattern' => $pattern)), $options);
         }
 
         if (null !== $maxLength) {
-            $options = array_merge(array('max_length' => $maxLength), $options);
+            $options = array_merge(array('attr' => array('maxlength' => $maxLength)), $options);
         }
 
         if ($requiredGuess) {

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1253,7 +1253,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testEmailWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'email', 'foo&bar', array(
-            'max_length' => 123,
+            'attr' => array('maxlength' => 123),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1419,7 +1419,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testPasswordWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'password', 'foo&bar', array(
-            'max_length' => 123,
+            'attr' => array('maxlength' => 123),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1490,7 +1490,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testTextarea()
     {
         $form = $this->factory->createNamed('name', 'textarea', 'foo&bar', array(
-            'pattern' => 'foo',
+            'attr' => array('pattern' => 'foo'),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1519,7 +1519,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testTextWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'text', 'foo&bar', array(
-            'max_length' => 123,
+            'attr' => array('maxlength' => 123),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1899,9 +1899,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
             'required' => true,
             'disabled' => true,
             'read_only' => true,
-            'max_length' => 10,
-            'pattern' => '\d+',
-            'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
+            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
         ));
 
         $html = $this->renderWidget($form->createView());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -68,16 +68,16 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->at(0))
             ->method('createNamed')
-            ->with(1, 'text', null, array('property_path' => '[1]', 'max_length' => 10, 'auto_initialize' => false))
+            ->with(1, 'text', null, array('property_path' => '[1]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
             ->will($this->returnValue($this->getForm('1')));
         $this->factory->expects($this->at(1))
             ->method('createNamed')
-            ->with(2, 'text', null, array('property_path' => '[2]', 'max_length' => 10, 'auto_initialize' => false))
+            ->with(2, 'text', null, array('property_path' => '[2]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
             ->will($this->returnValue($this->getForm('2')));
 
         $data = array(1 => 'string', 2 => 'string');
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', array('max_length' => '10'), false, false);
+        $listener = new ResizeFormListener('text', array('attr' => array('maxlength' => 10)), false, false);
         $listener->preSetData($event);
 
         $this->assertFalse($this->form->has('0'));
@@ -112,12 +112,12 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->once())
             ->method('createNamed')
-            ->with(1, 'text', null, array('property_path' => '[1]', 'max_length' => 10, 'auto_initialize' => false))
+            ->with(1, 'text', null, array('property_path' => '[1]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
             ->will($this->returnValue($this->getForm('1')));
 
         $data = array(0 => 'string', 1 => 'string');
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', array('max_length' => 10), true, false);
+        $listener = new ResizeFormListener('text', array('attr' => array('maxlength' => 10)), true, false);
         $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -31,7 +31,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form = $this->factory->create('collection', null, array(
             'type' => 'text',
             'options' => array(
-                'max_length' => 20,
+                'attr' => array('maxlength' => 20),
             ),
         ));
         $form->setData(array('foo@foo.com', 'foo@bar.com'));
@@ -41,15 +41,18 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertCount(2, $form);
         $this->assertEquals('foo@foo.com', $form[0]->getData());
         $this->assertEquals('foo@bar.com', $form[1]->getData());
-        $this->assertEquals(20, $form[0]->getConfig()->getOption('max_length'));
-        $this->assertEquals(20, $form[1]->getConfig()->getOption('max_length'));
+        $formAttrs0 = $form[0]->getConfig()->getOption('attr');
+        $formAttrs1 = $form[1]->getConfig()->getOption('attr');
+        $this->assertEquals(20, $formAttrs0['maxlength']);
+        $this->assertEquals(20, $formAttrs1['maxlength']);
 
         $form->setData(array('foo@baz.com'));
         $this->assertInstanceOf('Symfony\Component\Form\Form', $form[0]);
         $this->assertFalse(isset($form[1]));
         $this->assertCount(1, $form);
         $this->assertEquals('foo@baz.com', $form[0]->getData());
-        $this->assertEquals(20, $form[0]->getConfig()->getOption('max_length'));
+        $formAttrs0 = $form[0]->getConfig()->getOption('attr');
+        $this->assertEquals(20, $formAttrs0['maxlength']);
     }
 
     public function testThrowsExceptionIfObjectIsNotTraversable()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -132,10 +132,18 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMaxLengthToView()
     {
+        $form = $this->factory->create('form', null, array('attr' => array('maxlength' => 10)));
+        $view = $form->createView();
+
+        $this->assertSame(10, $view->vars['attr']['maxlength']);
+    }
+
+    public function testPassMaxLengthBCToView()
+    {
         $form = $this->factory->create('form', null, array('max_length' => 10));
         $view = $form->createView();
 
-        $this->assertSame(10, $view->vars['max_length']);
+        $this->assertSame(10, $view->vars['attr']['maxlength']);
     }
 
     public function testSubmitWithEmptyDataCreatesObjectIfClassAvailable()

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -399,7 +399,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->with('Application\Author', 'firstName')
             ->will($this->returnValue(new TypeGuess(
                 'text',
-                array('max_length' => 10),
+                array('attr' => array('maxlength' => 10)),
                 Guess::MEDIUM_CONFIDENCE
             )));
 
@@ -408,7 +408,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->with('Application\Author', 'firstName')
             ->will($this->returnValue(new TypeGuess(
                 'password',
-                array('max_length' => 7),
+                array('attr' => array('maxlength' => 7)),
                 Guess::HIGH_CONFIDENCE
             )));
 
@@ -416,7 +416,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'password', null, array('max_length' => 7))
+            ->with('firstName', 'password', null, array('attr' => array('maxlength' => 7)))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
@@ -450,7 +450,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 ->with('Application\Author', 'firstName')
                 ->will($this->returnValue(new TypeGuess(
                     'text',
-                    array('max_length' => 10),
+                    array('attr' => array('maxlength' => 10)),
                     Guess::MEDIUM_CONFIDENCE
                 )));
 
@@ -458,14 +458,14 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('max_length' => 11))
+            ->with('firstName', 'text', null, array('attr' => array('maxlength' => 11)))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
             'firstName',
             null,
-            array('max_length' => 11)
+            array('attr' => array('maxlength' => 11))
         );
 
         $this->assertEquals('builderInstance', $this->builder);
@@ -493,7 +493,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('max_length' => 20))
+            ->with('firstName', 'text', null, array('attr' => array('maxlength' => 20)))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
@@ -559,7 +559,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('pattern' => '[a-zA-Z]'))
+            ->with('firstName', 'text', null, array('attr' => array('pattern' => '[a-zA-Z]')))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(


### PR DESCRIPTION
Split of issue #9759

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | `max_length` and `pattern` in form options |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3461 |
