### PR TITLE
[Console] Added ability to set the process title

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -68,6 +68,7 @@ class Application
     private $dispatcher;
     private $terminalDimensions;
     private $defaultCommand;
+    private $processTitle = '%app% - %cmd%';
 
     /**
      * Constructor.
@@ -883,6 +884,15 @@ class Application
      */
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
     {
+        if (version_compare(PHP_VERSION, '5.5.0') >= 0) {
+            $processTitle = strtr($this->processTitle, array(
+                '%app%' => $this->name,
+                '%cmd%' => $command->getName(),
+            ));
+
+            @cli_set_process_title($processTitle);
+        }
+
         foreach ($command->getHelperSet() as $helper) {
             if ($helper instanceof InputAwareInterface) {
                 $helper->setInput($input);
@@ -1108,5 +1118,19 @@ class Application
     public function setDefaultCommand($commandName)
     {
         $this->defaultCommand = $commandName;
+    }
+
+    /**
+     * Sets the process title visible in tools such as top and ps.
+     * The available placeholders are:
+     *
+     * - %app% This application name
+     * - %cmd% The running command name
+     *
+     * @param string $processTitle The process title
+     */
+    public function setProcessTitle($processTitle)
+    {
+        $this->processTitle = $processTitle;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

As of PHP 5.5 it's possible to set CLI processes titles.

Output of the `ps` command. Before:
![before](https://f.cloud.github.com/assets/1586668/2438249/82818904-adef-11e3-9e84-13d6eea95220.png)

After:
![after](https://f.cloud.github.com/assets/1586668/2438251/86370de4-adef-11e3-9b7e-b1f9b23b973d.png)
