### PR TITLE
[Process] Fix process status in TTY mode

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -248,8 +248,6 @@ class Process
         $this->processPipes->unblock();
 
         if ($this->tty) {
-            $this->status = self::STATUS_TERMINATED;
-
             return;
         }
 

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -223,9 +223,24 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $process = $this->getProcess('echo "foo" >> /dev/null');
         $process->setTTY(true);
-        $process->run();
+        $process->start();
+        $this->assertTrue($process->isRunning());
+        $process->wait();
 
         $this->assertSame(Process::STATUS_TERMINATED, $process->getStatus());
+    }
+
+    public function testTTYCommandExitCode()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does have /dev/tty support');
+        }
+
+        $process = $this->getProcess('echo "foo" >> /dev/null');
+        $process->setTTY(true);
+        $process->run();
+
+        $this->assertTrue($process->isSuccessful());
     }
 
     public function testExitCodeText()

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -147,6 +147,14 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
     /**
      * @expectedException \Symfony\Component\Process\Exception\RuntimeException
      */
+    public function testTTYCommandExitCode()
+    {
+        parent::testTTYCommandExitCode();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
+     */
     public function testSignal()
     {
         parent::testSignal();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

When running a process with TTY mode, status in automatically set to `terminated`
once it's started.

It's wrong for two reasons :
- The status of the process is not yet terminated.
- The exitcode value is never caught
