### PR TITLE
[Config] XmlUtils::convertDomElementToArray does not handle '0'

### DIFF
--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -80,6 +80,7 @@ class XmlUtilsTest extends \PHPUnit_Framework_TestCase
             array(array('foo' => null), '<foo />'),
             array(array('foo' => 'bar'), '<foo>bar</foo>'),
             array(array('foo' => array('foo' => 'bar')), '<foo foo="bar"/>'),
+            array(array('foo' => array('foo' => 0)), '<foo><foo>0</foo></foo>'),
             array(array('foo' => array('foo' => 'bar')), '<foo><foo>bar</foo></foo>'),
             array(array('foo' => array('foo' => 'bar', 'value' => 'text')), '<foo foo="bar">text</foo>'),
             array(array('foo' => array('attr' => 'bar', 'foo' => 'text')), '<foo attr="bar"><foo>text</foo></foo>'),

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -132,7 +132,7 @@ class XmlUtils
         $nodeValue = false;
         foreach ($element->childNodes as $node) {
             if ($node instanceof \DOMText) {
-                if (trim($node->nodeValue)) {
+                if (strlen(trim($node->nodeValue)) > 0) {
                     $nodeValue = trim($node->nodeValue);
                     $empty = false;
                 }


### PR DESCRIPTION
`XmlUtils::convertDomElementToArray` does not handle `0` as a value of a text node, and interprets it as `null`.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | maybe? (if someone is depending on the previous behaviour.) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
