### PR TITLE
handle array root element

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -95,7 +95,14 @@ class ConstraintViolation implements ConstraintViolationInterface
      */
     public function __toString()
     {
-        $class = (string) (is_object($this->root) ? get_class($this->root) : $this->root);
+        if (is_object($this->root)) {
+            $class = get_class($this->root);
+        } elseif (is_array($this->root)) {
+            $class = "Array";
+        } else {
+            $class = (string) $this->root;
+        }
+
         $propertyPath = (string) $this->propertyPath;
         $code = $this->code;
 

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -33,4 +33,23 @@ EOF;
 
         $this->assertSame($expected, (string) $violation);
     }
+
+    public function testToStringHandlesArrayRoots()
+    {
+        $violation = new ConstraintViolation(
+            '42 cannot be used here',
+            'this is the message template',
+            array(),
+            array('some_value' =>  42),
+            'some_value',
+            null
+        );
+
+        $expected = <<<EOF
+Array.some_value:
+    42 cannot be used here
+EOF;
+
+        $this->assertSame($expected, (string) $violation);
+    }
 }


### PR DESCRIPTION
An array to string conversion notice was thrown when the root element of the thing being validated is an array.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
