### PR TITLE
[Twig Bridge] Fixed bug in ExpressionExtension

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/ExpressionExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/ExpressionExtension.php
@@ -30,7 +30,7 @@ class ExpressionExtension extends \Twig_Extension
         );
     }
 
-    private function createExpression($expression)
+    public function createExpression($expression)
     {
         return new Expression($expression);
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/ExpressionExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/ExpressionExtensionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use Symfony\Bridge\Twig\Extension\ExpressionExtension;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+class ExpressionExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    protected $helper;
+
+    public function testExpressionCreation()
+    {
+        $template = "{{ expression('1 == 1') }}";
+        $twig = new \Twig_Environment(new \Twig_Loader_String(), array('debug' => true, 'cache' => false, 'autoescape' => true, 'optimizations' => 0));
+        $twig->addExtension(new ExpressionExtension());
+
+        $output = $twig->render($template);
+        $this->assertEquals('1 == 1', $output);
+    }
+}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -28,7 +28,8 @@
         "symfony/translation": "~2.2",
         "symfony/yaml": "~2.0",
         "symfony/security": "~2.4",
-        "symfony/stopwatch": "~2.2"
+        "symfony/stopwatch": "~2.2",
+        "symfony/expression-language": "~2.4"
     },
     "suggest": {
         "symfony/form": "For using the FormExtension",
@@ -38,7 +39,8 @@
         "symfony/translation": "For using the TranslationExtension",
         "symfony/yaml": "For using the YamlExtension",
         "symfony/security": "For using the SecurityExtension",
-        "symfony/stopwatch": "For using the StopwatchExtension"
+        "symfony/stopwatch": "For using the StopwatchExtension",
+        "symfony/expression": "For using the ExpressionExtension"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Twig\\": "" }


### PR DESCRIPTION
Currently it's impossible to use the expression extension in Twig as the <code> ExpressionExtension ::createExpression</code> method is defined as private which will throw an exception: <code>Fatal error: Call to private method Symfony\Bridge\Twig\Extension\ExpressionExtension::createExpression() from context '__TwigTemplate_83f94baa63f1faa30cdacee32980572936c887ef25baa389ebddd7a666db3a9b'</code>

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
