### PR TITLE
[2.3][Process] Remove unreachable code + avoid skipping tests in sigchild environment

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -323,10 +323,6 @@ class Process
         }
 
         if ($this->processInformation['signaled']) {
-            if ($this->isSigchildEnabled()) {
-                throw new RuntimeException('The process has been signaled.');
-            }
-
             throw new RuntimeException(sprintf('The process has been signaled with signal "%s".', $this->processInformation['termsig']));
         }
 
@@ -1188,7 +1184,7 @@ class Process
 
         if (true !== @proc_terminate($this->process, $signal)) {
             if ($throwException) {
-                throw new RuntimeException(sprintf('Error while sending signal `%d`.', $signal));
+                throw new RuntimeException(sprintf('Error while sending signal `%s`.', $signal));
             }
 
             return false;

--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -27,106 +27,123 @@ class SimpleProcessTest extends AbstractProcessTest
 
     public function testGetExitCode()
     {
-        $this->skipIfPHPSigchild();
+        $this->skipIfPHPSigchild(); // This test use exitcode that is not available in this case
         parent::testGetExitCode();
     }
 
     public function testExitCodeCommandFailed()
     {
-        $this->skipIfPHPSigchild();
+        $this->skipIfPHPSigchild(); // This test use exitcode that is not available in this case
         parent::testExitCodeCommandFailed();
     }
 
     public function testProcessIsSignaledIfStopped()
     {
-        $this->skipIfPHPSigchild();
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. Term signal can not be retrieved');
         parent::testProcessIsSignaledIfStopped();
     }
 
     public function testProcessWithTermSignal()
     {
-        $this->skipIfPHPSigchild();
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. Term signal can not be retrieved');
         parent::testProcessWithTermSignal();
     }
 
     public function testProcessIsNotSignaled()
     {
-        $this->skipIfPHPSigchild();
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. Term signal can not be retrieved');
         parent::testProcessIsNotSignaled();
     }
 
     public function testProcessWithoutTermSignal()
     {
-        $this->skipIfPHPSigchild();
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. Term signal can not be retrieved');
         parent::testProcessWithoutTermSignal();
     }
 
     public function testExitCodeText()
     {
-        $this->skipIfPHPSigchild();
+        $this->skipIfPHPSigchild(); // This test use exitcode that is not available in this case
         parent::testExitCodeText();
     }
 
     public function testIsSuccessful()
     {
-        $this->skipIfPHPSigchild();
+        $this->skipIfPHPSigchild(); // This test use PID that is not available in this case
         parent::testIsSuccessful();
     }
 
     public function testIsNotSuccessful()
     {
-        $this->skipIfPHPSigchild();
+        $this->skipIfPHPSigchild(); // This test use PID that is not available in this case
         parent::testIsNotSuccessful();
     }
 
     public function testGetPid()
     {
-        $this->skipIfPHPSigchild();
+        $this->skipIfPHPSigchild(); // This test use PID that is not available in this case
         parent::testGetPid();
     }
 
     public function testGetPidIsNullBeforeStart()
     {
-        $this->skipIfPHPSigchild();
+        $this->skipIfPHPSigchild(); // This test use PID that is not available in this case
         parent::testGetPidIsNullBeforeStart();
     }
 
     public function testGetPidIsNullAfterRun()
     {
-        $this->skipIfPHPSigchild();
+        $this->skipIfPHPSigchild(); // This test use PID that is not available in this case
         parent::testGetPidIsNullAfterRun();
     }
 
     public function testSignal()
     {
-        $this->skipIfPHPSigchild();
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. The process can not be signaled.');
         parent::testSignal();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\LogicException
-     */
+    public function testProcessWithoutTermSignalIsNotSignaled()
+    {
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. Term signal can not be retrieved');
+        parent::testProcessWithoutTermSignalIsNotSignaled();
+    }
+
+    public function testProcessThrowsExceptionWhenExternallySignaled()
+    {
+        $this->skipIfPHPSigchild(); // This test use PID that is not available in this case
+        parent::testProcessThrowsExceptionWhenExternallySignaled();
+    }
+
+    public function testExitCodeIsAvailableAfterSignal()
+    {
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. The process can not be signaled.');
+        parent::testExitCodeIsAvailableAfterSignal();
+    }
+
     public function testSignalProcessNotRunning()
     {
-        $this->skipIfPHPSigchild();
+        $this->setExpectedException('Symfony\Component\Process\Exception\LogicException', 'Can not send signal on a non running process.');
         parent::testSignalProcessNotRunning();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
-     */
     public function testSignalWithWrongIntSignal()
     {
-        $this->skipIfPHPSigchild();
+        if ($this->enabledSigchild) {
+            $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. The process can not be signaled.');
+        } else {
+            $this->setExpectedException('Symfony\Component\Process\Exception\RuntimeException', 'Error while sending signal `-4`.');
+        }
         parent::testSignalWithWrongIntSignal();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
-     */
     public function testSignalWithWrongNonIntSignal()
     {
-        $this->skipIfPHPSigchild();
+        if ($this->enabledSigchild) {
+            $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. The process can not be signaled.');
+        } else {
+            $this->setExpectedException('Symfony\Component\Process\Exception\RuntimeException', 'Error while sending signal `Céphalopodes`.');
+        }
         parent::testSignalWithWrongNonIntSignal();
     }
 
@@ -142,6 +159,13 @@ class SimpleProcessTest extends AbstractProcessTest
     {
         if ($this->enabledSigchild) {
             $this->markTestSkipped('Your PHP has been compiled with --enable-sigchild, this test can not be executed');
+        }
+    }
+
+    private function expectExceptionIfPHPSigchild($classname, $message)
+    {
+        if ($this->enabledSigchild) {
+            $this->setExpectedException($classname, $message);
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

As mentioned by @Tobion in https://github.com/symfony/symfony/pull/10480#issuecomment-38002910, I removed the dead code. I also fixed/updated the test suite on PHP compiled with `--enable-sigchild`.
