### PR TITLE
[ExpressionLanguage] added division by zero as exception, instead of warning

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/DivisionByZero.php
+++ b/src/Symfony/Component/ExpressionLanguage/DivisionByZero.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage;
+
+class DivisionByZero extends \LogicException
+{
+    public function __construct()
+    {
+        parent::__construct('Division by zero exception');
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ExpressionLanguage\Node;
 
 use Symfony\Component\ExpressionLanguage\Compiler;
+use Symfony\Component\ExpressionLanguage\DivisionByZero;
 
 class BinaryNode extends Node
 {
@@ -135,6 +136,9 @@ class BinaryNode extends Node
             case '*':
                 return $left * $right;
             case '/':
+                if($right == 0) {
+                    throw new DivisionByZero();
+                }
                 return $left / $right;
             case '%':
                 return $left % $right;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

the exception file might need more thought (extends and the message)
checking the right hand value should be a loose check, since null / '' / 0 should all produce the exception.
