### PR TITLE
[Component][Profiler] Catch exceptions while profile saving

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -110,10 +110,16 @@ class Profiler
     public function saveProfile(Profile $profile)
     {
         // late collect
-        foreach ($profile->getCollectors() as $collector) {
-            if ($collector instanceof LateDataCollectorInterface) {
-                $collector->lateCollect();
+        try {
+            foreach ($profile->getCollectors() as $collector) {
+                if ($collector instanceof LateDataCollectorInterface) {
+                    $collector->lateCollect();
+                }
             }
+        } catch (\Exception $e) {
+            $this->logger->error(
+                sprintf('Some exceptions thrown while saving profile, with message: "%s"', $e->getMessage())
+            );
         }
 
         if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I have kernel event subscriber what depends on templating.helper.assets and have scope "request". and it's broke my profiler. Several cups of coffee and I found an error - exception while profile saves with message 'You cannot create a service "my.subscriber"'. This commit makes debugging easier.
