### PR TITLE
[2.4][HttpKernel] Fix issue #10209

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -127,7 +127,9 @@ class ProfilerListener implements EventSubscriberInterface
         foreach ($this->profiles as $request) {
             // isset call should be removed when requestStack is required
             if (isset($this->parents[$request]) && null !== $parentRequest = $this->parents[$request]) {
-                $this->profiles[$parentRequest]->addChild($this->profiles[$request]);
+                if (isset($this->profiles[$parentRequest])) {
+                    $this->profiles[$parentRequest]->addChild($this->profiles[$request]);
+                }
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Kernel;
 
 class ProfilerListenerTest extends \PHPUnit_Framework_TestCase
@@ -51,5 +53,51 @@ class ProfilerListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelRequest(new GetResponseEvent($kernel, $request, Kernel::MASTER_REQUEST));
         $listener->onKernelResponse(new FilterResponseEvent($kernel, $request, Kernel::MASTER_REQUEST, $response));
         $listener->onKernelTerminate(new PostResponseEvent($kernel, $request, $response));
+    }
+
+    /**
+     * Test a master and sub request with an exception and `onlyException` profiler option enabled.
+     */
+    public function testKernelTerminate()
+    {
+        $profile = $this->getMockBuilder('Symfony\Component\HttpKernel\Profiler\Profile')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $profiler = $this->getMockBuilder('Symfony\Component\HttpKernel\Profiler\Profiler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $profiler->expects($this->once())
+            ->method('collect')
+            ->will($this->returnValue($profile));
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+
+        $masterRequest = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $subRequest =  $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $response = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $onlyException = true;
+        $listener      = new ProfilerListener($profiler, null, $onlyException);
+
+        // master request
+        $listener->onKernelRequest(new GetResponseEvent($kernel, $masterRequest, Kernel::MASTER_REQUEST));
+        $listener->onKernelResponse(new FilterResponseEvent($kernel, $masterRequest, Kernel::MASTER_REQUEST, $response));
+
+        // sub request
+        $listener->onKernelRequest(new GetResponseEvent($kernel, $subRequest, Kernel::SUB_REQUEST));
+        $listener->onKernelException(new GetResponseForExceptionEvent($kernel, $subRequest, Kernel::SUB_REQUEST, new HttpException(404)));
+        $listener->onKernelResponse(new FilterResponseEvent($kernel, $subRequest, Kernel::SUB_REQUEST, $response));
+
+        $listener->onKernelTerminate(new PostResponseEvent($kernel, $masterRequest, $response));
     }
 }


### PR DESCRIPTION
When the profiler has `only_exception` option activated and a subrequest which
throw an exception, the parent profile cannot be found.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Fix issue #10209
