### PR TITLE
[Console] A better progress bar

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -23,6 +23,31 @@ UPGRADE FROM 2.x to 3.0
  * The methods `isQuiet`, `isVerbose`, `isVeryVerbose` and `isDebug` were added
    to `Symfony\Component\Console\Output\OutputInterface`.
 
+ * `ProgressHelper` has been removed in favor of `ProgressBar`.
+
+   Before:
+
+   ```
+   $h = new ProgressHelper();
+   $h->start($output, 10);
+   for ($i = 1; $i < 5; $i++) {
+       usleep(200000);
+       $h->advance();
+   }
+   $h->finish();
+   ```
+
+   After:
+
+   ```
+   $bar = new ProgressBar($output, 10);
+   $bar->start();
+   for ($i = 1; $i < 5; $i++) {
+       usleep(200000);
+       $bar->advance();
+   }
+   ```
+
 ### EventDispatcher
 
  * The interface `Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface`

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,8 +4,9 @@ CHANGELOG
 2.5.0
 -----
 
-* added a way to set a default command instead of `ListCommand`
-* added a way to set the process name of a command
+ * deprecated ProgressHelper in favor of ProgressBar
+ * added a way to set a default command instead of `ListCommand`
+ * added a way to set the process name of a command
 
 2.4.0
 -----

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -86,4 +86,21 @@ abstract class Helper implements HelperInterface
             return ceil($secs / $format[2]).' '.$format[1];
         }
     }
+
+    public static function formatMemory($memory)
+    {
+        if ($memory >= 1024 * 1024 * 1024) {
+            return sprintf('%.1f GB', $memory / 1024 / 1024 / 1024);
+        }
+
+        if ($memory >= 1024 * 1024) {
+            return sprintf('%.1f MB', $memory / 1024 / 1024);
+        }
+
+        if ($memory >= 1024) {
+            return sprintf('%d kB', $memory / 1024);
+        }
+
+        return sprintf('%d B', $memory);
+    }
 }

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -47,7 +47,7 @@ abstract class Helper implements HelperInterface
      *
      * @return integer The length of the string
      */
-    protected function strlen($string)
+    public static function strlen($string)
     {
         if (!function_exists('mb_strlen')) {
             return strlen($string);

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -59,4 +59,31 @@ abstract class Helper implements HelperInterface
 
         return mb_strlen($string, $encoding);
     }
+
+    public static function formatTime($secs)
+    {
+        static $timeFormats = array(
+            array(0, '< 1 sec'),
+            array(2, '1 sec'),
+            array(59, 'secs', 1),
+            array(60, '1 min'),
+            array(3600, 'mins', 60),
+            array(5400, '1 hr'),
+            array(86400, 'hrs', 3600),
+            array(129600, '1 day'),
+            array(604800, 'days', 86400),
+        );
+
+        foreach ($timeFormats as $format) {
+            if ($secs >= $format[0]) {
+                continue;
+            }
+
+            if (2 == count($format)) {
+                return $format[1];
+            }
+
+            return ceil($secs / $format[2]).' '.$format[1];
+        }
+    }
 }

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Helper;
 
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+
 /**
  * Helper is the base class for all helper classes.
  *
@@ -102,5 +104,18 @@ abstract class Helper implements HelperInterface
         }
 
         return sprintf('%d B', $memory);
+    }
+
+    public static function strlenWithoutDecoration(OutputFormatterInterface $formatter, $string)
+    {
+        $isDecorated = $formatter->isDecorated();
+        $formatter->setDecorated(false);
+        // remove <...> formatting
+        $string = $formatter->format($string);
+        // remove already formatted characters
+        $string = preg_replace("/\033\[[^m]*m/", '', $string);
+        $formatter->setDecorated($isDecorated);
+
+        return self::strlen($string);
     }
 }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -419,6 +419,35 @@ class ProgressBar
             '%elapsed%' => function (ProgressBar $bar) {
                 return str_pad(Helper::formatTime(time() - $bar->getStartTime()), 6, ' ', STR_PAD_LEFT);
             },
+            '%remaining%' => function (ProgressBar $bar) {
+                if (!$bar->getMaxSteps()) {
+                    throw new \LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
+                }
+
+                if (!$bar->getStep()) {
+                    $remaining = 0;
+                } else {
+                    $remaining = round((time() - $bar->getStartTime()) / $bar->getStep() * ($bar->getMaxSteps() - $bar->getStep()));
+                }
+
+                return str_pad(Helper::formatTime($remaining), 6, ' ', STR_PAD_LEFT);
+            },
+            '%estimated%' => function (ProgressBar $bar) {
+                if (!$bar->getMaxSteps()) {
+                    throw new \LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
+                }
+
+                if (!$bar->getStep()) {
+                    $estimated = 0;
+                } else {
+                    $estimated = round((time() - $bar->getStartTime()) / $bar->getStep() * $bar->getMaxSteps());
+                }
+
+                return str_pad(Helper::formatTime($estimated), 6, ' ', STR_PAD_LEFT);
+            },
+            '%memory%' => function (ProgressBar $bar) {
+                return str_pad(Helper::formatMemory(memory_get_usage(true)), 6, ' ', STR_PAD_LEFT);;
+            },
             '%current%' => function (ProgressBar $bar) {
                 return str_pad($bar->getStep(), $bar->getStepWidth(), ' ', STR_PAD_LEFT);
             },

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -44,8 +44,8 @@ class ProgressBar
     private $formatLineCount;
     private $messages;
 
-    static private $formatters;
-    static private $formats;
+    private static $formatters;
+    private static $formats;
 
     /**
      * Constructor.
@@ -87,6 +87,18 @@ class ProgressBar
     }
 
     /**
+     * Gets the placeholder formatter for a given name.
+     *
+     * @param string $name The placeholder name (including the delimiter char like %)
+     *
+     * @return callable|null A PHP callable
+     */
+    public static function getPlaceholderFormatterDefinition($name)
+    {
+        return isset(self::$formatters[$name]) ? self::$formatters[$name] : null;
+    }
+
+    /**
      * Sets a format for a given name.
      *
      * This method also allow you to override an existing format.
@@ -103,6 +115,18 @@ class ProgressBar
         self::$formats[$name] = $format;
     }
 
+    /**
+     * Gets the format for a given name.
+     *
+     * @param string $name The format name
+     *
+     * @return string|null A format string
+     */
+    public static function getFormatDefinition($name)
+    {
+        return isset(self::$formats[$name]) ? self::$formats[$name] : null;
+    }
+
     public function setMessage($message, $name = 'message')
     {
         $this->messages[$name] = $message;
@@ -116,7 +140,7 @@ class ProgressBar
     /**
      * Gets the progress bar start time.
      *
-     * @return int The progress bar start time
+     * @return integer The progress bar start time
      */
     public function getStartTime()
     {
@@ -126,7 +150,7 @@ class ProgressBar
     /**
      * Gets the progress bar maximal steps.
      *
-     * @return int The progress bar max steps
+     * @return integer The progress bar max steps
      */
     public function getMaxSteps()
     {
@@ -136,7 +160,7 @@ class ProgressBar
     /**
      * Gets the progress bar step.
      *
-     * @return int The progress bar step
+     * @return integer The progress bar step
      */
     public function getStep()
     {
@@ -146,7 +170,7 @@ class ProgressBar
     /**
      * Gets the progress bar step width.
      *
-     * @return int The progress bar step width
+     * @return integer The progress bar step width
      */
     public function getStepWidth()
     {
@@ -156,7 +180,7 @@ class ProgressBar
     /**
      * Gets the current progress bar percent.
      *
-     * @return int The current progress bar percent
+     * @return integer The current progress bar percent
      */
     public function getProgressPercent()
     {
@@ -166,7 +190,7 @@ class ProgressBar
     /**
      * Sets the progress bar width.
      *
-     * @param int $size The progress bar size
+     * @param integer $size The progress bar size
      */
     public function setBarWidth($size)
     {
@@ -176,7 +200,7 @@ class ProgressBar
     /**
      * Gets the progress bar width.
      *
-     * @return int The progress bar size
+     * @return integer The progress bar size
      */
     public function getBarWidth()
     {
@@ -257,7 +281,7 @@ class ProgressBar
     /**
      * Sets the redraw frequency.
      *
-     * @param int $freq The frequency in steps
+     * @param integer $freq The frequency in steps
      */
     public function setRedrawFrequency($freq)
     {
@@ -365,8 +389,8 @@ class ProgressBar
 
         $self = $this;
         $this->overwrite(preg_replace_callback("{%([a-z\-_]+)(?:\:([^%]+))?%}i", function ($matches) use ($self) {
-            if (isset(self::$formatters[$matches[1]])) {
-                $text = call_user_func(self::$formatters[$matches[1]], $self);
+            if ($formatter = $self::getPlaceholderFormatterDefinition($matches[1])) {
+                $text = call_user_func($formatter, $self);
             } elseif (isset($this->messages[$matches[1]])) {
                 $text = $this->messages[$matches[1]];
             } else {
@@ -433,7 +457,7 @@ class ProgressBar
         }
     }
 
-    static private function initPlaceholderFormatters()
+    private static function initPlaceholderFormatters()
     {
         return array(
             'bar' => function (ProgressBar $bar) {
@@ -490,7 +514,7 @@ class ProgressBar
         );
     }
 
-    static private function initFormats()
+    private static function initFormats()
     {
         return array(
             'quiet'         => ' %percent%%',

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -427,7 +427,7 @@ class TableHelper extends Helper
             $width += strlen($cell) - mb_strlen($cell, $encoding);
         }
 
-        $width += $this->strlen($cell) - $this->computeLengthWithoutDecoration($cell);
+        $width += $this->strlen($cell) - self::strlenWithoutDecoration($this->output->getFormatter(), $cell);
 
         $content = sprintf($this->cellRowContentFormat, $cell);
 
@@ -486,7 +486,7 @@ class TableHelper extends Helper
      */
     private function getCellWidth(array $row, $column)
     {
-        return isset($row[$column]) ? $this->computeLengthWithoutDecoration($row[$column]) : 0;
+        return isset($row[$column]) ? self::strlenWithoutDecoration($this->output->getFormatter(), $row[$column]) : 0;
     }
 
     /**
@@ -496,18 +496,6 @@ class TableHelper extends Helper
     {
         $this->columnWidths = array();
         $this->numberOfColumns = null;
-    }
-
-    private function computeLengthWithoutDecoration($string)
-    {
-        $formatter = $this->output->getFormatter();
-        $isDecorated = $formatter->isDecorated();
-        $formatter->setDecorated(false);
-
-        $string = $formatter->format($string);
-        $formatter->setDecorated($isDecorated);
-
-        return $this->strlen($string);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -298,6 +298,27 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAddingPlaceholderFormatter()
+    {
+        ProgressBar::setPlaceholderFormatter('%remaining_steps%', function (ProgressBar $bar) {
+            return $bar->getMaxSteps() - $bar->getStep();
+        });
+        $bar = new ProgressBar($output = $this->getOutputStream(), 3);
+        $bar->setFormat(' %remaining_steps% [%bar%]');
+
+        $bar->start();
+        $bar->advance();
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput(' 3 [>---------------------------]').
+            $this->generateOutput(' 2 [=========>------------------]').
+            $this->generateOutput(' 0 [============================]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
     protected function getOutputStream($decorated = true)
     {
         return new StreamOutput(fopen('php://memory', 'r+', false), StreamOutput::VERBOSITY_NORMAL, $decorated);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class ProgressBarTest extends \PHPUnit_Framework_TestCase
+{
+    protected $lastMessagesLength;
+
+    public function testAdvance()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->start();
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('    0 [>---------------------------]').
+            $this->generateOutput('    1 [->--------------------------]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testAdvanceWithStep()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->start();
+        $bar->advance(5);
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('    0 [>---------------------------]').
+            $this->generateOutput('    5 [----->----------------------]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testAdvanceMultipleTimes()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->start();
+        $bar->advance(3);
+        $bar->advance(2);
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('    0 [>---------------------------]').
+            $this->generateOutput('    3 [--->------------------------]').
+            $this->generateOutput('    5 [----->----------------------]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testCustomizations()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 10);
+        $bar->setBarWidth(10);
+        $bar->setBarCharacter('_');
+        $bar->setEmptyBarCharacter(' ');
+        $bar->setProgressCharacter('/');
+        $bar->setFormat(' %current%/%max% [%bar%] %percent%%');
+        $bar->start();
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('  0/10 [/         ]   0%').
+            $this->generateOutput('  1/10 [_/        ]  10%'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testPercent()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 50);
+        $bar->start();
+        $bar->display();
+        $bar->advance();
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            $this->generateOutput('  1/50 [>---------------------------]   2%').
+            $this->generateOutput('  2/50 [=>--------------------------]   4%'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testOverwriteWithShorterLine()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 50);
+        $bar->setFormat(' %current%/%max% [%bar%] %percent%%');
+        $bar->start();
+        $bar->display();
+        $bar->advance();
+
+        // set shorter format
+        $bar->setFormat(' %current%/%max% [%bar%]');
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            $this->generateOutput('  1/50 [>---------------------------]   2%').
+            $this->generateOutput('  2/50 [=>--------------------------]     '),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testSetCurrentProgress()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 50);
+        $bar->start();
+        $bar->display();
+        $bar->advance();
+        $bar->setCurrent(15);
+        $bar->setCurrent(25);
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            $this->generateOutput('  1/50 [>---------------------------]   2%').
+            $this->generateOutput(' 15/50 [========>-------------------]  30%').
+            $this->generateOutput(' 25/50 [==============>-------------]  50%'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage You must start the progress bar
+     */
+    public function testSetCurrentBeforeStarting()
+    {
+        $bar = new ProgressBar($this->getOutputStream());
+        $bar->setCurrent(15);
+    }
+
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage You can't regress the progress bar
+     */
+    public function testRegressProgress()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 50);
+        $bar->start();
+        $bar->setCurrent(15);
+        $bar->setCurrent(10);
+    }
+
+    public function testRedrawFrequency()
+    {
+        $bar = $this->getMock('Symfony\Component\Console\Helper\ProgressBar', array('display'), array($output = $this->getOutputStream(), 6));
+        $bar->expects($this->exactly(4))->method('display');
+
+        $bar->setRedrawFrequency(2);
+        $bar->start();
+        $bar->setCurrent(1);
+        $bar->advance(2);
+        $bar->advance(2);
+        $bar->advance(1);
+    }
+
+    public function testMultiByteSupport()
+    {
+        if (!function_exists('mb_strlen') || (false === $encoding = mb_detect_encoding('■'))) {
+            $this->markTestSkipped('The mbstring extension is needed for multi-byte support');
+        }
+
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->start();
+        $bar->setBarCharacter('■');
+        $bar->advance(3);
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('    0 [>---------------------------]').
+            $this->generateOutput('    3 [■■■>------------------------]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testClear()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 50);
+        $bar->start();
+        $bar->setCurrent(25);
+        $bar->clear();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            $this->generateOutput(' 25/50 [==============>-------------]  50%').
+            $this->generateOutput(''),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testPercentNotHundredBeforeComplete()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 200);
+        $bar->start();
+        $bar->display();
+        $bar->advance(199);
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('   0/200 [>---------------------------]   0%').
+            $this->generateOutput('   0/200 [>---------------------------]   0%').
+            $this->generateOutput(' 199/200 [===========================>]  99%').
+            $this->generateOutput(' 200/200 [============================] 100%'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testNonDecoratedOutput()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(false));
+        $bar->start();
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals('', stream_get_contents($output->getStream()));
+    }
+
+    public function testParallelBars()
+    {
+        $output = $this->getOutputStream();
+        $bar1 = new ProgressBar($output, 2);
+        $bar2 = new ProgressBar($output, 3);
+        $bar2->setProgressCharacter('#');
+        $bar3 = new ProgressBar($output);
+
+        $bar1->start();
+        $output->write("\n");
+        $bar2->start();
+        $output->write("\n");
+        $bar3->start();
+
+        for ($i = 1; $i <= 3; $i++) {
+            // up two lines
+            $output->write("\033[2A");
+            if ($i <= 2) {
+                $bar1->advance();
+            }
+            $output->write("\n");
+            $bar2->advance();
+            $output->write("\n");
+            $bar3->advance();
+        }
+        $output->write("\033[2A");
+        $output->write("\n");
+        $output->write("\n");
+        $bar3->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput(' 0/2 [>---------------------------]   0%')."\n".
+            $this->generateOutput(' 0/3 [#---------------------------]   0%')."\n".
+            rtrim($this->generateOutput('    0 [>---------------------------]')).
+
+            "\033[2A".
+            $this->generateOutput(' 1/2 [==============>-------------]  50%')."\n".
+            $this->generateOutput(' 1/3 [=========#------------------]  33%')."\n".
+            rtrim($this->generateOutput('    1 [->--------------------------]')).
+
+            "\033[2A".
+            $this->generateOutput(' 2/2 [============================] 100%')."\n".
+            $this->generateOutput(' 2/3 [==================#---------]  66%')."\n".
+            rtrim($this->generateOutput('    2 [-->-------------------------]')).
+
+            "\033[2A".
+            "\n".
+            $this->generateOutput(' 3/3 [============================] 100%')."\n".
+            rtrim($this->generateOutput('    3 [--->------------------------]')).
+
+            "\033[2A".
+            "\n".
+            "\n".
+            rtrim($this->generateOutput('    3 [============================]')),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    protected function getOutputStream($decorated = true)
+    {
+        return new StreamOutput(fopen('php://memory', 'r+', false), StreamOutput::VERBOSITY_NORMAL, $decorated);
+    }
+
+    protected function generateOutput($expected)
+    {
+        $expectedout = $expected;
+
+        if (null !== $this->lastMessagesLength) {
+            $expectedout = str_pad($expected, $this->lastMessagesLength, "\x20", STR_PAD_RIGHT);
+        }
+
+        $this->lastMessagesLength = strlen($expectedout);
+
+        return "\x0D".$expectedout;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -363,7 +363,6 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         $bar->finish();
 
         rewind($output->getStream());
-
         $this->assertEquals(
             $this->generateOutput(
                 " \033[44;37m Starting the demo... fingers crossed  \033[0m\n".
@@ -380,6 +379,27 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
                 " 15/15 ".str_repeat($done, 28)." 100%\n".
                 " 🏁  1 sec                       \033[41;37m 195 kB \033[0m"
             ),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testSetFormat()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->setFormat('normal');
+        $bar->start();
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('    0 [>---------------------------]'),
+            stream_get_contents($output->getStream())
+        );
+
+        $bar = new ProgressBar($output = $this->getOutputStream(), 10);
+        $bar->setFormat('normal');
+        $bar->start();
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('  0/10 [>---------------------------]   0%'),
             stream_get_contents($output->getStream())
         );
     }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -300,7 +300,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
     public function testAddingPlaceholderFormatter()
     {
-        ProgressBar::setPlaceholderFormatter('remaining_steps', function (ProgressBar $bar) {
+        ProgressBar::setPlaceholderFormatterDefinition('remaining_steps', function (ProgressBar $bar) {
             return $bar->getMaxSteps() - $bar->getStep();
         });
         $bar = new ProgressBar($output = $this->getOutputStream(), 3);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -319,6 +319,26 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testMultilineFormat()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 3);
+        $bar->setFormat("%bar%\nfoobar");
+
+        $bar->start();
+        $bar->advance();
+        $bar->clear();
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput(">---------------------------\nfoobar").
+            $this->generateOutput("=========>------------------\nfoobar").
+            $this->generateOutput("\n").
+            $this->generateOutput("============================\nfoobar"),
+            stream_get_contents($output->getStream())
+        );
+    }
+
     protected function getOutputStream($decorated = true)
     {
         return new StreamOutput(fopen('php://memory', 'r+', false), StreamOutput::VERBOSITY_NORMAL, $decorated);
@@ -334,6 +354,8 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         $this->lastMessagesLength = strlen($expectedout);
 
-        return "\x0D".$expectedout;
+        $count = substr_count($expected, "\n");
+
+        return "\x0D".($count ? sprintf("\033[%dA", $count) : '').$expectedout;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -69,7 +69,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         $bar->setBarCharacter('_');
         $bar->setEmptyBarCharacter(' ');
         $bar->setProgressCharacter('/');
-        $bar->setFormat(' %current%/%max% [%bar%] %percent%%');
+        $bar->setFormat(' %current%/%max% [%bar%] %percent:3s%%');
         $bar->start();
         $bar->advance();
 
@@ -102,7 +102,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
     public function testOverwriteWithShorterLine()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 50);
-        $bar->setFormat(' %current%/%max% [%bar%] %percent%%');
+        $bar->setFormat(' %current%/%max% [%bar%] %percent:3s%%');
         $bar->start();
         $bar->display();
         $bar->advance();
@@ -300,7 +300,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
     public function testAddingPlaceholderFormatter()
     {
-        ProgressBar::setPlaceholderFormatter('%remaining_steps%', function (ProgressBar $bar) {
+        ProgressBar::setPlaceholderFormatter('remaining_steps', function (ProgressBar $bar) {
             return $bar->getMaxSteps() - $bar->getStep();
         });
         $bar = new ProgressBar($output = $this->getOutputStream(), 3);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9573, #9574, #10187, #9951, related to #9788 |
| License | MIT |
| Doc PR | symfony/symfony-docs#3626 |

TODO:
- [x] add some docs

See what this PR allows you to do easily:

![cwzpvk](https://f.cloud.github.com/assets/47313/2302190/30cd80e4-a170-11e3-8d88-80c4e4ca8b23.gif)
## New ProgressBar class

First, this PR deprecates `ProgressHelper` in favor of `ProgressBar`. The main difference is that the new `ProgressBar` class represents a single progress bar, which allows for more than one bar to be displayed at a time:

``` php
use Symfony\Component\Console\Helper\ProgressBar;
use Symfony\Component\Console\Output\ConsoleOutput;

$output = new ConsoleOutput();

$bar1 = new ProgressBar($output, 10);
$bar2 = new ProgressBar($output, 20);
$bar2->setProgressCharacter('#');
$bar1->start();
print "\n";
$bar2->start();

for ($i = 1; $i <= 20; $i++) {
    // up one line
    $output->write("\033[1A");
    usleep(100000);
    if ($i <= 10) {
        $bar1->advance();
    }
    print "\n";
    $bar2->advance();
}
```

And here is how it looks like when run:

![progress-bars](https://f.cloud.github.com/assets/47313/2300612/4465889a-a0fd-11e3-8bc2-b1d2a0f5dc3d.gif)
## Format Placeholders

This pull request refactors the way placeholders in the progress bar are managed. It is now possible to add new placeholders or replace existing ones:

``` php
// set a new placeholder
ProgressBar::setPlaceholderFormatterDefinition('remaining_steps', function (ProgressBar $bar) {
    return $bar->getMaxSteps() - $bar->getStep();
});

// change the behavior of an existing placeholder
ProgressBar::setPlaceholderFormatterDefinition('max', function (ProgressBar $bar) {
    return $bar->getMaxSteps() ?: '~';
});
```

Several new built-in placeholders have also been added:
- `%remaining%`: Display the remaining time
- `%estimated%`: Display the estimated time of the whole "task"
- `%memory%`: Display the memory usage
## Formats

Formats can also be added (or built-in ones modified):

``` php
ProgressBar::setFormatDefinition('simple', '%current%');

$bar->setFormat('simple');
// is equivalent to
$bar->setFormat('%current%');
```

Built-in formats are:
- `quiet`
- `normal`
- `verbose`
- `quiet_nomax`
- `normal_nomax`
- `verbose_nomax`
## Format Messages

You can also set arbitrary messages that depends on the progression in the progress bar:

``` php
$bar = new ProgressBar($output, 10);
$bar->setFormat("%message% %current%/%max% [%bar%]");

$bar->setMessage('started');
$bar->start();

$bar->setMessage('advancing');
$bar->advance();

$bar->setMessage('finish');
$bar->finish();
```

You are not limited to a single message (`message` being just the default one):

``` php
$bar = new ProgressBar($output, 10);
$bar->setFormat("%message% %current%/%max% [%bar%] %end%");

$bar->setMessage('started');
$bar->setMessage('', 'end');
$bar->start();

$bar->setMessage('advancing');
$bar->advance();

$bar->setMessage('finish');
$bar->setMessage('ended...', 'end');
$bar->finish();
```
## Multiline Formats

A progress bar can now span more than one line:

``` php
$bar->setFormat("%current%/%max% [%bar%]\n%message%");
```
## Flexible Format Definitions

The hardcoded formatting for some placeholders (like `%percent%` or `%elapsed%`) have been removed in favor of a `sprintf`-like format:

``` php
$bar->setFormat("%current%/%max% [%bar%] %percent:3s%");
```

Notice the `%percent:3s%` placeholder. Here, `%3s` is going to be used when rendering the placeholder.
## ANSI colors and Emojis

The new progress bar output can now contain ANSI colors and.or Emojis (see the small video at the top of this PR).
