### PR TITLE
[Console] Rename Command::setProcessName to Command::setProcessTitle

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * deprecated TableHelper in favor of Table
  * deprecated ProgressHelper in favor of ProgressBar
  * added a way to set a default command instead of `ListCommand`
- * added a way to set the process name of a command
+ * added a way to set the process title of a command
 
 2.4.0
 -----

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -33,7 +33,7 @@ class Command
 {
     private $application;
     private $name;
-    private $processName;
+    private $processTitle;
     private $aliases = array();
     private $definition;
     private $help;
@@ -213,11 +213,11 @@ class Command
      */
     public function run(InputInterface $input, OutputInterface $output)
     {
-        if (null !== $this->processName) {
+        if (null !== $this->processTitle) {
             if (function_exists('cli_set_process_title')) {
-                cli_set_process_title($this->processName);
+                cli_set_process_title($this->processTitle);
             } elseif (function_exists('setproctitle')) {
-                setproctitle($this->processName);
+                setproctitle($this->processTitle);
             } elseif (OutputInterface::VERBOSITY_VERY_VERBOSE === $output->getVerbosity()) {
                 $output->writeln('<comment>Install the proctitle PECL to be able to change the process title.</comment>');
             }
@@ -423,20 +423,20 @@ class Command
     }
 
     /**
-     * Sets the process name of the command.
+     * Sets the process title of the command.
      *
      * This feature should be used only when creating a long process command,
      * like a daemon.
      *
      * PHP 5.5+ or the proctitle PECL library is required
      *
-     * @param string $name The process name
+     * @param string $title The process title
      *
      * @return Command The current instance
      */
-    public function setProcessName($name)
+    public function setProcessTitle($title)
     {
-        $this->processName = $name;
+        $this->processTitle = $title;
 
         return $this;
     }


### PR DESCRIPTION
To be more consistant with the underlying system.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no (because the 2.5 is not released yet) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |
