### PR TITLE
[HttpKernel] fixed serialization of the request data collector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -48,13 +48,20 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             $responseHeaders['Set-Cookie'] = $cookies;
         }
 
+        // attributes are serialized and as they can be anything, they need to be converted to strings.
         $attributes = array();
         foreach ($request->attributes->all() as $key => $value) {
             if ('_route' === $key && is_object($value)) {
-                $value = $value->getPath();
+                $attributes[$key] = $this->varToString($value->getPath());
+            } elseif ('_route_params' === $key) {
+                // we need to keep route params as an array (see getRouteParams())
+                foreach ($value as $k => $v) {
+                    $value[$k] = $this->varToString($v);
+                }
+                $attributes[$key] = $value;
+            } else {
+                $attributes[$key] = $this->varToString($value);
             }
-
-            $attributes[$key] = $value;
         }
 
         $content = null;

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -22,20 +22,19 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @dataProvider provider
-     */
-    public function testCollect(Request $request, Response $response)
+    public function testCollect()
     {
         $c = new RequestDataCollector();
 
-        $c->collect($request, $response);
+        $c->collect($this->createRequest(), $this->createResponse());
+
+        $attributes = $c->getRequestAttributes();
 
         $this->assertSame('request', $c->getName());
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\HeaderBag', $c->getRequestHeaders());
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestServer());
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestCookies());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestAttributes());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $attributes);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestRequest());
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestQuery());
         $this->assertSame('html', $c->getFormat());
@@ -43,6 +42,8 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('name' => 'foo'), $c->getRouteParams());
         $this->assertSame(array(), $c->getSessionAttributes());
         $this->assertSame('en', $c->getLocale());
+        $this->assertSame('Resource(stream)', $attributes->get('resource'));
+        $this->assertSame('Object(stdClass)', $attributes->get('object'));
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\HeaderBag', $c->getResponseHeaders());
         $this->assertSame('OK', $c->getStatusText());
@@ -52,10 +53,8 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test various types of controller callables.
-     *
-     * @dataProvider provider
      */
-    public function testControllerInspection(Request $request, Response $response)
+    public function testControllerInspection()
     {
         // make sure we always match the line number
         $r1 = new \ReflectionMethod($this, 'testControllerInspection');
@@ -136,7 +135,8 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         );
 
         $c = new RequestDataCollector();
-
+        $request = $this->createRequest();
+        $response = $this->createResponse();
         foreach ($controllerTests as $controllerTest) {
             $this->injectController($c, $controllerTest[1], $request);
             $c->collect($request, $response);
@@ -144,17 +144,20 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function provider()
+    protected function createRequest()
     {
-        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
-            return array(array(null, null));
-        }
-
         $request = Request::create('http://test.com/foo?bar=baz');
         $request->attributes->set('foo', 'bar');
         $request->attributes->set('_route', 'foobar');
         $request->attributes->set('_route_params', array('name' => 'foo'));
+        $request->attributes->set('resource', fopen(__FILE__, 'r'));
+        $request->attributes->set('object', new \stdClass());
 
+        return $request;
+    }
+
+    protected function createResponse()
+    {
         $response = new Response();
         $response->setStatusCode(200);
         $response->headers->set('Content-Type', 'application/json');
@@ -162,9 +165,7 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $response->headers->setCookie(new Cookie('bar','foo',new \DateTime('@946684800')));
         $response->headers->setCookie(new Cookie('bazz','foo','2000-12-12'));
 
-        return array(
-            array($request, $response)
-        );
+        return $response;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10361 |
| License | MIT |
| Doc PR | n/a |

This fixes a regression introduced in #10352.
