### PR TITLE
[HttpFoundation] Session id can be stored not only in cookies

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -712,7 +712,17 @@ class Request
     public function hasPreviousSession()
     {
         // the check for $this->session avoids malicious users trying to fake a session cookie with proper name
-        return $this->hasSession() && $this->cookies->has($this->session->getName());
+        if (!$this->hasSession()) {
+            return false;
+        }
+
+        $sessionName = $this->session->getName();
+
+        if ($this->cookies->has($sessionName)) {
+            return true;
+        }
+
+        return !ini_get('session.use_only_cookies') && !ini_get('session.use_cookies') && $this->query->has($sessionName);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1242,6 +1242,27 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($request->hasPreviousSession());
     }
 
+    public function testHasPreviousSessionWithoutCookies()
+    {
+        $request = new Request();
+
+        // Backup old values
+        $useOnlyCookies = ini_get('session.use_only_cookies');
+        $useCookies = ini_get('session.use_cookies');
+
+        ini_set('session.use_only_cookies', 0);
+        ini_set('session.use_cookies', 0);
+
+        $this->assertFalse($request->hasPreviousSession());
+        $request->query->set('MOCKSESSID', 'foo');
+        $this->assertFalse($request->hasPreviousSession());
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $this->assertTrue($request->hasPreviousSession());
+
+        ini_set('session.use_only_cookies', $useOnlyCookies);
+        ini_set('session.use_cookies', $useCookies);
+    }
+
     public function testToString()
     {
         $request = new Request();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| Fixed tickets | #10402 |
| License | MIT |

If `session.use_only_cookies` & `session.use_cookies` is `false`, session id can come from `GET`.
