### PR TITLE
[WIP][DependencyInjection] Issue #7555 - Resolve environment variables at runtime

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
@@ -57,4 +57,15 @@ class FrozenParameterBagTest extends \PHPUnit_Framework_TestCase
         $bag = new FrozenParameterBag(array());
         $bag->add(array());
     }
+
+    public function testResolveEnvironmentMaps()
+    {
+        $bag = new FrozenParameterBag(array('foo' => 'bar', 'environment_map' => array('foo' => 'SYMFONY_TEST')));
+
+        putenv('SYMFONY_TEST=baz');
+        $bag->resolveEnvironmentMap();
+        putenv('SYMFONY_TEST');
+
+        $this->assertEquals($bag->get('foo'), 'baz');
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -566,6 +566,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $this->container = new $class();
         $this->container->set('kernel', $this);
 
+        $this->postProcessContainer($this->container);
+
         if (!$fresh && $this->container->has('cache_warmer')) {
             $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'));
         }
@@ -674,6 +676,17 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
         // ensure these extensions are implicitly loaded
         $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($extensions));
+    }
+
+    /**
+     * Post processing of the Container after it was loaded from cache.
+     * This always occurs
+     *
+     * @param  ContainerInterface $container
+     */
+    protected function postProcessContainer(ContainerInterface $container)
+    {
+        $container->getParameterBag()->resolveEnvironmentMap();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | minimal |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7555 |
| License | MIT |
| Doc PR | TODO |
- [x] basic tests
- [ ] performance tests
- [ ] Deep tests
- [ ] documentation

This allows to set a parameter `environment_map` that contains a map `[$parameter => $env_var]`. This allows to call `ParameterBag::resolveEnvironmentMap` even after the bag was initially resolved and frozen. As mentioned by @stof, dependent parameter can not be resolved anymore, so it is forbidden to reference a parameter in the environment map elsewhere. However, `resolveEnvironmentMap` will use `resolveValue`, so it is possible to reference another parameter in the enviromnent variable.

`HttpKernel` now calls  `ParameterBag::resolveEnvironmentMap` after the `Container` was fully loaded.

I am not entirely sure of the implication of this method with the caching mechanism, the cache warmers, etc. I could use some help from someone with a better understanding of the whole thing.

The only BC break is that `environment_map` is not a valid parameter name anymore, it is reserved. 
