### PR TITLE
[Serializer] Unify usage of normalizer cache

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -151,7 +151,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
      */
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return (bool) $this->getDenormalizer($data, $type, $format = null);
+        return (bool) $this->getDenormalizer($data, $type, $format);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no (unless performance problems are considered bugs) |
| New feature? | no |
| BC breaks? | no (unless the exception structure should be simplified) |
| Deprecations? | no |
| Tests pass? | yes ( I had some test fails locally when running the whole suite, but not related to Serializer) |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Some clean-up of the Serialization class, which has methods to get the Normalizer/Denormalizer but then repeats that logic in normalizeObject()/denormalizeObject().

Took great care to keep the exception behavior exactly like it is now as the tests depend on it, but it's strange (the methods use different exception classes if no normalizer is found and the "no normalizer" LogicException only exists in normalizeObject/denomalizeObject. That could easily be simplified further, to the point where those functions could easily be merged into the calling methods, as it would just be a single line of code. There is also a duplicate call to $this->normalizeObject() in normalize() that just exists to throw the LogicException for Symfony\Component\Serializer\Tests\SerializerTest::testSerializeNoNormalizer. Other tests do not except that to be thrown there, though.

Also noticed that getNormalizer()/getDenormalizer() are documented as @inheritdocs, which is a lie as they are private. Added some basic docs there.

This is performance relevant, as not having the cache in the getter methods means all normalizers are checked again to verify if a normalizer supports the data.
