### PR TITLE
[Console] Added support for labels to ProgressHelper

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG
 =========
 
+* added support for labels to ProgressHelper
+
 2.5.0
 -----
 


### PR DESCRIPTION
Allows the addition of a label to the progress helper.  For long(er) running tasks it could be nice to provide some additional information on what is currently happening in textual form.

```
$progress = $this->getHelperSet()->get('progress');
$progress->setLabel('Starting download', $progress::LABEL_BOTTOM, $progress::LABEL_CENTER);
$progress->start($output, $end);
$progress->display();
for ($i = 0; $i < $end; $i++) {
    $x = $i + 1;
    $progress->updateLabel('Downloading ' . $x);
    $progress->advance();
    sleep(1);
}
$progress->finish();
```

The label can be position above or under the progress bar, and left/center/right aligned.  To allow for positioning over the progress bar, I had to move the line length padding code from overwrite() to display().

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
