### PR TITLE
Remove obsolete conditions

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -95,22 +95,10 @@ class TransNode extends \Twig_Node
 
         preg_match_all('/(?<!%)%([^%]+)%/', $msg, $matches);
 
-        if (version_compare(\Twig_Environment::VERSION, '1.5', '>=')) {
-            foreach ($matches[1] as $var) {
-                $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
-                if (!$vars->hasElement($key)) {
-                    $vars->addElement(new \Twig_Node_Expression_Name($var, $body->getLine()), $key);
-                }
-            }
-        } else {
-            $current = array();
-            foreach ($vars as $name => $var) {
-                $current[$name] = true;
-            }
-            foreach ($matches[1] as $var) {
-                if (!isset($current['%'.$var.'%'])) {
-                    $vars->setNode('%'.$var.'%', new \Twig_Node_Expression_Name($var, $body->getLine()));
-                }
+        foreach ($matches[1] as $var) {
+            $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
+            if (!$vars->hasElement($key)) {
+                $vars->addElement(new \Twig_Node_Expression_Name($var, $body->getLine()), $key);
             }
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -16,15 +16,6 @@ use Symfony\Bridge\Twig\Node\FormThemeNode;
 
 class FormThemeTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
-            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
-        }
-    }
-
     public function testConstructor()
     {
         $form = new \Twig_Node_Expression_Name('form', 0);

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -16,15 +16,6 @@ use Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode;
 
 class SearchAndRenderBlockNodeTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
-            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
-        }
-    }
-
     public function testCompileWidget()
     {
         $arguments = new \Twig_Node(array(

--- a/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
@@ -17,15 +17,6 @@ use Symfony\Bridge\Twig\Node\FormThemeNode;
 
 class FormThemeTokenParserTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
-            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
-        }
-    }
-
     /**
      * @dataProvider getTestsForFormTheme
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

In `composer.json`, Twig version is set to 1.12 as a minimum, so all conditions about earlier Twig versions can be safely removed.
