### PR TITLE
Fix TwigBundle dependencies

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,12 +18,8 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/twig-bridge": "~2.5",
-        "symfony/http-kernel": "~2.1"
-    },
-    "require-dev": {
-        "symfony/stopwatch": "~2.2",
-        "symfony/dependency-injection": "~2.0",
-        "symfony/config": "~2.2"
+        "symfony/framework-bundle": "~2.5",
+        "symfony/finder": "~2.5"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\TwigBundle\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

TwigBundle depends on FrameworkBundle and the Finder component.
The dependency on FrameworkBundle pulls in what used to be development dependencies, so that could be removed.
