### PR TITLE
[DataCollector] Improves the readability of the collected arrays in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -8,6 +8,7 @@
         <parameter key="web_profiler.controller.profiler.class">Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController</parameter>
         <parameter key="web_profiler.controller.router.class">Symfony\Bundle\WebProfilerBundle\Controller\RouterController</parameter>
         <parameter key="web_profiler.controller.exception.class">Symfony\Bundle\WebProfilerBundle\Controller\ExceptionController</parameter>
+        <parameter key="twig.extension.webprofiler.class">Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension</parameter>
     </parameters>
 
     <services>
@@ -29,6 +30,10 @@
             <argument type="service" id="profiler" on-invalid="null" />
             <argument type="service" id="twig" />
             <argument>%kernel.debug%</argument>
+        </service>
+
+        <service id="twig.extension.webprofiler" class="%twig.extension.webprofiler.class%" public="false">
+            <tag name="twig.extension" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/bag.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/bag.html.twig
@@ -1,16 +1,15 @@
 <table {% if class is defined %}class='{{ class }}'{% endif %} >
     <thead>
         <tr>
-            <th scope="col">Key</th>
-            <th scope="col">Value</th>
+            <th scope="col" style="width: 25%">Key</th>
+            <th scope="col" style="width: 75%">Value</th>
         </tr>
     </thead>
     <tbody>
         {% for key in bag.keys|sort %}
             <tr>
                 <th>{{ key }}</th>
-                {# JSON_UNESCAPED_SLASHES = 64, JSON_UNESCAPED_UNICODE = 256 #}
-                <td>{{ bag.get(key)|json_encode(64 b-or 256) }}</td>
+                <td><pre>{{ profiler_dump(bag.get(key)) }}</pre></td>
             </tr>
         {% endfor %}
     </tbody>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -170,6 +170,10 @@ pre, code {
     margin-left: 250px;
     padding: 30px 40px 40px;
 }
+#collector-content pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+}
 #navigation {
     float: left;
     width: 250px;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/table.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/table.html.twig
@@ -1,16 +1,15 @@
 <table {% if class is defined %}class='{{ class }}'{% endif %} >
     <thead>
         <tr>
-            <th scope="col">Key</th>
-            <th scope="col">Value</th>
+            <th scope="col" style="width: 25%">Key</th>
+            <th scope="col" style="width: 75%">Value</th>
         </tr>
     </thead>
     <tbody>
         {% for key in data|keys|sort %}
             <tr>
                 <th>{{ key }}</th>
-                {# JSON_UNESCAPED_SLASHES = 64, JSON_UNESCAPED_UNICODE = 256 #}
-                <td>{{ data[key]|json_encode(64 b-or 256) }}</td>
+                <td><pre>{{ profiler_dump(data[key]) }}</pre></td>
             </tr>
         {% endfor %}
     </tbody>

--- a/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Twig;
+
+use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
+
+/**
+ * Twig extension for the profiler
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class WebProfilerExtension extends \Twig_Extension
+{
+    /**
+     * @var ValueExporter
+     */
+    private $valueExporter;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('profiler_dump', array($this, 'dumpValue')),
+        );
+    }
+
+    public function dumpValue($value)
+    {
+        if (null === $this->valueExporter) {
+            $this->valueExporter = new ValueExporter();
+        }
+
+        return $this->valueExporter->exportValue($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'profiler';
+    }
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-kernel": "~2.2",
+        "symfony/http-kernel": "~2.3",
         "symfony/routing": "~2.2",
         "symfony/twig-bridge": "~2.2"
     },

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -25,7 +25,7 @@ class FormDataExtractorTest_SimpleValueExporter extends ValueExporter
     /**
      * {@inheritdoc}
      */
-    public function exportValue($value, $depth = 0)
+    public function exportValue($value, $depth = 1, $deep = false)
     {
         return is_object($value) ? sprintf('object(%s)', get_class($value)) : var_export($value, true);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -25,7 +25,7 @@ class FormDataExtractorTest_SimpleValueExporter extends ValueExporter
     /**
      * {@inheritdoc}
      */
-    public function exportValue($value)
+    public function exportValue($value, $depth = 0)
     {
         return is_object($value) ? sprintf('object(%s)', get_class($value)) : var_export($value, true);
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -51,14 +51,10 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $attributes = array();
         foreach ($request->attributes->all() as $key => $value) {
             if ('_route' === $key && is_object($value)) {
-                $attributes['_route'] = $this->varToString($value->getPath());
-            } elseif ('_route_params' === $key) {
-                foreach ($value as $key => $v) {
-                    $attributes['_route_params'][$key] = $this->varToString($v);
-                }
-            } else {
-                $attributes[$key] = $this->varToString($value);
+                $value = $value->getPath();
             }
+
+            $attributes[$key] = $value;
         }
 
         $content = null;

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -20,7 +20,8 @@ class ValueExporter
      * Converts a PHP value to a string.
      *
      * @param mixed   $value The PHP value
-     * @param integer $depth The depth of the value to export (only for internal usage)
+     * @param integer $depth only for internal usage
+     * @param Boolean $deep  only for internal usage
      *
      * @return string The string representation of the given value
      */

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -20,22 +20,29 @@ class ValueExporter
      * Converts a PHP value to a string.
      *
      * @param mixed $value The PHP value
+     * @param integer $depth The depth of the value to export
      *
      * @return string The string representation of the given value
      */
-    public function exportValue($value)
+    public function exportValue($value, $depth = 0)
     {
         if (is_object($value)) {
             return sprintf('Object(%s)', get_class($value));
         }
 
         if (is_array($value)) {
-            $a = array();
-            foreach ($value as $k => $v) {
-                $a[] = sprintf('%s => %s', $k, $this->exportValue($v));
+            if (empty($value)) {
+                return '[]';
             }
 
-            return sprintf("Array(%s)", implode(', ', $a));
+            $indent = str_repeat('  ', $depth);
+
+            $a = array();
+            foreach ($value as $k => $v) {
+                $a[] = sprintf('%s  %s => %s', $indent, $k, $this->exportValue($v, $depth + 1));
+            }
+
+            return sprintf("[\n%s%s\n%s]", $indent, implode(sprintf(", \n%s", $indent), $a), $indent);
         }
 
         if (is_resource($value)) {

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -19,12 +19,12 @@ class ValueExporter
     /**
      * Converts a PHP value to a string.
      *
-     * @param mixed $value The PHP value
-     * @param integer $depth The depth of the value to export
+     * @param mixed   $value The PHP value
+     * @param integer $depth The depth of the value to export (only for internal usage)
      *
      * @return string The string representation of the given value
      */
-    public function exportValue($value, $depth = 0)
+    public function exportValue($value, $depth = 1, $deep = false)
     {
         if (is_object($value)) {
             return sprintf('Object(%s)', get_class($value));
@@ -39,10 +39,17 @@ class ValueExporter
 
             $a = array();
             foreach ($value as $k => $v) {
-                $a[] = sprintf('%s  %s => %s', $indent, $k, $this->exportValue($v, $depth + 1));
+                if (is_array($v)) {
+                    $deep = true;
+                }
+                $a[] = sprintf('%s => %s', $k, $this->exportValue($v, $depth + 1, $deep));
             }
 
-            return sprintf("[\n%s%s\n%s]", $indent, implode(sprintf(", \n%s", $indent), $a), $indent);
+            if ($deep) {
+                return sprintf("[\n%s%s\n%s]", $indent, implode(sprintf(", \n%s", $indent), $a), str_repeat('  ', $depth - 1));
+            }
+
+            return sprintf("[%s]", implode(', ', $a));
         }
 
         if (is_resource($value)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This PR is based on #10155.

Original description:

It simply improves the readability of the collected arrays in the profiler:

**before**:

```
Array(date => Array(year => , month => , day => ), time => Array(hour => ))
```

**after**:

```
[
  date => [
      year => , 
      month => , 
      day => 
  ], 
  time => [
      hour => 
  ]
]
```
