### PR TITLE
[Yaml] Optimise Inline::evaluateScalar() for parsing strings.

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -386,51 +386,55 @@ class Inline
     private static function evaluateScalar($scalar)
     {
         $scalar = trim($scalar);
-
+        $scalarLower = strtolower($scalar);
         switch (true) {
-            case 'null' == strtolower($scalar):
+            case 'null' == $scalarLower:
             case '' == $scalar:
             case '~' == $scalar:
                 return null;
-            case 0 === strpos($scalar, '!str'):
-                return (string) substr($scalar, 5);
-            case 0 === strpos($scalar, '! '):
-                return intval(self::parseScalar(substr($scalar, 2)));
-            case 0 === strpos($scalar, '!!php/object:'):
-                if (self::$objectSupport) {
-                    return unserialize(substr($scalar, 13));
-                }
-
-                if (self::$exceptionOnInvalidType) {
-                    throw new ParseException('Object support when parsing a YAML file has been disabled.');
-                }
-
-                return null;
-            case ctype_digit($scalar):
-                $raw = $scalar;
-                $cast = intval($scalar);
-
-                return '0' == $scalar[0] ? octdec($scalar) : (((string) $raw == (string) $cast) ? $cast : $raw);
-            case '-' === $scalar[0] && ctype_digit(substr($scalar, 1)):
-                $raw = $scalar;
-                $cast = intval($scalar);
-
-                return '0' == $scalar[1] ? octdec($scalar) : (((string) $raw == (string) $cast) ? $cast : $raw);
-            case 'true' === strtolower($scalar):
+            case 'true' === $scalarLower:
                 return true;
-            case 'false' === strtolower($scalar):
+            case 'false' === $scalarLower:
                 return false;
-            case is_numeric($scalar):
-                return '0x' == $scalar[0].$scalar[1] ? hexdec($scalar) : floatval($scalar);
-            case 0 == strcasecmp($scalar, '.inf'):
-            case 0 == strcasecmp($scalar, '.NaN'):
-                return -log(0);
-            case 0 == strcasecmp($scalar, '-.inf'):
-                return log(0);
-            case preg_match('/^(-|\+)?[0-9,]+(\.[0-9]+)?$/', $scalar):
-                return floatval(str_replace(',', '', $scalar));
-            case preg_match(self::getTimestampRegex(), $scalar):
-                return strtotime($scalar);
+            // Optimise for returning strings.
+            case $scalar[0] === '+' || $scalar[0] === '-' || $scalar[0] === '.' || $scalar[0] === '!' || is_numeric($scalar[0]):
+                switch (true) {
+                    case 0 === strpos($scalar, '!str'):
+                        return (string) substr($scalar, 5);
+                    case 0 === strpos($scalar, '! '):
+                        return intval(self::parseScalar(substr($scalar, 2)));
+                    case 0 === strpos($scalar, '!!php/object:'):
+                        if (self::$objectSupport) {
+                            return unserialize(substr($scalar, 13));
+                        }
+
+                        if (self::$exceptionOnInvalidType) {
+                            throw new ParseException('Object support when parsing a YAML file has been disabled.');
+                        }
+
+                        return null;
+                    case ctype_digit($scalar):
+                        $raw = $scalar;
+                        $cast = intval($scalar);
+
+                        return '0' == $scalar[0] ? octdec($scalar) : (((string) $raw == (string) $cast) ? $cast : $raw);
+                    case '-' === $scalar[0] && ctype_digit(substr($scalar, 1)):
+                        $raw = $scalar;
+                        $cast = intval($scalar);
+
+                        return '0' == $scalar[1] ? octdec($scalar) : (((string) $raw == (string) $cast) ? $cast : $raw);
+                    case is_numeric($scalar):
+                        return '0x' == $scalar[0].$scalar[1] ? hexdec($scalar) : floatval($scalar);
+                    case 0 == strcasecmp($scalar, '.inf'):
+                    case 0 == strcasecmp($scalar, '.NaN'):
+                        return -log(0);
+                    case 0 == strcasecmp($scalar, '-.inf'):
+                        return log(0);
+                    case preg_match('/^(-|\+)?[0-9,]+(\.[0-9]+)?$/', $scalar):
+                        return floatval(str_replace(',', '', $scalar));
+                    case preg_match(self::getTimestampRegex(), $scalar):
+                        return strtotime($scalar);
+                }
             default:
                 return (string) $scalar;
         }

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -312,7 +312,9 @@ class Parser
         $removeComments = !preg_match($removeCommentsPattern, $this->currentLine);
 
         while ($this->moveToNextLine()) {
-            if ($this->getCurrentLineIndentation() === $newIndent) {
+            $indent = $this->getCurrentLineIndentation();
+
+            if ($indent === $newIndent) {
                 $removeComments = !preg_match($removeCommentsPattern, $this->currentLine);
             }
 
@@ -328,8 +330,6 @@ class Parser
 
                 continue;
             }
-
-            $indent = $this->getCurrentLineIndentation();
 
             if (preg_match('#^(?P<text> *)$#', $this->currentLine, $match)) {
                 // empty line


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The Drupal 8 installer does a lot of YAML parsing. With the patch attached it is significantly quicker.
![image](https://f.cloud.github.com/assets/769634/2237906/630c3308-9bcf-11e3-8038-35cbbeedd7e6.png)

https://drupal.org/node/1851234
