### PR TITLE
[Console] Disallowed commands overriding

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -387,11 +387,12 @@ class Application
     /**
      * Adds a command object.
      *
-     * If a command with the same name already exists, it will be overridden.
      *
      * @param Command $command A Command object
      *
      * @return Command The registered command
+     *
+     * @throws \LogicException If a command with the same name already exists or command has no definition
      *
      * @api
      */
@@ -409,9 +410,17 @@ class Application
             throw new \LogicException(sprintf('Command class "%s" is not correctly initialized. You probably forgot to call the parent constructor.', get_class($command)));
         }
 
+        if (isset($this->commands[$command->getName()])) {
+            throw new \LogicException(sprintf('Command "%s" already exists.', $command->getName()));
+        }
+
         $this->commands[$command->getName()] = $command;
 
         foreach ($command->getAliases() as $alias) {
+            if (isset($this->commands[$alias])) {
+                throw new \LogicException(sprintf('Command alias "%s" is already in use by "%s".', $alias, $this->commands[$alias]->getName()));
+            }
+
             $this->commands[$alias] = $command;
         }
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -139,6 +139,34 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->add(new \Foo5Command());
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Command "foo:bar" already exists.
+     */
+    public function testAddCommandWithTheSameName()
+    {
+        $application = new Application();
+        $application->add(new \FooCommand());
+        $application->add(new \FooCommand());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Command alias "afoobar" is already in use by "foo:bar".
+     */
+    public function testAddCommandWithExistingAlias()
+    {
+        $fooCommand = new \FooCommand();
+        $fooCommand->setAliases(array('afoobar'));
+
+        $foo1Command = new \Foo1Command();
+        $foo1Command->setAliases(array('afoobar'));
+
+        $application = new Application();
+        $application->add($fooCommand);
+        $application->add($foo1Command);
+    }
+
     public function testHasGet()
     {
         $application = new Application();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Console Application silently overrides existing commands, such behaviour is not really good.
