### PR TITLE
[Debug] error stacking + fatal screaming + case testing

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -14,46 +14,67 @@ namespace Symfony\Component\Debug;
 /**
  * Autoloader checking if the class is really defined in the file found.
  *
- * The ClassLoader will wrap all registered autoloaders providing a
- * findFile method and will throw an exception if a file is found but does
+ * The ClassLoader will wrap all registered autoloaders
+ * and will throw an exception if a file is found but does
  * not declare the class.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Christophe Coevoet <stof@notk.org>
+ * @author Nicolas Grekas <p@tchwork.com>
  *
  * @api
  */
 class DebugClassLoader
 {
-    private $classFinder;
+    private $classLoader;
+    private $isFinder;
+    private $wasFinder;
 
     /**
      * Constructor.
      *
-     * @param object $classFinder
+     * @param callable|object $classLoader
      *
      * @api
+     * @deprecated since 2.5, passing an object is deprecated and support for it will be removed in 3.0
      */
-    public function __construct($classFinder)
+    public function __construct($classLoader)
     {
-        $this->classFinder = $classFinder;
+        $this->wasFinder = is_object($classLoader) && method_exists($classLoader, 'findFile');
+
+        if ($this->wasFinder) {
+            $this->classLoader = array($classLoader, 'loadClass');
+            $this->isFinder = true;
+        } else {
+            $this->classLoader = $classLoader;
+            $this->isFinder = is_array($classLoader) && method_exists($classLoader[0], 'findFile');
+        }
     }
 
     /**
      * Gets the wrapped class loader.
      *
-     * @return object a class loader instance
+     * @return callable|object a class loader
+     *
+     * @deprecated since 2.5, returning an object is deprecated and support for it will be removed in 3.0
      */
     public function getClassLoader()
     {
-        return $this->classFinder;
+        if ($this->wasFinder) {
+            return $this->classLoader[0];
+        } else {
+            return $this->classLoader;
+        }
     }
 
     /**
-     * Replaces all autoloaders implementing a findFile method by a DebugClassLoader wrapper.
+     * Wraps all autoloaders
      */
     public static function enable()
     {
+        // Ensures we don't hit https://bugs.php.net/42098
+        class_exists(__NAMESPACE__.'\ErrorHandler', true);
+
         if (!is_array($functions = spl_autoload_functions())) {
             return;
         }
@@ -63,8 +84,8 @@ class DebugClassLoader
         }
 
         foreach ($functions as $function) {
-            if (is_array($function) && !$function[0] instanceof self && method_exists($function[0], 'findFile')) {
-                $function = array(new static($function[0]), 'loadClass');
+            if (!is_array($function) || !$function[0] instanceof self) {
+                $function = array(new static($function), 'loadClass');
             }
 
             spl_autoload_register($function);
@@ -86,7 +107,7 @@ class DebugClassLoader
 
         foreach ($functions as $function) {
             if (is_array($function) && $function[0] instanceof self) {
-                $function[0] = $function[0]->getClassLoader();
+                $function = $function[0]->getClassLoader();
             }
 
             spl_autoload_register($function);
@@ -99,10 +120,14 @@ class DebugClassLoader
      * @param string $class A class name to resolve to file
      *
      * @return string|null
+     *
+     * @deprecated Deprecated since 2.5, to be removed in 3.0.
      */
     public function findFile($class)
     {
-        return $this->classFinder->findFile($class);
+        if ($this->wasFinder) {
+            return $this->classLoader[0]->findFile($class);
+        }
     }
 
     /**
@@ -116,10 +141,55 @@ class DebugClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->classFinder->findFile($class)) {
-            require $file;
+        ErrorHandler::stackErrors();
 
-            if (!class_exists($class, false) && !interface_exists($class, false) && (!function_exists('trait_exists') || !trait_exists($class, false))) {
+        try {
+            if ($this->isFinder) {
+                if ($file = $this->classLoader[0]->findFile($class)) {
+                    require $file;
+                }
+            } else {
+                call_user_func($this->classLoader, $class);
+                $file = false;
+            }
+        } catch (\Exception $e) {
+            ErrorHandler::unstackErrors();
+
+            throw $e;
+        }
+
+        ErrorHandler::unstackErrors();
+
+        $exists = class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false));
+
+        if ($exists) {
+            $name = new \ReflectionClass($class);
+            $name = $name->getName();
+
+            if ($name !== $class) {
+                throw new \RuntimeException(sprintf('Case mismatch between loaded and declared class names: %s vs %s', $class, $name));
+            }
+        }
+
+        if ($file) {
+            if ('\\' == $class[0]) {
+                $class = substr($class, 1);
+            }
+
+            $i = -1;
+            $tail = str_replace('\\', DIRECTORY_SEPARATOR, $class).'.php';
+            $len = strlen($tail);
+
+            do {
+                $tail = substr($tail, $i+1);
+                $len -= $i+1;
+
+                if (! substr_compare($file, $tail, -$len, $len, true) && substr_compare($file, $tail, -$len, $len, false)) {
+                    throw new \RuntimeException(sprintf('Case mismatch between class and source file names: %s vs %s', $class, $file));
+                }
+            } while (false !== $i = strpos($tail, '\\'));
+
+            if (! $exists) {
                 if (false !== strpos($class, '/')) {
                     throw new \RuntimeException(sprintf('Trying to autoload a class with an invalid name "%s". Be careful that the namespace separator is "\" in PHP, not "/".', $class));
                 }

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -12,45 +12,133 @@
 namespace Symfony\Component\Debug\Tests;
 
 use Symfony\Component\Debug\DebugClassLoader;
+use Symfony\Component\Debug\ErrorHandler;
 
 class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var int Error reporting level before running tests.
+     */
+    private $errorReporting;
+
     private $loader;
 
     protected function setUp()
     {
+        $this->errorReporting = error_reporting(E_ALL | E_STRICT);
         $this->loader = new ClassLoader();
         spl_autoload_register(array($this->loader, 'loadClass'));
+        DebugClassLoader::enable();
     }
 
     protected function tearDown()
     {
+        DebugClassLoader::disable();
         spl_autoload_unregister(array($this->loader, 'loadClass'));
+        error_reporting($this->errorReporting);
     }
 
     public function testIdempotence()
     {
-        DebugClassLoader::enable();
         DebugClassLoader::enable();
 
         $functions = spl_autoload_functions();
         foreach ($functions as $function) {
             if (is_array($function) && $function[0] instanceof DebugClassLoader) {
                 $reflClass = new \ReflectionClass($function[0]);
-                $reflProp = $reflClass->getProperty('classFinder');
+                $reflProp = $reflClass->getProperty('classLoader');
                 $reflProp->setAccessible(true);
 
                 $this->assertNotInstanceOf('Symfony\Component\Debug\DebugClassLoader', $reflProp->getValue($function[0]));
-
-                DebugClassLoader::disable();
 
                 return;
             }
         }
 
-        DebugClassLoader::disable();
-
         $this->fail('DebugClassLoader did not register');
+    }
+
+    public function testUnsilencing()
+    {
+        ob_start();
+        $bak = array(
+            ini_set('log_errors', 0),
+            ini_set('display_errors', 1),
+        );
+
+        // See below: this will fail with parse error
+        // but this should not be @-silenced.
+        @ class_exists(__NAMESPACE__.'\TestingUnsilencing', true);
+
+        ini_set('log_errors', $bak[0]);
+        ini_set('display_errors', $bak[1]);
+        $output = ob_get_clean();
+
+        $this->assertStringMatchesFormat('%aParse error%a', $output);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Debug\Exception\DummyException
+     */
+    public function testStacking()
+    {
+        // the ContextErrorException must not be loaded to test the workaround
+        // for https://bugs.php.net/65322.
+        if (class_exists('Symfony\Component\Debug\Exception\ContextErrorException', false)) {
+            $this->markTestSkipped('The ContextErrorException class is already loaded.');
+        }
+
+        $exceptionHandler = $this->getMock('Symfony\Component\Debug\ExceptionHandler', array('handle'));
+        set_exception_handler(array($exceptionHandler, 'handle'));
+
+        $that = $this;
+        $exceptionCheck = function ($exception) use ($that) {
+            $that->assertInstanceOf('Symfony\Component\Debug\Exception\ContextErrorException', $exception);
+            $that->assertEquals(E_STRICT, $exception->getSeverity());
+            $that->assertStringStartsWith(__FILE__, $exception->getFile());
+            $that->assertRegexp('/^Runtime Notice: Declaration/', $exception->getMessage());
+        };
+
+        $exceptionHandler->expects($this->once())
+            ->method('handle')
+            ->will($this->returnCallback($exceptionCheck));
+        ErrorHandler::register();
+
+        try {
+            // Trigger autoloading + E_STRICT at compile time
+            // which in turn triggers $errorHandler->handle()
+            // that again triggers autoloading for ContextErrorException.
+            // Error stacking works around the bug above and everything is fine.
+
+            eval('
+                namespace '.__NAMESPACE__.';
+                class ChildTestingStacking extends TestingStacking { function foo($bar) {} }
+            ');
+        } catch (\Exception $e) {
+            restore_error_handler();
+            restore_exception_handler();
+
+            throw $e;
+        }
+
+        restore_error_handler();
+        restore_exception_handler();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testNameCaseMismatch()
+    {
+        class_exists(__NAMESPACE__.'\TestingCaseMismatch', true);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testFileCaseMismatch()
+    {
+        class_exists(__NAMESPACE__.'\Fixtures\CaseMismatch', true);
     }
 }
 
@@ -62,5 +150,14 @@ class ClassLoader
 
     public function findFile($class)
     {
+        if (__NAMESPACE__.'\TestingUnsilencing' === $class) {
+            eval('-- parse error --');
+        } elseif (__NAMESPACE__.'\TestingStacking' === $class) {
+            eval('namespace '.__NAMESPACE__.'; class TestingStacking { function foo() {} }');
+        } elseif (__NAMESPACE__.'\TestingCaseMismatch' === $class) {
+            eval('namespace '.__NAMESPACE__.'; class TestingCaseMisMatch {}');
+        } elseif (__NAMESPACE__.'\Fixtures\CaseMismatch' === $class) {
+            return __DIR__ . '/Fixtures/casemismatch.php';
+        }
     }
 }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/casemismatch.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/casemismatch.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+class CaseMismatch
+{
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

Ported from https://github.com/nicolas-grekas/Patchwork/

Three enhancements for Symfony debug mode:
- detect case mismatches between loaded class name, its declared name and its source file name
- dismiss hard to debug blank pages related to non-catchable-@-silenced fatal errors (`@(new Toto) + parse error in Toto.php` => enjoy debugging)
- work around https://bugs.php.net/42098 / https://bugs.php.net/54054 / https://bugs.php.net/60149 / https://bugs.php.net/65322 (fixed in 5.5.5)

An other thing I didn't port is scope isolation: the current `require` in autoloaders is done in their scope, so local $vars / $this (with access to private props/methods) is easily accessible from required files. Shouldn't proper separation prevent that?
