### PR TITLE
[Form] Fix "Array was modified outside object" in ResizeFormListener.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -139,10 +139,16 @@ class ResizeFormListener implements EventSubscriberInterface
         // The data mapper only adds, but does not remove items, so do this
         // here
         if ($this->allowDelete) {
+            $toDelete = array();
+
             foreach ($data as $name => $child) {
                 if (!$form->has($name)) {
-                    unset($data[$name]);
+                    $toDelete[] = $name;
                 }
+            }
+
+            foreach ($toDelete as $name) {
+                unset($data[$name]);
             }
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
-use ArrayObject;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
 use Symfony\Component\Form\FormBuilder;
@@ -259,7 +258,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->form->add($this->getForm('1'));
 
-        $data = new ArrayObject(array(0 => 'first', 1 => 'second', 2 => 'third'));
+        $data = new \ArrayObject(array(0 => 'first', 1 => 'second', 2 => 'third'));
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
         $listener->onSubmit($event);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
+use ArrayObject;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
 use Symfony\Component\Form\FormBuilder;
@@ -254,7 +255,20 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $event->getData());
     }
 
-    public function testOnSubmitDealsWithIteratorAggregate()
+    public function testOnSubmitDealsWithObjectBackedIteratorAggregate()
+    {
+        $this->form->add($this->getForm('1'));
+
+        $data = new ArrayObject(array(0 => 'first', 1 => 'second', 2 => 'third'));
+        $event = new FormEvent($this->form, $data);
+        $listener = new ResizeFormListener('text', array(), false, true);
+        $listener->onSubmit($event);
+
+        $this->assertArrayNotHasKey(0, $event->getData());
+        $this->assertArrayNotHasKey(2, $event->getData());
+    }
+
+    public function testOnSubmitDealsWithArrayBackedIteratorAggregate()
     {
         $this->form->add($this->getForm('1'));
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10405 |
| License | MIT |
| Doc PR |  |

This is the second pull request for this issue. The history of this is as follows:

Original Fix was added Feb 11th under Pull Request #10232.
Users began complaining of Doctrine ArrayCollection not being updated in forms.
Revert was added Feb 15th under Pull Request #10269.
Issue #10405 was opened on 7th Mar for the original bug.

Pull Request #10269 has a failing test that illustrates users concerns.
I have added failing tests to this pull request to illustrate the problems described in #10405.

All tests now pass, and all forms of $data are now supported, including arrays, DoctrineCollection, ArrayObject, and other IteratorAggregates.

**Details as follows:**

The onSubmit() method of the ResizeFormListener class is assuming the data is an array, and calling unset directly inside a foreach. This works fine in most scenarios, but if data is an instance of IteratorAggregate that is iterating over $data by reference, it breaks with the following error:

Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener::onSubmit(): ArrayIterator::next(): Array was modified outside object and internal position is no longer valid in ./vendor/symfony/symfony/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php line 142

This is because the foreach loop is using an Iterator in the background, but the ResizeFormListener has unset the underlying data directly, causing the value that the Iterators internal pointer is pointing to to change.

The Iterator provided by IteratorAggregate may or may not have the ability to modify it's underlying data. So it is not possible to rely on the Iterator to modify the data. Instead, it is simpler to avoid modifying $data at all while we are iterating over it. So instead, we simply iterate over $data once to determine the keys we need to delete, and store them. Then we iterate over the keys and delete them from $data.
