### PR TITLE
[Process] Do not show output in FailedException if it was disabled

### DIFF
--- a/src/Symfony/Component/Process/Exception/ProcessFailedException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessFailedException.php
@@ -28,16 +28,20 @@ class ProcessFailedException extends RuntimeException
             throw new InvalidArgumentException('Expected a failed process, but the given process was successful.');
         }
 
-        parent::__construct(
-            sprintf(
-                'The command "%s" failed.'."\nExit Code: %s(%s)\n\nOutput:\n================\n%s\n\nError Output:\n================\n%s",
-                $process->getCommandLine(),
-                $process->getExitCode(),
-                $process->getExitCodeText(),
+        $error = sprintf('The command "%s" failed.'."\nExit Code: %s(%s)",
+            $process->getCommandLine(),
+            $process->getExitCode(),
+            $process->getExitCodeText()
+        );
+
+        if (!$process->isOutputDisabled()) {
+            $error .= sprintf("\n\nOutput:\n================\n%s\n\nError Output:\n================\n%s",
                 $process->getOutput(),
                 $process->getErrorOutput()
-            )
-        );
+            );
+        }
+
+        parent::__construct($error);
 
         $this->process = $process;
     }

--- a/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
@@ -54,29 +54,82 @@ class ProcessFailedExceptionTest extends \PHPUnit_Framework_TestCase
 
         $process = $this->getMock(
             'Symfony\Component\Process\Process',
-            array('isSuccessful', 'getOutput', 'getErrorOutput', 'getExitCode', 'getExitCodeText'),
+            array('isSuccessful', 'getOutput', 'getErrorOutput', 'getExitCode', 'getExitCodeText', 'isOutputDisabled'),
             array($cmd)
         );
         $process->expects($this->once())
             ->method('isSuccessful')
             ->will($this->returnValue(false));
+
         $process->expects($this->once())
             ->method('getOutput')
             ->will($this->returnValue($output));
+
         $process->expects($this->once())
             ->method('getErrorOutput')
             ->will($this->returnValue($errorOutput));
+
         $process->expects($this->once())
             ->method('getExitCode')
             ->will($this->returnValue($exitCode));
+
         $process->expects($this->once())
             ->method('getExitCodeText')
             ->will($this->returnValue($exitText));
+
+        $process->expects($this->once())
+            ->method('isOutputDisabled')
+            ->will($this->returnValue(false));
 
         $exception = new ProcessFailedException($process);
 
         $this->assertEquals(
             "The command \"$cmd\" failed.\nExit Code: $exitCode($exitText)\n\nOutput:\n================\n{$output}\n\nError Output:\n================\n{$errorOutput}",
+            $exception->getMessage()
+        );
+    }
+
+    /**
+     * Tests that ProcessFailedException does not extract information from
+     * process output if it was previously disabled
+     */
+    public function testDisabledOutputInFailedExceptionDoesNotPopulateOutput()
+    {
+        $cmd = 'php';
+        $exitCode = 1;
+        $exitText = 'General error';
+
+        $process = $this->getMock(
+            'Symfony\Component\Process\Process',
+            array('isSuccessful', 'isOutputDisabled', 'getExitCode', 'getExitCodeText', 'getOutput', 'getErrorOutput'),
+            array($cmd)
+        );
+        $process->expects($this->once())
+            ->method('isSuccessful')
+            ->will($this->returnValue(false));
+
+        $process->expects($this->never())
+            ->method('getOutput');
+
+        $process->expects($this->never())
+            ->method('getErrorOutput');
+
+        $process->expects($this->once())
+            ->method('getExitCode')
+            ->will($this->returnValue($exitCode));
+
+        $process->expects($this->once())
+            ->method('getExitCodeText')
+            ->will($this->returnValue($exitText));
+
+        $process->expects($this->once())
+            ->method('isOutputDisabled')
+            ->will($this->returnValue(true));
+
+        $exception = new ProcessFailedException($process);
+
+        $this->assertEquals(
+            "The command \"$cmd\" failed.\nExit Code: $exitCode($exitText)",
             $exception->getMessage()
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

With the recent addition of the ability to disable the output, it was not taken into account within the `ProcessFailedException`. 

So, if the output was indeed disabled, and the process returns an error and triggers a `ProcessFailedException` exception (i.e via a mustRun), we could have another LogicException which is not  expected.
