### PR TITLE
[Validator] Removed PHP <5.3.3 specific code which is not officially supported

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -41,11 +41,6 @@ class EmailValidator extends ConstraintValidator
         if ($valid) {
             $host = substr($value, strpos($value, '@') + 1);
 
-            if (version_compare(PHP_VERSION, '5.3.3', '<') && strpos($host, '.') === false) {
-                // Likely not a FQDN, bug in PHP FILTER_VALIDATE_EMAIL prior to PHP 5.3.3
-                $valid = false;
-            }
-
             // Check for host DNS resource records
             if ($valid && $constraint->checkMX) {
                 $valid = $this->checkMX($host);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

There is some code in the validator component which handles a PHP bug for versions strictly inferiors to 5.3.3. Since these versions are not supported (the requirements say 5.3.3 minimum) I thought we could remove it.

Regards.
