### PR TITLE
[Form] Added check for parent disabled status in Button form elements

### DIFF
--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -321,7 +321,11 @@ class Button implements \IteratorAggregate, FormInterface
      */
     public function isDisabled()
     {
-        return $this->config->getDisabled();
+        if (null === $this->parent || !$this->parent->isDisabled()) {
+            return $this->config->getDisabled();
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | unclear |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10109 |
| License | MIT |
| Doc PR | - |

The Button form element did not check for the parent disabled configuration status,
making them behave differently to all other form widgets. 

This is specially visible in the situation of a top-level Form element being Disabled, which would disable all children widgets except the Buttons (and Submit buttons).

This patch simply ports the code from the base `Form.php` method in order to make the behaviour exactly the same.

Further action would include
- [ ] Document the possible Backward Compatibility issues
