### PR TITLE
[YAML] Added support for object-maps

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -314,7 +314,6 @@ class Inline
         throw new ParseException(sprintf('Malformed inline YAML string %s', $sequence));
     }
 
-
     /**
      * Parses a mapping to a YAML string.
      *
@@ -340,11 +339,10 @@ class Inline
                     ++$i;
                     continue 2;
                 case '}':
-                    if ($objectForMap === true) {
-                        return (object)$output;
-                    } else {
-                        return $output;
+                    if (true === $objectForMap ) {
+                        return (object) $output;
                     }
+                    return $output;
             }
 
             // key

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -26,7 +26,6 @@ class Inline
     private static $exceptionOnInvalidType = false;
     private static $objectSupport = false;
 
-
     /**
      * Converts a YAML string to a PHP array.
      *
@@ -257,7 +256,6 @@ class Inline
 
         return $output;
     }
-
 
     /**
      * Parses a sequence to a YAML string.

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -328,12 +328,7 @@ class Inline
      */
     private static function parseMapping($mapping, &$i = 0, $objectForMap = false)
     {
-        if ($objectForMap === true) {
-            $output = new \stdClass();
-        } else {
-            $output = array();
-        }
-
+        $output = array();
         $len = strlen($mapping);
         $i += 1;
 
@@ -345,7 +340,11 @@ class Inline
                     ++$i;
                     continue 2;
                 case '}':
-                    return $output;
+                    if ($objectForMap === true) {
+                        return (object)$output;
+                    } else {
+                        return $output;
+                    }
             }
 
             // key
@@ -354,29 +353,24 @@ class Inline
             // value
             $done = false;
 
-            if ($objectForMap === true) {
-                $editPosition = &$output->$key;
-            } else {
-                $editPosition = &$output[$key];
-            }
 
             while ($i < $len) {
                 switch ($mapping[$i]) {
                     case '[':
                         // nested sequence
-                        $editPosition = self::parseSequence($mapping, $i, $objectForMap);
+                        $output[$key] = self::parseSequence($mapping, $i, $objectForMap);
                         $done = true;
                         break;
                     case '{':
                         // nested mapping
-                        $editPosition = self::parseMapping($mapping, $i, $objectForMap);
+                        $output[$key] = self::parseMapping($mapping, $i, $objectForMap);
                         $done = true;
                         break;
                     case ':':
                     case ' ':
                         break;
                     default:
-                        $editPosition = self::parseScalar($mapping, array(',', '}'), array('"', "'"), $i);
+                        $output[$key] = self::parseScalar($mapping, array(',', '}'), array('"', "'"), $i);
                         $done = true;
                         --$i;
                 }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -339,9 +339,10 @@ class Inline
                     ++$i;
                     continue 2;
                 case '}':
-                    if (true === $objectForMap ) {
+                    if (true === $objectForMap) {
                         return (object) $output;
                     }
+
                     return $output;
             }
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -22,6 +22,23 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testParseWithMapObjects()
+    {
+        foreach ($this->getTestsForMapObjectParse() as $yaml => $value) {
+            $actual = Inline::parse($yaml, false, false, true);
+            if (is_object($value) === true) {
+                $this->assertInstanceOf(get_class($value), $actual);
+                $this->assertEquals(get_object_vars($value), get_object_vars($actual));
+            } elseif (is_array($value) === true) {
+                $this->assertEquals($value, $actual);
+                $this->assertMixedArraysSame($value, $actual);
+            } else {
+                $this->assertSame($value, $actual);
+            }
+        }
+
+    }
+
     public function testDump()
     {
         $testsForDump = $this->getTestsForDump();
@@ -182,6 +199,88 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    protected function getTestsForMapObjectParse()
+    {
+        return array(
+            '' => '',
+            'null' => null,
+            'false' => false,
+            'true' => true,
+            '12' => 12,
+            '-12' => -12,
+            '"quoted string"' => 'quoted string',
+            "'quoted string'" => 'quoted string',
+            '12.30e+02' => 12.30e+02,
+            '0x4D2' => 0x4D2,
+            '02333' => 02333,
+            '.Inf' => -log(0),
+            '-.Inf' => log(0),
+            "'686e444'" => '686e444',
+            '686e444' => 646e444,
+            '123456789123456789123456789123456789' => '123456789123456789123456789123456789',
+            '"foo\r\nbar"' => "foo\r\nbar",
+            "'foo#bar'" => 'foo#bar',
+            "'foo # bar'" => 'foo # bar',
+            "'#cfcfcf'" => '#cfcfcf',
+            '::form_base.html.twig' => '::form_base.html.twig',
+
+            '2007-10-30' => mktime(0, 0, 0, 10, 30, 2007),
+            '2007-10-30T02:59:43Z' => gmmktime(2, 59, 43, 10, 30, 2007),
+            '2007-10-30 02:59:43 Z' => gmmktime(2, 59, 43, 10, 30, 2007),
+            '1960-10-30 02:59:43 Z' => gmmktime(2, 59, 43, 10, 30, 1960),
+            '1730-10-30T02:59:43Z' => gmmktime(2, 59, 43, 10, 30, 1730),
+
+            '"a \\"string\\" with \'quoted strings inside\'"' => 'a "string" with \'quoted strings inside\'',
+            "'a \"string\" with ''quoted strings inside'''" => 'a "string" with \'quoted strings inside\'',
+
+            // sequences
+            // urls are no key value mapping. see #3609. Valid yaml "key: value" mappings require a space after the colon
+            '[foo, http://urls.are/no/mappings, false, null, 12]' => array('foo', 'http://urls.are/no/mappings', false, null, 12),
+            '[  foo  ,   bar , false  ,  null     ,  12  ]' => array('foo', 'bar', false, null, 12),
+            '[\'foo,bar\', \'foo bar\']' => array('foo,bar', 'foo bar'),
+
+            // mappings
+            '{foo:bar,bar:foo,false:false,null:null,integer:12}' => (object)array('foo' => 'bar', 'bar' => 'foo', 'false' => false, 'null' => null, 'integer' => 12),
+            '{ foo  : bar, bar : foo,  false  :   false,  null  :   null,  integer :  12  }' => (object)array('foo' => 'bar', 'bar' => 'foo', 'false' => false, 'null' => null, 'integer' => 12),
+            '{foo: \'bar\', bar: \'foo: bar\'}' => (object)array('foo' => 'bar', 'bar' => 'foo: bar'),
+            '{\'foo\': \'bar\', "bar": \'foo: bar\'}' => (object)array('foo' => 'bar', 'bar' => 'foo: bar'),
+            '{\'foo\'\'\': \'bar\', "bar\"": \'foo: bar\'}' => (object)array('foo\'' => 'bar', "bar\"" => 'foo: bar'),
+            '{\'foo: \': \'bar\', "bar: ": \'foo: bar\'}' => (object)array('foo: ' => 'bar', "bar: " => 'foo: bar'),
+
+            // nested sequences and mappings
+            '[foo, [bar, foo]]' => array('foo', array('bar', 'foo')),
+            '[foo, {bar: foo}]' => array('foo', (object)array('bar' => 'foo')),
+            '{ foo: {bar: foo} }' => (object)array('foo' => (object)array('bar' => 'foo')),
+            '{ foo: [bar, foo] }' => (object)array('foo' => array('bar', 'foo')),
+
+            '[  foo, [  bar, foo  ]  ]' => array('foo', array('bar', 'foo')),
+
+            '[{ foo: {bar: foo} }]' => array((object)array('foo' => (object)array('bar' => 'foo'))),
+
+            '[foo, [bar, [foo, [bar, foo]], foo]]' => array('foo', array('bar', array('foo', array('bar', 'foo')), 'foo')),
+
+            '[foo, {bar: foo, foo: [foo, {bar: foo}]}, [foo, {bar: foo}]]' => array('foo', (object)array('bar' => 'foo', 'foo' => array('foo', (object)array('bar' => 'foo'))), array('foo', (object)array('bar' => 'foo'))),
+
+            '[foo, bar: { foo: bar }]' => array('foo', '1' => (object)array('bar' => (object)array('foo' => 'bar'))),
+            '[foo, \'@foo.baz\', { \'%foo%\': \'foo is %foo%\', bar: \'%foo%\' }, true, \'@service_container\']' => array('foo', '@foo.baz', (object)array('%foo%' => 'foo is %foo%', 'bar' => '%foo%',), true, '@service_container',),
+
+
+            '{}' => new \stdClass(),
+            '{ foo  : bar, bar : {}  }' => (object)array('foo' => 'bar', 'bar' => new \stdClass()),
+            '{ foo  : [], bar : {}  }' => (object)array('foo' => array(), 'bar' => new \stdClass()),
+            '{foo: \'bar\', bar: {} }' => (object)array('foo' => 'bar', 'bar' => new \stdClass()),
+            '{\'foo\': \'bar\', "bar": {}}' => (object)array('foo' => 'bar', 'bar' => new \stdClass()),
+            '{\'foo\': \'bar\', "bar": \'{}\'}' => (object)array('foo' => 'bar', 'bar' => '{}'),
+
+            '[foo, [{}, {}]]' => array('foo', array(new \stdClass(), new \stdClass())),
+            '[foo, [[], {}]]' => array('foo', array(array(), new \stdClass())),
+            '[foo, [[{}, {}], {}]]' => array('foo', array(array(new \stdClass(), new \stdClass()), new \stdClass())),
+            '[foo, {bar: {}}]' => array('foo', '1' => (object)array('bar' => new \stdClass())),
+        );
+    }
+
+
+
     protected function getTestsForDump()
     {
         return array(
@@ -228,5 +327,28 @@ class InlineTest extends \PHPUnit_Framework_TestCase
 
             '[foo, \'@foo.baz\', { \'%foo%\': \'foo is %foo%\', bar: \'%foo%\' }, true, \'@service_container\']' => array('foo', '@foo.baz', array('%foo%' => 'foo is %foo%', 'bar' => '%foo%',), true, '@service_container',),
         );
+    }
+
+    protected function assertMixedArraysSame($a, $b)
+    {
+
+        foreach ($a as $key => $value) {
+            if (array_key_exists($key, $b)) {
+                if (is_array($value)) {
+                    $this->assertMixedArraysSame($value, $b[$key]);
+                } else {
+                    if (is_object($value) === true) {
+                        $this->assertEquals($value, $b[$key]);
+                        $this->assertInstanceOf(get_class($value), $b[$key]);
+                        $this->assertEquals(get_object_vars($value), get_object_vars($b[$key]));
+                    } else {
+                        $this->assertSame($value, $b[$key]);
+                    }
+                }
+            } else {
+                $this->assertFail();
+            }
+        }
+
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -240,46 +240,43 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             '[\'foo,bar\', \'foo bar\']' => array('foo,bar', 'foo bar'),
 
             // mappings
-            '{foo:bar,bar:foo,false:false,null:null,integer:12}' => (object)array('foo' => 'bar', 'bar' => 'foo', 'false' => false, 'null' => null, 'integer' => 12),
-            '{ foo  : bar, bar : foo,  false  :   false,  null  :   null,  integer :  12  }' => (object)array('foo' => 'bar', 'bar' => 'foo', 'false' => false, 'null' => null, 'integer' => 12),
-            '{foo: \'bar\', bar: \'foo: bar\'}' => (object)array('foo' => 'bar', 'bar' => 'foo: bar'),
-            '{\'foo\': \'bar\', "bar": \'foo: bar\'}' => (object)array('foo' => 'bar', 'bar' => 'foo: bar'),
-            '{\'foo\'\'\': \'bar\', "bar\"": \'foo: bar\'}' => (object)array('foo\'' => 'bar', "bar\"" => 'foo: bar'),
-            '{\'foo: \': \'bar\', "bar: ": \'foo: bar\'}' => (object)array('foo: ' => 'bar', "bar: " => 'foo: bar'),
+            '{foo:bar,bar:foo,false:false,null:null,integer:12}' => (object) array('foo' => 'bar', 'bar' => 'foo', 'false' => false, 'null' => null, 'integer' => 12),
+            '{ foo  : bar, bar : foo,  false  :   false,  null  :   null,  integer :  12  }' => (object) array('foo' => 'bar', 'bar' => 'foo', 'false' => false, 'null' => null, 'integer' => 12),
+            '{foo: \'bar\', bar: \'foo: bar\'}' => (object) array('foo' => 'bar', 'bar' => 'foo: bar'),
+            '{\'foo\': \'bar\', "bar": \'foo: bar\'}' => (object) array('foo' => 'bar', 'bar' => 'foo: bar'),
+            '{\'foo\'\'\': \'bar\', "bar\"": \'foo: bar\'}' => (object) array('foo\'' => 'bar', "bar\"" => 'foo: bar'),
+            '{\'foo: \': \'bar\', "bar: ": \'foo: bar\'}' => (object) array('foo: ' => 'bar', "bar: " => 'foo: bar'),
 
             // nested sequences and mappings
             '[foo, [bar, foo]]' => array('foo', array('bar', 'foo')),
-            '[foo, {bar: foo}]' => array('foo', (object)array('bar' => 'foo')),
-            '{ foo: {bar: foo} }' => (object)array('foo' => (object)array('bar' => 'foo')),
-            '{ foo: [bar, foo] }' => (object)array('foo' => array('bar', 'foo')),
+            '[foo, {bar: foo}]' => array('foo', (object) array('bar' => 'foo')),
+            '{ foo: {bar: foo} }' => (object) array('foo' => (object) array('bar' => 'foo')),
+            '{ foo: [bar, foo] }' => (object) array('foo' => array('bar', 'foo')),
 
             '[  foo, [  bar, foo  ]  ]' => array('foo', array('bar', 'foo')),
 
-            '[{ foo: {bar: foo} }]' => array((object)array('foo' => (object)array('bar' => 'foo'))),
+            '[{ foo: {bar: foo} }]' => array((object) array('foo' => (object) array('bar' => 'foo'))),
 
             '[foo, [bar, [foo, [bar, foo]], foo]]' => array('foo', array('bar', array('foo', array('bar', 'foo')), 'foo')),
 
-            '[foo, {bar: foo, foo: [foo, {bar: foo}]}, [foo, {bar: foo}]]' => array('foo', (object)array('bar' => 'foo', 'foo' => array('foo', (object)array('bar' => 'foo'))), array('foo', (object)array('bar' => 'foo'))),
+            '[foo, {bar: foo, foo: [foo, {bar: foo}]}, [foo, {bar: foo}]]' => array('foo', (object) array('bar' => 'foo', 'foo' => array('foo', (object) array('bar' => 'foo'))), array('foo', (object) array('bar' => 'foo'))),
 
-            '[foo, bar: { foo: bar }]' => array('foo', '1' => (object)array('bar' => (object)array('foo' => 'bar'))),
-            '[foo, \'@foo.baz\', { \'%foo%\': \'foo is %foo%\', bar: \'%foo%\' }, true, \'@service_container\']' => array('foo', '@foo.baz', (object)array('%foo%' => 'foo is %foo%', 'bar' => '%foo%',), true, '@service_container',),
-
+            '[foo, bar: { foo: bar }]' => array('foo', '1' => (object) array('bar' => (object) array('foo' => 'bar'))),
+            '[foo, \'@foo.baz\', { \'%foo%\': \'foo is %foo%\', bar: \'%foo%\' }, true, \'@service_container\']' => array('foo', '@foo.baz', (object) array('%foo%' => 'foo is %foo%', 'bar' => '%foo%',), true, '@service_container',),
 
             '{}' => new \stdClass(),
-            '{ foo  : bar, bar : {}  }' => (object)array('foo' => 'bar', 'bar' => new \stdClass()),
-            '{ foo  : [], bar : {}  }' => (object)array('foo' => array(), 'bar' => new \stdClass()),
-            '{foo: \'bar\', bar: {} }' => (object)array('foo' => 'bar', 'bar' => new \stdClass()),
-            '{\'foo\': \'bar\', "bar": {}}' => (object)array('foo' => 'bar', 'bar' => new \stdClass()),
-            '{\'foo\': \'bar\', "bar": \'{}\'}' => (object)array('foo' => 'bar', 'bar' => '{}'),
+            '{ foo  : bar, bar : {}  }' => (object) array('foo' => 'bar', 'bar' => new \stdClass()),
+            '{ foo  : [], bar : {}  }' => (object) array('foo' => array(), 'bar' => new \stdClass()),
+            '{foo: \'bar\', bar: {} }' => (object) array('foo' => 'bar', 'bar' => new \stdClass()),
+            '{\'foo\': \'bar\', "bar": {}}' => (object) array('foo' => 'bar', 'bar' => new \stdClass()),
+            '{\'foo\': \'bar\', "bar": \'{}\'}' => (object) array('foo' => 'bar', 'bar' => '{}'),
 
             '[foo, [{}, {}]]' => array('foo', array(new \stdClass(), new \stdClass())),
             '[foo, [[], {}]]' => array('foo', array(array(), new \stdClass())),
             '[foo, [[{}, {}], {}]]' => array('foo', array(array(new \stdClass(), new \stdClass()), new \stdClass())),
-            '[foo, {bar: {}}]' => array('foo', '1' => (object)array('bar' => new \stdClass())),
+            '[foo, {bar: {}}]' => array('foo', '1' => (object) array('bar' => new \stdClass())),
         );
     }
-
-
 
     protected function getTestsForDump()
     {

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -26,10 +26,10 @@ class InlineTest extends \PHPUnit_Framework_TestCase
     {
         foreach ($this->getTestsForMapObjectParse() as $yaml => $value) {
             $actual = Inline::parse($yaml, false, false, true);
-            if (is_object($value) === true) {
+            if (true === is_object($value)) {
                 $this->assertInstanceOf(get_class($value), $actual);
                 $this->assertEquals(get_object_vars($value), get_object_vars($actual));
-            } elseif (is_array($value) === true) {
+            } elseif (true === is_array($value)) {
                 $this->assertEquals($value, $actual);
                 $this->assertMixedArraysSame($value, $actual);
             } else {
@@ -334,7 +334,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
                 if (is_array($value)) {
                     $this->assertMixedArraysSame($value, $b[$key]);
                 } else {
-                    if (is_object($value) === true) {
+                    if (true === is_object($value)) {
                         $this->assertEquals($value, $b[$key]);
                         $this->assertInstanceOf(get_class($value), $b[$key]);
                         $this->assertEquals(get_object_vars($value), get_object_vars($b[$key]));


### PR DESCRIPTION
Previously, the parser treated maps (`{}`) the same as sets (`[]`).  Both were returned as a PHP associative array.  Since these are distinct entities, this can cause considerably problems if you treat the two types differently, especially when YAML is being serialized into another format such as JSON.

This PR enables empty-map support via a third optional parameter on the Parse method.  It defaults to `false`, which means that this commit does not break backwards compatibility.

If the user enables object-map support, maps are represented by a `stdClass()` object. Sets remain as PHP arrays.  This is compatible with other serialization methods, such as json_encode where empty objects are properly encoded to `{}`.

The tests are a little bulky, since `assertSame()` is too strict (e.g. two empty objects are not identical, since they are discrete objects), but `assertEquals()` is too loose (e.g. loses type-checking on the rest of the values).  I've implemented a recursive assert that uses the stricter `assertSame()` on non-objects, and a slightly looser combo of asserts for objects.

```
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
| License       | MIT
| Doc PR        | NA
```
