### PR TITLE
[HttpKernel] Fix gitignore

### DIFF
--- a/src/Symfony/Component/HttpKernel/.gitignore
+++ b/src/Symfony/Component/HttpKernel/.gitignore
@@ -1,5 +1,5 @@
 vendor/
 composer.lock
 phpunit.xml
-Tests/ProjectContainer.php
-Tests/classes.map
+Tests/Fixtures/cache/
+Tests/Fixtures/logs/


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

The kernel rootDir is Fixtures:

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Tests/KernelTest.php#L787-L789

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Tests/KernelTest.php#L800-L802
