### PR TITLE
[SecurityBundle] Allow 'have to match pattern' paths in AbstractFactory children configuration

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -290,7 +290,7 @@ class MainConfiguration implements ConfigurationInterface
             ->end()
         ;
 
-        $abstractFactoryKeys = array();
+        $abstractFactories = array();
         foreach ($factories as $factoriesAtPosition) {
             foreach ($factoriesAtPosition as $factory) {
                 $name = str_replace('-', '_', $factory->getKey());
@@ -299,7 +299,7 @@ class MainConfiguration implements ConfigurationInterface
                 ;
 
                 if ($factory instanceof AbstractFactory) {
-                    $abstractFactoryKeys[] = $name;
+                    $abstractFactories[$name] = $factory;
                 }
 
                 $factory->addConfiguration($factoryNode);
@@ -313,14 +313,16 @@ class MainConfiguration implements ConfigurationInterface
                 ->ifTrue(function ($v) {
                     return true === $v['security'] && isset($v['pattern']) && !isset($v['request_matcher']);
                 })
-                ->then(function ($firewall) use ($abstractFactoryKeys) {
-                    foreach ($abstractFactoryKeys as $k) {
-                        if (!isset($firewall[$k]['check_path'])) {
-                            continue;
-                        }
+                ->then(function ($firewall) use ($abstractFactories) {
+                    foreach ($abstractFactories as $k => $factory) {
+                        foreach ($factory->getPathOptions() as $pathOption) {
+                            if (!isset($firewall[$k][$pathOption])) {
+                                continue;
+                            }
 
-                        if (false !== strpos($firewall[$k]['check_path'], '/') && !preg_match('#'.$firewall['pattern'].'#', $firewall[$k]['check_path'])) {
-                            throw new \LogicException(sprintf('The check_path "%s" for login method "%s" is not matched by the firewall pattern "%s".', $firewall[$k]['check_path'], $k, $firewall['pattern']));
+                            if (false !== strpos($firewall[$k][$pathOption], '/') && !preg_match('#'.$firewall['pattern'].'#', $firewall[$k][$pathOption])) {
+                                throw new \LogicException(sprintf('The %s "%s" for login method "%s" is not matched by the firewall pattern "%s".', $pathOption, $firewall[$k][$pathOption], $k, $firewall['pattern']));
+                            }
                         }
                     }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -32,6 +32,8 @@ abstract class AbstractFactory implements SecurityFactoryInterface
         'require_previous_session'       => true,
     );
 
+    protected $pathOptions = array('check_path');
+
     protected $defaultSuccessHandlerOptions = array(
         'always_use_default_target_path' => false,
         'default_target_path'            => '/',
@@ -92,6 +94,20 @@ abstract class AbstractFactory implements SecurityFactoryInterface
     final public function addOption($name, $default = null)
     {
         $this->options[$name] = $default;
+    }
+
+    final public function setOptionAsPath($name)
+    {
+        if (!isset($this->options[$name])) {
+            throw new \InvalidArgumentException(sprintf('"%s" key is not defined as an option', $name));
+        }
+
+        $this->pathOptions[] = $name;
+    }
+
+    public function getPathOptions()
+    {
+        return array_unique($this->pathOptions);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -112,4 +112,39 @@ class MainConfigurationTest extends \PHPUnit_Framework_TestCase
         $configuration = new MainConfiguration(array(), array());
         $processedConfig = $processor->processConfiguration($configuration, array($config));
     }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage The baz_path "/baz" for login method "abstract_factory" is not matched by the firewall pattern "^/test"
+     */
+    public function testInvalidPathOptionCausesException()
+    {
+        $factory = $this->getMockForAbstractClass('Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory', array());
+
+        $factory
+            ->expects($this->any())
+            ->method('getKey')
+            ->will($this->returnValue('abstract_factory'))
+        ;
+
+        $factory->addOption('baz_path', '/');
+        $factory->setOptionAsPath('baz_path');
+
+        $config = array(
+            'firewalls' => array(
+                'stub' => array(
+                    'pattern' => '^/test',
+                    'abstract_factory' => array(
+                        'check_path'  => '/test/check',
+                        'baz_path'  => '/baz',
+                    ),
+                ),
+            ),
+        );
+        $config = array_merge(static::$minimalConfig, $config);
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration(array(array($factory)), array());
+        $processedConfig = $processor->processConfiguration($configuration, array($config));
+    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -70,6 +70,41 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new Reference('security.authentication.success_handler.foo.abstract_factory'), $arguments['index_5']);
     }
 
+    public function testSetOptionAsPath()
+    {
+        $factory = $this->getMockForAbstractClass('Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory', array());
+
+        $reflection = new \ReflectionClass($factory);
+        $pathOptions = $reflection->getProperty('pathOptions');
+        $pathOptions->setAccessible(true);
+
+        $this->assertNotContains('foo', $pathOptions->getValue($factory));
+        $factory->addOption('foo', '/bar');
+        $factory->setOptionAsPath('foo');
+        $this->assertContains('foo', $pathOptions->getValue($factory));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage "foo" key is not defined as an option
+     */
+    public function testSetOptionAsPathWithInvalidOption()
+    {
+        $factory = $this->getMockForAbstractClass('Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory', array());
+
+        $factory->setOptionAsPath('foo');
+    }
+
+    public function testGetPathOptions()
+    {
+        $factory = $this->getMockForAbstractClass('Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory', array());
+
+        $this->assertNotContains('foo', $factory->getPathOptions());
+        $factory->addOption('foo', '/bar');
+        $factory->setOptionAsPath('foo');
+        $this->assertContains('foo', $factory->getPathOptions());
+    }
+
     protected function callFactory($id, $config, $userProviderId, $defaultEntryPointId)
     {
         $factory = $this->getMockForAbstractClass('Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory', array());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

This PR allow security factories that extend AbstractFactory to define paths that have to match the firewall pattern (like `check_path`) in configuration.

What do you think about it ?

**TODO**
- [x] Add tests
