### PR TITLE
Bugfix - Logger Deprecation Notice

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Logger.php
@@ -101,7 +101,7 @@ class Logger implements LoggerInterface
      */
     public function crit($message, array $context = array())
     {
-        trigger_error('Use crit() which is PSR-3 compatible', E_USER_DEPRECATED);
+        trigger_error('Use critical() which is PSR-3 compatible', E_USER_DEPRECATED);
 
         $this->log('critical', $message, $context);
     }
@@ -111,7 +111,7 @@ class Logger implements LoggerInterface
      */
     public function err($message, array $context = array())
     {
-        trigger_error('Use err() which is PSR-3 compatible', E_USER_DEPRECATED);
+        trigger_error('Use error() which is PSR-3 compatible', E_USER_DEPRECATED);
 
         $this->log('error', $message, $context);
     }
@@ -121,7 +121,7 @@ class Logger implements LoggerInterface
      */
     public function warn($message, array $context = array())
     {
-        trigger_error('Use warn() which is PSR-3 compatible', E_USER_DEPRECATED);
+        trigger_error('Use warning() which is PSR-3 compatible', E_USER_DEPRECATED);
 
         $this->log('warning', $message, $context);
     }


### PR DESCRIPTION
This PR fixes the Logger deprecation notices to match the correct method name it should be informing of.
