### PR TITLE
[Expression Language] fix foo[index]

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -81,12 +81,12 @@ class GetAttrNode extends Node
                 return call_user_func_array(array($obj, $this->nodes['attribute']->evaluate($functions, $values)), $this->nodes['arguments']->evaluate($functions, $values));
 
             case self::ARRAY_CALL:
-                $values = $this->nodes['node']->evaluate($functions, $values);
-                if (!is_array($values) && !$values instanceof \ArrayAccess) {
+                $array = $this->nodes['node']->evaluate($functions, $values);
+                if (!is_array($array) && !$array instanceof \ArrayAccess) {
                     throw new \RuntimeException('Unable to get an item on a non-array.');
                 }
 
-                return $values[$this->nodes['attribute']->evaluate($functions, $values)];
+                return $array[$this->nodes['attribute']->evaluate($functions, $values)];
         }
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -27,6 +27,7 @@ class GetAttrNodeTest extends AbstractNodeTest
             array('bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
 
             array('baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
+            array('a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), array('foo' => array('b' => 'a', 'b'), 'index' => 'b')),
         );
     }
 
@@ -39,6 +40,7 @@ class GetAttrNodeTest extends AbstractNodeTest
             array('$foo->foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
 
             array('$foo->foo(array("b" => "a", 0 => "b"))', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
+            array('$foo[$index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This patch fixes the usage of variables as key in GetAttrNode.

``` php
$language = new \Symfony\Component\ExpressionLanguage\ExpressionLanguage();
$language->evaluate('foo[i]', ['foo' => ['a', 'b', 'c'], 'i' => 1]); // 'b'
```
