### PR TITLE
[WIP][Console] Add ContainerAwareCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
@@ -11,39 +11,24 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\Console\DependencyInjection\ContainerAwareCommand as BaseContainerAwareCommand;
 
 /**
  * Command.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class ContainerAwareCommand extends Command implements ContainerAwareInterface
+abstract class ContainerAwareCommand extends BaseContainerAwareCommand
 {
-    /**
-     * @var ContainerInterface|null
-     */
-    private $container;
-
     /**
      * @return ContainerInterface
      */
     protected function getContainer()
     {
-        if (null === $this->container) {
+        if (null === parent::getContainer()) {
             $this->container = $this->getApplication()->getKernel()->getContainer();
         }
 
-        return $this->container;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
+        return parent::getContainer();
     }
 }

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * added a way to set a default command instead of `ListCommand`
 * added a way to set the process name of a command
+* added ContainerAwareCommand
 
 2.4.0
 -----

--- a/src/Symfony/Component/Console/DependencyInjection/ContainerAwareCommand.php
+++ b/src/Symfony/Component/Console/DependencyInjection/ContainerAwareCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\DependencyInjection;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+/**
+ * Command.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+abstract class ContainerAwareCommand extends Command implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface|null
+     */
+    private $container;
+
+    /**
+     * @return ContainerInterface
+     */
+    protected function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In the spirit of #7435 I propose adding a ContainerAwareCommand to the Console Component. This is helpful when implementing both the DIC and the Console.

I'm fairly certain the code remaining in ContainerAwareCommand in the FrameworkBundle could also be dropped as the Container is injected into every command by the Application. This would also make it a little easier to move code between Projects using the Framework and those using only the Components.

Todo:
- [ ] Get feedback whether the code remaining in FrameworkBundle is actually necessary.
