### PR TITLE
[HttpFoundation] [Session] lazy session start for #6036

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LocalizedController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LocalizedController.php
@@ -19,6 +19,8 @@ class LocalizedController extends ContainerAware
 {
     public function loginAction()
     {
+        $this->container->get('request')->getSession()->start();
+
         // get the login error if there is one
         if ($this->container->get('request')->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
             $error = $this->container->get('request')->attributes->get(SecurityContext::AUTHENTICATION_ERROR);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
@@ -20,6 +20,8 @@ class LoginController extends ContainerAware
 {
     public function loginAction()
     {
+        $this->container->get('request')->getSession()->start();
+
         // get the login error if there is one
         if ($this->container->get('request')->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
             $error = $this->container->get('request')->attributes->get(SecurityContext::AUTHENTICATION_ERROR);

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -78,6 +78,10 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function has($name)
     {
+        if (!$this->isStarted() && !$this->storage->hasPreviousSession()) {
+            return false;
+        }
+
         return $this->storage->getBag($this->attributeName)->has($name);
     }
 
@@ -86,6 +90,10 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function get($name, $default = null)
     {
+        if (!$this->isStarted() && !$this->storage->hasPreviousSession()) {
+            return $default;
+        }
+
         return $this->storage->getBag($this->attributeName)->get($name, $default);
     }
 
@@ -102,6 +110,10 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function all()
     {
+        if (!$this->isStarted() && !$this->storage->hasPreviousSession()) {
+            return array();
+        }
+
         return $this->storage->getBag($this->attributeName)->all();
     }
 
@@ -154,6 +166,10 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function count()
     {
+        if (!$this->isStarted() && !$this->storage->hasPreviousSession()) {
+            return 0;
+        }
+
         return count($this->storage->getBag($this->attributeName)->all());
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -216,6 +216,14 @@ class MockArraySessionStorage implements SessionStorageInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function hasPreviousSession()
+    {
+        return !empty($this->id);
+    }
+
+    /**
      * Sets the MetadataBag.
      *
      * @param MetadataBag $bag

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -317,6 +317,14 @@ class NativeSessionStorage implements SessionStorageInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function hasPreviousSession()
+    {
+        return isset($_COOKIE[session_name()]);
+    }
+
+    /**
      * Sets session.* ini variables.
      *
      * For convenience we omit 'session.' from the beginning of the keys.

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
@@ -121,6 +121,13 @@ interface SessionStorageInterface
     public function clear();
 
     /**
+     * Checks that storage has previous session
+     *
+     * @return boolean True if previous session exiting, false otherwise.
+     */
+    public function hasPreviousSession();
+
+    /**
      * Gets a SessionBagInterface by name.
      *
      * @param string $name

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -82,6 +82,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         // tests defaults
         $this->assertNull($this->session->get('foo'));
         $this->assertEquals(1, $this->session->get('foo', 1));
+        $this->assertFalse($this->session->isStarted());
     }
 
     /**
@@ -91,6 +92,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $this->session->set($key, $value);
         $this->assertEquals($value, $this->session->get($key));
+        $this->assertTrue($this->session->isStarted());
     }
 
     /**
@@ -98,6 +100,9 @@ class SessionTest extends \PHPUnit_Framework_TestCase
      */
     public function testHas($key, $value)
     {
+        $this->assertFalse($this->session->has($key.'_lazy_start'));
+        $this->assertFalse($this->session->isStarted());
+
         $this->session->set($key, $value);
         $this->assertTrue($this->session->has($key));
         $this->assertFalse($this->session->has($key.'non_value'));
@@ -106,6 +111,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     public function testReplace()
     {
         $this->session->replace(array('happiness' => 'be good', 'symfony' => 'awesome'));
+        $this->assertTrue($this->session->isStarted());
         $this->assertEquals(array('happiness' => 'be good', 'symfony' => 'awesome'), $this->session->all());
         $this->session->replace(array());
         $this->assertEquals(array(), $this->session->all());
@@ -116,6 +122,10 @@ class SessionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAll($key, $value, $result)
     {
+        $this->assertEquals(array(), $this->session->all());
+        $this->session->all();
+        $this->assertFalse($this->session->isStarted());
+
         $this->session->set($key, $value);
         $this->assertEquals($result, $this->session->all());
     }
@@ -129,6 +139,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session->set($key, $value);
         $this->session->clear();
         $this->assertEquals(array(), $this->session->all());
+        $this->assertTrue($this->session->isStarted());
     }
 
     public function setProvider()
@@ -149,6 +160,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session->set($key, $value);
         $this->session->remove($key);
         $this->assertEquals(array('hi.world' => 'have a nice day'), $this->session->all());
+        $this->assertTrue($this->session->isStarted());
     }
 
     public function testInvalidate()
@@ -156,6 +168,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session->set('invalidate', 123);
         $this->session->invalidate();
         $this->assertEquals(array(), $this->session->all());
+        $this->assertTrue($this->session->isStarted());
     }
 
     public function testMigrate()
@@ -163,6 +176,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session->set('migrate', 321);
         $this->session->migrate();
         $this->assertEquals(321, $this->session->get('migrate'));
+        $this->assertTrue($this->session->isStarted());
     }
 
     public function testMigrateDestroy()
@@ -170,6 +184,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session->set('migrate', 333);
         $this->session->migrate(true);
         $this->assertEquals(333, $this->session->get('migrate'));
+        $this->assertTrue($this->session->isStarted());
     }
 
     public function testSave()
@@ -214,6 +229,9 @@ class SessionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetCount()
     {
+        $this->assertEquals(0, count($this->session));
+        $this->assertFalse($this->session->isStarted());
+
         $this->session->set('hello', 'world');
         $this->session->set('symfony2', 'rocks');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6036 |
| License | MIT |
| Doc PR |  |

This patch solve problem when session starts after call read method like get, has, count without checking that session isStarted.
