### PR TITLE
[2.3][Process] Fix #9160 : escaping an argument with a trailing backslash on windows fails

### DIFF
--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -52,6 +52,9 @@ class ProcessUtils
                 } elseif ('%' === $part) {
                     $escapedArgument .= '^%';
                 } else {
+                    if ('\\' === substr($part, -1)) {
+                        $part .= '\\';
+                    }
                     $escapedArgument .= escapeshellarg($part);
                 }
             }

--- a/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
@@ -31,6 +31,7 @@ class ProcessUtilsTest extends \PHPUnit_Framework_TestCase
                 array('^%"path"^%', '%path%'),
                 array('"<|>"\\"" "\\""\'f"', '<|>" "\'f'),
                 array('""', ''),
+                array('"with\trailingbs\\\\"', 'with\trailingbs\\'),
             );
         }
 
@@ -39,6 +40,7 @@ class ProcessUtilsTest extends \PHPUnit_Framework_TestCase
             array("'%path%'", '%path%'),
             array("'<|>\" \"'\\''f'", '<|>" "\'f'),
             array("''", ''),
+            array("'with\\trailingbs\\'", 'with\trailingbs\\'),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9160 |
| License | MIT |
