### PR TITLE
[Validator] Minor fix in XmlFileLoader

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
@@ -36,10 +36,10 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * Creates a new constraint instance for the given constraint name.
      *
-     * @param string $name The constraint name. Either a constraint relative
-     *                        to the default constraint namespace, or a fully
-     *                        qualified class name
-     * @param array $options The constraint options
+     * @param string $name   The constraint name. Either a constraint relative
+     *                       to the default constraint namespace, or a fully
+     *                       qualified class name
+     * @param mixed $options The constraint options
      *
      * @return Constraint
      *

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -105,7 +105,7 @@ class XmlFileLoader extends FileLoader
                 $options = null;
             }
 
-            $constraints[] = $this->newConstraint($node['name'], $options);
+            $constraints[] = $this->newConstraint((string) $node['name'], $options);
         }
 
         return $constraints;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

An instance of `\SimpleXMLElement` is passed to the `newConstraint` method instead of a string which can lead to weird type juggling issues.
