### PR TITLE
[Form][2.3] Fixes empty file-inputs getting treated as extra field.

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -556,7 +556,7 @@ class Form implements \IteratorAggregate, FormInterface
                 }
 
                 foreach ($this->children as $name => $child) {
-                    if (isset($submittedData[$name]) || $clearMissing) {
+                    if (array_key_exists($name, $submittedData) || $clearMissing) {
                         $child->submit(isset($submittedData[$name]) ? $submittedData[$name] : null, $clearMissing);
                         unset($submittedData[$name]);
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -115,7 +115,7 @@ class CompoundFormTest extends AbstractFormTest
         $child = $factory->create('file', null, array('auto_initialize' => false));
 
         $this->form->add($child);
-        $this->form->submit(array('file' => null));
+        $this->form->submit(array('file' => null), false);
 
         $this->assertCount(0, $this->form->getExtraData());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8575 (https://github.com/symfony/symfony/pull/8575#issuecomment-34867485) |
| License | MIT |

Re-applies 968fe23 (PR #8575).

The test for this already exists, it was just this line that got overwritten by https://github.com/symfony/symfony/commit/eb9f76d5bad120c1d4b3b30c2d8c73bb9d5928e8#diff-ca5e25b47f3ecc94cd557946aeb486c6L542

To clarify, this is a PR into 2.3 branch - this already exists in 2.4 (and later from this PR: https://github.com/symfony/symfony/pull/9146)
