### PR TITLE
Update CollectionType.php

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -28,7 +28,7 @@ class CollectionType extends AbstractType
     {
         if ($options['allow_add'] && $options['prototype']) {
             $prototype = $builder->create($options['prototype_name'], $options['type'], array_replace(array(
-                'label' => $options['prototype_name'].'label__',
+                'label' => ($options['label'] ? $options['prototype_name'].'label__' : false),
             ), $options['options']));
             $builder->setAttribute('prototype', $prototype->getForm());
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| License | MIT |

If I set label = false in formType class then this formType class is not displaying label block in twig view. In a case of prototype, label is rendered all the time.

The change of this line removes this problem.
