### PR TITLE
Bypass sigchild detection if phpinfo is not available

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1024,6 +1024,10 @@ class Process
             return self::$sigchild;
         }
 
+        if (!function_exists('phpinfo')) {
+            return self::$sigchild = false;
+        }
+
         ob_start();
         phpinfo(INFO_GENERAL);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | composer/composer#2711 |
| License | MIT |
| Doc PR | none |

This fixes composer/composer#2711, i.e. anyone disabling phpinfo for security (by obscurity, but whatever) reasons can not use the Process class anymore.
