### PR TITLE
[Form & Profiler] Improve error displaying

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -72,6 +72,9 @@
         font-weight: bold;
         color: #313131;
     }
+    .tree a.error {
+        color: #a33;
+    }
     .tree-details {
         border-left: 1px solid #dfdfdf;
         background: white;
@@ -173,7 +176,12 @@
 
 {% macro form_tree_entry(name, data) %}
     <li>
-        <a href="#details_{{ data.id }}">{{ name }}</a>
+        <a href="#details_{{ data.id }}" class="{% if data.errors is defined and data.errors|length > 0 %}error{% endif %}">
+            {{ name }}
+            {% if data.errors is defined and data.errors|length > 0 %}
+                ({{ data.errors|length }})
+            {% endif %}
+        </a>
 
         {% if data.children is not empty %}
             <ul>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

I made this PR, because on huge form, I can't find which field has error(s)

![The Form Profiler](https://f.cloud.github.com/assets/166890/1993693/7c5698a6-84de-11e3-9240-1d7181e37385.png)
