### PR TITLE
adds failing test case for non-catchable pattern in requirements

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -242,6 +242,12 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->getGenerator($routes)->generate('test', array('slug' => ''));
     }
 
+    public function testLookAroundInRequirements()
+    {
+        $routes = $this->getRoutes('test', new Route('/{foo}/bar/{baz}', array(), array('foo' => '.+(?=/bar/)', 'baz' => '.+?')));
+        $this->assertSame('/app.php/a/b/bar/c/d/e', $this->getGenerator($routes)->generate('test', array('foo' => 'a/b', 'baz' => 'c/d/e')));
+    }
+
     public function testSchemeRequirementDoesNothingIfSameCurrentScheme()
     {
         $routes = $this->getRoutes('test', new Route('/', array(), array('_scheme' => 'http'))); // BC


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| License | MIT |
| Doc PR | none |

If you have a non-catchable pattern in requirements like f.e. a positive lookahead (`.+(?=/foo/)`), the generator will not accept the parameter as the parameter itself cannot fulfil the requirement, but only matches in the context of the entire path.

I'm not sure how/if you would like to fix this, this only adds a failing test case. One way might be to generate the URL and run the matcher against the entire URL.

/cc @Tobion
