### PR TITLE
[Component][Filesystem] Dump assets on s3 protocol using the assets:install command

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -75,7 +75,7 @@ class Filesystem
     public function mkdir($dirs, $mode = 0777)
     {
         foreach ($this->toIterator($dirs) as $dir) {
-            if (is_dir($dir)) {
+            if (is_dir($dir) || "s3://" === substr($dirs, 0, 5)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -75,7 +75,7 @@ class Filesystem
     public function mkdir($dirs, $mode = 0777)
     {
         foreach ($this->toIterator($dirs) as $dir) {
-            if (is_dir($dir) || "s3://" === substr($dirs, 0, 5)) {
+            if (is_dir($dir) || "s3://" === substr($dir, 0, 5)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Hello,

When I try to dump my assets to my S3 bucket using the `assets:install s3://my-bucket` command, it just doesn't work because of the `is_dir` test in the `mkdir` function. 

According to https://github.com/symfony/AsseticBundle/issues/37, the s3 protocol doesn't really have directories, it only pretends to. 

So, I've just add an other test to avoid it when we using the S3 protocol. 

Dumping assets on S3 bucket, have to be used without `--symlink` option and only in production environment (take a long time to generate all assets).

It works well for me so I decided to create a pull request to share it with the community.

regards.
