### PR TITLE
[Security] Use more accurate variable name

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -58,10 +58,10 @@ class Firewall implements EventSubscriberInterface
         }
 
         // register listeners for this firewall
-        list($listeners, $exception) = $this->map->getListeners($event->getRequest());
-        if (null !== $exception) {
-            $this->exceptionListeners[$event->getRequest()] = $exception;
-            $exception->register($this->dispatcher);
+        list($listeners, $exceptionListener) = $this->map->getListeners($event->getRequest());
+        if (null !== $exceptionListener) {
+            $this->exceptionListeners[$event->getRequest()] = $exceptionListener;
+            $exceptionListener->register($this->dispatcher);
         }
 
         // initiate the listener chain


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Sorry for the noise, but everytime I open this class, I wonder what is `$exception`.
