### PR TITLE
[Debug] Check headers sent before sending PHP response

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -91,9 +91,11 @@ class ExceptionHandler
             $exception = FlattenException::create($exception);
         }
 
-        header(sprintf('HTTP/1.0 %s', $exception->getStatusCode()));
-        foreach ($exception->getHeaders() as $name => $value) {
-            header($name.': '.$value, false);
+        if (!headers_sent()) {
+            header(sprintf('HTTP/1.0 %s', $exception->getStatusCode()));
+            foreach ($exception->getHeaders() as $name => $value) {
+                header($name.': '.$value, false);
+            }
         }
 
         echo $this->decorate($this->getContent($exception), $this->getStylesheet($exception));


### PR DESCRIPTION
If the response contents has been sent before an error occurs, PHP triggers the warning "Cannot modify header information - headers already sent".

This change ensure that the useful error message is echoed, while it's impossible to change the HTTP status code and headers.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
