### PR TITLE
[Console] [Event] Added COMMAND_ADD event

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -36,6 +36,7 @@ use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Event\ConsoleCommandAddEvent;
 
 /**
  * An Application is the container for a collection of commands.
@@ -398,6 +399,11 @@ class Application
     public function add(Command $command)
     {
         $command->setApplication($this);
+
+        if (null !== $this->dispatcher) {
+            $event = new ConsoleCommandAddEvent($command);
+            $this->dispatcher->dispatch(ConsoleEvents::COMMAND_ADD, $event);
+        }
 
         if (!$command->isEnabled()) {
             $command->setApplication(null);

--- a/src/Symfony/Component/Console/ConsoleEvents.php
+++ b/src/Symfony/Component/Console/ConsoleEvents.php
@@ -31,6 +31,18 @@ final class ConsoleEvents
     const COMMAND = 'console.command';
 
     /**
+     * The COMMAND_ADD event allows you to attach listeners which are called when a command
+     * is added to the Application - after the application has been set on the command but
+     * before it has been registred with the application.
+     *
+     * The event listener method receives a Symfony\Component\Console\Event\ConsoleCommandAddEvent
+     * instance.
+     *
+     * @var string
+     */
+    const COMMAND_ADD = 'console.command-add';
+
+    /**
      * The TERMINATE event allows you to attach listeners after a command is
      * executed by the console.
      *

--- a/src/Symfony/Component/Console/Event/ConsoleCommandAddEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleCommandAddEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Event;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Enables access to a command immediately after
+ * is has been added to the application.
+ *
+ * This event is useful for decorating the command
+ * definition.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class ConsoleCommandAddEvent extends Event
+{
+    protected $command;
+
+    public function __construct(Command $command)
+    {
+        $this->command = $command;
+    }
+
+    /**
+     * Gets the command that is executed.
+     *
+     * @return Command A Command instance
+     */
+    public function getCommand()
+    {
+        return $this->command;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | tba |

This PR adds a COMMAND_ADD event. The primary use case is to enable listeners to modify the commands input definition, which is really useful in big CLI applications where commands share command traits.
