### PR TITLE
[Process] Add Process::disableOutput and Process::enableOutput methods

### DIFF
--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -29,6 +29,7 @@ class ProcessBuilder
     private $options = array();
     private $inheritEnv = true;
     private $prefix = array();
+    private $outputDisabled = false;
 
     public function __construct(array $arguments = array())
     {
@@ -154,6 +155,30 @@ class ProcessBuilder
         return $this;
     }
 
+    /**
+     * Disables fetching output and error output from the underlying process.
+     *
+     * @return Process
+     */
+    public function disableOutput()
+    {
+        $this->outputDisabled = true;
+
+        return $this;
+    }
+
+    /**
+     * Enables fetching output and error output from the underlying process.
+     *
+     * @return Process
+     */
+    public function enableOutput()
+    {
+        $this->outputDisabled = false;
+
+        return $this;
+    }
+
     public function getProcess()
     {
         if (0 === count($this->prefix) && 0 === count($this->arguments)) {
@@ -172,6 +197,12 @@ class ProcessBuilder
             $env = $this->env;
         }
 
-        return new Process($script, $this->cwd, $env, $this->stdin, $this->timeout, $options);
+        $process = new Process($script, $this->cwd, $env, $this->stdin, $this->timeout, $options);
+
+        if ($this->outputDisabled) {
+            $process->disableOutput();
+        }
+
+        return $process;
     }
 }

--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -101,10 +101,22 @@ class ProcessPipes
     /**
      * Returns an array of descriptors for the use of proc_open.
      *
+     * @param Boolean $disableOutput Whether to redirect STDOUT and STDERR to /dev/null or not.
+     *
      * @return array
      */
-    public function getDescriptors()
+    public function getDescriptors($disableOutput)
     {
+        if ($disableOutput) {
+            $nullstream = fopen(defined('PHP_WINDOWS_VERSION_BUILD') ? 'NUL' : '/dev/null', 'c');
+
+            return array(
+                array('pipe', 'r'),
+                $nullstream,
+                $nullstream,
+            );
+        }
+
         if ($this->useFiles) {
             return array(
                 array('pipe', 'r'),

--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -193,4 +193,23 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals("'/usr/bin/php'", $process->getCommandLine());
         }
     }
+
+    public function testShouldReturnProcessWithDisabledOutput()
+    {
+        $process = ProcessBuilder::create(array('/usr/bin/php'))
+            ->disableOutput()
+            ->getProcess();
+
+        $this->assertTrue($process->isOutputDisabled());
+    }
+
+    public function testShouldReturnProcessWithEnabledOutput()
+    {
+        $process = ProcessBuilder::create(array('/usr/bin/php'))
+            ->disableOutput()
+            ->enableOutput()
+            ->getProcess();
+
+        $this->assertFalse($process->isOutputDisabled());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9007 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3664 |

This is another implementation for #9007 that allows to disable the output/error-output storage in a Process in order to avoid using memory.
This is particularly useful when the process outputs large data and it's not read.
