### PR TITLE
[Debug] Fixed FlattenException lacks access to original Exception

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
  */
 class FlattenException
 {
+    private $original;
     private $message;
     private $code;
     private $previous;
@@ -35,6 +36,7 @@ class FlattenException
     public static function create(\Exception $exception, $statusCode = null, array $headers = array())
     {
         $e = new static();
+        $e->setOriginal($exception);
         $e->setMessage($exception->getMessage());
         $e->setCode($exception->getCode());
 
@@ -237,6 +239,16 @@ class FlattenException
                 'args'        => isset($entry['args']) ? $this->flattenArgs($entry['args']) : array(),
             );
         }
+    }
+
+    public function getOriginal()
+    {
+      return $this->original;
+    }
+
+    protected function setOriginal(\Exception $exception)
+    {
+      $this->original = $exception;
     }
 
     private function flattenArgs($args, $level = 0)


### PR DESCRIPTION
`FlattenException` lacks access to the original `Exception`, preventing access to e.g. `ErrorException::getSeverity()`.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
