### PR TITLE
[Console] Testing: use explicit assertion assertCount instead of assertEquals

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -106,7 +106,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $application->add(new \FooCommand());
         $commands = $application->all('foo');
-        $this->assertEquals(1, count($commands), '->all() takes a namespace as its first argument');
+        $this->assertCount(1, $commands, '->all() takes a namespace as its first argument');
     }
 
     public function testRegister()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

stumbled over this while batch cleaning tests for hhvm (which does not like `count` on objects - but this is not relevant here as its actually an array).
