### PR TITLE
[HttpFoundation] Implement Countable interface for RequestStack

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RequestStack.php
+++ b/src/Symfony/Component/HttpFoundation/RequestStack.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpFoundation;
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
-class RequestStack
+class RequestStack implements \Countable
 {
     /**
      * @var Request[]
@@ -99,5 +99,15 @@ class RequestStack
         }
 
         return $this->requests[$pos];
+    }
+
+    /**
+     * Implements \Countable.
+     *
+     * @return integer The number of requests in the stack
+     */
+    public function count()
+    {
+        return count($this->requests);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestStackTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestStackTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * RequestStackTest
+ *
+ * @author Chris Heng <hengkuanyen@gmail.com>
+ */
+class RequestStackTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmptyStack()
+    {
+        $stack = new RequestStack();
+
+        $this->assertSame(0, count($stack));
+        $this->assertNull($stack->getCurrentRequest());
+        $this->assertNull($stack->getParentRequest());
+        $this->assertNull($stack->getMasterRequest());
+        $this->assertNull($stack->pop());
+    }
+
+    public function testPushPop()
+    {
+        $request1 = new Request();
+        $request2 = new Request();
+        $request3 = new Request();
+
+        $stack = new RequestStack();
+        $stack->push($request1);
+
+        $this->assertSame($request1, $stack->getCurrentRequest());
+        $this->assertNull($stack->getParentRequest());
+        $this->assertSame($request1, $stack->getMasterRequest());
+        $this->assertSame(1, count($stack));
+
+        $stack->push($request2);
+
+        $this->assertSame($request2, $stack->getCurrentRequest());
+        $this->assertSame($request1, $stack->getParentRequest());
+        $this->assertSame($request1, $stack->getMasterRequest());
+        $this->assertSame(2, count($stack));
+
+        $stack->push($request3);
+
+        $this->assertSame($request3, $stack->getCurrentRequest());
+        $this->assertSame($request2, $stack->getParentRequest());
+        $this->assertSame($request1, $stack->getMasterRequest());
+        $this->assertSame(3, count($stack));
+
+        $this->assertSame($request3, $stack->pop());
+
+        $this->assertSame($request2, $stack->getCurrentRequest());
+        $this->assertSame($request1, $stack->getParentRequest());
+        $this->assertSame($request1, $stack->getMasterRequest());
+        $this->assertSame(2, count($stack));
+
+        $this->assertSame($request2, $stack->pop());
+        $this->assertSame($request1, $stack->pop());
+        $this->assertNull($stack->pop());
+        $this->assertSame(0, count($stack));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR makes it possible to obtain the number of requests currently in `RequestStack` with `count()`.

An example use case for this is keeping separate states in a listener for each level of subrequest. I initially tried differentiating between the request objects, but this doesn't work if the same request is reused for the subrequest.

I've also added test cases for `RequestStack`.
