### PR TITLE
[Serializer] Throw exception when unable to normalize embedded object

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -85,6 +85,9 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
                     $attributeValue = call_user_func($this->callbacks[$attributeName], $attributeValue);
                 }
                 if (null !== $attributeValue && !is_scalar($attributeValue)) {
+                    if (!$this->serializer instanceof NormalizerInterface) {
+                        throw new \LogicException(sprintf('Cannot normalize attribute "%s" because injected serializer is not a normalizer', $attributeName));
+                    }
                     $attributeValue = $this->serializer->normalize($attributeValue, $format);
                 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR intends to prevent Fatal Error about calling undefined method `normalize()` on object `$serializer` in the `GetSetMethodNormalizer` when injected serializer does not implement the `NormalizerInterface`. 
