### PR TITLE
[Security] Add constants for access decision strategies

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -22,6 +22,10 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 class AccessDecisionManager implements AccessDecisionManagerInterface
 {
+    const STRATEGY_AFFIRMATIVE = 'affirmative';
+    const STRATEGY_CONSENSUS   = 'consensus';
+    const STRATEGY_UNANIMOUS   = 'unanimous';
+
     private $voters;
     private $strategy;
     private $allowIfAllAbstainDecisions;
@@ -37,7 +41,7 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(array $voters, $strategy = 'affirmative', $allowIfAllAbstainDecisions = false, $allowIfEqualGrantedDeniedDecisions = true)
+    public function __construct(array $voters, $strategy = self::STRATEGY_AFFIRMATIVE, $allowIfAllAbstainDecisions = false, $allowIfEqualGrantedDeniedDecisions = true)
     {
         if (!$voters) {
             throw new \InvalidArgumentException('You must at least add one voter.');

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -77,34 +77,34 @@ class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             // affirmative
-            array('affirmative', $this->getVoters(1, 0, 0), false, true, true),
-            array('affirmative', $this->getVoters(1, 2, 0), false, true, true),
-            array('affirmative', $this->getVoters(0, 1, 0), false, true, false),
-            array('affirmative', $this->getVoters(0, 0, 1), false, true, false),
-            array('affirmative', $this->getVoters(0, 0, 1), true, true, true),
+            array(AccessDecisionManager::STRATEGY_AFFIRMATIVE, $this->getVoters(1, 0, 0), false, true, true),
+            array(AccessDecisionManager::STRATEGY_AFFIRMATIVE, $this->getVoters(1, 2, 0), false, true, true),
+            array(AccessDecisionManager::STRATEGY_AFFIRMATIVE, $this->getVoters(0, 1, 0), false, true, false),
+            array(AccessDecisionManager::STRATEGY_AFFIRMATIVE, $this->getVoters(0, 0, 1), false, true, false),
+            array(AccessDecisionManager::STRATEGY_AFFIRMATIVE, $this->getVoters(0, 0, 1), true, true, true),
 
             // consensus
-            array('consensus', $this->getVoters(1, 0, 0), false, true, true),
-            array('consensus', $this->getVoters(1, 2, 0), false, true, false),
-            array('consensus', $this->getVoters(2, 1, 0), false, true, true),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(1, 0, 0), false, true, true),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(1, 2, 0), false, true, false),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(2, 1, 0), false, true, true),
 
-            array('consensus', $this->getVoters(0, 0, 1), false, true, false),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(0, 0, 1), false, true, false),
 
-            array('consensus', $this->getVoters(0, 0, 1), true, true, true),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(0, 0, 1), true, true, true),
 
-            array('consensus', $this->getVoters(2, 2, 0), false, true, true),
-            array('consensus', $this->getVoters(2, 2, 1), false, true, true),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(2, 2, 0), false, true, true),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(2, 2, 1), false, true, true),
 
-            array('consensus', $this->getVoters(2, 2, 0), false, false, false),
-            array('consensus', $this->getVoters(2, 2, 1), false, false, false),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(2, 2, 0), false, false, false),
+            array(AccessDecisionManager::STRATEGY_CONSENSUS, $this->getVoters(2, 2, 1), false, false, false),
 
             // unanimous
-            array('unanimous', $this->getVoters(1, 0, 0), false, true, true),
-            array('unanimous', $this->getVoters(1, 0, 1), false, true, true),
-            array('unanimous', $this->getVoters(1, 1, 0), false, true, false),
+            array(AccessDecisionManager::STRATEGY_UNANIMOUS, $this->getVoters(1, 0, 0), false, true, true),
+            array(AccessDecisionManager::STRATEGY_UNANIMOUS, $this->getVoters(1, 0, 1), false, true, true),
+            array(AccessDecisionManager::STRATEGY_UNANIMOUS, $this->getVoters(1, 1, 0), false, true, false),
 
-            array('unanimous', $this->getVoters(0, 0, 2), false, true, false),
-            array('unanimous', $this->getVoters(0, 0, 2), true, true, true),
+            array(AccessDecisionManager::STRATEGY_UNANIMOUS, $this->getVoters(0, 0, 2), false, true, false),
+            array(AccessDecisionManager::STRATEGY_UNANIMOUS, $this->getVoters(0, 0, 2), true, true, true),
         );
     }
 


### PR DESCRIPTION
I suggest adding constants for the three access decision strategies (affirmative, consensus, unanimous).

They are difficult to spell, and without constants they are difficult to identify when reading the code.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
