### PR TITLE
[YAML] Improve performance of getNextEmbedBlock

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -323,18 +323,16 @@ class Parser
                 break;
             }
 
-            if ($removeComments && $this->isCurrentLineEmpty() || $this->isCurrentLineBlank()) {
-                if ($this->isCurrentLineBlank()) {
-                    $data[] = substr($this->currentLine, $newIndent);
-                }
-
+            if ($this->isCurrentLineBlank()) {
+                $data[] = substr($this->currentLine, $newIndent);
                 continue;
             }
 
-            if (preg_match('#^(?P<text> *)$#', $this->currentLine, $match)) {
-                // empty line
-                $data[] = $match['text'];
-            } elseif ($indent >= $newIndent) {
+            if ($removeComments && $this->isCurrentLineComment()) {
+                continue;
+            }
+
+            if ($indent >= $newIndent) {
                 $data[] = substr($this->currentLine, $newIndent);
             } elseif (0 == $indent) {
                 $this->moveToPreviousLine();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

By removing unnecessary preg_match and function calls - isCurrentLineEmpty() contains a call to isCurrentLineBlank() - therefore this function is called twice every time this condition is hit. The preg_match appears to legacy handling of blank lines.

This improves the performance of the Drupal 8 installer.
![image](https://f.cloud.github.com/assets/769634/2241426/69effb0c-9cd1-11e3-9145-e4fabd2ec870.png)
