### PR TITLE
[FrameworkBundle][Console] Load command from DIC after command from bundles.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -100,15 +100,15 @@ class Application extends BaseApplication
     {
         $container = $this->kernel->getContainer();
 
-        if ($container->hasParameter('console.command.ids')) {
-            foreach ($container->getParameter('console.command.ids') as $id) {
-                $this->add($container->get($id));
-            }
-        }
-
         foreach ($this->kernel->getBundles() as $bundle) {
             if ($bundle instanceof Bundle) {
                 $bundle->registerCommands($this);
+            }
+        }
+
+        if ($container->hasParameter('console.command.ids')) {
+            foreach ($container->getParameter('console.command.ids') as $id) {
+                $this->add($container->get($id));
             }
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

It's better to load a command from DIC after other one. Because it allow easy
override of default (symfony/assetic/doctrine) command. The end user could do:

```
# config.yml
services:
   assetic.command.dump:
       class: SensioLabs\Shim\Assetic\DumpCommand
       tags:
           - { name: console.command }
```

**Note**: This is not a new feature... It could be very cool to have it for symfony 2.4 ;)
