### PR TITLE
Add the line number in the exception

### DIFF
--- a/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
@@ -55,7 +55,7 @@ class TransTokenParser extends \Twig_TokenParser
                 $stream->next();
                 $locale =  $this->parser->getExpressionParser()->parseExpression();
             } elseif (!$stream->test(\Twig_Token::BLOCK_END_TYPE)) {
-                throw new \Twig_Error_Syntax('Unexpected token. Twig was looking for the "with" or "from" keyword.');
+                throw new \Twig_Error_Syntax('Unexpected token. Twig was looking for the "with" or "from" keyword.', $lineno);
             }
         }
 


### PR DESCRIPTION
If a variable is present in a trans tag, the line number wasn't displayed before this change ("the text isn't present in test"). So theorically no change is necessary in tests.
