### PR TITLE
[Form] Fixed bug that incorrectly causes the "required" attribute to be ...

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -67,7 +67,7 @@
 
 {% block choice_widget_collapsed %}
 {% spaceless %}
-    {% if required and empty_value is none and not empty_value_in_choices %}
+    {% if required and empty_value is none and not empty_value_in_choices and not multiple %}
         {% set required = false %}
     {% endif %}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_collapsed.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_collapsed.html.php
@@ -1,6 +1,9 @@
 <select
+    <?php if ($required && $empty_value === null && $empty_value_in_choices === false && $multiple === false):
+        $required = false;
+    endif; ?>
     <?php echo $view['form']->block($form, 'widget_attributes', array(
-        'required' => $required && (null !== $empty_value || $empty_value_in_choices)
+        'required' => $required
     )) ?>
     <?php if ($multiple): ?> multiple="multiple"<?php endif ?>
 >

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -636,6 +636,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
+            'required' => true,
             'multiple' => true,
             'expanded' => false,
         ));
@@ -643,6 +644,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
     [@name="name[]"]
+    [@required="required"]
     [@multiple="multiple"]
     [
         ./option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]


### PR DESCRIPTION
...omitted from select even though it contains the "multiple" attribute.

According to the HTML5 specification the required attribute should be allowed in this case: "A select element with a required attribute and **without** a multiple attribute, and whose size is “1”, must have a child option element."

Related PR: https://github.com/symfony/symfony/pull/9030

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
