### PR TITLE
[Filesystem] Added a LockHandler

### DIFF
--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * added LockHandler
+
 2.3.12
 ------
 
@@ -10,7 +15,7 @@ CHANGELOG
 -----
 
  * added the dumpFile() method to atomically write files
- 
+
 2.2.0
 -----
 

--- a/src/Symfony/Component/Filesystem/LockHandler.php
+++ b/src/Symfony/Component/Filesystem/LockHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+
+/**
+ * LockHandler class provides a simple abstraction to lock anything by means of
+ * a file lock.
+ *
+ * A locked file is created based on the lock name when calling lock(). Other
+ * lock handlers will not be able to lock the same name until it is released
+ * (explicitly by calling release() or implicitly when the instance holding the
+ * lock is destroyed).
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Romain Neutron <imprec@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class LockHandler
+{
+    private $file;
+    private $handle;
+
+    /**
+     * @param  string      $name     The lock name
+     * @param  string|null $lockPath The directory to store the lock. Default values will use temporary directory
+     * @throws IOException If the lock directory could not be created or is not writable
+     */
+    public function __construct($name, $lockPath = null)
+    {
+        $lockPath = $lockPath ?: sys_get_temp_dir();
+
+        if (!is_dir($lockPath)) {
+            $fs = new Filesystem();
+            $fs->mkdir($lockPath);
+        }
+
+        if (!is_writable($lockPath)) {
+            throw new IOException(sprintf('The directory "%s" is not writable.', $lockPath), 0, null, $lockPath);
+        }
+
+        $name = sprintf('%s-%s', preg_replace('/[^a-z0-9\._-]+/i', '-', $name), hash('sha256', $name));
+
+        $this->file = sprintf('%s/%s', $lockPath, $name);
+    }
+
+    /**
+     * Lock the resource
+     *
+     * @param  bool        $blocking wait until the lock is released
+     * @return bool        Returns true if the lock was acquired, false otherwise
+     * @throws IOException If the lock file could not be created or opened
+     */
+    public function lock($blocking = false)
+    {
+        if ($this->handle) {
+            return true;
+        }
+
+        // Set an error handler to not trigger the registered error handler if
+        // the file can not be opened.
+        set_error_handler('var_dump', 0);
+        $this->handle = @fopen($this->file, 'c');
+        restore_error_handler();
+
+        if (!$this->handle) {
+            throw new IOException(sprintf('Unable to fopen "%s".', $this->file), 0, null, $this->file);
+        }
+
+        // On Windows, even if PHP doc says the contrary, LOCK_NB works, see
+        // https://bugs.php.net/54129
+        if (!flock($this->handle, LOCK_EX | ($blocking ? 0 : LOCK_NB))) {
+            fclose($this->handle);
+            $this->handle = null;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Release the resource
+     */
+    public function release()
+    {
+        if ($this->handle) {
+            flock($this->handle, LOCK_UN | LOCK_NB);
+            fclose($this->handle);
+            $this->handle = null;
+        }
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/LockHandlerTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/LockHandlerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Symfony\Component\Filesystem\Tests;
+
+use Symfony\Component\Filesystem\LockHandler;
+
+class LockHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Symfony\Component\Filesystem\Exception\IOException
+     * @expectedExceptionMessage Failed to create "/a/b/c/d/e": mkdir(): Permission denied.
+     */
+    public function testConstructWhenRepositoryDoesNotExist()
+    {
+        new LockHandler('lock', '/a/b/c/d/e');
+    }
+
+    /**
+     * @expectedException Symfony\Component\Filesystem\Exception\IOException
+     * @expectedExceptionMessage The directory "/" is not writable.
+     */
+    public function testConstructWhenRepositoryIsNotWriteable()
+    {
+        new LockHandler('lock', '/');
+    }
+
+    public function testConstructSanitizeName()
+    {
+        $lock = new LockHandler('<?php echo "% hello word ! %" ?>');
+
+        $file = sprintf('%s/-php-echo-hello-word--4b3d9d0d27ddef3a78a64685dda3a963e478659a9e5240feaf7b4173a8f28d5f', sys_get_temp_dir());
+        // ensure the file does not exist before the lock
+        @unlink($file);
+
+        $lock->lock();
+
+        $this->assertFileExists($file);
+
+        $lock->release();
+    }
+
+    public function testLockRelease()
+    {
+        $name = 'symfony-test-filesystem.lock';
+
+        $l1 = new LockHandler($name);
+        $l2 = new LockHandler($name);
+
+        $this->assertTrue($l1->lock());
+        $this->assertFalse($l2->lock());
+
+        $l1->release();
+
+        $this->assertTrue($l2->lock());
+        $l2->release();
+    }
+
+    public function testLockTwice()
+    {
+        $name = 'symfony-test-filesystem.lock';
+
+        $lockHandler = new LockHandler($name);
+
+        $this->assertTrue($lockHandler->lock());
+        $this->assertTrue($lockHandler->lock());
+
+        $lockHandler->release();
+    }
+
+    public function testLockIsReleased()
+    {
+        $name = 'symfony-test-filesystem.lock';
+
+        $l1 = new LockHandler($name);
+        $l2 = new LockHandler($name);
+
+        $this->assertTrue($l1->lock());
+        $this->assertFalse($l2->lock());
+
+        $l1 = null;
+
+        $this->assertTrue($l2->lock());
+        $l2->release();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9357 , #3586 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3956/files |

Code sample:

``` php
    /**
     * {@inheritdoc}
     */
    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $lockHelper = new LockHandler('/tmp/acme/hello.lock');
        if (!$lockHelper->lock()) {
            $output->writeln('The command is already running in another process.');

            return 0;
        }

        $output->writeln(sprintf('Hello <comment>%s</comment>!', $input->getArgument('who')));

        for (;;) {
        }

        $output->writeln(sprintf('bye <comment>%s</comment>!', $input->getArgument('who')));

        $lockHelper->unlock();
    }
```

![process-lock](https://f.cloud.github.com/assets/408368/2443205/4f0bf3e8-ae30-11e3-9bd4-78e09e2973ad.png)
