### PR TITLE
allow the TextAreaFormField to be used with valid/invalid HTML

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
@@ -33,7 +33,7 @@ class TextareaFormField extends FormField
 
         $this->value = null;
         foreach ($this->node->childNodes as $node) {
-            $this->value .= $this->document->saveXML($node);
+            $this->value .= $node->wholeText;
         }
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Field/TextareaFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/TextareaFormFieldTest.php
@@ -29,5 +29,19 @@ class TextareaFormFieldTest extends FormFieldTestCase
         } catch (\LogicException $e) {
             $this->assertTrue(true, '->initialize() throws a \LogicException if the node is not a textarea');
         }
+
+        // Ensure that valid HTML can be used on a textarea.
+        $node = $this->createNode('textarea', 'foo bar <h1>Baz</h1>');
+        $field = new TextareaFormField($node);
+
+        $this->assertEquals('foo bar <h1>Baz</h1>', $field->getValue(), '->initialize() sets the value of the field to the textarea node value');
+
+        // Ensure that we don't do any DOM manipulation/validation by passing in
+        // "invalid" HTML.
+        $node = $this->createNode('textarea', 'foo bar <h1>Baz</h2>');
+        $field = new TextareaFormField($node);
+
+        $this->assertEquals('foo bar <h1>Baz</h2>', $field->getValue(), '->initialize() sets the value of the field to the textarea node value');
     }
+
 }


### PR DESCRIPTION
The TextAreaFormField previously used saveXML to get a representation of the child nodes of an textarea.
This works pretty fine on simple text is causes issues in case you have broken HTML, as saveXML
will potentially also break encoding/change the structure.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
