### PR TITLE
[Console] Fixed unsetting of setted attributes on OutputFormatterStyle

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -21,31 +21,31 @@ namespace Symfony\Component\Console\Formatter;
 class OutputFormatterStyle implements OutputFormatterStyleInterface
 {
     private static $availableForegroundColors = array(
-        'black'     => 30,
-        'red'       => 31,
-        'green'     => 32,
-        'yellow'    => 33,
-        'blue'      => 34,
-        'magenta'   => 35,
-        'cyan'      => 36,
-        'white'     => 37
+        'black'     => array('set' => 30, 'unset' => 39),
+        'red'       => array('set' => 31, 'unset' => 39),
+        'green'     => array('set' => 32, 'unset' => 39),
+        'yellow'    => array('set' => 33, 'unset' => 39),
+        'blue'      => array('set' => 34, 'unset' => 39),
+        'magenta'   => array('set' => 35, 'unset' => 39),
+        'cyan'      => array('set' => 36, 'unset' => 39),
+        'white'     => array('set' => 37, 'unset' => 39)
     );
     private static $availableBackgroundColors = array(
-        'black'     => 40,
-        'red'       => 41,
-        'green'     => 42,
-        'yellow'    => 43,
-        'blue'      => 44,
-        'magenta'   => 45,
-        'cyan'      => 46,
-        'white'     => 47
+        'black'     => array('set' => 40, 'unset' => 49),
+        'red'       => array('set' => 41, 'unset' => 49),
+        'green'     => array('set' => 42, 'unset' => 49),
+        'yellow'    => array('set' => 43, 'unset' => 49),
+        'blue'      => array('set' => 44, 'unset' => 49),
+        'magenta'   => array('set' => 45, 'unset' => 49),
+        'cyan'      => array('set' => 46, 'unset' => 49),
+        'white'     => array('set' => 47, 'unset' => 49)
     );
     private static $availableOptions = array(
-        'bold'          => 1,
-        'underscore'    => 4,
-        'blink'         => 5,
-        'reverse'       => 7,
-        'conceal'       => 8
+        'bold'          => array('set' => 1, 'unset' => 21),
+        'underscore'    => array('set' => 4, 'unset' => 24),
+        'blink'         => array('set' => 5, 'unset' => 25),
+        'reverse'       => array('set' => 7, 'unset' => 27),
+        'conceal'       => array('set' => 8, 'unset' => 28)
     );
 
     private $foreground;
@@ -201,22 +201,28 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
      */
     public function apply($text)
     {
-        $codes = array();
+        $setCodes = array();
+        $unsetCode = array();
 
         if (null !== $this->foreground) {
-            $codes[] = $this->foreground;
+            $setCodes[] = $this->foreground['set'];
+            $unsetCodes[] = $this->foreground['unset'];
         }
         if (null !== $this->background) {
-            $codes[] = $this->background;
+            $setCodes[] = $this->background['set'];
+            $unsetCodes[] = $this->background['unset'];
         }
         if (count($this->options)) {
-            $codes = array_merge($codes, $this->options);
+            foreach ($this->options as $option) {
+                $setCodes[] = $option['set'];
+                $unsetCodes[] = $option['unset'];
+            }
         }
 
-        if (0 === count($codes)) {
+        if (0 === count($setCodes)) {
             return $text;
         }
 
-        return sprintf("\033[%sm%s\033[0m", implode(';', $codes), $text);
+        return sprintf("\033[%sm%s\033[%sm", implode(';', $setCodes), $text, implode(';', $unsetCodes));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
@@ -1,27 +1,27 @@
 
 
-[37;41m                           [0m
-[37;41m  [Exception]              [0m
-[37;41m  Third exception [0m[34;41mcomment[0m[37;41m  [0m
-[37;41m                           [0m
+[37;41m                           [39;49m
+[37;41m  [Exception]              [39;49m
+[37;41m  Third exception [39;49m[34;41mcomment[39;49m[37;41m  [39;49m
+[37;41m                           [39;49m
 
 
 
 
-[37;41m                            [0m
-[37;41m  [Exception]               [0m
-[37;41m  Second exception [0m[33mcomment[0m[37;41m  [0m
-[37;41m                            [0m
+[37;41m                            [39;49m
+[37;41m  [Exception]               [39;49m
+[37;41m  Second exception [39;49m[33mcomment[39m[37;41m  [39;49m
+[37;41m                            [39;49m
 
 
 
 
-[37;41m                                       [0m
-[37;41m  [Exception]                          [0m
-[37;41m  First exception [0m[37;41m<p>[0m[37;41mthis is html[0m[37;41m</p>[0m[37;41m  [0m
-[37;41m                                       [0m
+[37;41m                                       [39;49m
+[37;41m  [Exception]                          [39;49m
+[37;41m  First exception [39;49m[37;41m<p>[39;49m[37;41mthis is html[39;49m[37;41m</p>[39;49m[37;41m  [39;49m
+[37;41m                                       [39;49m
 
 
-[32mfoo3:bar[0m
+[32mfoo3:bar[39m
 
 

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
@@ -18,13 +18,13 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
     public function testConstructor()
     {
         $style = new OutputFormatterStyle('green', 'black', array('bold', 'underscore'));
-        $this->assertEquals("\033[32;40;1;4mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[32;40;1;4mfoo\033[39;49;21;24m", $style->apply('foo'));
 
         $style = new OutputFormatterStyle('red', null, array('blink'));
-        $this->assertEquals("\033[31;5mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[31;5mfoo\033[39;25m", $style->apply('foo'));
 
         $style = new OutputFormatterStyle(null, 'white');
-        $this->assertEquals("\033[47mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[47mfoo\033[49m", $style->apply('foo'));
     }
 
     public function testForeground()
@@ -32,10 +32,10 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
         $style = new OutputFormatterStyle();
 
         $style->setForeground('black');
-        $this->assertEquals("\033[30mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[30mfoo\033[39m", $style->apply('foo'));
 
         $style->setForeground('blue');
-        $this->assertEquals("\033[34mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[34mfoo\033[39m", $style->apply('foo'));
 
         $this->setExpectedException('InvalidArgumentException');
         $style->setForeground('undefined-color');
@@ -46,10 +46,10 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
         $style = new OutputFormatterStyle();
 
         $style->setBackground('black');
-        $this->assertEquals("\033[40mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[40mfoo\033[49m", $style->apply('foo'));
 
         $style->setBackground('yellow');
-        $this->assertEquals("\033[43mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[43mfoo\033[49m", $style->apply('foo'));
 
         $this->setExpectedException('InvalidArgumentException');
         $style->setBackground('undefined-color');
@@ -60,19 +60,19 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
         $style = new OutputFormatterStyle();
 
         $style->setOptions(array('reverse', 'conceal'));
-        $this->assertEquals("\033[7;8mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[7;8mfoo\033[27;28m", $style->apply('foo'));
 
         $style->setOption('bold');
-        $this->assertEquals("\033[7;8;1mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[7;8;1mfoo\033[27;28;21m", $style->apply('foo'));
 
         $style->unsetOption('reverse');
-        $this->assertEquals("\033[8;1mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[8;1mfoo\033[28;21m", $style->apply('foo'));
 
         $style->setOption('bold');
-        $this->assertEquals("\033[8;1mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[8;1mfoo\033[28;21m", $style->apply('foo'));
 
         $style->setOptions(array('bold'));
-        $this->assertEquals("\033[1mfoo\033[0m", $style->apply('foo'));
+        $this->assertEquals("\033[1mfoo\033[21m", $style->apply('foo'));
 
         try {
             $style->setOption('foo');

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -31,7 +31,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("\\<info>some info\\</info>", OutputFormatter::escape('<info>some info</info>'));
 
         $this->assertEquals(
-            "\033[33mSymfony\\Component\\Console does work very well!\033[0m",
+            "\033[33mSymfony\\Component\\Console does work very well!\033[39m",
             $formatter->format('<comment>Symfony\Component\Console does work very well!</comment>')
         );
     }
@@ -46,19 +46,19 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($formatter->hasStyle('question'));
 
         $this->assertEquals(
-            "\033[37;41msome error\033[0m",
+            "\033[37;41msome error\033[39;49m",
             $formatter->format('<error>some error</error>')
         );
         $this->assertEquals(
-            "\033[32msome info\033[0m",
+            "\033[32msome info\033[39m",
             $formatter->format('<info>some info</info>')
         );
         $this->assertEquals(
-            "\033[33msome comment\033[0m",
+            "\033[33msome comment\033[39m",
             $formatter->format('<comment>some comment</comment>')
         );
         $this->assertEquals(
-            "\033[30;46msome question\033[0m",
+            "\033[30;46msome question\033[39;49m",
             $formatter->format('<question>some question</question>')
         );
     }
@@ -68,7 +68,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $formatter = new OutputFormatter(true);
 
         $this->assertEquals(
-            "\033[37;41msome \033[0m\033[32msome info\033[0m\033[37;41m error\033[0m",
+            "\033[37;41msome \033[39;49m\033[32msome info\033[39m\033[37;41m error\033[39;49m",
             $formatter->format('<error>some <info>some info</info> error</error>')
         );
     }
@@ -78,7 +78,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $formatter = new OutputFormatter(true);
 
         $this->assertEquals(
-            "\033[37;41msome error\033[0m\033[32msome info\033[0m",
+            "\033[37;41msome error\033[39;49m\033[32msome info\033[39m",
             $formatter->format('<error>some error</error><info>some info</info>')
         );
     }
@@ -88,7 +88,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $formatter = new OutputFormatter(true);
 
         $this->assertEquals(
-            "(\033[32m>=2.0,<2.3\033[0m)",
+            "(\033[32m>=2.0,<2.3\033[39m)",
             $formatter->format('(<info>>=2.0,<2.3</info>)')
         );
     }
@@ -98,7 +98,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $formatter = new OutputFormatter(true);
 
         $this->assertEquals(
-            "(\033[32mz>=2.0,<a2.3\033[0m)",
+            "(\033[32mz>=2.0,<a2.3\033[39m)",
             $formatter->format('(<info>'.$formatter->escape('z>=2.0,<a2.3').'</info>)')
         );
     }
@@ -108,7 +108,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $formatter = new OutputFormatter(true);
 
         $this->assertEquals(
-            "\033[37;41merror\033[0m\033[32minfo\033[0m\033[33mcomment\033[0m\033[37;41merror\033[0m",
+            "\033[37;41merror\033[39;49m\033[32minfo\033[39m\033[33mcomment\033[39m\033[37;41merror\033[39;49m",
             $formatter->format('<error>error<info>info<comment>comment</info>error</error>')
         );
     }
@@ -126,7 +126,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $style = new OutputFormatterStyle('blue', 'white');
         $formatter->setStyle('b', $style);
 
-        $this->assertEquals("\033[34;47msome \033[0m\033[34;47mcustom\033[0m\033[34;47m msg\033[0m", $formatter->format('<test>some <b>custom</b> msg</test>'));
+        $this->assertEquals("\033[34;47msome \033[39;49m\033[34;47mcustom\033[39;49m\033[34;47m msg\033[39;49m", $formatter->format('<test>some <b>custom</b> msg</test>'));
     }
 
     public function testRedefineStyle()
@@ -136,29 +136,29 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $style = new OutputFormatterStyle('blue', 'white');
         $formatter->setStyle('info', $style);
 
-        $this->assertEquals("\033[34;47msome custom msg\033[0m", $formatter->format('<info>some custom msg</info>'));
+        $this->assertEquals("\033[34;47msome custom msg\033[39;49m", $formatter->format('<info>some custom msg</info>'));
     }
 
     public function testInlineStyle()
     {
         $formatter = new OutputFormatter(true);
 
-        $this->assertEquals("\033[34;41msome text\033[0m", $formatter->format('<fg=blue;bg=red>some text</>'));
-        $this->assertEquals("\033[34;41msome text\033[0m", $formatter->format('<fg=blue;bg=red>some text</fg=blue;bg=red>'));
+        $this->assertEquals("\033[34;41msome text\033[39;49m", $formatter->format('<fg=blue;bg=red>some text</>'));
+        $this->assertEquals("\033[34;41msome text\033[39;49m", $formatter->format('<fg=blue;bg=red>some text</fg=blue;bg=red>'));
     }
 
     public function testNonStyleTag()
     {
         $formatter = new OutputFormatter(true);
 
-        $this->assertEquals("\033[32msome \033[0m\033[32m<tag>\033[0m\033[32m styled \033[0m\033[32m<p>\033[0m\033[32msingle-char tag\033[0m\033[32m</p>\033[0m", $formatter->format('<info>some <tag> styled <p>single-char tag</p></info>'));
+        $this->assertEquals("\033[32msome \033[39m\033[32m<tag>\033[39m\033[32m styled \033[39m\033[32m<p>\033[39m\033[32msingle-char tag\033[39m\033[32m</p>\033[39m", $formatter->format('<info>some <tag> styled <p>single-char tag</p></info>'));
     }
 
     public function testFormatLongString()
     {
         $formatter = new OutputFormatter(true);
         $long = str_repeat("\\", 14000);
-        $this->assertEquals("\033[37;41msome error\033[0m".$long, $formatter->format('<error>some error</error>'.$long));
+        $this->assertEquals("\033[37;41msome error\033[39;49m".$long, $formatter->format('<error>some error</error>'.$long));
     }
 
     public function testNotDecoratedFormatter()
@@ -186,16 +186,16 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
         $formatter->setDecorated(true);
 
         $this->assertEquals(
-            "\033[37;41msome error\033[0m", $formatter->format('<error>some error</error>')
+            "\033[37;41msome error\033[39;49m", $formatter->format('<error>some error</error>')
         );
         $this->assertEquals(
-            "\033[32msome info\033[0m", $formatter->format('<info>some info</info>')
+            "\033[32msome info\033[39m", $formatter->format('<info>some info</info>')
         );
         $this->assertEquals(
-            "\033[33msome comment\033[0m", $formatter->format('<comment>some comment</comment>')
+            "\033[33msome comment\033[39m", $formatter->format('<comment>some comment</comment>')
         );
         $this->assertEquals(
-            "\033[30;46msome question\033[0m", $formatter->format('<question>some question</question>')
+            "\033[30;46msome question\033[39;49m", $formatter->format('<question>some question</question>')
         );
     }
 
@@ -205,7 +205,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(<<<EOF
 \033[32m
-some text\033[0m
+some text\033[39m
 EOF
             , $formatter->format(<<<EOF
 <info>
@@ -215,7 +215,7 @@ EOF
 
         $this->assertEquals(<<<EOF
 \033[32msome text
-\033[0m
+\033[39m
 EOF
             , $formatter->format(<<<EOF
 <info>some text
@@ -226,7 +226,7 @@ EOF
         $this->assertEquals(<<<EOF
 \033[32m
 some text
-\033[0m
+\033[39m
 EOF
             , $formatter->format(<<<EOF
 <info>
@@ -239,7 +239,7 @@ EOF
 \033[32m
 some text
 more text
-\033[0m
+\033[39m
 EOF
             , $formatter->format(<<<EOF
 <info>

--- a/src/Symfony/Component/Console/Tests/Output/OutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/OutputTest.php
@@ -113,7 +113,7 @@ class OutputTest extends \PHPUnit_Framework_TestCase
         $output->getFormatter()->setStyle('FOO', $fooStyle);
         $output->setDecorated(true);
         $output->writeln('<foo>foo</foo>');
-        $this->assertEquals("\033[33;41;5mfoo\033[0m\n", $output->output, '->writeln() decorates the output');
+        $this->assertEquals("\033[33;41;5mfoo\033[39;49;25m\n", $output->output, '->writeln() decorates the output');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Unset only previous setted styles in place of all styles, before this fix,
OutputFormatterStyle reset all attributes with '\e[0m' sequence.
Now, if a foreground is setted, reset only the foreground so you can use innested attributes

Conflicts:
    src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
    src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
    src/Symfony/Component/Console/Tests/Output/OutputTest.php
