### PR TITLE
[FrameworkBundle] PhpExtractor bugfix and improvements

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
@@ -1,3 +1,19 @@
 This template is used for translation message extraction tests
 <?php echo $view['translator']->trans('single-quoted key') ?>
 <?php echo $view['translator']->trans("double-quoted key") ?>
+<?php echo $view['translator']->trans( "double-quoted key with whitespace" ) ?>
+<?php echo $view['translator']->trans("double-quoted key with \"escaped\" quotes") ?>
+<?php echo $view['translator']->trans(
+	'single-quoted key with whitespace'
+) ?>
+<?php echo $view['translator']->trans(<<<EOF
+heredoc key
+EOF
+) ?>
+
+<?php echo $view['translator']->trans( <<<EOF
+heredoc key with whitespace
+EOF
+   ) ?>
+
+<?php echo $view['translator']->trans('single-quoted key with "quote"') ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
@@ -1,19 +1,27 @@
 This template is used for translation message extraction tests
 <?php echo $view['translator']->trans('single-quoted key') ?>
 <?php echo $view['translator']->trans("double-quoted key") ?>
-<?php echo $view['translator']->trans( "double-quoted key with whitespace" ) ?>
-<?php echo $view['translator']->trans("double-quoted key with \"escaped\" quotes") ?>
-<?php echo $view['translator']->trans(
-	'single-quoted key with whitespace'
-) ?>
 <?php echo $view['translator']->trans(<<<EOF
 heredoc key
 EOF
 ) ?>
-
-<?php echo $view['translator']->trans( <<<EOF
-heredoc key with whitespace
+<?php echo $view['translator']->trans(<<<'EOF'
+nowdoc key
 EOF
-   ) ?>
+) ?>
+<?php echo $view['translator']->trans(
+    "double-quoted key with whitespace and escaped \$\n\" sequences"
+) ?>
+<?php echo $view['translator']->trans(
+    'single-quoted key with whitespace and nonescaped \$\n\' sequences'
+) ?>
+<?php echo $view['translator']->trans( <<<EOF
+heredoc key with whitespace and escaped \$\n sequences
+EOF
+) ?>
+<?php echo $view['translator']->trans( <<<'EOF'
+nowdoc key with whitespace and nonescaped \$\n sequences
+EOF
+) ?>
 
-<?php echo $view['translator']->trans('single-quoted key with "quote"') ?>
+<?php echo $view['translator']->trans('single-quoted key with "quote mark at the end"') ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
@@ -25,3 +25,9 @@ EOF
 ) ?>
 
 <?php echo $view['translator']->trans('single-quoted key with "quote mark at the end"') ?>
+
+<?php echo $view['translator']->transChoice(
+    '{0} There is no apples|{1} There is one apple|]1,Inf[ There are %count% apples',
+    10,
+    array('%count%' => 10)
+) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/PhpExtractorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/PhpExtractorTest.php
@@ -28,9 +28,15 @@ class PhpExtractorTest extends TestCase
         $extractor->extract(__DIR__.'/../Fixtures/Resources/views/', $catalogue);
 
         // Assert
-        $this->assertCount(2, $catalogue->all('messages'), '->extract() should find 1 translation');
+        $this->assertCount(8, $catalogue->all('messages'), '->extract() should find 1 translation');
         $this->assertTrue($catalogue->has('single-quoted key'), '->extract() should find the "single-quoted key" message');
         $this->assertTrue($catalogue->has('double-quoted key'), '->extract() should find the "double-quoted key" message');
+        $this->assertTrue($catalogue->has('single-quoted key with whitespace'), '->extract() should find the "single-quoted key with whitespace" message');
+        $this->assertTrue($catalogue->has('single-quoted key with "quote"'), '->extract() should find the "single-quoted key with "quote"" message');
+        $this->assertTrue($catalogue->has('double-quoted key with whitespace'), '->extract() should find the "double-quoted key with whitespace" message');
+        $this->assertTrue($catalogue->has('heredoc key'), '->extract() should find the "heredoc key" message');
+        $this->assertTrue($catalogue->has('heredoc key with whitespace'), '->extract() should find the "heredoc key with whitespace" message');
+        $this->assertTrue($catalogue->has("double-quoted key with \"escaped\" quotes"), '->extract() should find the "double-quoted key with "escaped" quotes" message');
         $this->assertEquals('prefixsingle-quoted key', $catalogue->get('single-quoted key'), '->extract() should apply "prefix" as prefix');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/PhpExtractorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/PhpExtractorTest.php
@@ -27,16 +27,26 @@ class PhpExtractorTest extends TestCase
         // Act
         $extractor->extract(__DIR__.'/../Fixtures/Resources/views/', $catalogue);
 
+        $expectedHeredoc = <<<EOF
+heredoc key with whitespace and escaped \$\n sequences
+EOF;
+        $expectedNowdoc = <<<'EOF'
+nowdoc key with whitespace and nonescaped \$\n sequences
+EOF;
         // Assert
-        $this->assertCount(8, $catalogue->all('messages'), '->extract() should find 1 translation');
-        $this->assertTrue($catalogue->has('single-quoted key'), '->extract() should find the "single-quoted key" message');
-        $this->assertTrue($catalogue->has('double-quoted key'), '->extract() should find the "double-quoted key" message');
-        $this->assertTrue($catalogue->has('single-quoted key with whitespace'), '->extract() should find the "single-quoted key with whitespace" message');
-        $this->assertTrue($catalogue->has('single-quoted key with "quote"'), '->extract() should find the "single-quoted key with "quote"" message');
-        $this->assertTrue($catalogue->has('double-quoted key with whitespace'), '->extract() should find the "double-quoted key with whitespace" message');
-        $this->assertTrue($catalogue->has('heredoc key'), '->extract() should find the "heredoc key" message');
-        $this->assertTrue($catalogue->has('heredoc key with whitespace'), '->extract() should find the "heredoc key with whitespace" message');
-        $this->assertTrue($catalogue->has("double-quoted key with \"escaped\" quotes"), '->extract() should find the "double-quoted key with "escaped" quotes" message');
-        $this->assertEquals('prefixsingle-quoted key', $catalogue->get('single-quoted key'), '->extract() should apply "prefix" as prefix');
+        $expectedCatalogue = array('messages' => array(
+            'single-quoted key' => 'prefixsingle-quoted key',
+            'double-quoted key' => 'prefixdouble-quoted key',
+            'heredoc key' => 'prefixheredoc key',
+            'nowdoc key' => 'prefixnowdoc key',
+            "double-quoted key with whitespace and escaped \$\n\" sequences" => "prefixdouble-quoted key with whitespace and escaped \$\n\" sequences",
+            'single-quoted key with whitespace and nonescaped \$\n\' sequences' => 'prefixsingle-quoted key with whitespace and nonescaped \$\n\' sequences',
+            'single-quoted key with "quote mark at the end"' => 'prefixsingle-quoted key with "quote mark at the end"',
+            $expectedHeredoc => "prefix".$expectedHeredoc,
+            $expectedNowdoc => "prefix".$expectedNowdoc,
+        ));
+        $actualCatalogue = $catalogue->all();
+
+        $this->assertEquals($expectedCatalogue, $actualCatalogue);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/PhpExtractorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/PhpExtractorTest.php
@@ -44,6 +44,7 @@ EOF;
             'single-quoted key with "quote mark at the end"' => 'prefixsingle-quoted key with "quote mark at the end"',
             $expectedHeredoc => "prefix".$expectedHeredoc,
             $expectedNowdoc => "prefix".$expectedNowdoc,
+            '{0} There is no apples|{1} There is one apple|]1,Inf[ There are %count% apples' => 'prefix{0} There is no apples|{1} There is one apple|]1,Inf[ There are %count% apples',
         ));
         $actualCatalogue = $catalogue->all();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
@@ -43,6 +43,12 @@ class PhpExtractor implements ExtractorInterface
             '(',
             self::MESSAGE_TOKEN,
         ),
+        array(
+            '->',
+            'transChoice',
+            '(',
+            self::MESSAGE_TOKEN,
+        ),
     );
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Translation;
+
+class PhpStringTokenParser
+{
+    protected static $replacements = array(
+        '\\' => '\\',
+        '$'  =>  '$',
+        'n'  => "\n",
+        'r'  => "\r",
+        't'  => "\t",
+        'f'  => "\f",
+        'v'  => "\v",
+        'e'  => "\x1B",
+    );
+
+    /**
+     * Parses a string token.
+     *
+     * @param string $str String token content
+     *
+     * @return string The parsed string
+     */
+    public static function parse($str)
+    {
+        $bLength = 0;
+        if ('b' === $str[0]) {
+            $bLength = 1;
+        }
+
+        if ('\'' === $str[$bLength]) {
+            return str_replace(
+                array('\\\\', '\\\''),
+                array(  '\\',   '\''),
+                substr($str, $bLength + 1, -1)
+            );
+        } else {
+            return self::parseEscapeSequences(substr($str, $bLength + 1, -1), '"');
+        }
+    }
+
+    /**
+     * Parses escape sequences in strings (all string types apart from single quoted).
+     *
+     * @param string      $str   String without quotes
+     * @param null|string $quote Quote type
+     *
+     * @return string String with escape sequences parsed
+     */
+    public static function parseEscapeSequences($str, $quote)
+    {
+        if (null !== $quote) {
+            $str = str_replace('\\' . $quote, $quote, $str);
+        }
+
+        return preg_replace_callback(
+            '~\\\\([\\\\$nrtfve]|[xX][0-9a-fA-F]{1,2}|[0-7]{1,3})~',
+            array(__CLASS__, 'parseCallback'),
+            $str
+        );
+    }
+
+    public static function parseCallback($matches)
+    {
+        $str = $matches[1];
+
+        if (isset(self::$replacements[$str])) {
+            return self::$replacements[$str];
+        } elseif ('x' === $str[0] || 'X' === $str[0]) {
+            return chr(hexdec($str));
+        } else {
+            return chr(octdec($str));
+        }
+    }
+
+    /**
+     * Parses a constant doc string.
+     *
+     * @param string $startToken Doc string start token content (<<<SMTHG)
+     * @param string $str        String token content
+     *
+     * @return string Parsed string
+     */
+    public static function parseDocString($startToken, $str)
+    {
+        // strip last newline (thanks tokenizer for sticking it into the string!)
+        $str = preg_replace('~(\r\n|\n|\r)$~', '', $str);
+
+        // nowdoc string
+        if (false !== strpos($startToken, '\'')) {
+            return $str;
+        }
+
+        return self::parseEscapeSequences($str, null);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
@@ -1,6 +1,51 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bundle\FrameworkBundle\Translation;
+
+/*
+ * The following is derived from code at http://github.com/nikic/PHP-Parser
+ *
+ * Copyright (c) 2011 by Nikita Popov
+ *
+ * Some rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *
+ *     * The names of the contributors may not be used to endorse or
+ *       promote products derived from this software without specific
+ *       prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 class PhpStringTokenParser
 {


### PR DESCRIPTION
PhpExtractor currently only handles simple strings which match an overly-specific token sequence.

This change adds support for 
- heredoc / nowdoc
- inconsistent whitespace when parsing
- escaped sequences in strings
- `transChoice`

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
