### PR TITLE
[Form] Allow lenient parsing of inputs in form types date, birthday and dates in datetime

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -39,7 +39,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
      * @param integer $timeFormat          The time format
      * @param integer $calendar            One of the \IntlDateFormatter calendar constants
      * @param string  $pattern             A pattern to pass to \IntlDateFormatter
-     * @param bool    $lenientDateParsing  Flag, whether the date parser should use lenient parsing
+     * @param Boolean $lenientDateParsing  Flag, whether the date parser should use lenient parsing
      *
      * @throws UnexpectedTypeException If a format is not supported or if a timezone is not a string
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -26,22 +26,24 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
     private $timeFormat;
     private $pattern;
     private $calendar;
+    private $lenientDateHandling;
 
     /**
      * Constructor.
      *
      * @see BaseDateTimeTransformer::formats for available format options
      *
-     * @param string  $inputTimezone  The name of the input timezone
-     * @param string  $outputTimezone The name of the output timezone
-     * @param integer $dateFormat     The date format
-     * @param integer $timeFormat     The time format
-     * @param integer $calendar       One of the \IntlDateFormatter calendar constants
-     * @param string  $pattern        A pattern to pass to \IntlDateFormatter
+     * @param string  $inputTimezone       The name of the input timezone
+     * @param string  $outputTimezone      The name of the output timezone
+     * @param integer $dateFormat          The date format
+     * @param integer $timeFormat          The time format
+     * @param integer $calendar            One of the \IntlDateFormatter calendar constants
+     * @param string  $pattern             A pattern to pass to \IntlDateFormatter
+     * @param bool    $lenientDateHandling Flag, whether the date parser should use lenient parsing
      *
      * @throws UnexpectedTypeException If a format is not supported or if a timezone is not a string
      */
-    public function __construct($inputTimezone = null, $outputTimezone = null, $dateFormat = null, $timeFormat = null, $calendar = \IntlDateFormatter::GREGORIAN, $pattern = null)
+    public function __construct($inputTimezone = null, $outputTimezone = null, $dateFormat = null, $timeFormat = null, $calendar = \IntlDateFormatter::GREGORIAN, $pattern = null, $lenientDateHandling = false)
     {
         parent::__construct($inputTimezone, $outputTimezone);
 
@@ -65,6 +67,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $this->timeFormat = $timeFormat;
         $this->calendar = $calendar;
         $this->pattern = $pattern;
+        $this->lenientDateHandling = $lenientDateHandling;
     }
 
     /**
@@ -162,7 +165,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $pattern = $this->pattern;
 
         $intlDateFormatter = new \IntlDateFormatter(\Locale::getDefault(), $dateFormat, $timeFormat, $timezone, $calendar, $pattern);
-        $intlDateFormatter->setLenient(false);
+        $intlDateFormatter->setLenient($this->lenientDateHandling);
 
         return $intlDateFormatter;
     }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -26,7 +26,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
     private $timeFormat;
     private $pattern;
     private $calendar;
-    private $lenientDateHandling;
+    private $lenientDateParsing;
 
     /**
      * Constructor.
@@ -39,11 +39,11 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
      * @param integer $timeFormat          The time format
      * @param integer $calendar            One of the \IntlDateFormatter calendar constants
      * @param string  $pattern             A pattern to pass to \IntlDateFormatter
-     * @param bool    $lenientDateHandling Flag, whether the date parser should use lenient parsing
+     * @param bool    $lenientDateParsing  Flag, whether the date parser should use lenient parsing
      *
      * @throws UnexpectedTypeException If a format is not supported or if a timezone is not a string
      */
-    public function __construct($inputTimezone = null, $outputTimezone = null, $dateFormat = null, $timeFormat = null, $calendar = \IntlDateFormatter::GREGORIAN, $pattern = null, $lenientDateHandling = false)
+    public function __construct($inputTimezone = null, $outputTimezone = null, $dateFormat = null, $timeFormat = null, $calendar = \IntlDateFormatter::GREGORIAN, $pattern = null, $lenientDateParsing = false)
     {
         parent::__construct($inputTimezone, $outputTimezone);
 
@@ -67,7 +67,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $this->timeFormat = $timeFormat;
         $this->calendar = $calendar;
         $this->pattern = $pattern;
-        $this->lenientDateHandling = $lenientDateHandling;
+        $this->lenientDateParsing = $lenientDateParsing;
     }
 
     /**
@@ -165,7 +165,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $pattern = $this->pattern;
 
         $intlDateFormatter = new \IntlDateFormatter(\Locale::getDefault(), $dateFormat, $timeFormat, $timezone, $calendar, $pattern);
-        $intlDateFormatter->setLenient($this->lenientDateHandling);
+        $intlDateFormatter->setLenient($this->lenientDateParsing);
 
         return $intlDateFormatter;
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -93,7 +93,7 @@ class DateTimeType extends AbstractType
         }
 
         if ('single_text' === $options['widget']) {
-            if ((self::HTML5_FORMAT === $pattern) && !$options['lenient_date_parsing']) {
+            if (self::HTML5_FORMAT === $pattern && !$options['lenient_date_parsing']) {
                 $builder->addViewTransformer(new DateTimeToRfc3339Transformer(
                     $options['model_timezone'],
                     $options['view_timezone']

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -93,7 +93,7 @@ class DateTimeType extends AbstractType
         }
 
         if ('single_text' === $options['widget']) {
-            if (self::HTML5_FORMAT === $pattern) {
+            if ((self::HTML5_FORMAT === $pattern) && !$options['lenient_date_parsing']) {
                 $builder->addViewTransformer(new DateTimeToRfc3339Transformer(
                     $options['model_timezone'],
                     $options['view_timezone']
@@ -105,7 +105,8 @@ class DateTimeType extends AbstractType
                     $dateFormat,
                     $timeFormat,
                     $calendar,
-                    $pattern
+                    $pattern,
+                    $options['lenient_date_parsing']
                 ));
             }
         } else {
@@ -117,6 +118,7 @@ class DateTimeType extends AbstractType
                 'empty_value',
                 'required',
                 'translation_domain',
+                'lenient_date_parsing',
             )));
 
             $timeOptions = array_intersect_key($options, array_flip(array(
@@ -208,26 +210,29 @@ class DateTimeType extends AbstractType
         };
 
         $resolver->setDefaults(array(
-            'input'          => 'datetime',
-            'model_timezone' => null,
-            'view_timezone'  => null,
-            'format'         => self::HTML5_FORMAT,
-            'date_format'    => null,
-            'widget'         => null,
-            'date_widget'    => $dateWidget,
-            'time_widget'    => $timeWidget,
-            'with_minutes'   => true,
-            'with_seconds'   => false,
+            'input'                => 'datetime',
+            'model_timezone'       => null,
+            'view_timezone'        => null,
+            'format'               => self::HTML5_FORMAT,
+            'date_format'          => null,
+            'widget'               => null,
+            'date_widget'          => $dateWidget,
+            'time_widget'          => $timeWidget,
+            'with_minutes'         => true,
+            'with_seconds'         => false,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
-            'by_reference'   => false,
-            'error_bubbling' => false,
+            'by_reference'         => false,
+            'error_bubbling'       => false,
             // If initialized with a \DateTime object, FormType initializes
             // this option to "\DateTime". Since the internal, normalized
             // representation is not \DateTime, but an array, we need to unset
             // this option.
-            'data_class'     => null,
-            'compound'       => $compound,
+            'data_class'           => null,
+            'compound'             => $compound,
+            // Enables lenient parsing of dates. If set to true, some invalid date formats
+            // will be automatically adjusted (for example 35.12.2013 -> 04.01.2013)
+            'lenient_date_parsing' => false,
         ));
 
         // Don't add some defaults in order to preserve the defaults

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -62,7 +62,8 @@ class DateType extends AbstractType
                 $dateFormat,
                 $timeFormat,
                 $calendar,
-                $pattern
+                $pattern,
+                $options['lenient_date_parsing']
             ));
         } else {
             $yearOptions = $monthOptions = $dayOptions = array(
@@ -190,25 +191,28 @@ class DateType extends AbstractType
         };
 
         $resolver->setDefaults(array(
-            'years'          => range(date('Y') - 5, date('Y') + 5),
-            'months'         => range(1, 12),
-            'days'           => range(1, 31),
-            'widget'         => 'choice',
-            'input'          => 'datetime',
-            'format'         => $format,
-            'model_timezone' => null,
-            'view_timezone'  => null,
-            'empty_value'    => $emptyValue,
+            'years'           => range(date('Y') - 5, date('Y') + 5),
+            'months'          => range(1, 12),
+            'days'            => range(1, 31),
+            'widget'          => 'choice',
+            'input'           => 'datetime',
+            'format'          => $format,
+            'model_timezone'  => null,
+            'view_timezone'   => null,
+            'empty_value'     => $emptyValue,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
-            'by_reference'   => false,
-            'error_bubbling' => false,
+            'by_reference'    => false,
+            'error_bubbling'  => false,
             // If initialized with a \DateTime object, FormType initializes
             // this option to "\DateTime". Since the internal, normalized
             // representation is not \DateTime, but an array, we need to unset
             // this option.
-            'data_class'     => null,
-            'compound'       => $compound,
+            'data_class'      => null,
+            'compound'        => $compound,
+            // Enables lenient parsing of dates. If set to true, some invalid date formats
+            // will be automatically adjusted (for example 35.12.2013 -> 04.01.2013)
+            'lenient_date_parsing' => false,
         ));
 
         $resolver->setNormalizers(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -191,25 +191,25 @@ class DateType extends AbstractType
         };
 
         $resolver->setDefaults(array(
-            'years'           => range(date('Y') - 5, date('Y') + 5),
-            'months'          => range(1, 12),
-            'days'            => range(1, 31),
-            'widget'          => 'choice',
-            'input'           => 'datetime',
-            'format'          => $format,
-            'model_timezone'  => null,
-            'view_timezone'   => null,
-            'empty_value'     => $emptyValue,
+            'years'                => range(date('Y') - 5, date('Y') + 5),
+            'months'               => range(1, 12),
+            'days'                 => range(1, 31),
+            'widget'               => 'choice',
+            'input'                => 'datetime',
+            'format'               => $format,
+            'model_timezone'       => null,
+            'view_timezone'        => null,
+            'empty_value'          => $emptyValue,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
-            'by_reference'    => false,
-            'error_bubbling'  => false,
+            'by_reference'         => false,
+            'error_bubbling'       => false,
             // If initialized with a \DateTime object, FormType initializes
             // this option to "\DateTime". Since the internal, normalized
             // representation is not \DateTime, but an array, we need to unset
             // this option.
-            'data_class'      => null,
-            'compound'        => $compound,
+            'data_class'           => null,
+            'compound'             => $compound,
             // Enables lenient parsing of dates. If set to true, some invalid date formats
             // will be automatically adjusted (for example 35.12.2013 -> 04.01.2013)
             'lenient_date_parsing' => false,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -474,8 +474,7 @@ class DateTimeTypeTest extends TypeTestCase
         $this->assertSame(array($error), $form->getErrors());
     }
 
-
-    public function testLenientDateParsing ()
+    public function testLenientDateParsing()
     {
         $form = $this->factory->create('datetime', null, array(
             'format' => 'yyyy-MM-dd',
@@ -491,8 +490,7 @@ class DateTimeTypeTest extends TypeTestCase
         $this->assertEquals('2014-01-04 00:00:00', $form->getData());
     }
 
-
-    public function testWithoutLenientDateParsing ()
+    public function testWithoutLenientDateParsing()
     {
         $form = $this->factory->create('datetime', null, array(
             'format' => 'yyyy-MM-dd',
@@ -505,5 +503,4 @@ class DateTimeTypeTest extends TypeTestCase
         $form->submit('2013-12-35');
         $this->assertNull($form->getData());
     }
-
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -474,4 +474,36 @@ class DateTimeTypeTest extends TypeTestCase
         $this->assertSame(array($error), $form->getErrors());
     }
 
+
+    public function testLenientDateParsing ()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'format' => 'yyyy-MM-dd',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'string',
+            'lenient_date_parsing' => true
+        ));
+
+        $form->submit('2013-12-35');
+
+        $this->assertEquals('2014-01-04 00:00:00', $form->getData());
+    }
+
+
+    public function testWithoutLenientDateParsing ()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'format' => 'yyyy-MM-dd',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'string',
+        ));
+
+        $form->submit('2013-12-35');
+        $this->assertNull($form->getData());
+    }
+
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -799,4 +799,36 @@ class DateTypeTest extends TypeTestCase
 
         $this->assertEquals($listChoices, $view['year']->vars['choices']);
     }
+
+
+    public function testLenientDateParsing ()
+    {
+        $form = $this->factory->create('date', null, array(
+            'format' => 'dd.MM.yyyy',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'string',
+            'lenient_date_parsing' => true
+        ));
+
+        $form->submit('35.12.2013');
+
+        $this->assertEquals('2014-01-04', $form->getData());
+    }
+
+
+    public function testWithoutLenientDateParsing ()
+    {
+        $form = $this->factory->create('date', null, array(
+            'format' => 'dd.MM.yyyy',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'string',
+        ));
+
+        $form->submit('35.12.2013');
+        $this->assertNull($form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -800,8 +800,7 @@ class DateTypeTest extends TypeTestCase
         $this->assertEquals($listChoices, $view['year']->vars['choices']);
     }
 
-
-    public function testLenientDateParsing ()
+    public function testLenientDateParsing()
     {
         $form = $this->factory->create('date', null, array(
             'format' => 'dd.MM.yyyy',
@@ -817,8 +816,7 @@ class DateTypeTest extends TypeTestCase
         $this->assertEquals('2014-01-04', $form->getData());
     }
 
-
-    public function testWithoutLenientDateParsing ()
+    public function testWithoutLenientDateParsing()
     {
         $form = $this->factory->create('date', null, array(
             'format' => 'dd.MM.yyyy',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #3730 |
| License | MIT |
| Doc PR | (not yet) |

This PR is about enabling lenient date parsing (name of the option debatable).
If you enable it, you can enter dates like "35.12.2013" which are automatically transformed to "4.1.2014" (this transformation happens before the validators are applied).

This was possible in earlier versions but disabled in 7e3213c.

BC is preserved by setting the default value to the current value, the only BC issue is when somebody created a form extension which added a field with the same name (unlikely).
