### PR TITLE
[Process] Fixed fatal errors in getOutput and getErrorOutput when process was not started 

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -296,9 +296,14 @@ class Process
      *
      * @throws RuntimeException When process timed out
      * @throws RuntimeException When process stopped after receiving signal
+     * @throws LogicException When process is not started
      */
     public function wait($callback = null)
     {
+        if (!$this->isStarted()) {
+            throw new LogicException(sprintf('Process must be started before calling %s', __FUNCTION__));
+        }
+
         $this->updateStatus(false);
         if (null !== $callback) {
             $this->callback = $this->buildCallback($callback);
@@ -366,10 +371,16 @@ class Process
      *
      * @return string The process output
      *
+     * @throws LogicException In case the process is not started
+     *
      * @api
      */
     public function getOutput()
     {
+        if (!$this->isStarted()) {
+            throw new LogicException(sprintf('Process must be started before calling %s', __FUNCTION__));
+        }
+
         $this->readPipes(false, defined('PHP_WINDOWS_VERSION_BUILD') ? !$this->processInformation['running'] : true);
 
         return $this->stdout;
@@ -398,10 +409,16 @@ class Process
      *
      * @return string The process error output
      *
+     * @throws LogicException In case the process is not started
+     *
      * @api
      */
     public function getErrorOutput()
     {
+        if (!$this->isStarted()) {
+            throw new LogicException(sprintf('Process must be started before calling %s', __FUNCTION__));
+        }
+
         $this->readPipes(false, defined('PHP_WINDOWS_VERSION_BUILD') ? !$this->processInformation['running'] : true);
 
         return $this->stderr;

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -617,6 +617,36 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $process->signal(SIGHUP);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     * @expectedExceptionMessage Process must be started before calling getOutput
+     */
+    public function testGetOutputProcessNotStarted()
+    {
+        $process = $this->getProcess('php -m');
+        $process->getOutput();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     * @expectedExceptionMessage Process must be started before calling getErrorOutput
+     */
+    public function testGetErrorOutputProcessNotStarted()
+    {
+        $process = $this->getProcess('php -m');
+        $process->getErrorOutput();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     * @expectedExceptionMessage Process must be started before calling wait
+     */
+    public function testWaitProcessWithoutTimeoutNotStarted()
+    {
+        $process = $this->getProcess('php -m')->setTimeout(null);
+        $process->wait();
+    }
+
     private function verifyPosixIsEnabled()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10022 |
| License | MIT |

This PR replaces #9452 and address the latest changes.
Side note : I've not updated `getExitCode`, `getExitCodeText` and `isSuccessful` as they were explicitly tested to return null in case the process is not started or terminated. I think it would be a BC break to do that.
