### PR TITLE
[Bug][DataCollector] Fix the regression caused by the removal of double-stringification

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -52,6 +52,8 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         foreach ($request->attributes->all() as $key => $value) {
             if ('_route' === $key && is_object($value)) {
                 $value = $value->getPath();
+            } elseif (is_object($value)) {
+                $value = $this->varToString($value);
             }
 
             $attributes[$key] = $value;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

With the commit dce66c9d79c7de7dde4ba9ad95382d0761f87109, an exception is thrown when an Object is part of the list of request parameters.

For example, the ParamFetcher object of the FosRestBundle included the Request object, and this object, included the Session object. The serialization fails when we use the PDO handler session.
