### PR TITLE
fix #10386 isbnValidator so to allow to specify with false any isbn10 or 113

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
@@ -45,7 +45,7 @@ class IsbnValidator extends ConstraintValidator
         $value = strtoupper($value);
         $valueLength = strlen($value);
 
-        if (10 === $valueLength && null !== $constraint->isbn10) {
+        if (10 === $valueLength && null !== $constraint->isbn10  && false !== $constraint->isbn10) {
             for ($i = 0; $i < 10; $i++) {
                 if ($value[$i] == 'X') {
                     $validation += 10 * intval(10 - $i);
@@ -55,13 +55,13 @@ class IsbnValidator extends ConstraintValidator
             }
 
             if ($validation % 11 != 0) {
-                if (null !== $constraint->isbn13) {
+                if (null !== $constraint->isbn13 && false !== $constraint->isbn13) {
                     $this->context->addViolation($constraint->bothIsbnMessage);
                 } else {
                     $this->context->addViolation($constraint->isbn10Message);
                 }
             }
-        } elseif (13 === $valueLength && null !== $constraint->isbn13) {
+        } elseif (13 === $valueLength && null !== $constraint->isbn13 && false !== $constraint->isbn13) {
             for ($i = 0; $i < 13; $i += 2) {
                 $validation += intval($value[$i]);
             }
@@ -70,16 +70,18 @@ class IsbnValidator extends ConstraintValidator
             }
 
             if ($validation % 10 != 0) {
-                if (null !== $constraint->isbn10) {
+                if (null !== $constraint->isbn10 && false !== $constraint->isbn10) {
                     $this->context->addViolation($constraint->bothIsbnMessage);
                 } else {
                     $this->context->addViolation($constraint->isbn13Message);
                 }
             }
         } else {
-            if (null !== $constraint->isbn10 && null !== $constraint->isbn13) {
+            if (null !== $constraint->isbn10 && null !== $constraint->isbn13 &&
+                false !== $constraint->isbn10 && false !== $constraint->isbn13
+            ) {
                 $this->context->addViolation($constraint->bothIsbnMessage);
-            } elseif (null !== $constraint->isbn10) {
+            } elseif (null !== $constraint->isbn10 && false !== $constraint->isbn10) {
                 $this->context->addViolation($constraint->isbn10Message);
             } else {
                 $this->context->addViolation($constraint->isbn13Message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
@@ -220,4 +220,18 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->validator->validate($isbn, $constraint);
     }
+
+    /**
+     * @dataProvider getInvalidIsbn
+     */
+    public function testInvalidIsbnMixed($isbn)
+    {
+        $constraint = new Isbn(array('isbn10' => false, 'isbn13' => true));
+        $this->context
+            ->expects($this->once())
+            ->method('addViolation')
+            ->with($constraint->isbn13Message);
+
+        $this->validator->validate($isbn, $constraint);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | yes |
| New Feature? | no |
| BC Breaks? | no |
| Deprecations? | no |
| Tests Pass? | yes |
| Fixed Tickets | #10386 |
| License | MIT |
| Doc PR | nope |

isbnValidator so to allow to specify with false any isbn10 or 13
