### PR TITLE
lazy session start for #6036 without bc

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Session;
 
+use Symfony\Component\HttpFoundation\Session\Storage\LazySessionStorageInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
@@ -78,6 +79,10 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function has($name)
     {
+        if (!$this->isExists()) {
+            return false;
+        }
+
         return $this->storage->getBag($this->attributeName)->has($name);
     }
 
@@ -86,6 +91,10 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function get($name, $default = null)
     {
+        if (!$this->isExists()) {
+            return $default;
+        }
+
         return $this->storage->getBag($this->attributeName)->get($name, $default);
     }
 
@@ -102,6 +111,10 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function all()
     {
+        if (!$this->isExists()) {
+            return array();
+        }
+
         return $this->storage->getBag($this->attributeName)->all();
     }
 
@@ -154,6 +167,10 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function count()
     {
+        if (!$this->isExists()) {
+            return 0;
+        }
+
         return count($this->storage->getBag($this->attributeName)->all());
     }
 
@@ -247,5 +264,18 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     public function getFlashBag()
     {
         return $this->getBag($this->flashName);
+    }
+
+    /**
+     * Is Session exists
+     *
+     * @return boolean
+     */
+    private function isExists()
+    {
+        return
+            $this->isStarted()
+            || !($this->storage instanceof LazySessionStorageInterface)
+            || $this->storage->hasPreviousSession();
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/LazyMockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/LazyMockArraySessionStorage.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage;
+
+/**
+ * LazyMockArraySessionStorage mocks the session for unit tests.
+ *
+ * No PHP session is actually started since a session can be initialized
+ * and shutdown only once per PHP execution cycle.
+ *
+ * When doing functional testing, you should use MockFileSessionStorage instead.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ * @author Drak <drak@zikula.org>
+ */
+class LazyMockArraySessionStorage extends MockArraySessionStorage implements LazySessionStorageInterface
+{
+     /**
+     * {@inheritdoc}
+     */
+    public function hasPreviousSession()
+    {
+        return !empty($this->id);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/LazySessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/LazySessionStorageInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage;
+
+/**
+ * LazyStorageInterface.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Drak <drak@zikula.org>
+ *
+ * @api
+ */
+interface LazySessionStorageInterface
+{
+    /**
+     * Checks that storage has previous session
+     *
+     * @return boolean True if previous session exiting, false otherwise.
+     */
+    public function hasPreviousSession();
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionLazyStartTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionLazyStartTest.php
@@ -14,16 +14,16 @@ namespace Symfony\Component\HttpFoundation\Tests\Session;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
-use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpFoundation\Session\Storage\LazyMockArraySessionStorage;
 
 /**
- * SessionTest
+ * LazySessionTest
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Drak <drak@zikula.org>
  */
-class SessionTest extends \PHPUnit_Framework_TestCase
+class SessionLazyStartTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface
@@ -37,7 +37,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->storage = new MockArraySessionStorage();
+        $this->storage = new LazyMockArraySessionStorage();
         $this->session = new Session($this->storage, new AttributeBag(), new FlashBag());
     }
 
@@ -47,42 +47,12 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session = null;
     }
 
-    public function testStart()
-    {
-        $this->assertEquals('', $this->session->getId());
-        $this->assertTrue($this->session->start());
-        $this->assertNotEquals('', $this->session->getId());
-    }
-
-    public function testIsStarted()
-    {
-        $this->assertFalse($this->session->isStarted());
-        $this->session->start();
-        $this->assertTrue($this->session->isStarted());
-    }
-
-    public function testSetId()
-    {
-        $this->assertEquals('', $this->session->getId());
-        $this->session->setId('0123456789abcdef');
-        $this->session->start();
-        $this->assertEquals('0123456789abcdef', $this->session->getId());
-    }
-
-    public function testSetName()
-    {
-        $this->assertEquals('MOCKSESSID', $this->session->getName());
-        $this->session->setName('session.test.com');
-        $this->session->start();
-        $this->assertEquals('session.test.com', $this->session->getName());
-    }
-
     public function testGet()
     {
         // tests defaults
         $this->assertNull($this->session->get('foo'));
         $this->assertEquals(1, $this->session->get('foo', 1));
-        $this->assertTrue($this->session->isStarted());
+        $this->assertFalse($this->session->isStarted());
     }
 
     /**
@@ -101,20 +71,13 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     public function testHas($key, $value)
     {
         $this->assertFalse($this->session->has($key.'_lazy_start'));
-        $this->assertTrue($this->session->isStarted());
-
-        $this->session->set($key, $value);
-        $this->assertTrue($this->session->has($key));
-        $this->assertFalse($this->session->has($key.'non_value'));
+        $this->assertFalse($this->session->isStarted());
     }
 
     public function testReplace()
     {
         $this->session->replace(array('happiness' => 'be good', 'symfony' => 'awesome'));
         $this->assertTrue($this->session->isStarted());
-        $this->assertEquals(array('happiness' => 'be good', 'symfony' => 'awesome'), $this->session->all());
-        $this->session->replace(array());
-        $this->assertEquals(array(), $this->session->all());
     }
 
     /**
@@ -124,10 +87,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(array(), $this->session->all());
         $this->session->all();
-        $this->assertTrue($this->session->isStarted());
-
-        $this->session->set($key, $value);
-        $this->assertEquals($result, $this->session->all());
+        $this->assertFalse($this->session->isStarted());
     }
 
     /**
@@ -187,59 +147,12 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->session->isStarted());
     }
 
-    public function testSave()
-    {
-        $this->session->start();
-        $this->session->save();
-    }
-
-    public function testGetId()
-    {
-        $this->assertEquals('', $this->session->getId());
-        $this->session->start();
-        $this->assertNotEquals('', $this->session->getId());
-    }
-
-    public function testGetFlashBag()
-    {
-        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface', $this->session->getFlashBag());
-    }
-
-    /**
-     * @covers Symfony\Component\HttpFoundation\Session\Session::getIterator
-     */
-    public function testGetIterator()
-    {
-        $attributes = array('hello' => 'world', 'symfony2' => 'rocks');
-        foreach ($attributes as $key => $val) {
-            $this->session->set($key, $val);
-        }
-
-        $i = 0;
-        foreach ($this->session as $key => $val) {
-            $this->assertEquals($attributes[$key], $val);
-            $i++;
-        }
-
-        $this->assertEquals(count($attributes), $i);
-    }
-
     /**
      * @covers \Symfony\Component\HttpFoundation\Session\Session::count
      */
     public function testGetCount()
     {
         $this->assertEquals(0, count($this->session));
-        $this->assertTrue($this->session->isStarted());
-
-        $this->session->set('hello', 'world');
-        $this->session->set('symfony2', 'rocks');
-
-        $this->assertCount(2, $this->session);
-    }
-
-    public function testGetMeta()
-    {
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\MetadataBag', $this->session->getMetadataBag());
+        $this->assertFalse($this->session->isStarted());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6036 |
| License | MIT |
| Doc PR |  |

This patch solve problem when session starts after call read method like get, has, count without checking that session isStarted.
