### PR TITLE
[Form] Make FormInterface::add docblock more explicit

### DIFF
--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -39,7 +39,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function getParent();
 
     /**
-     * Adds a child to the form.
+     * Adds or replaces a child to the form.
      *
      * @param FormInterface|string|integer $child   The FormInterface instance or the name of the child.
      * @param string|null                  $type    The child's type, if a name was passed.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When replacing a child form from within a form event, it's not obvious that you have to use the 'add' method. Though it's minor, this will save somebody a google search.
