### PR TITLE
[3.0][Console] Added isVerbosity* to OutputInterface

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -18,6 +18,11 @@ UPGRADE FROM 2.x to 3.0
    `DebugClassLoader`. The difference is that the constructor now takes a
    loader to wrap.
 
+### Console
+
+ * The methods `isQuiet`, `isVerbose`, `isVeryVerbose` and `isDebug` were added
+   to `Symfony\Component\Console\Output\OutputInteface`.
+
 ### EventDispatcher
 
  * The interface `Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Now, only `Output` have theses methods. But in the `Command` class, `execute` receive an instance of `OutputInterface`. So, to avoid coding against an implementation, theses method should be added to the interface.
