### PR TITLE
[FrameworkBundle] Thrown an HttpException instead returning a Response in RedirectController::redirectAction()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -39,11 +40,13 @@ class RedirectController extends ContainerAware
      * @param Boolean|array $ignoreAttributes Whether to ignore attributes or an array of attributes to ignore
      *
      * @return Response A Response instance
+     *
+     * @throws HttpException In case the route name is empty
      */
     public function redirectAction(Request $request, $route, $permanent = false, $ignoreAttributes = false)
     {
         if ('' == $route) {
-            return new Response(null, $permanent ? 410 : 404);
+            throw new HttpException($permanent ? 410 : 404);
         }
 
         $attributes = array();
@@ -75,11 +78,13 @@ class RedirectController extends ContainerAware
      * @param integer|null $httpsPort The HTTPS port (null to keep the current one for the same scheme or the configured port in the container)
      *
      * @return Response A Response instance
+     *
+     * @throws HttpException In case the path is empty
      */
     public function urlRedirectAction(Request $request, $path, $permanent = false, $scheme = null, $httpPort = null, $httpsPort = null)
     {
         if ('' == $path) {
-            return new Response(null, $permanent ? 410 : 404);
+            throw new HttpException($permanent ? 410 : 404);
         }
 
         $statusCode = $permanent ? 301 : 302;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
@@ -27,13 +28,19 @@ class RedirectControllerTest extends TestCase
         $request = new Request();
         $controller = new RedirectController();
 
-        $returnResponse = $controller->redirectAction($request, '', true);
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
-        $this->assertEquals(410, $returnResponse->getStatusCode());
+        try {
+            $controller->redirectAction($request, '', true);
+            $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
+        } catch (HttpException $e) {
+            $this->assertSame(410, $e->getStatusCode());
+        }
 
-        $returnResponse = $controller->redirectAction($request, '', false);
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
-        $this->assertEquals(404, $returnResponse->getStatusCode());
+        try {
+            $controller->redirectAction($request, '', false);
+            $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
+        } catch (HttpException $e) {
+            $this->assertSame(404, $e->getStatusCode());
+        }
     }
 
     /**
@@ -98,13 +105,19 @@ class RedirectControllerTest extends TestCase
         $request = new Request();
         $controller = new RedirectController();
 
-        $returnResponse = $controller->urlRedirectAction($request, '', true);
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
-        $this->assertEquals(410, $returnResponse->getStatusCode());
+        try {
+            $controller->urlRedirectAction($request, '', true);
+            $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
+        } catch (HttpException $e) {
+            $this->assertSame(410, $e->getStatusCode());
+        }
 
-        $returnResponse = $controller->urlRedirectAction($request, '', false);
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
-        $this->assertEquals(404, $returnResponse->getStatusCode());
+        try {
+            $controller->urlRedirectAction($request, '', false);
+            $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
+        } catch (HttpException $e) {
+            $this->assertSame(404, $e->getStatusCode());
+        }
     }
 
     public function testFullURL()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9243 |
| License | MIT |
| Doc PR | - |

I'm considering this to be a bug fix, since before, a missing path or route name would result in rendering a blank page.
