### PR TITLE
[ExpressionLanguage] added some tests for the built-in constant() function

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -45,4 +45,13 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
         $parsedExpression = $expressionLanguage->parse('1 + 1', array());
         $this->assertSame($savedParsedExpression, $parsedExpression);
     }
+
+    public function testConstantFunction()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertEquals(PHP_VERSION, $expressionLanguage->evaluate('constant("PHP_VERSION")'));
+
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertEquals('constant("PHP_VERSION")', $expressionLanguage->compile('constant("PHP_VERSION")'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10216 |
| License | MIT |
| Doc PR | n/a |
