### PR TITLE
[Console] [Event] Added COMMAND_INITIALIZE event

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -399,6 +399,10 @@ class Application
     {
         $command->setApplication($this);
 
+        if (null !== $this->dispatcher) {
+            $command->setDispatcher($this->dispatcher);
+        }
+
         if (!$command->isEnabled()) {
             $command->setApplication(null);
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -21,6 +21,9 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandInitializeEvent;
 
 /**
  * Base class for all commands.
@@ -44,6 +47,7 @@ class Command
     private $code;
     private $synopsis;
     private $helperSet;
+    private $dispatcher;
 
     /**
      * Constructor.
@@ -67,6 +71,11 @@ class Command
         if (!$this->name) {
             throw new \LogicException('The command name cannot be empty.');
         }
+    }
+
+    public function setDispatcher(EventDispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
     }
 
     /**
@@ -236,6 +245,11 @@ class Command
             if (!$this->ignoreValidationErrors) {
                 throw $e;
             }
+        }
+
+        if (null !== $this->dispatcher) {
+            $event = new ConsoleCommandInitializeEvent($this, $input, $output);
+            $this->dispatcher->dispatch(ConsoleEvents::COMMAND_INITIALIZE, $event);
         }
 
         $this->initialize($input, $output);

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandInitializeEvent;
 
@@ -73,7 +73,7 @@ class Command
         }
     }
 
-    public function setDispatcher(EventDispatcher $dispatcher)
+    public function setDispatcher(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
     }

--- a/src/Symfony/Component/Console/ConsoleEvents.php
+++ b/src/Symfony/Component/Console/ConsoleEvents.php
@@ -31,6 +31,19 @@ final class ConsoleEvents
     const COMMAND = 'console.command';
 
     /**
+     * The COMMAND_INITIALIZE event allows you to attach listeners which can act upon the
+     * command before it has been executed but after its values have been bound.
+     *
+     * This is useful for validation for example.
+     *
+     * The event listener method receives a Symfony\Component\Console\Event\ConsoleCommandInitializeEvent
+     * instance.
+     *
+     * @var string
+     */
+    const COMMAND_INITIALIZE = 'console.command-initialize';
+
+    /**
      * The TERMINATE event allows you to attach listeners after a command is
      * executed by the console.
      *
@@ -52,4 +65,6 @@ final class ConsoleEvents
      * @var string
      */
     const EXCEPTION = 'console.exception';
+
+
 }

--- a/src/Symfony/Component/Console/ConsoleEvents.php
+++ b/src/Symfony/Component/Console/ConsoleEvents.php
@@ -65,6 +65,4 @@ final class ConsoleEvents
      * @var string
      */
     const EXCEPTION = 'console.exception';
-
-
 }

--- a/src/Symfony/Component/Console/Event/ConsoleCommandInitializeEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleCommandInitializeEvent.php
@@ -21,4 +21,3 @@ namespace Symfony\Component\Console\Event;
 class ConsoleCommandInitializeEvent extends ConsoleEvent
 {
 }
-

--- a/src/Symfony/Component/Console/Event/ConsoleCommandInitializeEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleCommandInitializeEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Event;
+
+/**
+ * Allows listeners to do things to a command after
+ * values have been bound to its input fields. Runs just
+ * before the "intiialize" method.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class ConsoleCommandInitializeEvent extends ConsoleEvent
+{
+}
+

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -811,9 +811,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function testRunWithDispatcher()
     {
+        $dispatcher = $this->getDispatcher();
         $application = new Application();
         $application->setAutoExit(false);
-        $application->setDispatcher($this->getDispatcher());
+        $application->setDispatcher($dispatcher);
 
         $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
             $output->write('foo.');
@@ -822,6 +823,16 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester = new ApplicationTester($application);
         $tester->run(array('command' => 'foo'));
         $this->assertEquals('before.foo.after.', $tester->getDisplay());
+
+        $command = $application->get('foo');
+
+        $refl = new \ReflectionClass(get_class($command));
+        $reflProp = $refl->getProperty('dispatcher');
+        $reflProp->setAccessible(true);
+        $commandDispatcher = $reflProp->getValue($command);
+
+        $this->assertNotNull($commandDispatcher);
+        $this->assertSame($dispatcher, $commandDispatcher);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -288,20 +288,18 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $testCase = $this;
 
         $command = new \TestCommand();
-        $in = new StringInput('');
-        $out = new NullOutput();
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addListener('console.command-initialize',
-            function (ConsoleCommandInitializeEvent $event) use ($testCase, $command, $in, $out) {
-                $testCase->assertSame($command, $event->getCommand());
-                $testCase->assertSame($in, $event->getInput());
-                $testCase->assertSame($out, $event->getOutput());
+            function (ConsoleCommandInitializeEvent $event) use ($command) {
+                $event->getOutput()->writeln('Listener called');
             }
         );
         $command->setDispatcher($dispatcher);
 
-        $command->run($in, $out);
+        $tester = new CommandTester($command);
+        $tester->execute(array());
+        $this->assertContains('Listener called'.PHP_EOL, $tester->getDisplay());
     }
 
     public function testSetCode()

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Console\Event\ConsoleCommandInitializeEvent;
 
 class CommandTest extends \PHPUnit_Framework_TestCase
 {
@@ -279,6 +281,27 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command = new \TestCommand();
 
         $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
+    }
+
+    public function testRunWithDispatcher()
+    {
+        $testCase = $this;
+
+        $command = new \TestCommand();
+        $in = new StringInput('');
+        $out = new NullOutput();
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('console.command-initialize',
+            function (ConsoleCommandInitializeEvent $event) use ($testCase, $command, $in, $out) {
+                $testCase->assertSame($command, $event->getCommand());
+                $testCase->assertSame($in, $event->getInput());
+                $testCase->assertSame($out, $event->getOutput());
+            }
+        );
+        $command->setDispatcher($dispatcher);
+
+        $command->run($in, $out);
     }
 
     public function testSetCode()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | tba |

This event fires before the initialize() method is called on the command, enabling listeners to validate the input prior to execution.
