### PR TITLE
[Debug] Fixed recursion level incrementing in FlattenException::flattenArgs().

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -249,7 +249,7 @@ class FlattenException
                 if ($level > 10) {
                     $result[$key] = array('array', '*DEEP NESTED ARRAY*');
                 } else {
-                    $result[$key] = array('array', $this->flattenArgs($value, ++$level));
+                    $result[$key] = array('array', $this->flattenArgs($value, $level + 1));
                 }
             } elseif (null === $value) {
                 $result[$key] = array('null', null);


### PR DESCRIPTION
The internal `$level` variable for tracking the recursion level is pre-incremented on the parent level of the recursion already.

This causes later array elements in an array that has more than 10 elements to get obscured by `'*DEEP NESTED ARRAY*'`, even though the elements are on the first/top level of the array.

The incremented `$level` value needs to be passed to the recursive call to `FlattenException::flattenArgs()` only.

Discovered in debugging exceptions in Drupal (which happens to use very large multi-dimensional arrays for legacy reasons).

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
