### PR TITLE
[DomCrawler] Fixed incorrect handling of image inputs

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -384,7 +384,24 @@ class Form extends Link implements \ArrayAccess
 
         // add submitted button if it has a valid name
         if ('form' !== $this->button->nodeName && $this->button->hasAttribute('name') && $this->button->getAttribute('name')) {
-            $this->set(new Field\InputFormField($document->importNode($this->button, true)));
+            if ('input' == $this->button->nodeName && 'image' == $this->button->getAttribute('type')) {
+                $name = $this->button->getAttribute('name');
+                $this->button->setAttribute('value', '0');
+
+                // temporarily change the name of the input node for the x coordinate
+                $this->button->setAttribute('name', $name.'.x');
+                $this->set(new Field\InputFormField($document->importNode($this->button, true)));
+
+                // temporarily change the name of the input node for the y coordinate
+                $this->button->setAttribute('name', $name.'.y');
+                $this->set(new Field\InputFormField($document->importNode($this->button, true)));
+
+                // restore the original name of the input node
+                $this->button->setAttribute('name', $name);
+            }
+            else {
+                $this->set(new Field\InputFormField($document->importNode($this->button, true)));
+            }
         }
 
         // find form elements corresponding to the current form

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -224,6 +224,11 @@ class FormTest extends \PHPUnit_Framework_TestCase
                  array('foobar' => array('InputFormField', 'foobar')),
             ),
             array(
+                'turns an image input into x and y fields',
+                '<input type="image" name="bar" />',
+                array('bar.x' => array('InputFormField', '0'), 'bar.y' => array('InputFormField', '0')),
+            ),
+            array(
                 'returns textareas',
                 '<textarea name="foo">foo</textarea>
                  <input type="submit" />',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10204 |
| License | MIT |
| Doc PR |  |

A possible approach to fix #10204, but I'm open to suggestions to fix this another way, as this might not be the most 'elegant' way.

Initially, my thoughts were to create a new DomCrawler\Field\FormField subclass, especially for image inputs. However, this does not solve the problem, because such a FormField would still exist under 1 name in the FormFieldRegistry.

Instead, I've changed it to have 2 separate FormFields instead (which both reference the same input node), with different names (.x and .y) so that both values can be set separately and will both be submitted.
