### PR TITLE
[Process] Fix comparisons against process exitcode

### DIFF
--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -280,7 +280,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     {
         $process = $this->getProcess('php -m');
         $process->run();
-        $this->assertEquals(0, $process->getExitCode());
+        $this->assertSame(0, $process->getExitCode());
     }
 
     public function testStatus()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Use identical comparison instead of equal. In case the exitcode has not been caught, `Process::isSuccessful` returns true instead of false. It should not happen, but it's much more clean like that.
