### PR TITLE
[DataCollector] Improves the readability of the collected arrays in the profiler.

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -25,7 +25,7 @@ class FormDataExtractorTest_SimpleValueExporter extends ValueExporter
     /**
      * {@inheritdoc}
      */
-    public function exportValue($value)
+    public function exportValue($value, $depth = 0)
     {
         return is_object($value) ? sprintf('object(%s)', get_class($value)) : var_export($value, true);
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -30,11 +30,11 @@ class ValueExporter
             return sprintf('Object(%s)', get_class($value));
         }
 
-        if (is_array($value) && empty($value)) {
-            return '[]';
-        }
-
         if (is_array($value)) {
+            if (empty($value)) {
+                return '[]';
+            }
+
             $indent = str_repeat('  ', $depth);
 
             $a = array();

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -20,22 +20,29 @@ class ValueExporter
      * Converts a PHP value to a string.
      *
      * @param mixed $value The PHP value
+     * @param integer $depth The depth of the value to export
      *
      * @return string The string representation of the given value
      */
-    public function exportValue($value)
+    public function exportValue($value, $depth = 0)
     {
         if (is_object($value)) {
             return sprintf('Object(%s)', get_class($value));
         }
 
+        if (is_array($value) && empty($value)) {
+            return '[]';
+        }
+
         if (is_array($value)) {
+            $indent = str_repeat('  ', $depth);
+
             $a = array();
             foreach ($value as $k => $v) {
-                $a[] = sprintf('%s => %s', $k, $this->exportValue($v));
+                $a[] = sprintf('%s  %s => %s', $indent, $k, $this->exportValue($v, $depth + 1));
             }
 
-            return sprintf("Array(%s)", implode(', ', $a));
+            return sprintf("[\n%s%s\n%s]", $indent, implode(sprintf(", \n%s", $indent), $a), $indent);
         }
 
         if (is_resource($value)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

It simply improves the readability of the collected arrays in the profiler:

**before**:

```
Array(date => Array(year => , month => , day => ), time => Array(hour => ))
```

**after**:

```
[
  date => [
      year => , 
      month => , 
      day => 
  ], 
  time => [
      hour => 
  ]
]
```
