### PR TITLE
[DomCrawler] Added support for <area> tags to be treated as links

### DIFF
--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\DomCrawler;
 
 /**
- * Link represents an HTML link (an HTML a tag).
+ * Link represents an HTML link (an HTML a or area tag).
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
@@ -188,7 +188,7 @@ class Link
      */
     protected function setNode(\DOMNode $node)
     {
-        if ('a' != $node->nodeName) {
+        if ('a' != $node->nodeName && 'area' != $node->nodeName) {
             throw new \LogicException(sprintf('Unable to click on a "%s" tag.', $node->nodeName));
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
@@ -74,6 +74,18 @@ class LinkTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $link->getUri());
     }
 
+    /**
+     * @dataProvider getGetUriTests
+     */
+    public function testGetUriOnArea($url, $currentUri, $expected)
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML(sprintf('<html><map><area href="%s" /></map></html>', $url));
+        $link = new Link($dom->getElementsByTagName('area')->item(0), $currentUri);
+
+        $this->assertEquals($expected, $link->getUri());
+    }
+
     public function getGetUriTests()
     {
         return array(


### PR DESCRIPTION
The [HTML area tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area) behaves exactly like the `a` tag in that they're both clickable, and if it has a `href` follows a link. The Link class works the same with both tags.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
