### PR TITLE
[Form] Add shortcuts to set data class and validation groups

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -29,6 +29,16 @@ class FormType extends BaseType
      */
     private $propertyAccessor;
 
+    /**
+     * @var string
+     */
+    private $dataClass;
+
+    /**
+     * @var array
+     */
+    private $validationGroups;
+
     public function __construct(PropertyAccessorInterface $propertyAccessor = null)
     {
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
@@ -171,7 +181,7 @@ class FormType extends BaseType
         ));
 
         $resolver->setDefaults(array(
-            'data_class'         => $dataClass,
+            'data_class'         => $dataClass ?: $this->dataClass,
             'empty_data'         => $emptyData,
             'trim'               => true,
             'required'           => true,
@@ -187,6 +197,7 @@ class FormType extends BaseType
             'inherit_data'       => $inheritData,
             'compound'           => true,
             'method'             => 'POST',
+            'validation_groups'  => $this->validationGroups,
             // According to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt)
             // section 4.2., empty URIs are considered same-document references
             'action'             => '',
@@ -195,6 +206,26 @@ class FormType extends BaseType
         $resolver->setAllowedTypes(array(
             'label_attr' => 'array',
         ));
+    }
+
+    /**
+     * Allow to set data class in that form.
+     *
+     * @param string $dataClass
+     */
+    public function setDataClass($dataClass)
+    {
+        $this->dataClass = $dataClass;
+    }
+
+    /**
+     * Allow to set validation groups or disable them in that form.
+     *
+     * @param array $validationGroups
+     */
+    public function setValidationGroups(array $validationGroups)
+    {
+        $this->validationGroups = $validationGroups;
     }
 
     /**


### PR DESCRIPTION
Thanks to those simple shortcuts, when declaring forms as services, you can simply set the data class and/or validation groups.

Sample config:

``` xml
<service id="acme.form.type.user" class="%acme.form.type.user.class%">
    <call method="setDataClass">
        <argument>%some_default_data_class%</argument>
    </call>
    <call method="setValidationGroups">
        <argument>%some_default_groups%</argument>
    </call>
    <tag name="form.type" alias="acme_user_form" />
</service>
```

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes* |
| License | MIT |
| Doc PR | n/a (yet) |

\* - will fix if not =)
