### PR TITLE
[Debug] ExceptionHandlerInterface to allow third party exception handlers to handle fatal errors caught by ErrorHandler

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -155,7 +155,7 @@ class ErrorHandler
             $exceptionHandler = set_exception_handler('var_dump');
             restore_exception_handler();
 
-            if (is_array($exceptionHandler) && $exceptionHandler[0] instanceof ExceptionHandler) {
+            if (is_array($exceptionHandler) && $exceptionHandler[0] instanceof ExceptionHandlerInterface) {
                 if (self::$stackedErrorLevels) {
                     self::$stackedErrors[] = func_get_args();
 
@@ -263,7 +263,7 @@ class ErrorHandler
         $exceptionHandler = set_exception_handler('var_dump');
         restore_exception_handler();
 
-        if (is_array($exceptionHandler) && $exceptionHandler[0] instanceof ExceptionHandler) {
+        if (is_array($exceptionHandler) && $exceptionHandler[0] instanceof ExceptionHandlerInterface) {
             $this->handleFatalError($exceptionHandler[0], $error);
         }
     }
@@ -284,7 +284,7 @@ class ErrorHandler
         );
     }
 
-    private function handleFatalError(ExceptionHandler $exceptionHandler, array $error)
+    private function handleFatalError(ExceptionHandlerInterface $exceptionHandler, array $error)
     {
         $level = isset($this->levels[$error['type']]) ? $this->levels[$error['type']] : $error['type'];
         $message = sprintf('%s: %s in %s line %d', $level, $error['message'], $error['file'], $error['line']);

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -29,7 +29,7 @@ if (!defined('ENT_SUBSTITUTE')) {
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ExceptionHandler
+class ExceptionHandler implements ExceptionHandlerInterface
 {
     private $debug;
     private $charset;
@@ -57,13 +57,13 @@ class ExceptionHandler
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Sends a response for the given Exception.
      *
      * If you have the Symfony HttpFoundation component installed,
      * this method will use it to create and send the response. If not,
      * it will fallback to plain PHP functions.
-     *
-     * @param \Exception $exception An \Exception instance
      *
      * @see sendPhpResponse
      * @see createResponse

--- a/src/Symfony/Component/Debug/ExceptionHandlerInterface.php
+++ b/src/Symfony/Component/Debug/ExceptionHandlerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug;
+
+/**
+ * An ExceptionHandler does something useful with an exception.
+ *
+ * @author Andrew Moore <me@andrewmoore.ca>
+ */
+interface ExceptionHandlerInterface
+{
+    /**
+     * Handles an exception.
+     *
+     * @param \Exception $exception An \Exception instance
+     */
+    public function handle(\Exception $exception);
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (other project) |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| Related tickets | schmittjoh/JMSDebuggingBundle#68 |
| License | MIT |
| Doc PR |  |

The current `ErrorHandler` is extremely strict on how it selects whether to run an `ExceptionHandler` when an `E_FATAL` occurs.

This modification allows any class that implements `ExceptionHandlerInterface` to handle a `FatalErrorException` created by the `ErrorHandler`.
