### PR TITLE
[Serializer] added support for is.* methods in GetSetMethodNormalizer

### DIFF
--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -7,6 +7,10 @@ in 2.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.4.0...v2.4.1
 
+* 2.4.3 (2014-02-23)
+
+ * feature #10297 [Serializer] added support for is.* methods in GetSetMethodNormalizer (tiraeth)
+
 * 2.4.2 (2014-02-12)
 
  * bug #10215 [Routing] reduced recursion in dumper (arnaud-lb)

--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -7,10 +7,6 @@ in 2.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.4.0...v2.4.1
 
-* 2.4.3 (2014-02-23)
-
- * feature #10297 [Serializer] added support for is.* methods in GetSetMethodNormalizer (tiraeth)
-
 * 2.4.2 (2014-02-12)
 
  * bug #10215 [Routing] reduced recursion in dumper (arnaud-lb)

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.5.0
+-----
+
+ * added support for `is.*` getters in `GetSetMethodNormalizer`
+
 2.4.0
 -----
 

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -220,7 +220,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
     private function isGetMethod(\ReflectionMethod $method)
     {
         $methodLength = strlen($method->name);
-        
+
         return (
             ((0 === strpos($method->name, 'get') && 3 < $methodLength) ||
             (0 === strpos($method->name, 'is') && 2 < $methodLength)) &&

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -219,11 +219,11 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
      */
     private function isGetMethod(\ReflectionMethod $method)
     {
+        $methodLength = strlen($method->name);
+        
         return (
-            ((0 === strpos($method->name, 'get') &&
-            3 < strlen($method->name)) ||
-            (0 === strpos($method->name, 'is') &&
-            2 < strlen($method->name))) &&
+            ((0 === strpos($method->name, 'get') && 3 < $methodLength) ||
+            (0 === strpos($method->name, 'is') && 2 < $methodLength)) &&
             0 === $method->getNumberOfRequiredParameters()
         );
     }

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -88,7 +88,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
         $attributes = array();
         foreach ($reflectionMethods as $method) {
             if ($this->isGetMethod($method)) {
-                $attributeName = lcfirst(substr($method->name, 3));
+                $attributeName = lcfirst(substr($method->name, 0 === strpos($method->name, 'is') ? 2 : 3));
 
                 if (in_array($attributeName, $this->ignoredAttributes)) {
                     continue;
@@ -211,17 +211,19 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
     }
 
     /**
-     * Checks if a method's name is get.* and can be called without parameters.
+     * Checks if a method's name is get.* or is.*, and can be called without parameters.
      *
      * @param \ReflectionMethod $method the method to check
      *
-     * @return Boolean whether the method is a getter.
+     * @return Boolean whether the method is a getter or boolean getter.
      */
     private function isGetMethod(\ReflectionMethod $method)
     {
         return (
-            0 === strpos($method->name, 'get') &&
-            3 < strlen($method->name) &&
+            ((0 === strpos($method->name, 'get') &&
+            3 < strlen($method->name)) ||
+            (0 === strpos($method->name, 'is') &&
+            2 < strlen($method->name))) &&
             0 === $method->getNumberOfRequiredParameters()
         );
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -43,7 +43,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
-        $this->assertEquals(true, $obj->isBaz());
+        $this->assertTrue($obj->isBaz());
     }
 
     public function testDenormalizeOnCamelCaseFormat()
@@ -86,7 +86,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
             __NAMESPACE__.'\GetConstructorDummy', 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
-        $this->assertEquals(true, $obj->isBaz());
+        $this->assertTrue($obj->isBaz());
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -26,9 +26,10 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $obj = new GetSetDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
+        $obj->setBaz(true);
         $obj->setCamelCase('camelcase');
         $this->assertEquals(
-            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar', 'camelCase' => 'camelcase'),
+            array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar', 'camelCase' => 'camelcase'),
             $this->normalizer->normalize($obj, 'any')
         );
     }
@@ -36,12 +37,13 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     public function testDenormalize()
     {
         $obj = $this->normalizer->denormalize(
-            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'),
             __NAMESPACE__.'\GetSetDummy',
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
+        $this->assertEquals(true, $obj->isBaz());
     }
 
     public function testDenormalizeOnCamelCaseFormat()
@@ -80,10 +82,11 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     public function testConstructorDenormalize()
     {
         $obj = $this->normalizer->denormalize(
-            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'),
             __NAMESPACE__.'\GetConstructorDummy', 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
+        $this->assertEquals(true, $obj->isBaz());
     }
 
     /**
@@ -93,7 +96,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->normalizer->setCallbacks($callbacks);
 
-        $obj = new GetConstructorDummy('', $value);
+        $obj = new GetConstructorDummy('', $value, true);
 
         $this->assertEquals(
             $result,
@@ -109,18 +112,19 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->normalizer->setCallbacks(array('bar' => null));
 
-        $obj = new GetConstructorDummy('baz', 'quux');
+        $obj = new GetConstructorDummy('baz', 'quux', true);
 
         $this->normalizer->normalize($obj, 'any');
     }
 
     public function testIgnoredAttributes()
     {
-        $this->normalizer->setIgnoredAttributes(array('foo', 'bar', 'camelCase'));
+        $this->normalizer->setIgnoredAttributes(array('foo', 'bar', 'baz', 'camelCase'));
 
         $obj = new GetSetDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
+        $obj->setBaz(true);
 
         $this->assertEquals(
             array('fooBar' => 'foobar'),
@@ -138,7 +142,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
                     },
                 ),
                 'baz',
-                array('foo' => '', 'bar' => 'baz'),
+                array('foo' => '', 'bar' => 'baz', 'baz' => true),
                 'Change a string',
             ),
             array(
@@ -148,7 +152,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
                     },
                 ),
                 'baz',
-                array('foo' => '', 'bar' => null),
+                array('foo' => '', 'bar' => null, 'baz' => true),
                 'Null an item'
             ),
             array(
@@ -158,7 +162,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
                     },
                 ),
                 new \DateTime('2011-09-10 06:30:00'),
-                array('foo' => '', 'bar' => '10-09-2011 06:30:00'),
+                array('foo' => '', 'bar' => '10-09-2011 06:30:00', 'baz' => true),
                 'Format a date',
             ),
             array(
@@ -172,8 +176,8 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
                         return $foos;
                     },
                 ),
-                array(new GetConstructorDummy('baz', ''), new GetConstructorDummy('quux', '')),
-                array('foo' => '', 'bar' => 'bazquux'),
+                array(new GetConstructorDummy('baz', '', false), new GetConstructorDummy('quux', '', false)),
+                array('foo' => '', 'bar' => 'bazquux', 'baz' => true),
                 'Collect a property',
             ),
             array(
@@ -182,8 +186,8 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
                         return count($bars);
                     },
                 ),
-                array(new GetConstructorDummy('baz', ''), new GetConstructorDummy('quux', '')),
-                array('foo' => '', 'bar' => 2),
+                array(new GetConstructorDummy('baz', '', false), new GetConstructorDummy('quux', '', false)),
+                array('foo' => '', 'bar' => 2, 'baz' => true),
                 'Count a property',
             ),
         );
@@ -194,6 +198,7 @@ class GetSetDummy
 {
     protected $foo;
     private $bar;
+    private $baz;
     protected $camelCase;
 
     public function getFoo()
@@ -214,6 +219,16 @@ class GetSetDummy
     public function setBar($bar)
     {
         $this->bar = $bar;
+    }
+
+    public function isBaz()
+    {
+        return $this->baz;
+    }
+
+    public function setBaz($baz)
+    {
+        $this->baz = $baz;
     }
 
     public function getFooBar()
@@ -241,11 +256,13 @@ class GetConstructorDummy
 {
     protected $foo;
     private $bar;
+    private $baz;
 
-    public function __construct($foo, $bar)
+    public function __construct($foo, $bar, $baz)
     {
         $this->foo = $foo;
         $this->bar = $bar;
+        $this->baz = $baz;
     }
 
     public function getFoo()
@@ -256,6 +273,11 @@ class GetConstructorDummy
     public function getBar()
     {
         return $this->bar;
+    }
+
+    public function isBaz()
+    {
+        return $this->baz;
     }
 
     public function otherMethod()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10297 |
| License | MIT |
| Doc PR | N/A |

Using `is` prefix for boolean variables is considered a standard, not only in PHP but also in Java (from which Symfony2 derives lot standards).

I was not sure if this is BCB but answered "no". Was not sure if I should update `CHANGELOG` file and did so, but if you find it irrelevant, go ahead and merge without it. I don't know if I should create a PR for docs because it does not explicitly say that the normalizer supports only `get.*` methods as getters.

_Note: Objects that contain behaviour also can use other prefixes like `can`, `has`, `should`, but their presence in `GetSetMethodNormalizer` is relevant as they do not provide state (`has` is debatable)._
