### PR TITLE
[Form] fixed ChoiceListCache (made hash more unique)

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -166,7 +166,12 @@ class ChoiceType extends AbstractType
             $choices = null !== $options['choices'] ? $options['choices'] : array();
 
             // Reuse existing choice lists in order to increase performance
-            $hash = hash('sha256', json_encode(array($choices, $options['preferred_choices'])));
+            $hashBase = json_encode(array($choices, $options['preferred_choices']));
+            if (isset($choices[0]) && is_object($choices[0])) {
+                $hashBase .= get_class($choices[0]);
+            }
+
+            $hash = hash('sha256', $hashBase);
 
             if (!isset($choiceListCache[$hash])) {
                 $choiceListCache[$hash] = new SimpleChoiceList($choices, $options['preferred_choices']);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -416,7 +416,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $form->submit('foobar');
 
-        $this->assertSame(null, $form->getData());
+        $this->assertNull($form->getData());
         $this->assertSame('foobar', $form->getViewData());
         $this->assertEmpty($form->getExtraData());
         $this->assertFalse($form->isSynchronized());
@@ -481,7 +481,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $form->submit('foobar');
 
-        $this->assertSame(null, $form->getData());
+        $this->assertNull($form->getData());
         $this->assertSame('foobar', $form->getViewData());
         $this->assertEmpty($form->getExtraData());
         $this->assertFalse($form->isSynchronized());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -335,6 +335,42 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertEquals(array('2', '3'), $form->getViewData());
     }
 
+    /**
+     * @return array
+     */
+    public function provideForChoiceListCacheTest()
+    {
+        return array(
+            array(array('field1' => 0, 'field2' => 3), array('field1' => 0, 'field2' => 3)),
+            array(array('field1' => 0, 'field2' => 4), array('field1' => 0)),
+        );
+    }
+
+    /**
+     * @param array $submitted
+     * @param array $expectedData
+     *
+     * @dataProvider provideForChoiceListCacheTest
+     */
+    public function testSubmitObjectChoiceWithUniqueHash($submitted, $expectedData)
+    {
+        $choice = $this->factory->createNamed('field1', 'choice', null, array(
+            'choices' => $this->objectChoices,
+            'auto_initialize' => false
+        ));
+        array_pop($this->objectChoices);
+        $anotherChoice = $this->factory->createNamed('field2', 'choice', null, array(
+            'choices' => $this->objectChoices,
+            'auto_initialize' => false
+        ));
+
+        $form = $this->factory->create();
+        $form->add($choice)
+            ->add($anotherChoice);
+        $form->submit($submitted);
+        $this->assertEquals($expectedData, $form->getData());
+    }
+
     public function testSubmitSingleExpandedRequired()
     {
         $form = $this->factory->create('choice', null, array(


### PR DESCRIPTION
this PR refers to this issue: https://github.com/symfony/symfony/issues/10027

_Especially naming in the unittests wasn't that easy for me. I'm open for any better suggestions._

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/10027 |
| License | MIT |
| Doc PR | none |
