### PR TITLE
[Stopwatch] Allow getting duration of events without calling stop()

### DIFF
--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -126,6 +126,18 @@ class Stopwatch
     }
 
     /**
+     * Returns a specific event by name
+     *
+     * @param string $name The event name
+     *
+     * @return StopwatchEvent A StopwatchEvent instance
+     */
+    public function getEvent($name)
+    {
+        return end($this->activeSections)->getEvent($name);
+    }
+
+    /**
      * Gets all events for a given section.
      *
      * @param string $id A section identifier
@@ -291,6 +303,24 @@ class Section
     public function lap($name)
     {
         return $this->stopEvent($name)->start();
+    }
+
+    /**
+     * Returns a specific event by name
+     *
+     * @param string $name The event name
+     *
+     * @return StopwatchEvent The event
+     *
+     * @throws \LogicException When the event is not known
+     */
+    public function getEvent($name)
+    {
+        if (!isset($this->events[$name])) {
+            throw new \LogicException(sprintf('Event "%s" is not known.', $name));
+        }
+
+        return $this->events[$name];
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -171,8 +171,17 @@ class StopwatchEvent
      */
     public function getDuration()
     {
+        $periods = $this->periods;
+        $stopped = count($periods);
+        $left = count($this->started) - $stopped;
+
+        for ($i = 0; $i < $left; $i++) {
+            $index = $stopped + $i;
+            $periods[] = new StopwatchPeriod($this->started[$index], $this->getNow());
+        }
+
         $total = 0;
-        foreach ($this->periods as $period) {
+        foreach ($periods as $period) {
             $total += $period->getDuration();
         }
 

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -82,6 +82,22 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
     }
 
+    public function testDurationBeforeStop()
+    {
+        $event = new StopwatchEvent(microtime(true) * 1000);
+        $event->start();
+        usleep(200000);
+        $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
+
+        $event = new StopwatchEvent(microtime(true) * 1000);
+        $event->start();
+        usleep(100000);
+        $event->stop();
+        $event->start();
+        usleep(100000);
+        $this->assertEquals(100, $event->getDuration(), null, self::DELTA);
+    }
+
     /**
      * @expectedException \LogicException
      */

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -29,6 +29,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
         $this->assertEquals('cat', $event->getCategory());
+        $this->assertSame($event, $stopwatch->getEvent('foo'));
     }
 
     public function testIsStarted()
@@ -90,6 +91,15 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
         $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testUnknownEvent()
+    {
+        $stopwatch = new Stopwatch();
+        $stopwatch->getEvent('foo');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [#10175](https://github.com/symfony/symfony/issues/10175) |
| License | MIT |
| Doc PR | [#3539](https://github.com/symfony/symfony-docs/pull/3539) |
