### PR TITLE
[DependencyInjection] Allow parameters to be used to specify Factory Service

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -36,6 +36,7 @@ class ResolveParameterPlaceHoldersPass implements CompilerPassInterface
             try {
                 $definition->setClass($parameterBag->resolveValue($definition->getClass()));
                 $definition->setFile($parameterBag->resolveValue($definition->getFile()));
+                $definition->setFactoryService($parameterBag->resolveValue($definition->getFactoryService()));
                 $definition->setArguments($parameterBag->resolveValue($definition->getArguments()));
 
                 $calls = array();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | None, but there is no current documentation either. |

This allow to use a parameter for the factoryService of a Definition. Just like for class, file, method call, etc.

Useful mostly to allow the specification of a secondary provider. For example: A bundle might provides a feature through several services, the main/default one is specified through configuration. The features requires access to an other provider that is not a directly referenceable service. Being able to use parameter as the FactoryService allow me to do something like this:

``` yaml
underlying_provider:
  class: %underlying_provider.class%
  factory_service: %main_service_name%
  factory_method: getUnderlyingServiceProvider
  arguments:
      - %whatever%
```

In the mean time, this can be achieved using:

``` yaml
main_service: @%main_service_name%

underlying_provider:
  class: %underlying_provider.class%
  factory_service: main_service
  factory_method: getUnderlyingServiceProvider
  arguments:
      - %whatever%
```
