### PR TITLE
[HttpFoundation] json_encode options

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -95,7 +95,7 @@ class JsonResponse extends Response
      */
     public function setData($data = array())
     {
-        $this->data = @json_encode($data, $this->encodingOptions);
+        $this->data = @json_encode($data, $this->getEncodingOptions());
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new \InvalidArgumentException($this->transformJsonError());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

PR #9915 introduced the possibility to overwrite the options we use while calling `json_encode` - right now, if i want to extend `JsonResponse` i have to call `setEncondingOptions` in my constructor which causes the encoded string to be decoded and re-encoded again (this time using the correct/intended options).

if we would rely on `getEncodingOptions` in the first place, we could save one roundtrip, since my own `JsonResponse` could define `getEncodingOptions` like this:

```
protected function getEncodingOptions()
{
  return parent::getEncodingOptions() | JSON_PRETTY_PRINT;
}
```

and there would be no need to decode & re-encoding the whole thing at all - just because i would want to have pretty printed json.

WDYT?
