### PR TITLE
[HttpFoundation] Add dev-dependency on Symfony Expression-Language for unit tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "symfony/expression-language": "~2.4"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\HttpFoundation\\": "" },
         "classmap": [ "Symfony/Component/HttpFoundation/Resources/stubs" ]


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This component is needed to test ExpressionRequestMatcher
