### PR TITLE
[Routing] Invalid characters in path to the application for Windows

### DIFF
--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -60,7 +60,19 @@ class YamlFileLoader extends FileLoader
             $this->yamlParser = new YamlParser();
         }
 
-        $config = $this->yamlParser->parse(file_get_contents($path));
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // encode Windows paths
+            $config = $this->yamlParser->parse(iconv('cp1251', 'utf-8', file_get_contents($path)));
+            if (is_array($config)) {
+                foreach ($config as $key => $node) {
+                    if (!empty($node['resource'])) {
+                        $config[$key]['resource'] = iconv('utf-8', 'cp1251', $node['resource']);
+                    }
+                }
+            }
+        } else {
+            $config = $this->yamlParser->parse(file_get_contents($path));
+        }
 
         $collection = new RouteCollection();
         $collection->addResource(new FileResource($path));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Unable to run the application on Windows if the path to application contains characters outside the ASCII

Example bad path:
- `C:\Documents and Settings\Администратор\Рабочий стол\application\`
- `C:\Documents and Settings\Администратор\Мои документы\application\`

**Example**
Launch the application at `C:\Тест\`
After start seeing error:

```
The YAML value does not appear to be valid UTF-8.
```

The problem is that the file `C:\Тест\app\cache\dev\assetic\routing.yml` contains the code:

``` yaml
_assetic:
    resource: .
    type: assetic
_app:
    resource: 'C:\Тест\app\config\routing_dev.yml'
```

_This problem only in dev mode_
