### PR TITLE
[FrameworkBundle] Fixed wrong redirect url if path contains some query parameters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -100,7 +100,11 @@ class RedirectController extends ContainerAware
 
         $qs = $request->getQueryString();
         if ($qs) {
-            $qs = '?'.$qs;
+            if (strpos($path, '?') === false) {
+                $qs = '?'.$qs;
+            } else {
+                $qs = '&'.$qs;
+            }
         }
 
         $port = '';

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -199,7 +199,36 @@ class RedirectControllerTest extends TestCase
         $this->assertRedirectUrl($returnValue, $expectedUrl);
     }
 
-    private function createRequestObject($scheme, $host, $port, $baseUrl)
+    public function pathQueryParamsProvider()
+    {
+        return array(
+            array('http://www.example.com/base/redirect-path', '/redirect-path',  ''),
+            array('http://www.example.com/base/redirect-path?foo=bar', '/redirect-path?foo=bar',  ''),
+            array('http://www.example.com/base/redirect-path?foo=bar', '/redirect-path', 'foo=bar'),
+            array('http://www.example.com/base/redirect-path?foo=bar&abc=example', '/redirect-path?foo=bar', 'abc=example'),
+            array('http://www.example.com/base/redirect-path?foo=bar&abc=example&baz=def', '/redirect-path?foo=bar', 'abc=example&baz=def'),
+        );
+    }
+
+    /**
+     * @dataProvider pathQueryParamsProvider
+     */
+    public function testPathQueryParams($expectedUrl, $path, $queryString)
+    {
+        $scheme = 'http';
+        $host = 'www.example.com';
+        $baseUrl = '/base';
+        $port = 80;
+
+        $request = $this->createRequestObject($scheme, $host, $port, $baseUrl, $queryString);
+
+        $controller = $this->createRedirectController();
+
+        $returnValue = $controller->urlRedirectAction($request, $path, false, $scheme, $port, null);
+        $this->assertRedirectUrl($returnValue, $expectedUrl);
+    }
+
+    private function createRequestObject($scheme, $host, $port, $baseUrl, $queryString = '')
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $request
@@ -218,6 +247,10 @@ class RedirectControllerTest extends TestCase
             ->expects($this->any())
             ->method('getBaseUrl')
             ->will($this->returnValue($baseUrl));
+        $request
+            ->expects($this->any())
+            ->method('getQueryString')
+            ->will($this->returnValue($queryString));
 
         return $request;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
