### PR TITLE
[Finder] () is also a valid delimiter

### DIFF
--- a/src/Symfony/Component/Finder/Expression/Regex.php
+++ b/src/Symfony/Component/Finder/Expression/Regex.php
@@ -65,7 +65,11 @@ class Regex implements ValueInterface
             $start = substr($m[1], 0, 1);
             $end   = substr($m[1], -1);
 
-            if (($start === $end && !preg_match('/[*?[:alnum:] \\\\]/', $start)) || ($start === '{' && $end === '}')) {
+            if (
+                ($start === $end && !preg_match('/[*?[:alnum:] \\\\]/', $start))
+                || ($start === '{' && $end === '}')
+                || ($start === '(' && $end === ')')
+            ) {
                 return new self(substr($m[1], 1, -1), $m[2], $end);
             }
         }


### PR DESCRIPTION
The `Regex` class should also accept `()` as delimiters, as they are valid PREG delimiters: http://3v4l.org/D8v54

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
