### PR TITLE
[DependencyInjection] made some perf improvements

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
@@ -17,11 +17,15 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class Container extends AbstractContainer
 {
+    private static $parameters = array(
+
+        );
+
     /**
      * Constructor.
      */
     public function __construct()
     {
-        parent::__construct();
+        parent::__construct(new ParameterBag(self::$parameters));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
@@ -16,11 +16,15 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
+    private static $parameters = array(
+
+        );
+
     /**
      * Constructor.
      */
     public function __construct()
     {
-        parent::__construct();
+        parent::__construct(new ParameterBag(self::$parameters));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -16,15 +16,16 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
+    private static $parameters = array(
+            'empty_value' => '',
+            'some_string' => '-',
+        );
 
     /**
      * Constructor.
      */
     public function __construct()
     {
-        $this->parameters = $this->getDefaultParameters();
-
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
@@ -68,11 +69,11 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        if (!(isset($this->parameters[$name]) || array_key_exists($name, $this->parameters))) {
+        if (!(isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters))) {
             throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
         }
 
-        return $this->parameters[$name];
+        return self::$parameters[$name];
     }
 
     /**
@@ -82,7 +83,7 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
+        return isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters);
     }
 
     /**
@@ -99,21 +100,9 @@ class ProjectServiceContainer extends Container
     public function getParameterBag()
     {
         if (null === $this->parameterBag) {
-            $this->parameterBag = new FrozenParameterBag($this->parameters);
+            $this->parameterBag = new FrozenParameterBag(self::$parameters);
         }
 
         return $this->parameterBag;
-    }
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
-            'empty_value' => '',
-            'some_string' => '-',
-        );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services11.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services11.php
@@ -16,7 +16,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
+    private static $parameters = array(
+
+        );
 
     /**
      * Constructor.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -16,22 +16,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        parent::__construct(new ParameterBag($this->getDefaultParameters()));
-    }
-
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
+    private static $parameters = array(
             'foo' => '%baz%',
             'baz' => 'bar',
             'bar' => 'foo is %%foo bar',
@@ -47,5 +32,12 @@ class ProjectServiceContainer extends Container
                 7 => 'null',
             ),
         );
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(new ParameterBag(self::$parameters));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -16,12 +16,18 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
+    private static $parameters = array(
+            'baz_class' => 'BazClass',
+            'foo_class' => 'Bar\\FooClass',
+            'foo' => 'bar',
+        );
+
     /**
      * Constructor.
      */
     public function __construct()
     {
-        parent::__construct(new ParameterBag($this->getDefaultParameters()));
+        parent::__construct(new ParameterBag(self::$parameters));
         $this->methodMap = array(
             'bar' => 'getBarService',
             'baz' => 'getBazService',
@@ -369,19 +375,5 @@ class ProjectServiceContainer extends Container
         $instance->foo = 'bar';
 
         return $instance;
-    }
-
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
-            'baz_class' => 'BazClass',
-            'foo_class' => 'Bar\\FooClass',
-            'foo' => 'bar',
-        );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -16,15 +16,17 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
+    private static $parameters = array(
+            'baz_class' => 'BazClass',
+            'foo_class' => 'Bar\\FooClass',
+            'foo' => 'bar',
+        );
 
     /**
      * Constructor.
      */
     public function __construct()
     {
-        $this->parameters = $this->getDefaultParameters();
-
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
@@ -320,11 +322,11 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        if (!(isset($this->parameters[$name]) || array_key_exists($name, $this->parameters))) {
+        if (!(isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters))) {
             throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
         }
 
-        return $this->parameters[$name];
+        return self::$parameters[$name];
     }
 
     /**
@@ -334,7 +336,7 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
+        return isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters);
     }
 
     /**
@@ -351,22 +353,9 @@ class ProjectServiceContainer extends Container
     public function getParameterBag()
     {
         if (null === $this->parameterBag) {
-            $this->parameterBag = new FrozenParameterBag($this->parameters);
+            $this->parameterBag = new FrozenParameterBag(self::$parameters);
         }
 
         return $this->parameterBag;
-    }
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
-            'baz_class' => 'BazClass',
-            'foo_class' => 'Bar\\FooClass',
-            'foo' => 'bar',
-        );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR optimizes the creation of dumped containers drastically (thanks @jpauli for the hint).

The Container class generated by the PHP dumper does not include the `getDefaultParameters()` method anymore. It does not seem like a big deal to me as I fail to see a use case where someone would override this method.
