### PR TITLE
[FrameworkBundle] Fix PathPackage CLI usage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -44,7 +44,7 @@
         </service>
 
         <service id="templating.asset.path_package" class="%templating.asset.path_package.class%" abstract="true">
-            <argument type="service" id="request" />
+            <argument type="service" id="request_stack" />
             <argument /> <!-- version -->
             <argument /> <!-- version format -->
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/PathPackage.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/PathPackage.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Templating\Asset;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Templating\Asset\PathPackage as BasePathPackage;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * The path packages adds a version and a base path to asset URLs.
@@ -24,12 +25,18 @@ class PathPackage extends BasePathPackage
     /**
      * Constructor.
      *
-     * @param Request $request The current request
-     * @param string  $version The version
-     * @param string  $format  The version format
+     * @param Request $requestStack The current request
+     * @param string  $version      The version
+     * @param string  $format       The version format
      */
-    public function __construct(Request $request, $version = null, $format = null)
+    public function __construct(RequestStack $requestStack, $version = null, $format = null)
     {
-        parent::__construct($request->getBasePath(), $version, $format);
+        if ($request = $requestStack->getCurrentRequest() instanceof Request) {
+            $path = $request->getBasePath();
+        } else {
+            $path = "/";
+        }
+
+        parent::__construct($path, $version, $format);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/PathPackage.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/PathPackage.php
@@ -31,8 +31,8 @@ class PathPackage extends BasePathPackage
      */
     public function __construct(RequestStack $requestStack, $version = null, $format = null)
     {
-        if ($request = $requestStack->getCurrentRequest() instanceof Request) {
-            $path = $request->getBasePath();
+        if ($requestStack->getCurrentRequest() instanceof Request) {
+            $path = $requestStack->getCurrentRequest()->getBasePath();
         } else {
             $path = "/";
         }


### PR DESCRIPTION
Fix PathPackage CLI use by injecting RequestStack instead of Request
If there is no request in stack, we set "/" as default basePath

[FrameworkBundle] Inject RequestStack instead of Request

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | --- |
| License | MIT |
| Doc PR | --- |
