### PR TITLE
[FrameworkBundle][Console] Add parameter descriptors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -115,17 +115,6 @@ abstract class Descriptor implements DescriptorInterface
     abstract protected function describeRoute(Route $route, array $options = array());
 
     /**
-     * Describes a specific container parameter.
-     *
-     * @param mixed $parameterValue
-     * @param array $options
-     */
-    protected function describeContainerParameter($parameterValue, array $options = array())
-    {
-        $this->write($this->formatParameter($parameterValue));
-    }
-
-    /**
      * Describes container parameters.
      *
      * @param ParameterBag $parameters

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -180,6 +180,14 @@ abstract class Descriptor implements DescriptorInterface
     abstract protected function describeContainerAlias(Alias $alias, array $options = array());
 
     /**
+     * Describes a container parameter.
+     *
+     * @param parameter
+     * @param array $options
+     */
+    abstract protected function describeContainerParameter($parameter, array $options = array());
+
+    /**
      * Formats a value as string.
      *
      * @param mixed $value

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -135,6 +135,16 @@ class JsonDescriptor extends Descriptor
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function describeContainerParameter($parameter, array $options = array())
+    {
+        $key = isset($options['parameter']) ? $options['parameter'] : '';
+
+        $this->writeData(array($key => $this->formatParameter($parameter)), $options);
+    }
+
+    /**
      * Writes data as json.
      *
      * @param array $data

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -212,7 +212,7 @@ class MarkdownDescriptor extends Descriptor
      */
     protected function describeContainerParameter($parameter, array $options = array())
     {
-        $this->write(isset($options['parameter']) ? sprintf("%s\n%s\n%s", $options['parameter'], str_repeat('~', strlen($options['parameter'])), $this->formatParameter($parameter)): $parameter);
+        $this->write(isset($options['parameter']) ? sprintf("%s\n%s\n\n%s", $options['parameter'], str_repeat('=', strlen($options['parameter'])), $this->formatParameter($parameter)): $parameter);
     }
 
     private function formatRouterConfig(array $array)

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -207,6 +207,14 @@ class MarkdownDescriptor extends Descriptor
         $this->write(isset($options['id']) ? sprintf("%s\n%s\n\n%s\n", $options['id'], str_repeat('~', strlen($options['id'])), $output) : $output);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function describeContainerParameter($parameter, array $options = array())
+    {
+        $this->write(isset($options['parameter']) ? sprintf("%s\n%s\n%s", $options['parameter'], str_repeat('~', strlen($options['parameter'])), $this->formatParameter($parameter)): $parameter);
+    }
+
     private function formatRouterConfig(array $array)
     {
         if (!count($array)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -277,6 +277,14 @@ class TextDescriptor extends Descriptor
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function describeContainerParameter($parameter, array $options = array())
+    {
+        $this->writeText($this->formatParameter($parameter), $options);
+    }
+
+    /**
      * @param array $array
      *
      * @return string

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -385,7 +385,7 @@ class XmlDescriptor extends Descriptor
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($parameterXML = $dom->createElement('parameter'));
 
-        if (isset( $options['parameter'])) {
+        if (isset($options['parameter'])) {
             $parameterXML->setAttribute('key', $options['parameter']);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -92,6 +92,14 @@ class XmlDescriptor extends Descriptor
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function describeContainerParameter($parameter, array $options = array())
+    {
+        $this->writeDocument($this->getContainerParameterDocument($parameter, $options));
+    }
+
+    /**
      * Writes DOM document.
      *
      * @param \DOMDocument $dom
@@ -362,6 +370,26 @@ class XmlDescriptor extends Descriptor
 
         $aliasXML->setAttribute('service', (string) $alias);
         $aliasXML->setAttribute('public', $alias->isPublic() ? 'true' : 'false');
+
+        return $dom;
+    }
+
+    /**
+     * @param $parameter
+     * @param array $options
+     *
+     * @return \DOMDocument
+     */
+    private function getContainerParameterDocument($parameter, $options = array())
+    {
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->appendChild($parameterXML = $dom->createElement('parameter'));
+
+        if (isset( $options['parameter'])) {
+            $parameterXML->setAttribute('key', $options['parameter']);
+        }
+
+        $parameterXML->appendChild(new \DOMText($this->formatParameter($parameter)));
 
         return $dom;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -87,6 +87,21 @@ abstract class AbstractDescriptorTest extends \PHPUnit_Framework_TestCase
         return $this->getDescriptionTestData(ObjectsProvider::getContainerAliases());
     }
 
+    /** @dataProvider getDescribeContainerParameterTestData */
+    public function testDescribeContainerParameter($parameter, $expectedDescription, array $options)
+    {
+        $this->assertDescription($expectedDescription, $parameter, $options);
+    }
+
+    public function getDescribeContainerParameterTestData()
+    {
+        $data = $this->getDescriptionTestData(ObjectsProvider::getContainerParameter());
+
+        array_push($data[0], array('parameter' => 'database_name'));
+
+        return $data;
+    }
+
     abstract protected function getDescriptor();
     abstract protected function getFormat();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -66,6 +66,16 @@ class ObjectsProvider
         );
     }
 
+    public static function getContainerParameter()
+    {
+        $builder = new ContainerBuilder();
+        $builder->setParameter('database_name', 'symfony');
+
+        return array(
+            'parameter' =>  $builder
+        );
+    }
+
     public static function getContainerBuilders()
     {
         $builder1 = new ContainerBuilder();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/parameter.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/parameter.json
@@ -1,0 +1,3 @@
+{
+    "database_name": "symfony"
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/parameter.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/parameter.md
@@ -1,0 +1,4 @@
+database_name
+=============
+
+symfony

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/parameter.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/parameter.txt
@@ -1,0 +1,1 @@
+symfony

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/parameter.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/parameter.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter key="database_name">symfony</parameter>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10345 |
| License | MIT |
| Doc PR | n/a |

I've added several descriptors for each format, henceforth :
`php app/console container:debug --parameter=database_name --format=txt` will output:
`symfony`

`php app/console container:debug --parameter=database_name --format=json` will output:

``` json
{
    "database_name": "symfony"
}
```

`php app/console container:debug --parameter=database_name --format=xml` will output :

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<parameter key="database_name">symfony</parameter>
```

and `php app/console container:debug --parameter=database_name --format=md` will output :

``` md
database_name
=============

symfony
```

what do you think ?
