### PR TITLE
[Translation] [Loader] Add INI_SCANNER_RAW to parse ini files

### DIFF
--- a/src/Symfony/Component/Translation/Loader/IniFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IniFileLoader.php
@@ -35,7 +35,7 @@ class IniFileLoader extends ArrayLoader implements LoaderInterface
             throw new NotFoundResourceException(sprintf('File "%s" not found.', $resource));
         }
 
-        $messages = parse_ini_file($resource, true);
+        $messages = parse_ini_file($resource, true, INI_SCANNER_RAW);
 
         $catalogue = parent::load($messages, $locale, $domain);
         $catalogue->addResource(new FileResource($resource));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

INI_SCANNER_RAW change the default scanner mode of parse_ini_files to parse all values without evaluate. This allow values with single quotes, "no" and "false" and raise an error if you use the deprecated "#" as comment character.
This change is specially good for shared translations, because a translator haven't to know that he can't use a few restricted terms.
And has a residual improvement: it's twice fast that use the default value (INI_SCANNER_NORMAL) in my tests
