### PR TITLE
[Form] Added pluralization support for labels

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -219,7 +219,7 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|transchoice(translation_count, {}, translation_domain) }}</label>
     {%- endif %}
 {%- endblock form_label %}
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
@@ -22,7 +22,7 @@ class StubTranslator implements TranslatorInterface
 
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
-        return '[trans]'.$id.'[/trans]';
+        return '[trans count='.$number.']'.$id.'[/trans]';
     }
 
     public function setLocale($locale)

--- a/src/Symfony/Bridge/Twig/Tests/Extension/custom_widgets.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/custom_widgets.html.twig
@@ -11,7 +11,7 @@
     {% if label is empty %}
         {% set label = name|humanize %}
     {% endif %}
-    <label>Custom label: {{ label|trans({}, translation_domain) }}</label>
+    <label>Custom label: {{ label|transchoice(translation_count, {}, translation_domain) }}</label>
 {% endspaceless %}
 {% endblock _names_entry_label %}
 
@@ -20,6 +20,6 @@
     {% if label is empty %}
         {% set label = name|humanize %}
     {% endif %}
-    <label>Custom name label: {{ label|trans({}, translation_domain) }}</label>
+    <label>Custom name label: {{ label|transchoice(translation_count, {}, translation_domain) }}</label>
 {% endspaceless %}
 {% endblock _name_c_entry_label %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -4,5 +4,5 @@
 <?php if (!$label) { $label = isset($label_format)
     ? strtr($label_format, array('%name%' => $name, '%id%' => $id))
     : $view['form']->humanize($name); } ?>
-<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>
+<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->transchoice($label, $translation_count, array(), $translation_domain)) ?></label>
 <?php endif ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTranslator.php
@@ -22,7 +22,7 @@ class StubTranslator implements TranslatorInterface
 
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
-        return '[trans]'.$id.'[/trans]';
+        return '[trans count='.$number.']'.$id.'[/trans]';
     }
 
     public function setLocale($locale)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Custom/_name_c_entry_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Custom/_name_c_entry_label.html.php
@@ -1,2 +1,2 @@
 <?php if (!$label) { $label = $view['form']->humanize($name); } ?>
-<label>Custom name label: <?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>
+<label>Custom name label: <?php echo $view->escape($view['translator']->transchoice($label, $translation_count, array(), $translation_domain)) ?></label>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Custom/_names_entry_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Custom/_names_entry_label.html.php
@@ -1,4 +1,4 @@
 <?php if (!$label) {
     $label = $view['form']->humanize($name);
 } ?>
-<label>Custom label: <?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>
+<label>Custom label: <?php echo $view->escape($view['translator']->transchoice($label, $translation_count, array(), $translation_domain)) ?></label>

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -98,6 +98,7 @@ abstract class BaseType extends AbstractType
             'block_prefixes'      => $blockPrefixes,
             'unique_block_prefix' => $uniqueBlockPrefix,
             'translation_domain'  => $translationDomain,
+            'translation_count'   => $options['translation_count'],
             // Using the block name here speeds up performance in collection
             // forms, where each entry has the same full block name.
             // Including the type is important too, because if rows of a
@@ -120,6 +121,7 @@ abstract class BaseType extends AbstractType
             'label_format'       => null,
             'attr'               => array(),
             'translation_domain' => null,
+            'translation_count'  => 1,
             'auto_initialize'    => true,
         ));
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -216,6 +216,10 @@ class ChoiceType extends AbstractType
             return $options['expanded'];
         };
 
+        $translationCount = function (Options $options) {
+            return $options['multiple'] ? 2 : 1;
+        };
+
         $resolver->setDefaults(array(
             'multiple'          => false,
             'expanded'          => false,
@@ -227,6 +231,7 @@ class ChoiceType extends AbstractType
             'placeholder'       => $placeholder,
             'error_bubbling'    => false,
             'compound'          => $compound,
+            'translation_count' => $translationCount,
             // The view data is always a string, even if the "data" option
             // is manually set to an object.
             // See https://github.com/symfony/symfony/pull/5582

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class FileType extends AbstractType
@@ -49,11 +50,16 @@ class FileType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        $translationCount = function (Options $options) {
+            return $options['multiple'] ? 2 : 1;
+        };
+
         $resolver->setDefaults(array(
             'compound' => false,
             'data_class' => 'Symfony\Component\HttpFoundation\File\File',
             'empty_data' => null,
             'multiple' => false,
+            'translation_count' => $translationCount,
         ));
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -49,7 +49,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         $this->assertMatchesXpath($html,
 '/div
     [
-        ./label[@for="name"][@class="my&label&class required"][.="[trans]foo&bar[/trans]"]
+        ./label[@for="name"][@class="my&label&class required"][.="[trans count=1]foo&bar[/trans]"]
         /following-sibling::input[@id="name"][@class="my&class"]
     ]
 '
@@ -534,12 +534,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     [
         ./div
             [
-                ./label[@for="name_first"][.="[trans]Test[/trans]"]
+                ./label[@for="name_first"][.="[trans count=1]Test[/trans]"]
                 /following-sibling::input[@type="text"][@id="name_first"][@required="required"]
             ]
         /following-sibling::div
             [
-                ./label[@for="name_second"][.="[trans]Test2[/trans]"]
+                ./label[@for="name_second"][.="[trans count=1]Test2[/trans]"]
                 /following-sibling::input[@type="text"][@id="name_second"][@required="required"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
@@ -677,9 +677,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/div
     [
-        ./div[./label[.="Custom label: [trans]0[/trans]"]]
-        /following-sibling::div[./label[.="Custom label: [trans]1[/trans]"]]
-        /following-sibling::div[./label[.="Custom label: [trans]2[/trans]"]]
+        ./div[./label[.="Custom label: [trans count=1]0[/trans]"]]
+        /following-sibling::div[./label[.="Custom label: [trans count=1]1[/trans]"]]
+        /following-sibling::div[./label[.="Custom label: [trans count=1]2[/trans]"]]
     ]
 '
         );
@@ -700,8 +700,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/div
     [
-        ./label[.="Custom name label: [trans]ChoiceA[/trans]"]
-        /following-sibling::label[.="Custom name label: [trans]ChoiceB[/trans]"]
+        ./label[.="Custom name label: [trans count=1]ChoiceA[/trans]"]
+        /following-sibling::label[.="Custom name label: [trans count=1]ChoiceB[/trans]"]
     ]
 '
         );

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -147,7 +147,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [.="[trans]Name[/trans]"]
+    [.="[trans count=1]Name[/trans]"]
 '
         );
     }
@@ -162,7 +162,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@class="required"]
-    [.="[trans]Name[/trans]"]
+    [.="[trans count=1]Name[/trans]"]
 '
         );
     }
@@ -177,7 +177,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [.="[trans]Custom label[/trans]"]
+    [.="[trans count=1]Custom label[/trans]"]
 '
         );
     }
@@ -190,7 +190,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [.="[trans]Custom label[/trans]"]
+    [.="[trans count=1]Custom label[/trans]"]
 '
         );
     }
@@ -205,7 +205,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [.="[trans]Overridden label[/trans]"]
+    [.="[trans count=1]Overridden label[/trans]"]
 '
         );
     }
@@ -257,7 +257,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 '/label
     [@for="name"]
     [@class="my&class required"]
-    [.="[trans]Custom label[/trans]"]
+    [.="[trans count=1]Custom label[/trans]"]
 '
         );
     }
@@ -278,7 +278,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
             '/label
     [@for="name"]
     [@class="my&class required"]
-    [.="[trans]Custom label[/trans]"]
+    [.="[trans count=1]Custom label[/trans]"]
 '
         );
     }
@@ -294,8 +294,35 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="myform_myfield"]
-    [.="[trans]form.myfield[/trans]"]
+    [.="[trans count=1]form.myfield[/trans]"]
 '
+        );
+    }
+
+    /**
+     * @dataProvider translationCountProvider
+     */
+    public function testLabelWithTranslationCount($translationCount)
+    {
+        $form = $this->factory->createNamed('name', 'text');
+        $html = $this->renderLabel($form->createView(), 'Custom label', array(
+            'translation_count' => $translationCount,
+        ));
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="name"]
+    [.="[trans count='.$translationCount.']Custom label[/trans]"]
+'
+        );
+    }
+
+    public function translationCountProvider()
+    {
+        return array(
+            array(0),
+            array(1),
+            array(2),
         );
     }
 
@@ -310,7 +337,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="myform_myfield"]
-    [.="[trans]form.myform_myfield[/trans]"]
+    [.="[trans count=1]form.myform_myfield[/trans]"]
 '
         );
     }
@@ -328,7 +355,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="myform_myfield"]
-    [.="[trans]form.myfield[/trans]"]
+    [.="[trans count=1]form.myfield[/trans]"]
 '
         );
     }
@@ -346,7 +373,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="myform_myfield"]
-    [.="[trans]field.myfield[/trans]"]
+    [.="[trans count=1]field.myfield[/trans]"]
 '
         );
     }
@@ -813,9 +840,9 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 '/div
     [
         ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
-        /following-sibling::label[@for="name_0"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::label[@for="name_0"][.="[trans count=1]Choice&A[/trans]"]
         /following-sibling::input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
-        /following-sibling::label[@for="name_1"][.="[trans]Choice&B[/trans]"]
+        /following-sibling::label[@for="name_1"][.="[trans count=1]Choice&B[/trans]"]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
     [count(./input)=3]
@@ -836,11 +863,11 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 '/div
     [
         ./input[@type="radio"][@name="name"][@id="name_placeholder"][not(@checked)]
-        /following-sibling::label[@for="name_placeholder"][.="[trans]Test&Me[/trans]"]
+        /following-sibling::label[@for="name_placeholder"][.="[trans count=1]Test&Me[/trans]"]
         /following-sibling::input[@type="radio"][@name="name"][@id="name_0"][@checked]
-        /following-sibling::label[@for="name_0"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::label[@for="name_0"][.="[trans count=1]Choice&A[/trans]"]
         /following-sibling::input[@type="radio"][@name="name"][@id="name_1"][not(@checked)]
-        /following-sibling::label[@for="name_1"][.="[trans]Choice&B[/trans]"]
+        /following-sibling::label[@for="name_1"][.="[trans count=1]Choice&B[/trans]"]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
     [count(./input)=4]
@@ -860,9 +887,9 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 '/div
     [
         ./input[@type="radio"][@name="name"][@id="name_0"][@checked]
-        /following-sibling::label[@for="name_0"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::label[@for="name_0"][.="[trans count=1]Choice&A[/trans]"]
         /following-sibling::input[@type="radio"][@name="name"][@id="name_1"][not(@checked)]
-        /following-sibling::label[@for="name_1"][.="[trans]Choice&B[/trans]"]
+        /following-sibling::label[@for="name_1"][.="[trans count=1]Choice&B[/trans]"]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
     [count(./input)=3]
@@ -883,11 +910,11 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 '/div
     [
         ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
-        /following-sibling::label[@for="name_0"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::label[@for="name_0"][.="[trans count=1]Choice&A[/trans]"]
         /following-sibling::input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)]
-        /following-sibling::label[@for="name_1"][.="[trans]Choice&B[/trans]"]
+        /following-sibling::label[@for="name_1"][.="[trans count=1]Choice&B[/trans]"]
         /following-sibling::input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
-        /following-sibling::label[@for="name_2"][.="[trans]Choice&C[/trans]"]
+        /following-sibling::label[@for="name_2"][.="[trans count=1]Choice&C[/trans]"]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
     [count(./input)=4]

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -411,14 +411,14 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
         ./tr
             [
                 ./td
-                    [./label[@for="name_first"][.="[trans]Test[/trans]"]]
+                    [./label[@for="name_first"][.="[trans count=1]Test[/trans]"]]
                 /following-sibling::td
                     [./input[@type="password"][@id="name_first"][@required="required"]]
             ]
         /following-sibling::tr
             [
                 ./td
-                    [./label[@for="name_second"][.="[trans]Test2[/trans]"]]
+                    [./label[@for="name_second"][.="[trans count=1]Test2[/trans]"]]
                 /following-sibling::td
                     [./input[@type="password"][@id="name_second"][@required="required"]]
             ]
@@ -446,9 +446,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/table
     [
-        ./tr[./td/label[.="Custom label: [trans]0[/trans]"]]
-        /following-sibling::tr[./td/label[.="Custom label: [trans]1[/trans]"]]
-        /following-sibling::tr[./td/label[.="Custom label: [trans]2[/trans]"]]
+        ./tr[./td/label[.="Custom label: [trans count=1]0[/trans]"]]
+        /following-sibling::tr[./td/label[.="Custom label: [trans count=1]1[/trans]"]]
+        /following-sibling::tr[./td/label[.="Custom label: [trans count=1]2[/trans]"]]
     ]
 '
         );

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -115,6 +115,24 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertEquals('messages', $view['child']->vars['translation_domain']);
     }
 
+    public function testDefaulttranslationCount()
+    {
+        $view = $this->factory->createNamedBuilder('parent', 'form')
+            ->add('child', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals(1, $view['child']->vars['translation_count']);
+    }
+
+    public function testPasstranslationCount()
+    {
+        $form = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array('label' => 'My label', 'translation_count' => 5));
+        $view = $form->createView();
+
+        $this->assertSame(5, $view->vars['translation_count']);
+    }
+
     public function testPassLabelToView()
     {
         $form = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array('label' => 'My label'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1294,4 +1294,26 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         // Trigger data initialization
         $form->getViewData();
     }
+
+    public function testtranslationCountSingle()
+    {
+        $form = $this->factory->create('choice', null, array(
+            'multiple'  => false,
+            'choices'   => $this->choices,
+        ));
+        $view = $form->createView();
+
+        $this->assertEquals(1, $view->vars['translation_count']);
+    }
+
+    public function testtranslationCountMultiple()
+    {
+        $form = $this->factory->create('choice', null, array(
+            'multiple'  => true,
+            'choices'   => $this->choices,
+        ));
+        $view = $form->createView();
+
+        $this->assertEquals(2, $view->vars['translation_count']);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -74,6 +74,24 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertEquals('', $view->vars['value']);
     }
 
+    public function testTranslationCountSingle()
+    {
+        $form = $this->factory->createBuilder('file')->getForm();
+        $view = $form->createView();
+
+        $this->assertEquals(1, $view->vars['translation_count']);
+    }
+
+    public function testTranslationCountMultiple()
+    {
+        $form = $this->factory->createBuilder('file', null, array(
+            'multiple' => true,
+        ))->getForm();
+        $view = $form->createView();
+
+        $this->assertEquals(2, $view->vars['translation_count']);
+    }
+
     private function createUploadedFileMock($name, $originalName, $valid)
     {
         $file = $this


### PR DESCRIPTION
Adds an options for all field types: `translation_count` an integer that is passed to `transchoice` to allow the pluralization of labels.

By default, it is `1` for all field types, except `FileType` and `ChoiceType` that default to `$multiple ? 2 : 1`.

The templates need to be changed to use `transchoice(translation_count, {}, translation_domain)`, but the ones still using `trans({}, translation_domain)` will continue to work just fine. You will notice the `count` variable that is added, this is to allow translation strings like this:

```
{0} No items{1} One item|]1,Inf] %count% items
```

As far as I know, everything is tested, but I am not that familiar with forms, perhaps someone should take a look. 

**Heads up**: Even though this PR does not introduce a BC break for the usage itself, it modifies the output of `StubTranslator::transchoice` so quite a few unrelated tests were broken and had to be adjusted.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10108 |
| License | MIT |
| Doc PR | symfony/symfony-docs#3810 |
- [x] write tests
- [x] submit changes to the documentation
