### PR TITLE
[WIP][Routing] Extended Expression Language in a routing component

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -27,6 +27,13 @@ class PhpMatcherDumper extends MatcherDumper
     private $expressionLanguage;
 
     /**
+     * @param ExpressionLanguage $expressionLanguage
+     */
+    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null) {
+        $this->expressionLanguage = $expressionLanguage;
+    }
+
+    /**
      * Dumps a set of routes to a PHP class.
      *
      * Available options:

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -29,7 +29,8 @@ class PhpMatcherDumper extends MatcherDumper
     /**
      * @param ExpressionLanguage $expressionLanguage
      */
-    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null) {
+    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null)
+    {
         $this->expressionLanguage = $expressionLanguage;
     }
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -87,6 +87,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     {
         $this->expressionLanguage = $expressionLanguage;
     }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -81,6 +81,12 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     }
 
     /**
+     * @param ExpressionLanguage $expressionLanguage
+     */
+    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null) {
+        $this->expressionLanguage = $expressionLanguage;
+    }
+    /**
      * {@inheritdoc}
      */
     public function match($pathinfo)

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -83,7 +83,8 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     /**
      * @param ExpressionLanguage $expressionLanguage
      */
-    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null) {
+    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null)
+    {
         $this->expressionLanguage = $expressionLanguage;
     }
     /**

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -159,7 +159,8 @@ class Router implements RouterInterface, RequestMatcherInterface
     /**
      * @param ExpressionLanguage $expressionLanguage
      */
-    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null) {
+    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null)
+    {
         $this->expressionLanguage = $expressionLanguage;
     }
     /**
@@ -260,6 +261,7 @@ class Router implements RouterInterface, RequestMatcherInterface
             $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
             if (method_exists($this->matcher,'setExpressionLanguage'))
                 $this->matcher->setExpressionLanguage($this->expressionLanguage);
+
             return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
         }
 
@@ -269,6 +271,7 @@ class Router implements RouterInterface, RequestMatcherInterface
             $dumper = $this->getMatcherDumperInstance();
             if (method_exists($dumper,'setExpressionLanguage'))
                  $dumper->setExpressionLanguage($this->expressionLanguage);
+
             $options = array(
                 'class'      => $class,
                 'base_class' => $this->options['matcher_base_class'],
@@ -282,6 +285,7 @@ class Router implements RouterInterface, RequestMatcherInterface
         $this->matcher = new $class($this->context);
         if (method_exists($this->matcher,'setExpressionLanguage'))
             $this->matcher->setExpressionLanguage($this->expressionLanguage);
+
         return $this->matcher;
     }
 

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -264,7 +264,7 @@ class Router implements RouterInterface, RequestMatcherInterface
                 $this->matcher->setExpressionLanguage($this->expressionLanguage);
             }
 
-            return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
+            return $this->matcher;
         }
 
         $class = $this->options['matcher_cache_class'];

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -163,6 +163,7 @@ class Router implements RouterInterface, RequestMatcherInterface
     {
         $this->expressionLanguage = $expressionLanguage;
     }
+
     /**
      * Gets an option value.
      *
@@ -259,8 +260,9 @@ class Router implements RouterInterface, RequestMatcherInterface
 
         if (null === $this->options['cache_dir'] || null === $this->options['matcher_cache_class']) {
             $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
-            if (method_exists($this->matcher,'setExpressionLanguage'))
+            if (method_exists($this->matcher, 'setExpressionLanguage')) {
                 $this->matcher->setExpressionLanguage($this->expressionLanguage);
+            }
 
             return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
         }
@@ -269,8 +271,9 @@ class Router implements RouterInterface, RequestMatcherInterface
         $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
         if (!$cache->isFresh()) {
             $dumper = $this->getMatcherDumperInstance();
-            if (method_exists($dumper,'setExpressionLanguage'))
+            if (method_exists($dumper, 'setExpressionLanguage')) {
                  $dumper->setExpressionLanguage($this->expressionLanguage);
+            }
 
             $options = array(
                 'class'      => $class,
@@ -283,8 +286,9 @@ class Router implements RouterInterface, RequestMatcherInterface
         require_once $cache;
 
         $this->matcher = new $class($this->context);
-        if (method_exists($this->matcher,'setExpressionLanguage'))
-            $this->matcher->setExpressionLanguage($this->expressionLanguage);
+        if (method_exists($this->matcher, 'setExpressionLanguage')){
+             $this->matcher->setExpressionLanguage($this->expressionLanguage);
+        }
 
         return $this->matcher;
     }

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -286,7 +286,7 @@ class Router implements RouterInterface, RequestMatcherInterface
         require_once $cache;
 
         $this->matcher = new $class($this->context);
-        if (method_exists($this->matcher, 'setExpressionLanguage')){
+        if (method_exists($this->matcher, 'setExpressionLanguage')) {
              $this->matcher->setExpressionLanguage($this->expressionLanguage);
         }
 

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -272,7 +272,7 @@ class Router implements RouterInterface, RequestMatcherInterface
         if (!$cache->isFresh()) {
             $dumper = $this->getMatcherDumperInstance();
             if (method_exists($dumper, 'setExpressionLanguage')) {
-                 $dumper->setExpressionLanguage($this->expressionLanguage);
+                $dumper->setExpressionLanguage($this->expressionLanguage);
             }
 
             $options = array(
@@ -287,7 +287,7 @@ class Router implements RouterInterface, RequestMatcherInterface
 
         $this->matcher = new $class($this->context);
         if (method_exists($this->matcher, 'setExpressionLanguage')) {
-             $this->matcher->setExpressionLanguage($this->expressionLanguage);
+            $this->matcher->setExpressionLanguage($this->expressionLanguage);
         }
 
         return $this->matcher;

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Routing;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\ConfigCache;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface;
@@ -69,6 +70,11 @@ class Router implements RouterInterface, RequestMatcherInterface
      * @var LoggerInterface|null
      */
     protected $logger;
+
+    /**
+     * @var ExpressionLanguage|null
+     */
+    private $expressionLanguage;
 
     /**
      * Constructor.
@@ -150,6 +156,12 @@ class Router implements RouterInterface, RequestMatcherInterface
         $this->options[$key] = $value;
     }
 
+    /**
+     * @param ExpressionLanguage $expressionLanguage
+     */
+    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null) {
+        $this->expressionLanguage = $expressionLanguage;
+    }
     /**
      * Gets an option value.
      *
@@ -245,6 +257,9 @@ class Router implements RouterInterface, RequestMatcherInterface
         }
 
         if (null === $this->options['cache_dir'] || null === $this->options['matcher_cache_class']) {
+            $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
+            if (method_exists($this->matcher,'setExpressionLanguage'))
+                $this->matcher->setExpressionLanguage($this->expressionLanguage);
             return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
         }
 
@@ -252,7 +267,8 @@ class Router implements RouterInterface, RequestMatcherInterface
         $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
         if (!$cache->isFresh()) {
             $dumper = $this->getMatcherDumperInstance();
-
+            if (method_exists($dumper,'setExpressionLanguage'))
+                 $dumper->setExpressionLanguage($this->expressionLanguage);
             $options = array(
                 'class'      => $class,
                 'base_class' => $this->options['matcher_base_class'],
@@ -263,7 +279,10 @@ class Router implements RouterInterface, RequestMatcherInterface
 
         require_once $cache;
 
-        return $this->matcher = new $class($this->context);
+        $this->matcher = new $class($this->context);
+        if (method_exists($this->matcher,'setExpressionLanguage'))
+            $this->matcher->setExpressionLanguage($this->expressionLanguage);
+        return $this->matcher;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | not yet |
- [ ] add tests
- [ ] add docs
- [x] gather feedback for my changes

A new expression language engine in a routing component can't extended with new custom functions, in my project i need custom function in a route condition.

with this patch and a custom compilerpass in my bundle i can added my custom function (version_compare of php).
this feature work with symfony/routing >= 2.4

``` php
class OverrideServiceCompilerPass implements CompilerPassInterface
{
    public function process(ContainerBuilder $container){


        $definition = $container->getDefinition('router.default');

        $definition->addMethodCall('setExpressionLanguage',array(new Reference('examplebundle.routing_expression_language')));

    }
} 
```

a code of examplebundle.routing_expression_language is here:

``` php
class NewExpressionLanguage extends ExpressionLanguage
{

    protected function registerFunctions()
    {
        parent::registerFunctions();

        $this->register('compare', function ($version1, $version2, $operator) {
            return sprintf('version_compare(%s, %s, %s)', $version1, $version2, $operator);
        }, function (array $values, $version1, $version2, $operator) {
            return version_compare($version1, $version2, $operator);
        });
    }

}
```
