### PR TITLE
[Form] Fixed set "empty_data" option with empty string to return empty string not null 

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -142,8 +142,8 @@ class FormType extends BaseType
                 };
             }
 
-            return function (FormInterface $form) {
-                return $form->getConfig()->getCompound() ? array() : '';
+            return function (FormInterface $form, $defaultValue = '') {
+                return $form->getConfig()->getCompound() ? array() : $defaultValue;
             };
         };
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -1106,7 +1106,7 @@ class Form implements \IteratorAggregate, FormInterface
         $transformers = $this->config->getViewTransformers();
 
         if (!$transformers) {
-            return '' === $value ? null : $value;
+            return $value;
         }
 
         for ($i = count($transformers) - 1; $i >= 0; --$i) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -43,8 +43,20 @@ class UrlTypeTest extends TypeTestCase
 
         $form->submit('');
 
-        $this->assertNull($form->getData());
+        $this->assertSame('',$form->getData()); // the data given was empty string so we should compare it to empty
         $this->assertSame('', $form->getViewData());
+    }
+
+    public function testSubmitAddsNoDefaultProtocolIfNull()
+    {
+      $form = $this->factory->create('url', null, array(
+        'default_protocol' => 'http',
+      ));
+
+      $form->submit(null);
+
+      $this->assertNull($form->getData());
+      $this->assertSame('', $form->getViewData());
     }
 
     public function testSubmitAddsNoDefaultProtocolIfSetToNull()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #5906 |
| License | MIT |
| Doc PR | - |

I see no reason to check here the empty string value and return this with null value. This is place where the param was manualy requested by the user with the "empty_value" option so when he given it, he must have a reason to force string not null, so if he want to return empty string there is no reason to convert it to null value. 

I see also no changes that will be done in the future flow with the methods normToModel and normToView. 

So I'm pretty sure that resolves that issue.
