### PR TITLE
[FrameworkBundle] config:dump-reference command can now dump current configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.5.0
 -----
 
+ * Added `config:debug` command
  * Added `yaml:lint` command
  * Deprecated the `RouterApacheDumperCommand` which will be removed in Symfony 3.0.
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+/**
+ * A console command for dumping available configuration reference
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ * @author Wouter J <waldio.webdesign@gmail.com>
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class AbstractConfigCommand extends ContainerDebugCommand
+{
+    protected function listBundles(OutputInterface $output)
+    {
+        $output->writeln('Available registered bundles with their extension alias if available:');
+
+        $table = $this->getHelperSet()->get('table');
+        $table->setHeaders(array('Bundle name', 'Extension alias'));
+        foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
+            $extension = $bundle->getContainerExtension();
+            $table->addRow(array($bundle->getName(), $extension ? $extension->getAlias() : ''));
+        }
+
+        $table->render($output);
+    }
+
+    protected function findExtention($name)
+    {
+        $extension = null;
+
+        $bundles = $this->getContainer()->get('kernel')->getBundles();
+
+        if (preg_match('/Bundle$/', $name)) {
+            // input is bundle name
+
+            if (isset($bundles[$name])) {
+                $extension = $bundles[$name]->getContainerExtension();
+            }
+
+            if (!$extension) {
+                throw new \LogicException(sprintf('No extensions with configuration available for "%s"', $name));
+            }
+        } else {
+            foreach ($bundles as $bundle) {
+                $extension = $bundle->getContainerExtension();
+
+                if ($extension && $name === $extension->getAlias()) {
+                    break;
+                }
+
+                $extension = null;
+            }
+
+            if (!$extension) {
+                throw new \LogicException(sprintf('No extension with alias "%s" is enabled', $name));
+            }
+        }
+
+        return $extension;
+    }
+
+    public function validateConfiguration(Extension $extension, $configuration)
+    {
+        if (!$configuration) {
+            throw new \LogicException(sprintf('The extension with alias "%s" does not have its getConfiguration() method setup', $extension->getAlias()));
+        }
+
+        if (!$configuration instanceof ConfigurationInterface) {
+            throw new \LogicException(sprintf('Configuration class "%s" should implement ConfigurationInterface in order to be dumpable', get_class($configuration)));
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * A console command for dumping available configuration reference
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class ConfigDebugCommand extends AbstractConfigCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('config:debug')
+            ->setDefinition(array(
+                new InputArgument('name', InputArgument::OPTIONAL, 'The Bundle name or the extension alias'),
+            ))
+            ->setDescription('Dumps the current configuration for an extension')
+            ->setHelp(<<<EOF
+
+The <info>%command.name%</info> command dumps the current configuration for an
+extension/bundle.
+
+Either the extension alias or bundle name can be used:
+
+  <info>php %command.full_name% framework</info>
+  <info>php %command.full_name% FrameworkBundle</info>
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $name = $input->getArgument('name');
+
+        if (empty($name)) {
+            $this->listBundles($output);
+
+            return;
+        }
+
+        $extension = $this->findExtention($name);
+
+        $kernel = $this->getContainer()->get('kernel');
+        $method = new \ReflectionMethod($kernel, 'buildContainer');
+        $method->setAccessible(true);
+        $container = $method->invoke($kernel);
+
+        $configs = $container->getExtensionConfig($extension->getAlias());
+        $configuration = $extension->getConfiguration($configs, $container);
+
+        $this->validateConfiguration($extension, $configuration);
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration($configuration, $configs);
+
+        $config = $container->getParameterBag()->resolveValue($config);
+
+        if ($name === $extension->getAlias()) {
+            $output->writeln(sprintf('# Current configuration for extension with alias: "%s"', $name));
+        } else {
+            $output->writeln(sprintf('# Current configuration for "%s"', $name));
+        }
+
+        $output->writeln(Yaml::dump(array($extension->getAlias() => $config), 3));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -17,15 +17,15 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * A console command for dumping available configuration reference
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  * @author Wouter J <waldio.webdesign@gmail.com>
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-class ConfigDumpReferenceCommand extends ContainerDebugCommand
+class ConfigDumpReferenceCommand extends AbstractConfigCommand
 {
     /**
      * {@inheritdoc}
@@ -43,13 +43,16 @@ class ConfigDumpReferenceCommand extends ContainerDebugCommand
 The <info>%command.name%</info> command dumps the default configuration for an
 extension/bundle.
 
-The extension alias or bundle name can be used:
+Either the extension alias or bundle name can be used:
 
   <info>php %command.full_name% framework</info>
   <info>php %command.full_name% FrameworkBundle</info>
 
 With the <info>format</info> option specifies the format of the configuration,
-this is either <comment>yaml</comment> or <comment>xml</comment>. When the option is not provided, <comment>yaml</comment> is used.
+this is either <comment>yaml</comment> or <comment>xml</comment>.
+When the option is not provided, <comment>yaml</comment> is used.
+
+  <info>php %command.full_name% FrameworkBundle --format=xml</info>
 EOF
             )
         ;
@@ -62,65 +65,24 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $bundles = $this->getContainer()->get('kernel')->getBundles();
-        $containerBuilder = $this->getContainerBuilder();
-
         $name = $input->getArgument('name');
 
         if (empty($name)) {
-            $output->writeln('Available registered bundles with their extension alias if available:');
-
-            $table = $this->getHelperSet()->get('table');
-            $table->setHeaders(array('Bundle name', 'Extension alias'));
-            foreach ($bundles as $bundle) {
-                $extension = $bundle->getContainerExtension();
-                $table->addRow(array($bundle->getName(), $extension ? $extension->getAlias() : ''));
-            }
-            $table->render($output);
+            $this->listBundles($output);
 
             return;
         }
 
-        $extension = null;
+        $extension = $this->findExtention($name);
 
-        if (preg_match('/Bundle$/', $name)) {
-            // input is bundle name
+        $configuration = $extension->getConfiguration(array(), $this->getContainerBuilder());
 
-            if (isset($bundles[$name])) {
-                $extension = $bundles[$name]->getContainerExtension();
-            }
+        $this->validateConfiguration($extension, $configuration);
 
-            if (!$extension) {
-                throw new \LogicException(sprintf('No extensions with configuration available for "%s"', $name));
-            }
-
-            $message = 'Default configuration for "'.$name.'"';
+        if ($name === $extension->getAlias()) {
+            $message = sprintf('Default configuration for extension with alias: "%s"', $name);
         } else {
-            foreach ($bundles as $bundle) {
-                $extension = $bundle->getContainerExtension();
-
-                if ($extension && $extension->getAlias() === $name) {
-                    break;
-                }
-
-                $extension = null;
-            }
-
-            if (!$extension) {
-                throw new \LogicException(sprintf('No extension with alias "%s" is enabled', $name));
-            }
-
-            $message = 'Default configuration for extension with alias: "'.$name.'"';
-        }
-
-        $configuration = $extension->getConfiguration(array(), $containerBuilder);
-
-        if (!$configuration) {
-            throw new \LogicException(sprintf('The extension with alias "%s" does not have it\'s getConfiguration() method setup', $extension->getAlias()));
-        }
-
-        if (!$configuration instanceof ConfigurationInterface) {
-            throw new \LogicException(sprintf('Configuration class "%s" should implement ConfigurationInterface in order to be dumpable', get_class($configuration)));
+            $message = sprintf('Default configuration for "%s"', $name);
         }
 
         switch ($input->getOption('format')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -86,8 +86,6 @@ EOF
 
     /**
      * {@inheritdoc}
-     *
-     * @throws \LogicException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | I guess |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I did not add `xml` support as I don't know how to do that. ping @stof 

sample:

``` yaml
framework:
    secret: ThisTokenIsNotSoSecretChangeIt
    router:
        resource: /home/greg/dev/labs/se/app/config/routing_dev.yml
        strict_requirements: true
        http_port: 80
        https_port: 443
    form:
        enabled: true
        csrf_protection: { enabled: null, field_name: null }
    csrf_protection:
        enabled: true
        field_name: _token
    validation:
        enable_annotations: true
        enabled: true
        translation_domain: validators
    templating:
        engines: [twig]
        assets_version: null
        assets_version_format: '%%s?%%s'
        hinclude_default_template: null
        form: { resources: ['FrameworkBundle:Form'] }
        assets_base_urls: { http: {  }, ssl: {  } }
        loaders: {  }
        packages: {  }
    default_locale: en
    trusted_hosts: {  }
    trusted_proxies: {  }
    session:
        storage_id: session.storage.native
        handler_id: session.handler.native_file
        save_path: /home/greg/dev/labs/se/app/cache/dev/sessions
        metadata_update_threshold: '0'
    fragments:
        enabled: true
        path: /_fragment
    http_method_override: true
    profiler:
        only_exceptions: false
        enabled: true
        collect: true
        only_master_requests: false
        dsn: 'file:/home/greg/dev/labs/se/app/cache/dev/profiler'
        username: ''
        password: ''
        lifetime: 86400
    ide: null
    esi:
        enabled: false
    translator:
        enabled: false
        fallback: en
    annotations:
        cache: file
        file_cache_dir: /home/greg/dev/labs/se/app/cache/dev/annotations
        debug: true
    serializer:
        enabled: false
```
