### PR TITLE
[ClassLoader] A PSR-4 compatible class loader

### DIFF
--- a/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
@@ -12,9 +12,9 @@
 namespace Symfony\Component\ClassLoader;
 
 /**
- * ClassLoader implements an PSR-4 class loader
+ * A PSR-4 compatible class loader.
  *
- * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
+ * See http://www.php-fig.org/psr/psr-4/
  *
  * @author Alexander M. Turek <me@derrabus.de>
  */
@@ -31,13 +31,14 @@ class Psr4ClassLoader
      */
     public function addPrefix($prefix, $baseDir)
     {
-        $prefix = trim($prefix, '\\') . '\\';
+        $prefix = trim($prefix, '\\').'\\';
         $baseDir = rtrim($baseDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $this->prefixes[] = array($prefix, $baseDir);
     }
 
     /**
      * @param string $class
+     *
      * @return string|null
      */
     public function findFile($class)
@@ -46,7 +47,7 @@ class Psr4ClassLoader
 
         foreach ($this->prefixes as $current) {
             list($currentPrefix, $currentBaseDir) = $current;
-            if (strpos($class, $currentPrefix) === 0) {
+            if (0 === strpos($class, $currentPrefix)) {
                 $classWithoutPrefix = substr($class, strlen($currentPrefix));
                 $file = $currentBaseDir . str_replace('\\', DIRECTORY_SEPARATOR, $classWithoutPrefix) . '.php';
                 if (file_exists($file)) {
@@ -60,12 +61,13 @@ class Psr4ClassLoader
 
     /**
      * @param string $class
+     *
      * @return bool
      */
     public function loadClass($class)
     {
         $file = $this->findFile($class);
-        if ($file !== null) {
+        if (null !== $file) {
             require $file;
 
             return true;

--- a/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ClassLoader;
+
+/**
+ * ClassLoader implements an PSR-4 class loader
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+class Psr4ClassLoader
+{
+    /**
+     * @var array
+     */
+    private $prefixes = array();
+
+    /**
+     * @param string $prefix
+     * @param string $baseDir
+     */
+    public function addPrefix($prefix, $baseDir)
+    {
+        $prefix = trim($prefix, '\\') . '\\';
+        $baseDir = rtrim($baseDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $this->prefixes[] = array($prefix, $baseDir);
+    }
+
+    /**
+     * @param string $class
+     * @return string|null
+     */
+    public function findFile($class)
+    {
+        $class = ltrim($class, '\\');
+
+        foreach ($this->prefixes as $current) {
+            list($currentPrefix, $currentBaseDir) = $current;
+            if (strpos($class, $currentPrefix) === 0) {
+                $classWithoutPrefix = substr($class, strlen($currentPrefix));
+                $file = $currentBaseDir . str_replace('\\', DIRECTORY_SEPARATOR, $classWithoutPrefix) . '.php';
+                if (file_exists($file)) {
+                    return $file;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $class
+     * @return bool
+     */
+    public function loadClass($class)
+    {
+        $file = $this->findFile($class);
+        if ($file !== null) {
+            require $file;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Registers this instance as an autoloader.
+     *
+     * @param bool $prepend
+     */
+    public function register($prepend = false)
+    {
+        spl_autoload_register(array($this, 'loadClass'), true, $prepend);
+    }
+
+    /**
+     * Removes this instance from the registered autoloaders.
+     */
+    public function unregister()
+    {
+        spl_autoload_unregister(array($this, 'loadClass'));
+    }
+} 

--- a/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
@@ -91,4 +91,4 @@ class Psr4ClassLoader
     {
         spl_autoload_unregister(array($this, 'loadClass'));
     }
-} 
+}

--- a/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
@@ -55,14 +55,12 @@ class Psr4ClassLoader
                 }
             }
         }
-
-        return;
     }
 
     /**
      * @param string $class
      *
-     * @return bool
+     * @return Boolean
      */
     public function loadClass($class)
     {
@@ -79,7 +77,7 @@ class Psr4ClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param bool $prepend
+     * @param Boolean $prepend
      */
     public function register($prepend = false)
     {

--- a/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
@@ -56,7 +56,7 @@ class Psr4ClassLoader
             }
         }
 
-        return null;
+        return;
     }
 
     /**

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Class_With_Underscores.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Class_With_Underscores.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Acme\DemoLib;
+
+class Class_With_Underscores
+{
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Acme\DemoLib;
+
+class Foo
+{
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Lets/Go/Deeper/Class_With_Underscores.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Lets/Go/Deeper/Class_With_Underscores.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Acme\DemoLib\Lets\Go\Deeper;
+
+class Class_With_Underscores
+{
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Lets/Go/Deeper/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Lets/Go/Deeper/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Acme\DemoLib\Lets\Go\Deeper;
+
+class Foo
+{
+} 

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Lets/Go/Deeper/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/psr-4/Lets/Go/Deeper/Foo.php
@@ -4,4 +4,4 @@ namespace Acme\DemoLib\Lets\Go\Deeper;
 
 class Foo
 {
-} 
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Psr4ClassLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Psr4ClassLoaderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ClassLoader\Tests;
+
+use Symfony\Component\ClassLoader\Psr4ClassLoader;
+
+class Psr4ClassLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $className
+     * @dataProvider getLoadClassTests
+     */
+    public function testLoadClass($className)
+    {
+        $loader = new Psr4ClassLoader();
+        $loader->addPrefix(
+            'Acme\\DemoLib',
+            __DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'psr-4'
+        );
+        $loader->loadClass($className);
+        $this->assertTrue(class_exists($className), sprintf('loadClass() should load %s', $className));
+    }
+
+    /**
+     * @return array
+     */
+    public function getLoadClassTests()
+    {
+        return array(
+            array('Acme\\DemoLib\\Foo'),
+            array('Acme\\DemoLib\\Class_With_Underscores'),
+            array('Acme\\DemoLib\\Lets\\Go\\Deeper\\Foo'),
+            array('Acme\\DemoLib\\Lets\\Go\\Deeper\\Class_With_Underscores')
+        );
+    }
+
+    /**
+     * @param string $className
+     * @dataProvider getLoadNonexistentClassTests
+     */
+    public function testLoadNonexistentClass($className)
+    {
+        $loader = new Psr4ClassLoader();
+        $loader->addPrefix(
+            'Acme\\DemoLib',
+            __DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'psr-4'
+        );
+        $loader->loadClass($className);
+        $this->assertFalse(class_exists($className), sprintf('loadClass() should not load %s', $className));
+    }
+
+    /**
+     * @return array
+     */
+    public function getLoadNonexistentClassTests()
+    {
+        return array(
+            array('Acme\\DemoLib\\I_Do_Not_Exist'),
+            array('UnknownVendor\\SomeLib\\I_Do_Not_Exist')
+        );
+    }
+} 

--- a/src/Symfony/Component/ClassLoader/Tests/Psr4ClassLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Psr4ClassLoaderTest.php
@@ -68,4 +68,4 @@ class Psr4ClassLoaderTest extends \PHPUnit_Framework_TestCase
             array('UnknownVendor\\SomeLib\\I_Do_Not_Exist')
         );
     }
-} 
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This is a PSR-4 compatible class loader that I'd like to contribute to the ClassLoader component. Since PSR-4 is the most recent FIG standard for an autoloader, I thought a compatible loader should be part of a feature-complete ClassLoader component.

See: http://www.php-fig.org/psr/psr-4/

PSR-4 does neither replace PSR-0, nor are those standards 100% compatible. This is why I implemented the standard as a new class.

If you decide that my PR is worth merging, I would also provide a PR for symfony-docs with a documentation.
