### PR TITLE
[Translation] Update PluralizationRules.php

### DIFF
--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -114,6 +114,7 @@ class PluralizationRules
             case 'pap':
             case 'ps':
             case 'pt':
+            case 'xbr':
             case 'so':
             case 'sq':
             case 'sv':
@@ -134,7 +135,6 @@ class PluralizationRules
             case 'ln':
             case 'mg':
             case 'nso':
-            case 'xbr':
             case 'ti':
             case 'wa':
                 return (($number == 0) || ($number == 1)) ? 0 : 1;


### PR DESCRIPTION
As a native brazilian portuguese speaker, and also respecting http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#pt definitions, 0 elements are normally used in plural form.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
