### PR TITLE
[2.3][Process] Fix escaping on Windows

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -142,13 +142,13 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldEscapeArguments()
     {
-        $pb = new ProcessBuilder(array('%path%', 'foo " bar'));
+        $pb = new ProcessBuilder(array('%path%', 'foo " bar', '%baz%baz'));
         $proc = $pb->getProcess();
 
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->assertSame('^%"path"^% "foo "\\"" bar"', $proc->getCommandLine());
+            $this->assertSame('^%"path"^% "foo \\" bar" "%baz%baz"', $proc->getCommandLine());
         } else {
-            $this->assertSame("'%path%' 'foo \" bar'", $proc->getCommandLine());
+            $this->assertSame("'%path%' 'foo \" bar' '%baz%baz'", $proc->getCommandLine());
         }
     }
 

--- a/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
@@ -30,7 +30,7 @@ class ProcessUtilsTest extends \PHPUnit_Framework_TestCase
                 array('"\"php\" \"-v\""', '"php" "-v"'),
                 array('"foo bar"', 'foo bar'),
                 array('^%"path"^%', '%path%'),
-                array('"<|>"\\"" "\\""\'f"', '<|>" "\'f'),
+                array('"<|>\\" \\"\'f"', '<|>" "\'f'),
                 array('""', ''),
                 array('"with\trailingbs\\\\"', 'with\trailingbs\\'),
             );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Windows escaping is broken since the last merges.

After digging more on Windows escaping, I realised some things: 
- We forbid environment variable expansion by escaping `%APPDATA%` to `^%"APPDATA"^%`
- We explicitly ask for variable expansion at runtime (running the command line with the [`/V:ON`](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Process/Process.php#L235) flag). Running a command containing `!APPDATA!` will be escaped and expanded (our previous rule is easily overriden)
- On platform that are not windows, we use strong escaping that prevents any variable expansion (`$PATH` will be escaped to `'$PATH'` that is not interpreted as the current PATH)

We have three possibilities:
- Keep this behavior as this.
- Prefer a consistent API and use a strong escaping strategy everywhere, but it would result in a BC break (see #8975).
- Allow environment variable expansion and escape `%APPDATA%` to `"%APPDATA%"`

Any thoughts about this ?
