### PR TITLE
[Routing] reduced recursion in dumper

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
@@ -55,26 +55,27 @@ class DumperPrefixCollection extends DumperCollection
     public function addPrefixRoute(DumperRoute $route)
     {
         $prefix = $route->getRoute()->compile()->getStaticPrefix();
+        $collection = $this;
 
         // Same prefix, add to current leave
-        if ($this->prefix === $prefix) {
-            $this->add($route);
+        if ($collection->prefix === $prefix) {
+            $collection->add($route);
 
-            return $this;
+            return $collection;
         }
 
         // Prefix starts with route's prefix
-        if ('' === $this->prefix || 0 === strpos($prefix, $this->prefix)) {
-            $collection = new DumperPrefixCollection();
-            $collection->setPrefix(substr($prefix, 0, strlen($this->prefix)+1));
-            $this->add($collection);
+        if ('' === $collection->prefix || 0 === strpos($prefix, $collection->prefix)) {
+            $child = new DumperPrefixCollection();
+            $child->setPrefix(substr($prefix, 0, strlen($collection->prefix)+1));
+            $collection->add($child);
 
-            return $collection->addPrefixRoute($route);
+            return $child->addPrefixRoute($route);
         }
 
         // No match, fallback to parent (recursively)
 
-        if (null === $parent = $this->getParent()) {
+        if (null === $parent = $collection->getParent()) {
             throw new \LogicException("The collection root must not have a prefix");
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | sensiolabs/SensioFrameworkExtraBundle/issues/275 |
| License | MIT |

This reduces recursion in the route dumper, avoiding issues with xdebug's recursion limit.
