### PR TITLE
[Process] The suffixes are empty if PHP_WINDOWS_VERSION_BUILD is not defined

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -72,10 +72,11 @@ class ExecutableFinder
             );
         }
 
-        $suffixes = array('');
+        $suffixes = $this->suffixes;
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $pathExt = getenv('PATHEXT');
-            $suffixes = $pathExt ? explode(PATH_SEPARATOR, $pathExt) : $this->suffixes;
+            if ($pathExt = getenv('PATHEXT')) {
+                $suffixes = explode(PATH_SEPARATOR, $pathExt);
+            }
         }
         foreach ($suffixes as $suffix) {
             foreach ($dirs as $dir) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
