### PR TITLE
[Form] Set a root block_name with '@' sign

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -45,6 +45,12 @@ abstract class BaseType extends AbstractType
         $blockName = $options['block_name'] ?: $form->getName();
         $translationDomain = $options['translation_domain'];
 
+        $isRootBlockName = false;
+        if (0 === strpos($blockName, '@')) {
+            $blockName = substr($blockName, 1);
+            $isRootBlockName = true;
+        }
+
         if ($view->parent) {
             if ('' !== ($parentFullName = $view->parent->vars['full_name'])) {
                 $id = sprintf('%s_%s', $view->parent->vars['id'], $name);
@@ -75,6 +81,10 @@ abstract class BaseType extends AbstractType
             array_unshift($blockPrefixes, $type->getName());
         }
         $blockPrefixes[] = $uniqueBlockPrefix;
+
+        if ($isRootBlockName) {
+            $blockPrefixes[] = $blockName;
+        }
 
         if (!$translationDomain) {
             $translationDomain = 'messages';

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -131,5 +131,40 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertFalse($view->vars['multipart']);
     }
 
+    public function testBlockName()
+    {
+        $form = $this->factory->createNamedBuilder('parent', 'form')
+            ->add('child', $this->getTestedType(), array('block_name' => 'custom'))
+            ->getForm();
+
+        $type = $form->get('child')->getConfig()->getType()->getName();
+
+        $view = $form->createView();
+
+        $expected = array(
+            $type,
+            '_parent_custom'
+            );
+        $this->assertEquals($expected, $view['child']->vars['block_prefixes']);
+    }
+
+    public function testBlockNameWithRootSign()
+    {
+        $form = $this->factory->createNamedBuilder('parent', 'form')
+            ->add('child', $this->getTestedType(), array('block_name' => '@custom'))
+            ->getForm();
+
+        $type = $form->get('child')->getConfig()->getType()->getName();
+
+        $view = $form->createView();
+
+        $expected = array(
+            $type,
+            '_parent_custom',
+            'custom'
+            );
+        $this->assertEquals($expected, $view['child']->vars['block_prefixes']);
+    }
+
     abstract protected function getTestedType();
 }


### PR DESCRIPTION
The 'block_name' option in FormType is limited because it use the parent hierarchy in blocks names.

This commit adds the possibility to use a root block name by using the '@' sign.
i.e:

``` php
array('block_name' => '@customblock')
```

should create block_prefixes like 

``` php
Array (
     0 => 'form'
     1 => '_parent_customblock'
     2 => 'customblock'
 )
```

As '@' is an invalid character for block name, the commit should not break old code.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
