### PR TITLE
[ExpressionLanguage] Added a failing test to prove that EL does not respect 'lazy operator'

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -54,4 +54,14 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
         $expressionLanguage = new ExpressionLanguage();
         $this->assertEquals('constant("PHP_VERSION")', $expressionLanguage->compile('constant("PHP_VERSION")'));
     }
+
+    public function testLazyOperator()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+
+        $object = $this->getMockBuilder('stdClass')->setMethods(array('foo'))->getMock();
+        $object->expects($this->never())->method('foo');
+
+        $this->assertFalse($expressionLanguage->evaluate('false and object.foo()', array('object' => $object)));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

``` php

    /**
     * @Method("GET")
     * @Route("/foobar", name="foobar")
     * @Template()
     * @Security("is_granted('ROLE_USER') and user.foobar()")
     */
    public function foobarAction()
    {

    }
```

If the user is not connected, this throw an exception: `RuntimeException: "Unable to get a property on a non-object."` in `vendor/symfony/symfony/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php at line 78`.
