### PR TITLE
[Validator] Fixed constraint violation to string not handling array

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -95,7 +95,10 @@ class ConstraintViolation implements ConstraintViolationInterface
      */
     public function __toString()
     {
-        $class = (string) (is_object($this->root) ? get_class($this->root) : $this->root);
+        $class = is_object($this->root)
+            ? get_class($this->root)
+            : (is_array($this->root) ? 'Array' : (string) $this->root);
+
         $propertyPath = (string) $this->propertyPath;
         $code = $this->code;
 

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -33,4 +33,23 @@ EOF;
 
         $this->assertSame($expected, (string) $violation);
     }
+
+    public function testToStringHandlesArraysRootAsValue()
+    {
+        $violation = new ConstraintViolation(
+            'Array',
+            '{{ value }}',
+            array('{{ value }}' => array(1, 2, 3)),
+            array(),
+            'property.path',
+            null
+        );
+
+        $expected = <<<EOF
+Array.property.path:
+    Array
+EOF;
+
+        $this->assertSame($expected, (string) $violation);
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints\Type;
 
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -230,6 +231,16 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->metadataFactory->addMetadata($metadata);
 
         $this->validator->validateValue($entity, new Valid());
+    }
+
+    public function testValidateValueViolationsToStringHandlesArrays()
+    {
+        $violations = $this->validator->validateValue(
+            array(),
+            array(new Type(array('type' => 'string')))
+        );
+
+        $this->assertInternalType('string', (string) $violations);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This bug was introduced on [PR-790 [2.3] [Validator] added comparison constraints and validators](https://github.com/symfony/symfony/pull/790)

Due to the change on root (to become the value):

``` diff
-        $context = new ExecutionContext($this->createVisitor(null), $this->translator, $this->translationDomain);
+        $context = new ExecutionContext($this->createVisitor($value), $this->translator, $this->translationDomain);
```

https://github.com/symfony/symfony/pull/790/files#diff-f4a93c3d8fcb85a24ea41c2a993e6d83R163

My change on:

``` diff
-        $class = (string) (is_object($this->root) ? get_class($this->root) : $this->root);
+        $class = is_object($this->root)
+            ? get_class($this->root)
+            : (is_array($this->root) ? 'Array' : (string) $this->root);
+
```

Is inspired on [TypeValidator](https://github.com/symfony/symfony/blob/07992d352c8293cdae5a65e7e27fac5254ecbc49/src/Symfony/Component/Validator/Constraints/TypeValidator.php#L47)
