### PR TITLE
[IBAN validator] Fixed and improved handling of lowercase values

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Iban.php
+++ b/src/Symfony/Component/Validator/Constraints/Iban.php
@@ -19,4 +19,5 @@ use Symfony\Component\Validator\Constraint;
 class Iban extends Constraint
 {
     public $message = 'This is not a valid International Bank Account Number (IBAN).';
+    public $acceptLowercase = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -30,14 +30,20 @@ class IbanValidator extends ConstraintValidator
             return;
         }
 
+        if ($constraint->acceptLowercase) {
+            $valueToCheck = strtoupper($value);
+        } else {
+            $valueToCheck = $value;
+        }
+
         // An IBAN without a country code is not an IBAN.
-        if (0 === preg_match('/[A-Za-z]/', $value)) {
+        if (0 === preg_match('/[A-Z]/', $valueToCheck)) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return;
         }
 
-        $teststring = preg_replace('/\s+/', '', $value);
+        $teststring = preg_replace('/\s+/', '', $valueToCheck);
 
         if (strlen($teststring) < 4) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
@@ -50,7 +56,7 @@ class IbanValidator extends ConstraintValidator
             .strval(ord($teststring{1}) - 55)
             .substr($teststring, 2, 2);
 
-        $teststring = preg_replace_callback('/[A-Za-z]/', function ($letter) {
+        $teststring = preg_replace_callback('/[A-Z]/', function ($letter) {
             return intval(ord(strtolower($letter[0])) - 87);
         }, $teststring);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10481 |
| License | MIT |

The IBAN validator didn't correctly handle strings with lowercase letters. It seemed to accept lowercase values as well, but actually didn't.

This PR introduces an `acceptLowercase` option which on default is `false` to avoid any BC breaks. If you set it to true, IBAN strings containing lowercase letter will also pass if they are otherwise valid.
