### PR TITLE
In Brazilian Portuguese zero is singular

### DIFF
--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -114,7 +114,6 @@ class PluralizationRules
             case 'pap':
             case 'ps':
             case 'pt':
-            case 'xbr':
             case 'so':
             case 'sq':
             case 'sv':
@@ -137,6 +136,7 @@ class PluralizationRules
             case 'nso':
             case 'ti':
             case 'wa':
+            case 'xbr':
                 return (($number == 0) || ($number == 1)) ? 0 : 1;
 
             case 'be':


### PR DESCRIPTION
PluralizationRules was correct, but https://github.com/symfony/symfony/commit/324ad4ccfd631313d1e040cd2683c27007e75cf2 broke it.

Online references (in brazilian portuguese):

http://lgcooper.wordpress.com/2008/10/08/zero-e-plural-ou-singular/

http://g1.globo.com/platb/portugues/2007/04/
http://g1.globo.com/platb/portugues/2010/01/

http://duvidas.dicio.com.br/zero-grau-ou-zero-graus/

http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html
