### PR TITLE
[AbstractFactory] [Factory] [SecurityBundle] fix options & providerKey n...

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -169,13 +169,11 @@ abstract class AbstractFactory implements SecurityFactoryInterface
 
     protected function createAuthenticationSuccessHandler($container, $id, $config)
     {
-        if (isset($config['success_handler'])) {
-            return $config['success_handler'];
-        }
+        $handlerName = isset($config['success_handler']) ? $config['success_handler'] : 'security.authentication.success_handler';
 
         $successHandlerId = 'security.authentication.success_handler.'.$id.'.'.str_replace('-', '_', $this->getKey());
 
-        $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator('security.authentication.success_handler'));
+        $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator($handlerName));
         $successHandler->replaceArgument(1, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
         $successHandler->addMethodCall('setProviderKey', array($id));
 
@@ -184,13 +182,11 @@ abstract class AbstractFactory implements SecurityFactoryInterface
 
     protected function createAuthenticationFailureHandler($container, $id, $config)
     {
-        if (isset($config['failure_handler'])) {
-            return $config['failure_handler'];
-        }
+        $handlerName = isset($config['failure_handler']) ? $config['failure_handler'] : 'security.authentication.failure_handler';
 
         $id = 'security.authentication.failure_handler.'.$id.'.'.str_replace('-', '_', $this->getKey());
 
-        $failureHandler = $container->setDefinition($id, new DefinitionDecorator('security.authentication.failure_handler'));
+        $failureHandler = $container->setDefinition($id, new DefinitionDecorator($handlerName));
         $failureHandler->replaceArgument(2, array_intersect_key($config, $this->defaultFailureHandlerOptions));
 
         return $id;


### PR DESCRIPTION
...ot passed to custom success_handler & failure_handler

When defining a custom success_handle or failure_handler, no arguments where passed to the constructor. This patch assume that a custom handler will inherit the default one, so we could retrieved the firewall properties, and if needed, add more arguments.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | No |
| Fixed tickets | #9272 |
| License | MIT |

Allow options & providerKey from firewall configuration to be passed to custom handlers.

This pull request references this other one : https://github.com/symfony/symfony/pull/9279 but for the 2.2 branch and rebased.

As discussed in the previous pull request, this could be seen as a BC break because someone could have implemented a handler which doesn't have a constructor with the same signature as the default one, or doesn't inherit the default one.

Maybe `AuthenticationSuccessHandlerInterface` should define the `public function setOptions(array $options)` and `public function setProviderKey($providerKey)` methods.
Then, we could use the `addMethodCall('setOptions', array($options));` from the DefinitionDecorator, instead of `replaceArgument`.

Anyway, `public function setProviderKey($providerKey)` is currently used by the `createAuthenticationSuccessHandler` although the `AuthenticationSuccessHandlerInterface` doesn't describe it: 

``` php

    protected function createAuthenticationSuccessHandler($container, $id, $config)
    {
        [...]
        $successHandler->replaceArgument(1, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
        $successHandler->addMethodCall('setProviderKey', array($id));
        [...]
    }
```
