### PR TITLE
[Form] Added additional data attributes for collection type output

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -31,8 +31,16 @@
 
 {% block collection_widget %}
 {% spaceless %}
+    {% set attr = attr|merge({
+        'data-form-widget': 'collection',
+        'data-collection-allow-add': allow_add,
+        'data-collection-allow-delete': allow_delete,
+    }) %}
     {% if prototype is defined %}
-        {% set attr = attr|merge({'data-prototype': form_row(prototype) }) %}
+        {% set attr = attr|merge({
+            'data-prototype-name': prototype_name,
+            'data-prototype': form_row(prototype)
+        }) %}
     {% endif %}
     {{ block('form_widget') }}
 {% endspaceless %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/collection_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/collection_widget.html.php
@@ -1,4 +1,8 @@
+<?php $attr['data-form-widget'] = 'collection' ?>
+<?php $attr['data-collection-allow-add'] = $allow_add ?>
+<?php $attr['data-collection-allow-delete'] = $allow_delete ?>
 <?php if (isset($prototype)): ?>
+    <?php $attr['data-prototype-name'] = $prototype_name; ?>
     <?php $attr['data-prototype'] = $view->escape($view['form']->row($prototype)) ?>
 <?php endif ?>
 <?php echo $view['form']->widget($form, array('attr' => $attr)) ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -56,6 +56,7 @@ class CollectionType extends AbstractType
 
         if ($form->getConfig()->hasAttribute('prototype')) {
             $view->vars['prototype'] = $form->getConfig()->getAttribute('prototype')->createView($view);
+            $view->vars['prototype_name'] = $options['prototype_name'];
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -290,6 +290,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/div
+    [@data-form-widget="collection"]
     [
         ./div[./input[@type="text"][@value="a"]]
         /following-sibling::div[./input[@type="text"][@value="b"]]
@@ -312,6 +313,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/div
+    [@data-form-widget="collection"]
     [
         ./div[./div/div/input[@type="text"][@value="a"]]
         /following-sibling::div[./div/div/textarea[.="b"]]
@@ -330,6 +332,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/div
+    [@data-form-widget="collection"]
     [./input[@type="hidden"][@id="name__token"]]
     [count(./div)=0]
 '
@@ -351,6 +354,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/div
+    [@data-form-widget="collection"]
     [
         ./div
             [
@@ -676,6 +680,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/div
+    [@data-form-widget="collection"]
     [
         ./div[./label[.="Custom label: [trans]0[/trans]"]]
         /following-sibling::div[./label[.="Custom label: [trans]1[/trans]"]]

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1760,16 +1760,33 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testCollectionPrototype()
     {
         $form = $this->factory->createNamedBuilder('name', 'form', array('items' => array('one', 'two', 'three')))
-            ->add('items', 'collection', array('allow_add' => true))
+            ->add('items', 'collection', array(
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'prototype_name' => '__item__'
+                ))
             ->getForm()
             ->createView();
 
         $html = $this->renderWidget($form);
 
         $this->assertMatchesXpath($html,
-            '//div[@id="name_items"][@data-prototype]
+            '//div
+                [@id="name_items"]
+                [@data-form-widget="collection"]
+                [@data-prototype]
+                [@data-prototype-name="__item__"]
+                [@data-prototype-allow-add="data-collection-allow-add"]
+                [@data-prototype-allow-add="data-collection-allow-delete"]
             |
-            //table[@id="name_items"][@data-prototype]'
+            //table
+                [@id="name_items"]
+                [@data-form-widget="collection"]
+                [@data-prototype]
+                [@data-prototype-name="__item__"]
+                [@data-prototype-allow-add="data-collection-allow-add"]
+                [@data-prototype-allow-add="data-collection-allow-delete"]
+            '
         );
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -200,6 +200,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/table
+    [@data-form-widget="collection"]
     [
         ./tr[./td/input[@type="text"][@value="a"]]
         /following-sibling::tr[./td/input[@type="text"][@value="b"]]
@@ -218,6 +219,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/table
+    [@data-form-widget="collection"]
     [./tr[@style="display: none"][./td[@colspan="2"]/input[@type="hidden"][@id="name__token"]]]
     [count(./tr[./td/input])=1]
 '
@@ -445,6 +447,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/table
+    [@data-form-widget="collection"]
     [
         ./tr[./td/label[.="Custom label: [trans]0[/trans]"]]
         /following-sibling::tr[./td/label[.="Custom label: [trans]1[/trans]"]]


### PR DESCRIPTION
Refactored and up to date w/ master version of: #7713

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | na |
| License | MIT |
| Doc PR | WIP |
- [x] fix the tests as they have not been updated yet
- [ ] submit changes to the documentation

---

I've added 4 extra data-\* attributes to collections in twig and php views for easier js manipulation.

New attributes:
- `data-form-widget='collection'`: This is a collection and all children are form types
- `data-collection-allow-add`: Allow adding of new elements
- `data-collection-allow-delete`: Allow deletion of elements (new and existing)
- `data-prototype-name`: The prototype name

This should make javascript integration much easier.

Example js:

``` js
$('[data-form-widget=collection]').each(function(){

    var $collection = $(this),
        prototypeString = $collection.data('prototype'),
        prototypeName = $collection.data('prototypeName') || '__name__',
        prototypeNameRegx = new RegExp(prototypeName+"(label__)?","g"),
        count = $collection.children().length;

    console.log(this, count, prototypeString);

    var $deleteLink = $("<span />", {
        'class': 'js-delete',
        'text': 'Delete'
    });

    var $addLink = $("<span />", {
        'class': 'js-add',
        'text': 'Add'
    });

    if($collection.data('collectionAllowDelete')) {

        $collection
            .children()
            .append($deleteLink.clone(true));

        $collection.on('click', '.js-delete', function(){
            event.preventDefault();
            $(this).parent().remove();
        });
    }

    if($collection.data('collectionAllowAdd')) {

        $addLink.click(function(event){
            event.preventDefault();
            var newPrototypeString = prototypeString.replace(prototypeNameRegx, count),
                $newPrototype = $(newPrototypeString).append($deleteLink.clone(true));
            $newPrototype.insertBefore($addLink);
            count++;
        });

        $collection.append($addLink);
    }
});
```

Replaces #7713
