### PR TITLE
[SwiftMailer] [MonologBundle] send error log mails from CLI

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Handler;
 
 use Monolog\Handler\SwiftMailerHandler as BaseSwiftMailerHandler;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 
 /**
@@ -39,6 +40,16 @@ class SwiftMailerHandler extends BaseSwiftMailerHandler
      * @param PostResponseEvent $event
      */
     public function onKernelTerminate(PostResponseEvent $event)
+    {
+        $this->instantFlush = true;
+    }
+
+    /**
+     * After the CLI application has been terminated we will always flush messages
+     *
+     * @param ConsoleTerminateEvent $event
+     */
+    public function onCliTerminate(ConsoleTerminateEvent $event)
     {
         $this->instantFlush = true;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Given I have symfony2 application with Monolog configured to send mail on error logs.
When I have exception thrown from CLI task
Then I should receive error mail

However this is not true because `Monolog/SwiftMailerHandler` is doing force flush only on `kernel.terminate`, but not on `console.terminate`

This PR fixes issue together with https://github.com/symfony/MonologBundle/pull/73
