### PR TITLE
[EventDispatcher] Throw exception is subscriber is miss configured

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -120,6 +120,9 @@ class EventDispatcher implements EventDispatcherInterface
     public function addSubscriber(EventSubscriberInterface $subscriber)
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
+            if (is_int($eventName)) {
+                throw new \InvalidArgumentException(sprintf('The EventSubscriber "%s" is mis configured. Did you mean "%s => \'%s\'" ?', get_class($subscriber), $eventName, print_r($params, true)));
+            }
             if (is_string($params)) {
                 $this->addListener($eventName, array($subscriber, $params));
             } elseif (is_string($params[0])) {

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -183,6 +183,16 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->dispatcher->hasListeners(self::postFoo));
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The EventSubscriber "Symfony\Component\EventDispatcher\Tests\TestEventSubscriberTypo" is mis configured. Did you mean "0 => 'pre.foo'" ?
+     */
+    public function testAddSubscriberThrowExceptionIfSubscriberMisConfigured()
+    {
+        $eventSubscriber = new TestEventSubscriberTypo();
+        $this->dispatcher->addSubscriber($eventSubscriber);
+    }
+
     public function testAddSubscriberWithPriorities()
     {
         $eventSubscriber = new TestEventSubscriber();
@@ -319,6 +329,17 @@ class TestEventSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array('pre.foo' => 'preFoo', 'post.foo' => 'postFoo');
+    }
+}
+
+class TestEventSubscriberTypo implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        // User should use:
+        // return array('pre.foo' => 'preFoo');
+        // instead of:
+        return array('pre.foo', 'preFoo');
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | maybe |
| New feature? | no |
| BC breaks? | maybe |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Lot of new comers (during trainings) made the same typo:

``` php
class TestEventSubscriberTypo implements EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return array('pre.foo', 'preFoo');
    }
}
```

instead of

``` php
class TestEventSubscriberTypo implements EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return array('pre.foo' => 'preFoo');
    }
}
```

So I added a check.

This can be a BC break as the event name can be an int. But I think (I hope?)
nobody do that.
