### PR TITLE
[WIP][ExpressionLanguage] Use getters on protected/private properties

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -69,6 +69,11 @@ class GetAttrNode extends Node
                 }
 
                 $property = $this->nodes['attribute']->attributes['value'];
+                $method   = 'get' . preg_replace('/(?:^|_)(.?)/e', "strtoupper('$1')", $property);
+
+                if (method_exists($obj, $method)) {
+                    return $obj->{$method}();
+                }
 
                 return $obj->$property;
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -25,6 +25,7 @@ class GetAttrNodeTest extends AbstractNodeTest
             array('a', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), array('foo' => array('b' => 'a', 'b'))),
 
             array('bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
+            array('foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('qux'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
 
             array('baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
             array('a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), array('foo' => array('b' => 'a', 'b'), 'index' => 'b')),
@@ -58,8 +59,15 @@ class Obj
 {
     public $foo = 'bar';
 
+    protected $qux = 'foo';
+
     public function foo()
     {
         return 'baz';
+    }
+
+    public function getQux()
+    {
+        return $this->qux;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#3684 |

Allows for and defaults to accessing object properties through getters, if they exists.  

While this can be done with method calls as currently implemented, this is a convenience piece. Example would be when using Entities (ORM or ODM), which are typically created with private or protected properties and full getters/setters.

**todo**:
- [ ] Feeback
- [ ] Update tests
