### PR TITLE
[Form] Fix double attributes rendering on form tag

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -19,13 +19,16 @@
 
 {% block form_widget_compound %}
 {% spaceless %}
-    <div {{ block('widget_container_attributes') }}>
-        {% if form.parent is empty %}
-            {{ form_errors(form) }}
-        {% endif %}
+    {% if form.parent is empty %}
+        {{ form_errors(form) }}
         {{ block('form_rows') }}
         {{ form_rest(form) }}
-    </div>
+    {% else %}
+        <div {{ block('widget_container_attributes') }}>
+            {{ block('form_rows') }}
+            {{ form_rest(form) }}
+        </div>
+    {% endif %}
 {% endspaceless %}
 {% endblock form_widget_compound %}
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

There is a very weird issue not tracked as part of Symfony 2.4. When creating a form and consuming it using TwigEngine, for the given piece of twig template: 

``` html
{{ form(my_form, {
    'method': 'POST',
    'action': '/process',
        'attr': {
            'data-name': 'test',
            'class': 'form'
        }
}) }}
```

It does generate this HTML:

``` html
<form name="contact" method="post" action="/process" data-name="test" class="form">
    <div id="contact" data-name="test" class="form">
        <div>
            <label for="contact_email" class="required">Email</label>
            <input type="email" id="contact_email" name="contact[email]" required="required" />
        </div>
        <!-- ... -->
    </div>
</form>
```

As you may see, it duplicates the attributes of form inside of a div which is the direct child of the form start.
Tracking down the issue, form calls form_start, which renders the form tag. After that, it calls form_widget which makes an initial decision of calling form_widget_compound, creating the div tag with all form attributes.
This patch proposes a fix to not create this initial div tag if form has no parent (root element), properly addressing the issue of duplicated classes (and other items).

This issue affects master and 2.4 from what I've seen.
