### PR TITLE
[Security] Adding __toString() method to Role class

### DIFF
--- a/src/Symfony/Component/Security/Core/Role/Role.php
+++ b/src/Symfony/Component/Security/Core/Role/Role.php
@@ -38,4 +38,14 @@ class Role implements RoleInterface
     {
         return $this->role;
     }
+
+    /**
+     * Returns a string representation of the role
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->role;
+    }
 }

--- a/src/Symfony/Component/Security/Tests/Core/Role/RoleTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Role/RoleTest.php
@@ -21,4 +21,20 @@ class RoleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('FOO', $role->getRole());
     }
+
+    /**
+     * @dataProvider getToStringFixtures
+     */
+    public function testToString($role, $expected)
+    {
+        $this->assertEquals($role, $expected);
+    }
+
+    public function getToStringFixtures()
+    {
+        return array(
+            array(new Role(null), ''),
+            array(new Role('FOO'), 'FOO')
+        );
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | possibly ? |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |

This PR proposes adding the `toString()` method to the `\Symfony\Component\Security\Core\Role\Role` class. This should ease the comparison of role strings and instances of `Role` itself. For example, in the `FOSUserBundle` the `User` model contains roles which are represented as strings. This makes comparisons between arrays of `Role` objects and role strings difficult without creating your own `Role` class with a `__toString()`,  and this isn't always desirable.

I found some conversation around [adding the `\Seriazable` interface to the `Role` class](https://github.com/symfony/symfony/pull/4934), and I realise that this might also be considered a BC break if people are relying on the fact that it will not cast to a string.
