### PR TITLE
[Form] Implemented attributes for choices

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -96,7 +96,8 @@
                 {{ block('choice_widget_options') }}
             </optgroup>
         {% else %}
-            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
+            {% set attr = choice.attributes %}
+            <option {% if attr is not empty %}{{ block('option_attributes') }} {% endif %}value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
         {% endif %}
     {% endfor %}
 {% endspaceless %}
@@ -421,3 +422,16 @@
     {%- endfor -%}
 {% endspaceless %}
 {% endblock button_attributes %}
+
+{% block option_attributes %}
+{% spaceless %}
+    {%- for attrname, attrvalue in attr -%}
+        {{- " " -}}
+        {% if attrvalue is sameas(true) -%}
+            {{- attrname }}="{{ attrname }}"
+        {%- elseif attrvalue is not sameas(false) -%}
+            {{- attrname }}="{{ attrvalue }}"
+        {%- endif -%}
+    {%- endfor -%}
+{% endspaceless %}
+{% endblock option_attributes %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_options.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_options.html.php
@@ -6,6 +6,6 @@
             <?php echo $formHelper->block($form, 'choice_widget_options', array('choices' => $choice)) ?>
         </optgroup>
     <?php else: ?>
-        <option value="<?php echo $view->escape($choice->value) ?>"<?php if ($is_selected($choice->value, $value)): ?> selected="selected"<?php endif?>><?php echo $view->escape($translatorHelper->trans($choice->label, array(), $translation_domain)) ?></option>
+        <option <?php if (!empty($choice->attributes)): ?><?php echo $view['form']->block($form, 'option_attributes', array('attr' => $choice->attributes)) ?> <?php endif; ?>value="<?php echo $view->escape($choice->value) ?>"<?php if ($is_selected($choice->value, $value)): ?> selected="selected"<?php endif?>><?php echo $view->escape($translatorHelper->trans($choice->label, array(), $translation_domain)) ?></option>
     <?php endif ?>
 <?php endforeach ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/option_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/option_attributes.html.php
@@ -1,0 +1,7 @@
+<?php foreach ($attr as $k => $v): ?>
+<?php if ($v === true): ?>
+<?php printf('%s="%s" ', $view->escape($k), $view->escape($k)) ?>
+<?php elseif ($v !== false): ?>
+<?php printf('%s="%s" ', $view->escape($k), $view->escape($v)) ?>
+<?php endif ?>
+<?php endforeach ?>

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -64,35 +64,36 @@ class ObjectChoiceList extends ChoiceList
     /**
      * Creates a new object choice list.
      *
-     * @param array|\Traversable       $choices           The array of choices. Choices may also be given
+     * @param array|\Traversable        $choices          The array of choices. Choices may also be given
      *                                                    as hierarchy of unlimited depth by creating nested
      *                                                    arrays. The title of the sub-hierarchy can be
      *                                                    stored in the array key pointing to the nested
      *                                                    array. The topmost level of the hierarchy may also
      *                                                    be a \Traversable.
-     * @param string                   $labelPath         A property path pointing to the property used
+     * @param string                    $labelPath        A property path pointing to the property used
      *                                                    for the choice labels. The value is obtained
-             *                                            by calling the getter on the object. If the
+     *                                                    by calling the getter on the object. If the
      *                                                    path is NULL, the object's __toString() method
      *                                                    is used instead.
-     * @param array                    $preferredChoices  A flat array of choices that should be
+     * @param array                     $preferredChoices A flat array of choices that should be
      *                                                    presented to the user with priority.
-     * @param string                   $groupPath         A property path pointing to the property used
+     * @param string                    $groupPath        A property path pointing to the property used
      *                                                    to group the choices. Only allowed if
      *                                                    the choices are given as flat array.
-     * @param string                   $valuePath         A property path pointing to the property used
+     * @param string                    $valuePath        A property path pointing to the property used
      *                                                    for the choice values. If not given, integers
      *                                                    are generated instead.
      * @param PropertyAccessorInterface $propertyAccessor The reflection graph for reading property paths.
+     * @param array                     $attributes       The choices' attributes.
      */
-    public function __construct($choices, $labelPath = null, array $preferredChoices = array(), $groupPath = null, $valuePath = null, PropertyAccessorInterface $propertyAccessor = null)
+    public function __construct($choices, $labelPath = null, array $preferredChoices = array(), $groupPath = null, $valuePath = null, PropertyAccessorInterface $propertyAccessor = null, array $attributes = array())
     {
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
         $this->labelPath = null !== $labelPath ? new PropertyPath($labelPath) : null;
         $this->groupPath = null !== $groupPath ? new PropertyPath($groupPath) : null;
         $this->valuePath = null !== $valuePath ? new PropertyPath($valuePath) : null;
 
-        parent::__construct($choices, array(), $preferredChoices);
+        parent::__construct($choices, array(), $preferredChoices, $attributes);
     }
 
     /**
@@ -103,11 +104,12 @@ class ObjectChoiceList extends ChoiceList
      * @param array|\Traversable $choices          The choices to write into the list.
      * @param array              $labels           Ignored.
      * @param array              $preferredChoices The choices to display with priority.
+     * @param array              $attributes       The choices' attributes.
      *
      * @throws InvalidArgumentException When passing a hierarchy of choices and using
      *                                   the "groupPath" option at the same time.
      */
-    protected function initialize($choices, array $labels, array $preferredChoices)
+    protected function initialize($choices, array $labels, array $preferredChoices, array $attributes = array())
     {
         if (null !== $this->groupPath) {
             $groupedChoices = array();
@@ -145,7 +147,7 @@ class ObjectChoiceList extends ChoiceList
 
         $this->extractLabels($choices, $labels);
 
-        parent::initialize($choices, $labels, $preferredChoices);
+        parent::initialize($choices, $labels, $preferredChoices, $attributes);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
@@ -34,18 +34,19 @@ class SimpleChoiceList extends ChoiceList
     /**
      * Creates a new simple choice list.
      *
-     * @param array $choices The array of choices with the choices as keys and
-     *                       the labels as values. Choices may also be given
-     *                       as hierarchy of unlimited depth by creating nested
-     *                       arrays. The title of the sub-hierarchy is stored
-     *                       in the array key pointing to the nested array.
+     * @param array $choices          The array of choices with the choices as keys and
+     *                                the labels as values. Choices may also be given
+     *                                as hierarchy of unlimited depth by creating nested
+     *                                arrays. The title of the sub-hierarchy is stored
+     *                                in the array key pointing to the nested array.
      * @param array $preferredChoices A flat array of choices that should be
      *                                presented to the user with priority.
+     * @param array $attributes       The choices' attributes having the same structure than $choices.
      */
-    public function __construct(array $choices, array $preferredChoices = array())
+    public function __construct(array $choices, array $preferredChoices = array(), array $attributes = array())
     {
         // Flip preferred choices to speed up lookup
-        parent::__construct($choices, $choices, array_flip($preferredChoices));
+        parent::__construct($choices, $choices, array_flip($preferredChoices), $attributes);
     }
 
     /**
@@ -85,11 +86,14 @@ class SimpleChoiceList extends ChoiceList
      * @param array|\Traversable $choices            The list of choices.
      * @param array              $labels             Ignored.
      * @param array              $preferredChoices   The preferred choices.
+     * @param array              $attributes         The choices' attributes.
      */
-    protected function addChoices(array &$bucketForPreferred, array &$bucketForRemaining, $choices, array $labels, array $preferredChoices)
+    protected function addChoices(array &$bucketForPreferred, array &$bucketForRemaining, $choices, array $labels, array $preferredChoices, array $attributes = array())
     {
         // Add choices to the nested buckets
         foreach ($choices as $choice => $label) {
+            $attribute = isset($attributes[$choice]) ? $attributes[$choice] : array();
+
             if (is_array($label)) {
                 // Don't do the work if the array is empty
                 if (count($label) > 0) {
@@ -99,7 +103,8 @@ class SimpleChoiceList extends ChoiceList
                         $bucketForRemaining,
                         $label,
                         $label,
-                        $preferredChoices
+                        $preferredChoices,
+                        $attribute
                     );
                 }
             } else {
@@ -108,7 +113,8 @@ class SimpleChoiceList extends ChoiceList
                     $bucketForRemaining,
                     $choice,
                     $label,
-                    $preferredChoices
+                    $preferredChoices,
+                    $attribute
                 );
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
@@ -40,16 +40,25 @@ class ChoiceView
     public $label;
 
     /**
+     * The choice's attributes.
+     *
+     * @var array
+     */
+    public $attributes;
+
+    /**
      * Creates a new ChoiceView.
      *
-     * @param mixed  $data  The original choice.
-     * @param string $value The view representation of the choice.
-     * @param string $label The label displayed to humans.
+     * @param mixed  $data       The original choice.
+     * @param string $value      The view representation of the choice.
+     * @param string $label      The label displayed to humans.
+     * @param array  $attributes The choice's attributes.
      */
-    public function __construct($data, $value, $label)
+    public function __construct($data, $value, $label, array $attributes = array())
     {
         $this->data = $data;
         $this->value = $value;
         $this->label = $label;
+        $this->attributes = $attributes;
     }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
@@ -1968,5 +1969,103 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
         // no foo
         $this->assertSame('<button type="button" id="button" name="button">[trans]Button[/trans]</button>', $html);
+    }
+
+    public function testWidgetChoiceAttributes()
+    {
+        $form = $this->factory->createNamed('choice', 'choice', null, array(
+            'choices' => array('a' => 'A', 'b' => 'B', 'c' => 'C'),
+            'choices_attr' => array(
+                'a' => array('disabled' => true, 'data-foo' => 'bar'),
+                'c' => array('disabled' => true, 'data-bar' => 'baz'),
+            ),
+        ));
+
+        $html = $this->renderWidget($form->createView());
+
+        $this->assertMatchesXpath($html,
+            '/select
+                [@name="choice"]
+                [
+                    ./option[@disabled][@data-foo="bar"][@value="a"]
+                    /following-sibling::option[not(@disabled)][@value="b"]
+                    /following-sibling::option[@disabled][@data-bar="baz"][@value="c"]
+                ]
+            '
+        );
+    }
+
+    public function testWidgetChoiceListAttributes()
+    {
+        $form = $this->factory->createNamed('choice', 'choice', null, array(
+            'choice_list' => new SimpleChoiceList(array('a' => 'A', 'b' => 'B', 'c' => 'C'), array(), array(
+                    'a' => array('disabled' => true, 'data-foo' => 'bar'),
+                    'c' => array('disabled' => true, 'data-bar' => 'baz'),
+                ))
+        ));
+
+        $html = $this->renderWidget($form->createView());
+
+        $this->assertMatchesXpath($html,
+            '/select
+                [@name="choice"]
+                [
+                    ./option[@disabled][@data-foo="bar"][@value="a"]
+                    /following-sibling::option[not(@disabled)][@value="b"]
+                    /following-sibling::option[@disabled][@data-bar="baz"][@value="c"]
+                ]
+            '
+        );
+    }
+
+    public function testWidgetRadioAttributesFromChoice()
+    {
+        $form = $this->factory->createNamed('choice', 'choice', null, array(
+            'choices' => array('a' => 'A', 'b' => 'B', 'c' => 'C'),
+            'choices_attr' => array(
+                'a' => array('disabled' => true, 'data-foo' => 'bar'),
+                'c' => array('disabled' => true, 'data-bar' => 'baz'),
+            ),
+            'expanded' => true,
+        ));
+
+        $html = $this->renderWidget($form->createView());
+
+        $this->assertMatchesXpath($html,
+            '/div
+                [@id="choice"]
+                [
+                    ./input[@type="radio"][@disabled][@data-foo="bar"][@value="a"]
+                    /following-sibling::input[@type="radio"][not(@disabled)][@value="b"]
+                    /following-sibling::input[@type="radio"][@disabled][@data-bar="baz"][@value="c"]
+                ]
+            '
+        );
+    }
+
+    public function testWidgetCheckboxAttributesFromChoice()
+    {
+        $form = $this->factory->createNamed('choice', 'choice', null, array(
+            'choices' => array('a' => 'A', 'b' => 'B', 'c' => 'C'),
+            'choices_attr' => array(
+                'a' => array('disabled' => true, 'data-foo' => 'bar'),
+                'c' => array('disabled' => true, 'data-bar' => 'baz'),
+            ),
+            'expanded' => true,
+            'multiple' => true,
+        ));
+
+        $html = $this->renderWidget($form->createView());
+
+        $this->assertMatchesXpath($html,
+            '/div
+                [@id="choice"]
+                [
+                    ./input[@type="checkbox"][@disabled][@data-foo="bar"][@value="a"]
+                    /following-sibling::input[@type="checkbox"][not(@disabled)][@value="b"]
+                    /following-sibling::input[@type="checkbox"][@disabled][@data-bar="baz"][@value="c"]
+                ]
+            '
+        );
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ChoiceListTest.php
@@ -48,6 +48,25 @@ class ChoiceListTest extends AbstractChoiceListTest
         $this->assertEquals(array(0 => new ChoiceView($this->obj1, '0', 'A'), 2 => new ChoiceView($this->obj3, '2', 'C'), 3 => new ChoiceView($this->obj4, '3', 'D')), $this->list->getRemainingViews());
     }
 
+    public function testInitAttributes()
+    {
+        $list = new ChoiceList(
+            array($this->obj1, $this->obj2, $this->obj3, $this->obj4),
+            array('A', 'B', 'C', 'D'),
+            array(),
+            array(array('foo' => 'bar1'), array('foo' => 'bar2'), array('foo' => 'bar3'))
+        );
+
+        $this->assertEquals(array(
+                0 => new ChoiceView($this->obj1, '0', 'A', array('foo' => 'bar1')),
+                1 => new ChoiceView($this->obj2, '1', 'B', array('foo' => 'bar2')),
+                2 => new ChoiceView($this->obj3, '2', 'C', array('foo' => 'bar3')),
+                3 => new ChoiceView($this->obj4, '3', 'D')
+            ),
+            $list->getRemainingViews()
+        );
+    }
+
     /**
      * Necessary for interoperability with MongoDB cursors or ORM relations as
      * choices parameter. A choice itself that is an object implementing \Traversable
@@ -92,6 +111,38 @@ class ChoiceListTest extends AbstractChoiceListTest
             'Group 1' => array(0 => new ChoiceView($this->obj1, '0', 'A')),
             'Group 2' => array(3 => new ChoiceView($this->obj4, '3', 'D'))
         ), $this->list->getRemainingViews());
+    }
+
+    public function testInitNestedAttributes()
+    {
+        $list = new ChoiceList(
+            array(
+                'Group 1' => array($this->obj1, $this->obj2),
+                'Group 2' => array($this->obj3, $this->obj4),
+            ),
+            array(
+                'Group 1' => array('A', 'B'),
+                'Group 2' => array('C', 'D'),
+            ),
+            array(),
+            array(
+                'Group 1' => array(array('foo' => 'bar1'), array('foo' => 'bar2')),
+                'Group 2' => array(array(), array('foo' => 'bar4'))
+            )
+        );
+
+        $this->assertEquals(array(
+                'Group 1' => array(
+                    new ChoiceView($this->obj1, '0', 'A', array('foo' => 'bar1')),
+                    new ChoiceView($this->obj2, '1', 'B', array('foo' => 'bar2'))
+                ),
+                'Group 2' => array(
+                    2 => new ChoiceView($this->obj3, '2', 'C'),
+                    3 => new ChoiceView($this->obj4, '3', 'D', array('foo' => 'bar4'))
+                )
+            ),
+            $list->getRemainingViews()
+        );
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
@@ -63,6 +63,24 @@ class ObjectChoiceListTest extends AbstractChoiceListTest
         $this->assertEquals(array(0 => new ChoiceView($this->obj1, '0', 'A'), 2 => new ChoiceView($this->obj3, '2', 'C'), 3 => new ChoiceView($this->obj4, '3', 'D')), $this->list->getRemainingViews());
     }
 
+    public function testInitAttributes()
+    {
+        $list = new ObjectChoiceList(
+            array($this->obj1, $this->obj2, $this->obj3, $this->obj4),
+            'name', array(), null, null, null,
+            array(array('foo' => 'bar1'), array('foo' => 'bar2'), array('foo' => 'bar3'), array('foo' => 'bar4'))
+        );
+
+        $this->assertEquals(array(
+                0 => new ChoiceView($this->obj1, '0', 'A', array('foo' => 'bar1')),
+                1 => new ChoiceView($this->obj2, '1', 'B', array('foo' => 'bar2')),
+                2 => new ChoiceView($this->obj3, '2', 'C', array('foo' => 'bar3')),
+                3 => new ChoiceView($this->obj4, '3', 'D', array('foo' => 'bar4'))
+            ),
+            $list->getRemainingViews()
+        );
+    }
+
     public function testInitNestedArray()
     {
         $this->assertSame(array($this->obj1, $this->obj2, $this->obj3, $this->obj4), $this->list->getChoices());
@@ -75,6 +93,34 @@ class ObjectChoiceListTest extends AbstractChoiceListTest
             'Group 1' => array(0 => new ChoiceView($this->obj1, '0', 'A')),
             'Group 2' => array(3 => new ChoiceView($this->obj4, '3', 'D'))
         ), $this->list->getRemainingViews());
+    }
+
+    public function testInitNestedAttributes()
+    {
+        $list = new ObjectChoiceList(
+            array(
+                'Group 1' => array($this->obj1, $this->obj2),
+                'Group 2' => array($this->obj3, $this->obj4),
+            ),
+            'name', array(), null, null, null,
+            array(
+                'Group 1' => array(array('foo' => 'bar1'), array('foo' => 'bar2')),
+                'Group 2' => array(array(), array('foo' => 'bar4'))
+            )
+        );
+
+        $this->assertEquals(array(
+                'Group 1' => array(
+                    new ChoiceView($this->obj1, '0', 'A', array('foo' => 'bar1')),
+                    new ChoiceView($this->obj2, '1', 'B', array('foo' => 'bar2'))
+                ),
+                'Group 2' => array(
+                    2 => new ChoiceView($this->obj3, '2', 'C'),
+                    3 => new ChoiceView($this->obj4, '3', 'D', array('foo' => 'bar4'))
+                )
+            ),
+            $list->getRemainingViews()
+        );
     }
 
     public function testInitArrayWithGroupPath()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/SimpleChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/SimpleChoiceListTest.php
@@ -27,6 +27,23 @@ class SimpleChoiceListTest extends AbstractChoiceListTest
         $this->assertEquals(array(0 => new ChoiceView('a', 'a', 'A'), 2 => new ChoiceView('c', 'c', 'C')), $this->list->getRemainingViews());
     }
 
+    public function testInitAttributes()
+    {
+        $list = new SimpleChoiceList(
+            array('a' => 'A', 'b' => 'B', 'c' => 'C'),
+            array(),
+            array('a' => array('foo' => 'bar1'), 'c' => array('foo' => 'bar3'))
+        );
+
+        $this->assertEquals(array(
+                new ChoiceView('a', 'a', 'A', array('foo' => 'bar1')),
+                new ChoiceView('b', 'b', 'B'),
+                new ChoiceView('c', 'c', 'C', array('foo' => 'bar3'))
+            ),
+            $list->getRemainingViews()
+        );
+    }
+
     public function testInitNestedArray()
     {
         $this->assertSame(array(0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd'), $this->list->getChoices());
@@ -39,6 +56,34 @@ class SimpleChoiceListTest extends AbstractChoiceListTest
             'Group 1' => array(0 => new ChoiceView('a', 'a', 'A')),
             'Group 2' => array(3 => new ChoiceView('d', 'd', 'D'))
         ), $this->list->getRemainingViews());
+    }
+
+    public function testInitNestedAttributes()
+    {
+        $list = new SimpleChoiceList(
+            array(
+                'Group 1' => array('a' => 'A', 'b' => 'B'),
+                'Group 2' => array('c' => 'C', 'd' => 'D'),
+            ),
+            array(),
+            array(
+                'Group 1' => array('a' => array('foo' => 'bar1'), 'b' => array('foo' => 'bar2')),
+                'Group 2' => array('c' => array(), 'd' => array('foo' => 'bar4'))
+            )
+        );
+
+        $this->assertEquals(array(
+                'Group 1' => array(
+                    new ChoiceView('a', 'a', 'A', array('foo' => 'bar1')),
+                    new ChoiceView('b', 'b', 'B', array('foo' => 'bar2'))
+                ),
+                'Group 2' => array(
+                    2 => new ChoiceView('c', 'c', 'C'),
+                    3 => new ChoiceView('d', 'd', 'D', array('foo' => 'bar4'))
+                )
+            ),
+            $list->getRemainingViews()
+        );
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
## Use cases

Add attributes to choices like it's possible with any other element for example to add microdata attributes to use in select2 templates or disable choices.
## Usage

There are a few ways to apply attributes to choices:
### By specifying the choices_attr option

Note: It works only when using `choices`. See below for when using `choice_list`.
#### As an array

``` php
$builder->add('choice', 'choice', null, array(
    'choices' => array('a' => 'A', 'b' => 'B', 'c' => 'C'),
    'choices_attr' => array(
        'a' => array('disabled' => true, 'data-foo' => 'bar'),
        'c' => array('disabled' => true, 'data-foo' => 'bar'),
    ),
));
```
#### As a callable

``` php
$builder->add('choice', 'choice', null, array(
    'choices' => array('a' => 'A', 'b' => 'B', 'c' => 'C'),
    'choices_attr' => function ($choice) {
        $attributes = array();

        if ('A' === $choice || 'C' === $choice) {
            $attributes['disabled'] = true;
            $attributes['data-foo'] = 'bar';
        }

        return $attributes;    
    }
));
```
### By passing the attributes to the choice lists

``` php
$builder->add('choice', 'choice', null, array(
    'choice_list' => new SimpleChoiceList(
        array('a' => 'A', 'b' => 'B', 'c' => 'C'), array(), array(
            'a' => array('disabled' => true, 'data-foo' => 'bar'),
            'c' => array('disabled' => true, 'data-bar' => 'baz'),
        )
    )
);
```

Edit : It is related to the following issues

https://github.com/symfony/symfony/pull/7510
https://github.com/symfony/symfony/pull/9694
https://github.com/symfony/symfony/issues/3836
