### PR TITLE
[2.3][Validator] Minor fix in IBAN validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -31,7 +31,7 @@ class IbanValidator extends ConstraintValidator
         }
 
         // An IBAN without a country code is not an IBAN.
-        if (0 === preg_match('/[A-Za-z]/', $value)) {
+        if (0 === preg_match('/[A-Z]/', $value)) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return;
@@ -50,7 +50,7 @@ class IbanValidator extends ConstraintValidator
             .strval(ord($teststring{1}) - 55)
             .substr($teststring, 2, 2);
 
-        $teststring = preg_replace_callback('/[A-Za-z]/', function ($letter) {
+        $teststring = preg_replace_callback('/[A-Z]/', function ($letter) {
             return intval(ord(strtolower($letter[0])) - 87);
         }, $teststring);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -182,6 +182,10 @@ class IbanValidatorTest extends \PHPUnit_Framework_TestCase
             array('foo'),
             array('123'),
             array('0750447346'),
+
+            //Ibans with lower case values are invalid
+            array('Ae260211000000230064016'),
+            array('ae260211000000230064016')
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10481, #10489 |
| License | MIT |

Added more values to unit tests of IBAN validator to make clear it doesn't accept lower case letters.

> Permitted IBAN characters are the digits 0 to 9 and the 26 upper-case Latin alphabetic characters A to Z.
> http://en.wikipedia.org/wiki/International_Bank_Account_Number

Also made little adjustment to code which meant to validate lowercase letters but actually was useless.
