### PR TITLE
[Debug] add a screaming mode to ErrorHandler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -32,5 +32,12 @@
             <argument>deprecation</argument>
             <argument type="service" id="logger" on-invalid="null" />
         </service>
+
+        <service id="debug.scream_logger_listener" class="%debug.errors_logger_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <tag name="monolog.logger" channel="scream" />
+            <argument>scream</argument>
+            <argument type="service" id="logger" on-invalid="null" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -3,16 +3,16 @@
 {% import _self as logger %}
 
 {% block toolbar %}
-    {% if collector.counterrors or collector.countdeprecations %}
+    {% if collector.counterrors or collector.countdeprecations or collector.countscreams %}
         {% set icon %}
             <img width="15" height="28" alt="Logs" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAcCAYAAABoMT8aAAAA4klEQVQ4y2P4//8/AyWYYXgYwOPp6Xnc3t7+P7EYpB6k7+zZs2ADNEjRjIwDAgKWgAywIUfz8+fPVzg7O/8AGeCATQEQnAfi/SAah/wcV1dXvAYUgORANA75ehcXl+/4DHAABRIe+ZrhbgAhTHsDiEgHBA0glA6GfSDiw5mZma+A+sphBlhVVFQ88vHx+Xfu3Ll7QP5haOjjwtuAuGHv3r3NIMNABqh8+/atsaur666vr+9XUlwSHx//AGQANxCbAnEWyGQicRMQ9wBxIQM0qjiBWAFqkB00/glhayBWHwb1AgB38EJsUtxtWwAAAABJRU5ErkJggg==" />
             {% if collector.counterrors %}
                 {% set status_color = "red" %}
-            {% else %}
+            {% elseif collector.countdeprecations %}
                 {% set status_color = "yellow" %}
             {% endif %}
-            {% set error_count = collector.counterrors + collector.countdeprecations %}
-            <span class="sf-toolbar-status sf-toolbar-status-{{ status_color }}">{{ error_count }}</span>
+            {% set error_count = collector.counterrors + collector.countdeprecations + collector.countscreams %}
+            <span class="sf-toolbar-status{% if status_color is defined %}} sf-toolbar-status-{{ status_color }}{% endif %}">{{ error_count }}</span>
         {% endset %}
         {% set text %}
             {% if collector.counterrors %}
@@ -27,6 +27,12 @@
                     <span class="sf-toolbar-status sf-toolbar-status-yellow">{{ collector.countdeprecations }}</span>
                 </div>
             {% endif %}
+            {% if collector.countscreams %}
+                <div class="sf-toolbar-info-piece">
+                    <b>Silenced Errors</b>
+                    <span class="sf-toolbar-status sf-toolbar-status">{{ collector.countscreams }}</span>
+                </div>
+            {% endif %}
         {% endset %}
         {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
     {% endif %}
@@ -36,8 +42,8 @@
 <span class="label">
     <span class="icon"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAgCAYAAAAMq2gFAAABjElEQVRIx2MIDw+vd3R0/GFvb/+fGtjFxeVJSUmJ1f///5nv37/PAMMMzs7OVLMEhoODgy/k5+cHJCYmagAtZAJbRG1L0DEwxCYALeOgiUXbt2+/X1NT8xTEdnd3/wi0SI4mFgHBDCBeCLXoF5BtwkCEpvNAvB8JnydCTwgQR0It+g1kWxNjUQEQOyDhAiL0gNUiWWRDjEUOyMkUZsCoRaMWjVpEvEVkFkGjFmEUqgc+fvx4hVYWIReqzi9evKileaoDslnu3LkTNLQtGk3edLPIycnpL9Bge5pb1NXVdQNosDmGRcAm7F+QgKur6783b95cBQoeRGv1kII3QPOdAoZF8+fPP4PUqnx55syZVKCEI1rLh1hsAbWEZ8aMGaUoFoFcMG3atKdIjfSPISEhawICAlaQgwMDA1f6+/sfB5rzE2Sej4/PD3C7DkjoAHHVoUOHLpSVlX3w8vL6Sa34Alr6Z8WKFaCoMARZxAHEoFZ/HBD3A/FyIF4BxMvIxCC964F4G6hZDMTxQCwJAGWE8pur5kFDAAAAAElFTkSuQmCC" alt="Logger"></span>
     <strong>Logs</strong>
-    {% if collector.counterrors or collector.countdeprecations %}
-        {% set error_count = collector.counterrors + collector.countdeprecations %}
+    {% if collector.counterrors or collector.countdeprecations or collector.countscreams %}
+        {% set error_count = collector.counterrors + collector.countdeprecations + collector.countscreams %}
         <span class="count">
             <span>{{ error_count }}</span>
         </span>
@@ -74,7 +80,7 @@
     {% if collector.logs %}
         <ul class="alt">
             {% for log in collector.logs if priority >= 0 and log.priority >= priority or priority < 0 and log.context.type|default(0) == priority %}
-                <li class="{{ cycle(['odd', 'even'], loop.index) }}{% if log.priority >= 400 %} error{% elseif log.priority >= 300 %} warning{% endif %}">
+                <li class="{{ cycle(['odd', 'even'], loop.index) }}{% if log.priority >= 400 %} error{% elseif log.priority >= 300 %} warning{% endif %}{% if log.context.scream is defined %} scream{% endif %}">
                     {{ logger.display_message(loop.index, log) }}
                 </li>
             {% else %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -275,6 +275,9 @@ ul.alt li.warning {
     background-color: #ffcc00;
     margin-bottom: 1px;
 }
+ul.alt li.scream, ul.alt li.scream strong {
+    color: gray;
+}
 ul.sf-call-stack li {
     text-size: small;
     padding: 0 0 0 20px;

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -46,11 +46,8 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
     public function lateCollect()
     {
         if (null !== $this->logger) {
-            $this->data = array(
-                'error_count'       => $this->logger->countErrors(),
-                'logs'              => $this->sanitizeLogs($this->logger->getLogs()),
-                'deprecation_count' => $this->computeDeprecationCount()
-            );
+            $this->data = $this->computeErrorsCount();
+            $this->data['logs'] = $this->sanitizeLogs($this->logger->getLogs());
         }
     }
 
@@ -79,6 +76,11 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
     public function countDeprecations()
     {
         return isset($this->data['deprecation_count']) ? $this->data['deprecation_count'] : 0;
+    }
+
+    public function countScreams()
+    {
+        return isset($this->data['scream_count']) ? $this->data['scream_count'] : 0;
     }
 
     /**
@@ -119,12 +121,21 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         return $context;
     }
 
-    private function computeDeprecationCount()
+    private function computeErrorsCount()
     {
-        $count = 0;
+        $count = array(
+            'error_count' => $this->logger->countErrors(),
+            'deprecation_count' => 0,
+            'scream_count' => 0,
+        );
+
         foreach ($this->logger->getLogs() as $log) {
-            if (isset($log['context']['type']) && ErrorHandler::TYPE_DEPRECATION === $log['context']['type']) {
-                $count++;
+            if (isset($log['context']['type'])) {
+                if (ErrorHandler::TYPE_DEPRECATION === $log['context']['type']) {
+                    ++$count['deprecation_count'];
+                } elseif (isset($log['context']['scream'])) {
+                    ++$count['scream_count'];
+                }
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -19,7 +19,7 @@ class LoggerDataCollectorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getCollectTestData
      */
-    public function testCollect($nb, $logs, $expectedLogs, $expectedDeprecationCount)
+    public function testCollect($nb, $logs, $expectedLogs, $expectedDeprecationCount, $expectedScreamCount)
     {
         $logger = $this->getMock('Symfony\Component\HttpKernel\Log\DebugLoggerInterface');
         $logger->expects($this->once())->method('countErrors')->will($this->returnValue($nb));
@@ -32,6 +32,7 @@ class LoggerDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($nb, $c->countErrors());
         $this->assertSame($expectedLogs ? $expectedLogs : $logs, $c->getLogs());
         $this->assertSame($expectedDeprecationCount, $c->countDeprecations());
+        $this->assertSame($expectedScreamCount, $c->countScreams());
     }
 
     public function getCollectTestData()
@@ -41,28 +42,33 @@ class LoggerDataCollectorTest extends \PHPUnit_Framework_TestCase
                 1,
                 array(array('message' => 'foo', 'context' => array())),
                 null,
-                0
+                0,
+                0,
             ),
             array(
                 1,
                 array(array('message' => 'foo', 'context' => array('foo' => fopen(__FILE__, 'r')))),
                 array(array('message' => 'foo', 'context' => array('foo' => 'Resource(stream)'))),
-                0
+                0,
+                0,
             ),
             array(
                 1,
                 array(array('message' => 'foo', 'context' => array('foo' => new \stdClass()))),
                 array(array('message' => 'foo', 'context' => array('foo' => 'Object(stdClass)'))),
-                0
+                0,
+                0,
             ),
             array(
                 1,
                 array(
                     array('message' => 'foo', 'context' => array('type' => ErrorHandler::TYPE_DEPRECATION)),
-                    array('message' => 'foo2', 'context' => array('type' => ErrorHandler::TYPE_DEPRECATION))
+                    array('message' => 'foo2', 'context' => array('type' => ErrorHandler::TYPE_DEPRECATION)),
+                    array('message' => 'foo3', 'context' => array('type' => E_USER_WARNING, 'scream' => 0)),
                 ),
                 null,
-                2
+                2,
+                1,
             ),
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Collect and display silenced PHP errors in the debug toolbar.
