### PR TITLE
[Form] Update DateTime objects only if the actual value has changed

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -81,6 +81,13 @@ class PropertyPathMapper implements DataMapperInterface
             // Write-back is disabled if the form is not synchronized (transformation failed),
             // if the form was not submitted and if the form is disabled (modification not allowed)
             if (null !== $propertyPath && $config->getMapped() && $form->isSubmitted() && $form->isSynchronized() && !$form->isDisabled()) {
+
+                // If the field is of type DateTime and the data is the same skip the update to
+                // keep the original object hash
+                if($form->getData() instanceof \DateTime && $form->getData() == $this->propertyAccessor->getValue($data, $propertyPath)) {
+                    continue;
+                }
+
                 // If the data is identical to the value in $data, we are
                 // dealing with a reference
                 if (!is_object($data) || !$config->getByReference() || $form->getData() !== $this->propertyAccessor->getValue($data, $propertyPath)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -84,7 +84,7 @@ class PropertyPathMapper implements DataMapperInterface
 
                 // If the field is of type DateTime and the data is the same skip the update to
                 // keep the original object hash
-                if($form->getData() instanceof \DateTime && $form->getData() == $this->propertyAccessor->getValue($data, $propertyPath)) {
+                if ($form->getData() instanceof \DateTime && $form->getData() == $this->propertyAccessor->getValue($data, $propertyPath)) {
                     continue;
                 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5331 |
| License | MIT |
| Doc PR | - |

Right now the Form component replaces DateTime fields with new Objects, therefore the hash is changing.
This leads to unnecessary database updated when working with doctrine. With this patch the DateTime object
of the actual entity is only replaced if the value has been changed.
