### PR TITLE
Added PHP 5.6 to travis as "allowed_failure" build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:
     allow_failures:
         - php: hhvm
+        - php: 5.6
 
 services: mongodb
 


### PR DESCRIPTION
Check if symfony works with PHP 5.6.
