### PR TITLE
[DataCollector] Improves the readability of the collected arrays in the profiler.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -78,6 +78,12 @@
         margin-left: 250px;
         padding: 30px 40px 40px;
     }
+    .tree .errors {
+        color: #aa3333;
+    }
+    .tree .active.errors {
+        color: #aa3333;
+    }
     .form-type {
         color: #999999;
     }
@@ -173,7 +179,7 @@
 
 {% macro form_tree_entry(name, data) %}
     <li>
-        <a href="#details_{{ data.id }}">{{ name }}</a>
+        <a{% if data.errors is defined and data.errors|length > 0 %} class="errors"{% endif %} href="#details_{{ data.id }}">{{ name }}</a>
 
         {% if data.children is not empty %}
             <ul>

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -25,7 +25,7 @@ class FormDataExtractorTest_SimpleValueExporter extends ValueExporter
     /**
      * {@inheritdoc}
      */
-    public function exportValue($value)
+    public function exportValue($value, $depth = 0)
     {
         return var_export($value, true);
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -20,22 +20,29 @@ class ValueExporter
      * Converts a PHP value to a string.
      *
      * @param mixed $value The PHP value
+     * @param integer $depth The depth of the value to export
      *
      * @return string The string representation of the given value
      */
-    public function exportValue($value)
+    public function exportValue($value, $depth = 0)
     {
         if (is_object($value)) {
             return sprintf('Object(%s)', get_class($value));
         }
 
+        if (is_array($value) && empty($value)) {
+            return '[]';
+        }
+
         if (is_array($value)) {
+            $indent = str_repeat('  ', $depth);
+
             $a = array();
             foreach ($value as $k => $v) {
-                $a[] = sprintf('%s => %s', $k, $this->exportValue($v));
+                $a[] = sprintf('%s  %s => %s', $indent, $k, $this->exportValue($v, $depth + 1));
             }
 
-            return sprintf("Array(%s)", implode(', ', $a));
+            return sprintf("[\n%s%s\n%s]", $indent, implode(sprintf(", \n%s", $indent), $a), $indent);
         }
 
         if (is_resource($value)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

It simply improves the readability of the collected arrays in the profiler:

**before**:

```
Array(date => Array(year => , month => , day => ), time => Array(hour => ))
```

**after**:

```
[
  date => [
      year => , 
      month => , 
      day => 
  ], 
  time => [
      hour => 
  ]
]
```

The errors are also highlighted in the form tree.

![tree](https://f.cloud.github.com/assets/890645/2017660/668966c4-87ff-11e3-9290-7ca11e781520.png)
