### PR TITLE
[Process] Fix wording for class documentation

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -17,7 +17,7 @@ use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Exception\RuntimeException;
 
 /**
- * Process is a thin wrapper around proc_* functions to ease
+ * Process is a thin wrapper around proc_* functions to easily
  * start independent PHP processes.
  *
  * @author Fabien Potencier <fabien@symfony.com>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | ---- |
| License | MIT |

"ease start" didn't make a lot of sense. This PR fixes this minor wording issue.
