### PR TITLE
 [Routing] add support for optional placeholders in the host

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -20,6 +20,8 @@ namespace Symfony\Component\Routing;
 class RouteCompiler implements RouteCompilerInterface
 {
     const REGEX_DELIMITER = '#';
+    const HOST_SEPARATOR = '.';
+    const PATH_SEPARATOR = '/';
 
     /**
      * This string defines the characters that are automatically considered separators in front of
@@ -39,15 +41,13 @@ class RouteCompiler implements RouteCompilerInterface
     {
         $staticPrefix = null;
         $hostVariables = array();
-        $pathVariables = array();
         $variables = array();
-        $tokens = array();
         $regex = null;
         $hostRegex = null;
         $hostTokens = array();
 
         if ('' !== $host = $route->getHost()) {
-            $result = self::compilePattern($route, $host, true);
+            $result = self::compileHostPattern($route, $host);
 
             $hostVariables = $result['variables'];
             $variables = array_merge($variables, $hostVariables);
@@ -58,7 +58,7 @@ class RouteCompiler implements RouteCompilerInterface
 
         $path = $route->getPath();
 
-        $result = self::compilePattern($route, $path, false);
+        $result = self::compilePathPattern($route, $path);
 
         $staticPrefix = $result['staticPrefix'];
 
@@ -80,18 +80,107 @@ class RouteCompiler implements RouteCompilerInterface
         );
     }
 
-    private static function compilePattern(Route $route, $pattern, $isHost)
+    /**
+     * Compile route host pattern
+     *
+     * @param Route  $route
+     * @param string $pattern
+     *
+     * @return array
+     * @throws \LogicException
+     * @throws \DomainException
+     */
+    private static function compileHostPattern(Route $route, $pattern)
     {
         $tokens = array();
         $variables = array();
-        $matches = array();
-        $pos = 0;
-        $defaultSeparator = $isHost ? '.' : '/';
+        $pos = strlen($pattern);
 
-        // Match all variables enclosed in "{}" and iterate over them. But we only want to match the innermost variable
-        // in case of nested "{}", e.g. {foo{bar}}. This in ensured because \w does not match "{" or "}" itself.
-        preg_match_all('#\{\w+\}#', $pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
-        foreach ($matches as $match) {
+        foreach (array_reverse(self::getVariableMatches($pattern)) as $match) {
+            $varName = substr($match[0][0], 1, -1);
+            // get all static text following the current variable
+            $variableEnd = $match[0][1] + strlen($match[0][0]);
+            $sequentText = substr($pattern, $variableEnd, $pos - $variableEnd);
+            $pos = $match[0][1];
+            $sequentChar = strlen($sequentText) > 0 ? substr($sequentText, 0, 1) : '';
+            $isSeparator = '' !== $sequentChar && false !== strpos(static::SEPARATORS, $sequentChar);
+
+            self::validateVariable($pattern, $varName, $variables);
+
+            if ($isSeparator && strlen($sequentText) > 1) {
+                $tokens[] = array('text', substr($sequentText, 1));
+            } elseif (!$isSeparator && strlen($sequentText) > 0) {
+                $tokens[] = array('text', $sequentText);
+            }
+
+            $regexp = $route->getRequirement($varName);
+            if (null === $regexp) {
+                $precedingPattern = (string) substr($pattern, 0, $pos);
+                // Find the next static character after the variable that functions as a separator. By default, this separator and '/'
+                // are disallowed for the variable. This default requirement makes sure that optional variables can be matched at all
+                // and that the generating-matching-combination of URLs unambiguous, i.e. the params used for generating the URL are
+                // the same that will be matched. Example: new Route('/{page}.{_format}', array('_format' => 'html'))
+                // If {page} would also match the separating dot, {_format} would never match as {page} will eagerly consume everything.
+                // Also even if {_format} was not optional the requirement prevents that {page} matches something that was originally
+                // part of {_format} when generating the URL, e.g. _format = 'mobile.html'.
+                $previousSeparator = self::findPreviousSeparator($precedingPattern);
+                $regexp = sprintf(
+                    '[^%s%s]+',
+                    self::HOST_SEPARATOR !== $previousSeparator && '' !== $previousSeparator ? preg_quote($previousSeparator, self::REGEX_DELIMITER) : '',
+                    preg_quote(self::HOST_SEPARATOR, self::REGEX_DELIMITER)
+                );
+
+                if (('' !== $previousSeparator && !preg_match('#\{\w+\}$#', $precedingPattern)) || '' === $precedingPattern) {
+                    // When we have a separator, which is disallowed for the variable, we can optimize the regex with a possessive
+                    // quantifier. This prevents useless backtracking of PCRE and improves performance by 20% for matching those patterns.
+                    // Given the above example, there is no point in backtracking into {page} (that forbids the dot) when a dot must follow
+                    // after it. This optimization cannot be applied when the next char is no real separator or when the next variable is
+                    // directly adjacent, e.g. '/{x}{y}'.
+                    $regexp .= '+';
+                }
+            }
+
+            $tokens[] = array('variable', $isSeparator ? $sequentChar : '', $regexp, $varName);
+            $variables[] = $varName;
+        }
+
+        if ($pos > 0) {
+            $tokens[] = array('text', substr($pattern, 0, $pos));
+        }
+
+        $firstOptional = self::getFirstOptionalKey($route, $tokens);
+
+        // compute the matching regexp
+        $regexp = '';
+        for ($i = 0, $nbToken = count($tokens); $i < $nbToken; $i++) {
+            $regexp = self::computeHostRegexp($tokens, $i, $firstOptional, true) . $regexp;
+        }
+
+        return array(
+            'staticPrefix' => 'text' === $tokens[0][0] ? $tokens[0][1] : '',
+            'regex' => self::REGEX_DELIMITER.'^'.$regexp.'$'.self::REGEX_DELIMITER.'s',
+            'tokens' => array_reverse($tokens),
+            'variables' => array_reverse($variables),
+        );
+    }
+
+    /**
+     * Compile route path pattern
+     *
+     * @param Route  $route
+     * @param string $pattern
+     *
+     * @return array
+     * @throws \LogicException
+     * @throws \DomainException
+     */
+    private static function compilePathPattern(Route $route, $pattern)
+    {
+        $tokens = array();
+        $variables = array();
+        $pos = 0;
+
+        foreach (self::getVariableMatches($pattern) as $match) {
             $varName = substr($match[0][0], 1, -1);
             // get all static text preceding the current variable
             $precedingText = substr($pattern, $pos, $match[0][1] - $pos);
@@ -99,12 +188,7 @@ class RouteCompiler implements RouteCompilerInterface
             $precedingChar = strlen($precedingText) > 0 ? substr($precedingText, -1) : '';
             $isSeparator = '' !== $precedingChar && false !== strpos(static::SEPARATORS, $precedingChar);
 
-            if (is_numeric($varName)) {
-                throw new \DomainException(sprintf('Variable name "%s" cannot be numeric in route pattern "%s". Please use a different name.', $varName, $pattern));
-            }
-            if (in_array($varName, $variables)) {
-                throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $pattern, $varName));
-            }
+            self::validateVariable($pattern, $varName, $variables);
 
             if ($isSeparator && strlen($precedingText) > 1) {
                 $tokens[] = array('text', substr($precedingText, 0, -1));
@@ -125,8 +209,8 @@ class RouteCompiler implements RouteCompilerInterface
                 $nextSeparator = self::findNextSeparator($followingPattern);
                 $regexp = sprintf(
                     '[^%s%s]+',
-                    preg_quote($defaultSeparator, self::REGEX_DELIMITER),
-                    $defaultSeparator !== $nextSeparator && '' !== $nextSeparator ? preg_quote($nextSeparator, self::REGEX_DELIMITER) : ''
+                    preg_quote(self::PATH_SEPARATOR, self::REGEX_DELIMITER),
+                    self::PATH_SEPARATOR !== $nextSeparator && '' !== $nextSeparator ? preg_quote($nextSeparator, self::REGEX_DELIMITER) : ''
                 );
                 if (('' !== $nextSeparator && !preg_match('#^\{\w+\}#', $followingPattern)) || '' === $followingPattern) {
                     // When we have a separator, which is disallowed for the variable, we can optimize the regex with a possessive
@@ -146,23 +230,12 @@ class RouteCompiler implements RouteCompilerInterface
             $tokens[] = array('text', substr($pattern, $pos));
         }
 
-        // find the first optional token
-        $firstOptional = PHP_INT_MAX;
-        if (!$isHost) {
-            for ($i = count($tokens) - 1; $i >= 0; $i--) {
-                $token = $tokens[$i];
-                if ('variable' === $token[0] && $route->hasDefault($token[3])) {
-                    $firstOptional = $i;
-                } else {
-                    break;
-                }
-            }
-        }
+        $firstOptional = self::getFirstOptionalKey($route, $tokens);
 
         // compute the matching regexp
         $regexp = '';
         for ($i = 0, $nbToken = count($tokens); $i < $nbToken; $i++) {
-            $regexp .= self::computeRegexp($tokens, $i, $firstOptional);
+            $regexp .= self::computePathRegexp($tokens, $i, $firstOptional, false);
         }
 
         return array(
@@ -171,6 +244,52 @@ class RouteCompiler implements RouteCompilerInterface
             'tokens' => array_reverse($tokens),
             'variables' => $variables,
         );
+    }
+
+    /**
+     * Validate route pattern variable
+     *
+     * @param string $pattern   Route pattern
+     * @param string $varName   Route variable
+     * @param array  $variables Already used variables
+     *
+     * @return bool
+     * @throws \LogicException
+     * @throws \DomainException
+     */
+    private static function validateVariable($pattern, $varName, $variables)
+    {
+        if (is_numeric($varName)) {
+            throw new \DomainException(sprintf('Variable name "%s" cannot be numeric in route pattern "%s". Please use a different name.', $varName, $pattern));
+        }
+        if (in_array($varName, $variables)) {
+            throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $pattern, $varName));
+        }
+
+        return true;
+    }
+
+    /**
+     * Find the first optional token
+     *
+     * @param Route $route
+     * @param array $tokens
+     *
+     * @return int
+     */
+    private static function getFirstOptionalKey(Route $route, array $tokens)
+    {
+        $firstOptional = PHP_INT_MAX;
+        for ($i = count($tokens) - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+            if ('variable' === $token[0] && $route->hasDefault($token[3])) {
+                $firstOptional = $i;
+            } else {
+                break;
+            }
+        }
+
+        return $firstOptional;
     }
 
     /**
@@ -193,15 +312,35 @@ class RouteCompiler implements RouteCompilerInterface
     }
 
     /**
-     * Computes the regexp used to match a specific token. It can be static text or a subpattern.
+     * Returns the previous static character in the Route pattern that will serve as a separator.
+     *
+     * @param string $pattern The route pattern
+     *
+     * @return string The previous static character that functions as separator (or empty string when none available)
+     */
+    private static function findPreviousSeparator($pattern)
+    {
+        if ('' == $pattern) {
+            // return empty string if pattern is empty or false (false which can be returned by substr)
+            return '';
+        }
+        // first remove all placeholders from the pattern so we can find the next real static character
+        $pattern = preg_replace('#\{\w+\}(?!.*\{\w+\})#', '', $pattern);
+        $separator = substr($pattern, -1);
+
+        return !empty($separator) && false !== strpos(static::SEPARATORS, $separator) ? $separator : '';
+    }
+
+    /**
+     * Computes the regexp used to match a specific path token. It can be static text or a subpattern.
      *
      * @param array   $tokens        The route tokens
      * @param integer $index         The index of the current token
      * @param integer $firstOptional The index of the first optional token
      *
-     * @return string The regexp pattern for a single token
+     * @return string The path regexp pattern for a single token
      */
-    private static function computeRegexp(array $tokens, $index, $firstOptional)
+    private static function computePathRegexp(array $tokens, $index, $firstOptional)
     {
         $token = $tokens[$index];
         if ('text' === $token[0]) {
@@ -229,5 +368,60 @@ class RouteCompiler implements RouteCompilerInterface
                 return $regexp;
             }
         }
+    }
+
+    /**
+     * Computes the regexp used to match a specific host token. It can be static text or a subpattern.
+     *
+     * @param array   $tokens        The route tokens
+     * @param integer $index         The index of the current token
+     * @param integer $firstOptional The index of the first optional token
+     *
+     * @return string The host regexp pattern for a single token
+     */
+    private static function computeHostRegexp(array $tokens, $index, $firstOptional)
+    {
+        $token = $tokens[$index];
+        if ('text' === $token[0]) {
+            // Text tokens
+            return preg_quote($token[1], self::REGEX_DELIMITER);
+        } else {
+            // Variable tokens
+            if (0 === $index && 0 === $firstOptional) {
+                // When the only token is an optional variable token, the separator is required
+                return sprintf('(?P<%s>%s)%s?', $token[3], $token[2], preg_quote($token[1], self::REGEX_DELIMITER));
+            } else {
+                $regexp = sprintf('(?P<%s>%s)%s', $token[3], $token[2], preg_quote($token[1], self::REGEX_DELIMITER));
+                if ($index >= $firstOptional) {
+                    // Enclose each optional token in a subpattern to make it optional.
+                    // "?:" means it is non-capturing, i.e. the portion of the subject string that
+                    // matched the optional subpattern is not passed back.
+                    $regexp = "$regexp)?";
+                    $nbTokens = count($tokens);
+                    if ($nbTokens - 1 == $index) {
+                        // Close the optional subpatterns
+                        $regexp = str_repeat("(?:", $nbTokens - $firstOptional - (0 === $firstOptional ? 1 : 0)) . $regexp;
+                    }
+                }
+
+                return $regexp;
+            }
+        }
+    }
+
+    /**
+     * Gets all variable matches
+     *
+     * @param string $pattern
+     *
+     * @return array
+     */
+    private static function getVariableMatches($pattern)
+    {
+        // Match all variables enclosed in "{}" and iterate over them. But we only want to match the innermost variable
+        // in case of nested "{}", e.g. {foo{bar}}. This in ensured because \w does not match "{" or "}" itself.
+        preg_match_all('#\{\w+\}#', $pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+
+        return $matches;
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.apache
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.apache
@@ -125,26 +125,35 @@ RewriteCond %{ENV:__ROUTING_host_5} =1
 RewriteCond %{REQUEST_URI} ^/route11$
 RewriteRule .* app.php [QSA,L,E=_ROUTING_route:route11,E=_ROUTING_param_var1:%{ENV:__ROUTING_host_5_var1}]
 
+RewriteCond %{HTTP:Host} ^(?:([^\.]++)\.)?example\.com$
+RewriteRule .? - [E=__ROUTING_host_6:1,E=__ROUTING_host_6_var1:%1]
+
 # route12
-RewriteCond %{ENV:__ROUTING_host_5} =1
+RewriteCond %{ENV:__ROUTING_host_6} =1
 RewriteCond %{REQUEST_URI} ^/route12$
-RewriteRule .* app.php [QSA,L,E=_ROUTING_route:route12,E=_ROUTING_param_var1:%{ENV:__ROUTING_host_5_var1},E=_ROUTING_default_var1:val]
+RewriteRule .* app.php [QSA,L,E=_ROUTING_route:route12,E=_ROUTING_param_var1:%{ENV:__ROUTING_host_6_var1},E=_ROUTING_default_var1:val]
+
+RewriteCond %{HTTP:Host} ^([^\.]++)\.example\.com$
+RewriteRule .? - [E=__ROUTING_host_7:1,E=__ROUTING_host_7_var1:%1]
 
 # route13
-RewriteCond %{ENV:__ROUTING_host_5} =1
+RewriteCond %{ENV:__ROUTING_host_7} =1
 RewriteCond %{REQUEST_URI} ^/route13/([^/]++)$
-RewriteRule .* app.php [QSA,L,E=_ROUTING_route:route13,E=_ROUTING_param_var1:%{ENV:__ROUTING_host_5_var1},E=_ROUTING_param_name:%1]
+RewriteRule .* app.php [QSA,L,E=_ROUTING_route:route13,E=_ROUTING_param_var1:%{ENV:__ROUTING_host_7_var1},E=_ROUTING_param_name:%1]
+
+RewriteCond %{HTTP:Host} ^(?:([^\.]++)\.)?example\.com$
+RewriteRule .? - [E=__ROUTING_host_8:1,E=__ROUTING_host_8_var1:%1]
 
 # route14
-RewriteCond %{ENV:__ROUTING_host_5} =1
+RewriteCond %{ENV:__ROUTING_host_8} =1
 RewriteCond %{REQUEST_URI} ^/route14/([^/]++)$
-RewriteRule .* app.php [QSA,L,E=_ROUTING_route:route14,E=_ROUTING_param_var1:%{ENV:__ROUTING_host_5_var1},E=_ROUTING_param_name:%1,E=_ROUTING_default_var1:val]
+RewriteRule .* app.php [QSA,L,E=_ROUTING_route:route14,E=_ROUTING_param_var1:%{ENV:__ROUTING_host_8_var1},E=_ROUTING_param_name:%1,E=_ROUTING_default_var1:val]
 
 RewriteCond %{HTTP:Host} ^c\.example\.com$
-RewriteRule .? - [E=__ROUTING_host_6:1]
+RewriteRule .? - [E=__ROUTING_host_9:1]
 
 # route15
-RewriteCond %{ENV:__ROUTING_host_6} =1
+RewriteCond %{ENV:__ROUTING_host_9} =1
 RewriteCond %{REQUEST_URI} ^/route15/([^/]++)$
 RewriteRule .* app.php [QSA,L,E=_ROUTING_route:route15,E=_ROUTING_param_name:%1]
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -240,27 +240,33 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#s', $host, $hostMatches)) {
-            if (0 === strpos($pathinfo, '/route1')) {
-                // route11
-                if ($pathinfo === '/route11') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
-                }
+            // route11
+            if ($pathinfo === '/route11') {
+                return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+            }
 
-                // route12
-                if ($pathinfo === '/route12') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
-                }
+        }
 
-                // route13
-                if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
-                }
+        if (preg_match('#^(?:(?P<var1>[^\\.]++)\\.)?example\\.com$#s', $host, $hostMatches)) {
+            // route12
+            if ($pathinfo === '/route12') {
+                return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+            }
 
-                // route14
-                if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
-                }
+        }
 
+        if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#s', $host, $hostMatches)) {
+            // route13
+            if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+            }
+
+        }
+
+        if (preg_match('#^(?:(?P<var1>[^\\.]++)\\.)?example\\.com$#s', $host, $hostMatches)) {
+            // route14
+            if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
             }
 
         }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -252,27 +252,33 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#s', $host, $hostMatches)) {
-            if (0 === strpos($pathinfo, '/route1')) {
-                // route11
-                if ($pathinfo === '/route11') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
-                }
+            // route11
+            if ($pathinfo === '/route11') {
+                return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+            }
 
-                // route12
-                if ($pathinfo === '/route12') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
-                }
+        }
 
-                // route13
-                if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
-                }
+        if (preg_match('#^(?:(?P<var1>[^\\.]++)\\.)?example\\.com$#s', $host, $hostMatches)) {
+            // route12
+            if ($pathinfo === '/route12') {
+                return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+            }
 
-                // route14
-                if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
-                }
+        }
 
+        if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#s', $host, $hostMatches)) {
+            // route13
+            if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+            }
+
+        }
+
+        if (preg_match('#^(?:(?P<var1>[^\\.]++)\\.)?example\\.com$#s', $host, $hostMatches)) {
+            // route14
+            if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
             }
 
         }

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -497,6 +497,25 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testWithOptionalSubDomainAndAbsolute()
+    {
+        $routes = $this->getRoutes('test', new Route('/', array('opt1' => '', 'opt2' => ''), array(), array(), '{opt1}.{opt2}.{mand}.example.com'));
+
+        $this->assertEquals('http://sub1.example.com/app.php/', $this->getGenerator($routes, array('host' => 'sub1.example.com'))->generate('test', array('mand' => 'sub1'), true));
+        $this->assertEquals('http://sub2.sub1.example.com/app.php/', $this->getGenerator($routes, array('host' => 'sub2.sub1.example.com'))->generate('test', array('mand' => 'sub1', 'opt2' => 'sub2'), true));
+        $this->assertEquals('http://sub3.sub2.sub1.example.com/app.php/', $this->getGenerator($routes, array('host' => 'sub3.sub2.sub1.example.com'))->generate('test', array('mand' => 'sub1', 'opt2' => 'sub2', 'opt1' => 'sub3'), true));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
+     */
+    public function testWithInvalidOptionalSubDomainOrder()
+    {
+        $routes = $this->getRoutes('test', new Route('/', array('opt1' => '', 'opt2' => ''), array(), array(), '{opt1}.{opt2}.example.com'));
+
+        $this->getGenerator($routes, array('host' => 'sub2.sub1.example.com'))->generate('test', array('opt1' => 'sub1'), true);
+    }
+
     public function testGenerateRelativePath()
     {
         $routes = new RouteCollection();

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -220,8 +220,8 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                     array('text', '/hello'),
                 ),
                 '#^www\.example\.(?P<tld>[^\.]++)$#s', array('tld'), array(
-                    array('variable', '.', '[^\.]++', 'tld'),
-                    array('text', 'www.example'),
+                    array('text', 'www.example.'),
+                    array('variable', '', '[^\.]++', 'tld'),
                 ),
             ),
             array(
@@ -231,9 +231,9 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                     array('text', '/hello'),
                 ),
                 '#^(?P<locale>[^\.]++)\.example\.(?P<tld>[^\.]++)$#s', array('locale', 'tld'), array(
-                    array('variable', '.', '[^\.]++', 'tld'),
-                    array('text', '.example'),
-                    array('variable', '', '[^\.]++', 'locale'),
+                    array('variable', '.', '[^\.]++', 'locale'),
+                    array('text', 'example.'),
+                    array('variable', '', '[^\.]++', 'tld'),
                 ),
             ),
             array(
@@ -242,10 +242,44 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                 '/hello', '#^/hello$#s', array('locale', 'tld'), array(), array(
                     array('text', '/hello'),
                 ),
-                '#^(?P<locale>[^\.]++)\.example\.(?P<tld>[^\.]++)$#s', array('locale', 'tld'), array(
-                    array('variable', '.', '[^\.]++', 'tld'),
-                    array('text', '.example'),
-                    array('variable', '', '[^\.]++', 'locale'),
+                '#^(?:(?P<locale>[^\.]++)\.)?example\.(?P<tld>[^\.]++)$#s', array('locale', 'tld'), array(
+                    array('variable', '.', '[^\.]++', 'locale'),
+                    array('text', 'example.'),
+                    array('variable', '', '[^\.]++', 'tld'),
+                ),
+            ),
+            array(
+                'Route with host variables that has a optional and mandatory sub-domains',
+                array('/hello', array('opt1' => 'o1', 'opt2' => 'o2'), array(), array(), '{opt1}.{opt2}.{mand}.example.com'),
+                '/hello', '#^/hello$#s', array('opt1', 'opt2', 'mand'), array(), array(
+                    array('text', '/hello'),
+                ),
+                '#^(?:(?:(?P<opt1>[^\.]++)\.)?(?P<opt2>[^\.]++)\.)?(?P<mand>[^\.]++)\.example\.com$#s', array('opt1', 'opt2', 'mand'), array(
+                    array('variable', '.', '[^\.]++', 'opt1'),
+                    array('variable', '.', '[^\.]++', 'opt2'),
+                    array('variable', '.', '[^\.]++', 'mand'),
+                    array('text', 'example.com'),
+                ),
+            ),
+            array(
+                'Route with host that is optional variable',
+                array('/hello', array('host' => 'example.com'), array('host' => '.+'), array(), '{host}'),
+                '/hello', '#^/hello$#s', array('host'), array(), array(
+                    array('text', '/hello'),
+                ),
+                '#^(?P<host>.+)?$#s', array('host'), array(
+                    array('variable', '', '.+', 'host'),
+                ),
+            ),
+            array(
+                'Route with host that has partial optional sub-domain variable',
+                array('/', array('sub' => 'test'), array(), array(), '{sub}part.example.com'),
+                '/', '#^/$#s', array('sub'), array(), array(
+                    array('text', '/'),
+                ),
+                '#^(?:(?P<sub>[^\.]++))?part\.example\.com$#s', array('sub'), array(
+                    array('variable', '', '[^\.]++', 'sub'),
+                    array('text', 'part.example.com'),
                 ),
             ),
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7306 |
| License | MIT |

New feature to support optional placeholders in host pattern. The main difference is that host pattern cannot be parsed same as path pattern.
In path optional placeholders are located in the end like 

```
/example/{mandatory}/{optional1}/{optional2}
```

And hosts can have optional placeholders in the beginning like

```
{optional1}.{optional2}.{mandatory}.example.com
```

So I have split compilePattern() method in compilePathPattern() and compileHostPattern() that have different compiling flow.
The goal was to be able configure host like

``` yaml
example:
    path:     /example
    host:     {subdomain}.example.com
    defaults: { subdomain: "" }
```

and match _http://example.com_ and _http://something.example.com_
