### PR TITLE
[DependencyInjection] remove missing-service suggestions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -295,19 +295,7 @@ class Container implements IntrospectableContainerInterface
             // $method is set to the right value, proceed
         } else {
             if (self::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
-                if (!$id) {
-                    throw new ServiceNotFoundException($id);
-                }
-
-                $alternatives = array();
-                foreach (array_keys($this->services) as $key) {
-                    $lev = levenshtein($id, $key);
-                    if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {
-                        $alternatives[] = $key;
-                    }
-                }
-
-                throw new ServiceNotFoundException($id, null, null, $alternatives);
+                throw new ServiceNotFoundException($id);
             }
 
             return null;

--- a/src/Symfony/Component/DependencyInjection/Exception/ServiceNotFoundException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ServiceNotFoundException.php
@@ -21,21 +21,12 @@ class ServiceNotFoundException extends InvalidArgumentException
     private $id;
     private $sourceId;
 
-    public function __construct($id, $sourceId = null, \Exception $previous = null, array $alternatives = array())
+    public function __construct($id, $sourceId = null, \Exception $previous = null)
     {
         if (null === $sourceId) {
             $msg = sprintf('You have requested a non-existent service "%s".', $id);
         } else {
             $msg = sprintf('The service "%s" has a dependency on a non-existent service "%s".', $sourceId, $id);
-        }
-
-        if ($alternatives) {
-            if (1 == count($alternatives)) {
-                $msg .= ' Did you mean this: "';
-            } else {
-                $msg .= ' Did you mean one of these: "';
-            }
-            $msg .= implode('", "', $alternatives).'"?';
         }
 
         parent::__construct($msg, 0, $previous);

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -202,30 +202,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($sc->get('', ContainerInterface::NULL_ON_INVALID_REFERENCE));
     }
 
-    public function testGetThrowServiceNotFoundException()
-    {
-        $sc = new ProjectServiceContainer();
-        $sc->set('foo', $foo = new \stdClass());
-        $sc->set('bar', $foo = new \stdClass());
-        $sc->set('baz', $foo = new \stdClass());
-
-        try {
-            $sc->get('foo1');
-            $this->fail('->get() throws an Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException if the key does not exist');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException', $e, '->get() throws an Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException if the key does not exist');
-            $this->assertEquals('You have requested a non-existent service "foo1". Did you mean this: "foo"?', $e->getMessage(), '->get() throws an Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException with some advices');
-        }
-
-        try {
-            $sc->get('bag');
-            $this->fail('->get() throws an Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException if the key does not exist');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException', $e, '->get() throws an Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException if the key does not exist');
-            $this->assertEquals('You have requested a non-existent service "bag". Did you mean one of these: "bar", "baz"?', $e->getMessage(), '->get() throws an Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException with some advices');
-        }
-    }
-
     public function testGetCircularReference()
     {
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This is a rollback of 729db0fde: a change which introduced a significant performance penalty for little gain. During normal use of ContainerBuilder, `levenshtein()` is called many times each time a service is requested for the first time. In a container with just 20 services, for example, this will result in 400 calls to `levenshtein()`. That's a significant performance hit which only serves to provide some convenience for the comparatively rare situation when a developer asks for a truly non-existent service.

Simple code to demo:

``` php
<?php

use Symfony\Component\DependencyInjection\ContainerBuilder;

require 'vendor/autoload.php';

$builder = new ContainerBuilder();

/** Register a service with this ContainerBuilder ... */
$service = new \stdClass();
$builder->set('my_service', $service);

/** ... then fetch it */
$fetchedService = $builder->get('my_service');
```
