### PR TITLE
[Bug][Form] Fix W3C markup validation of the empty select option tag

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -72,7 +72,7 @@
     {% endif %}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
         {% if empty_value is not none %}
-            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
+            <option{% if empty_value is empty %} label=" "{% endif %} value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
         {% endif %}
         {% if preferred_choices|length > 0 %}
             {% set options = preferred_choices %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_collapsed.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_collapsed.html.php
@@ -4,7 +4,7 @@
     )) ?>
     <?php if ($multiple): ?> multiple="multiple"<?php endif ?>
 >
-    <?php if (null !== $empty_value): ?><option value=""<?php if ($required and empty($value) && "0" !== $value): ?> selected="selected"<?php endif?>><?php echo $view->escape($view['translator']->trans($empty_value, array(), $translation_domain)) ?></option><?php endif; ?>
+    <?php if (null !== $empty_value): ?><option <?php if (empty($empty_value)): ?> label=" "<?php endif ?> value=""<?php if ($required and empty($value) && "0" !== $value): ?> selected="selected"<?php endif?>><?php echo $view->escape($view['translator']->trans($empty_value, array(), $translation_domain)) ?></option><?php endif; ?>
     <?php if (count($preferred_choices) > 0): ?>
         <?php echo $view['form']->block($form, 'choice_widget_options', array('choices' => $preferred_choices)) ?>
         <?php if (count($choices) > 0 && null !== $separator): ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FormController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FormController.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\Form\FormInterface;
+
+class FormController extends ContainerAware
+{
+    public function phpChoiceSingleRequiredAction()
+    {
+        return $this->render('TestBundle:Form:form.html.php', $this->createForm());
+    }
+
+    public function twigChoiceSingleRequiredAction()
+    {
+        return $this->render('TestBundle:Form:form.html.twig', $this->createForm());
+    }
+
+    public function phpChoiceMultipleRequiredAction()
+    {
+        return $this->render('TestBundle:Form:form.html.php', $this->createForm(array('multiple' => true)));
+    }
+
+    public function twigChoiceMultipleRequiredAction()
+    {
+        return $this->render('TestBundle:Form:form.html.twig', $this->createForm(array('multiple' => true)));
+    }
+
+    public function phpChoiceSingleNotRequiredAction()
+    {
+        return $this->render('TestBundle:Form:form.html.php', $this->createForm(array('required' => false)));
+    }
+
+    public function twigChoiceSingleNotRequiredAction()
+    {
+        return $this->render('TestBundle:Form:form.html.twig', $this->createForm(array('required' => false)));
+    }
+
+    public function phpChoiceMultipleNotRequiredAction()
+    {
+        return $this->render('TestBundle:Form:form.html.php', $this->createForm(array('multiple' => true, 'required' => false)));
+    }
+
+    public function twigChoiceMultipleNotRequiredAction()
+    {
+        return $this->render('TestBundle:Form:form.html.twig', $this->createForm(array('multiple' => true, 'required' => false)));
+    }
+
+    public function phpChoiceSingleNotRequiredEmptyValueAction()
+    {
+        return $this->render('TestBundle:Form:form.html.php', $this->createForm(array('required' => false, 'empty_value' => 'Empty label')));
+    }
+
+    public function twigChoiceSingleNotRequiredEmptyValueAction()
+    {
+        return $this->render('TestBundle:Form:form.html.twig', $this->createForm(array('required' => false, 'empty_value' => 'Empty label')));
+    }
+
+    protected function render($view, FormInterface $form)
+    {
+        return $this->container->get('templating')->renderResponse($view, array('form' => $form->createView()));
+    }
+
+    protected function createForm(array $options = array())
+    {
+        $options = array_merge(array(
+            'choices' => $this->getChoices(),
+        ), $options);
+
+        $form = $this->container->get('form.factory')->create()
+            ->add('choice', 'choice', $options)
+        ;
+
+        return $form;
+    }
+
+    protected function getChoices()
+    {
+        return array('choice1' => 'Choice 1', 'choice2' => 'Choice 2', 'choice3' => 'Choice 3');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -44,3 +44,43 @@ fragment_home:
 fragment_inlined:
     path:     /fragment_inlined
     defaults: { _controller: TestBundle:Fragment:inlined }
+
+form_php_choice_single_required:
+    path:     /form_php/choice_single_required
+    defaults: { _controller: TestBundle:Form:phpChoiceSingleRequired }
+
+form_twig_choice_single_required:
+    path:     /form_twig/choice_single_required
+    defaults: { _controller: TestBundle:Form:twigChoiceSingleRequired }
+
+form_php_choice_multiple_required:
+    path:     /form_php/choice_multiple_required
+    defaults: { _controller: TestBundle:Form:phpChoiceMultipleRequired }
+
+form_twig_choice_multiple_required:
+    path:     /form_twig/choice_multiple_required
+    defaults: { _controller: TestBundle:Form:twigChoiceMultipleRequired }
+
+form_php_choice_single_not_required:
+    path:     /form_php/choice_single_not_required
+    defaults: { _controller: TestBundle:Form:phpChoiceSingleNotRequired }
+
+form_twig_choice_single_not_required:
+    path:     /form_twig/choice_single_not_required
+    defaults: { _controller: TestBundle:Form:twigChoiceSingleNotRequired }
+
+form_php_choice_multiple_not_required:
+    path:     /form_php/choice_multiple_not_required
+    defaults: { _controller: TestBundle:Form:phpChoiceMultipleNotRequired }
+
+form_twig_choice_multiple_not_required:
+    path:     /form_twig/choice_multiple_not_required
+    defaults: { _controller: TestBundle:Form:twigChoiceMultipleNotRequired }
+
+form_php_choice_single_not_required_empty_value:
+    path:     /form_php/choice_single_not_required_empty_value
+    defaults: { _controller: TestBundle:Form:phpChoiceSingleNotRequiredEmptyValue }
+
+form_twig_choice_single_not_required_empty_value:
+    path:     /form_twig/choice_single_not_required_empty_value
+    defaults: { _controller: TestBundle:Form:twigChoiceSingleNotRequiredEmptyValue }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/views/Form/form.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/views/Form/form.html.php
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+    <?php echo $view['form']->form($form) ?>
+</body>
+</html>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/views/Form/form.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/views/Form/form.html.twig
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+    {{ form(form) }}
+</body>
+</html>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FormTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FormTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+/**
+ * @group functional
+ */
+class FormTest extends WebTestCase
+{
+    /**
+     * Tests the required single select form with the php engine.
+     */
+    public function testFormPhpChoiceSingleRequired()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_php/choice_single_required');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(3, $select->children()->count());
+    }
+
+    /**
+     * Tests the required single select form with the twig engine.
+     */
+    public function testFormTwigChoiceSingleRequired()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_twig/choice_single_required');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(3, $select->children()->count());
+    }
+
+    /**
+     * Tests the required multiple select form with the php engine.
+     */
+    public function testFormPhpChoiceMultipleRequired()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_php/choice_multiple_required');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(3, $select->children()->count());
+    }
+
+    /**
+     * Tests the required multiple select form with the twig engine.
+     */
+    public function testFormTwigChoiceMultipleRequired()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_twig/choice_multiple_required');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(3, $select->children()->count());
+    }
+
+    /**
+     * Tests the empty value option and label attribute of the single select
+     * form with the php engine.
+     */
+    public function testFormPhpChoiceSingleNotRequired()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_php/choice_single_not_required');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(4, $select->children()->count());
+
+        $firstOption = $select->children()->first();
+
+        $this->assertEquals(' ', $firstOption->attr('label'));
+        $this->assertEquals('', $firstOption->text());
+    }
+
+    /**
+     * Tests the empty value option and label attribute of the single select
+     * form with the twig engine.
+     */
+    public function testFormTwigChoiceSingleNotRequired()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_twig/choice_single_not_required');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(4, $select->children()->count());
+
+        $firstOption = $select->children()->first();
+
+        $this->assertEquals(' ', $firstOption->attr('label'));
+        $this->assertEquals('', $firstOption->text());
+    }
+
+    /**
+     * Tests the empty value option and label attribute of the multiple select
+     * form with the php engine.
+     */
+    public function testFormPhpChoiceMultipleNotRequired()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_php/choice_multiple_not_required');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(3, $select->children()->count());
+    }
+
+    /**
+     * Tests the empty value option and label attribute of the multiple select
+     * form with the twig engine.
+     */
+    public function testFormTwigChoiceMultipleNotRequired()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_twig/choice_multiple_not_required');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(3, $select->children()->count());
+    }
+
+    /**
+     * Test the empty value option and label attribute of the single select
+     * form with the php engine.
+     */
+    public function testFormPhpChoiceSingleNotRequiredEmptyValue()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_php/choice_single_not_required_empty_value');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(4, $select->children()->count());
+
+        $firstOption = $select->children()->first();
+
+        $this->assertNull($firstOption->attr('label'));
+        $this->assertEquals('Empty label', $firstOption->text());
+    }
+
+    /**
+     * Test the empty value option and label attribute of the single select
+     * form with the twig engine.
+     */
+    public function testFormTwigChoiceSingleNotRequiredEmptyValue()
+    {
+        $client = static::createClient(array('test_case' => 'Form', 'root_config' => 'config.yml'));
+        $crawler = $client->request('GET', '/form_twig/choice_single_not_required_empty_value');
+        $select = $crawler->filter('#form_choice');
+
+        $this->assertEquals(4, $select->children()->count());
+
+        $firstOption = $select->children()->first();
+
+        $this->assertNull($firstOption->attr('label'));
+        $this->assertEquals('Empty label', $firstOption->text());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Form/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Form/bundles.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+
+return array(
+    new FrameworkBundle(),
+    new TwigBundle(),
+    new TestBundle(),
+);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Form/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Form/config.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    templating:
+        engines: ['twig', 'php']

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Form/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Form/routing.yml
@@ -1,0 +1,2 @@
+_formtest_bundle:
+    resource: @TestBundle/Resources/config/routing.yml


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

To spend the HTML5 W3C validation, the Option tag can not have a empty label. it's therefore necessary to add Label attribute.
