### PR TITLE
Avoid levenshtein comparison when using ContainerBuilder.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -75,7 +75,6 @@ class Container implements IntrospectableContainerInterface
     protected $scopedServices = array();
     protected $scopeStacks = array();
     protected $loading = array();
-    protected $levenshtein = true;
 
     /**
      * Constructor.
@@ -294,12 +293,10 @@ class Container implements IntrospectableContainerInterface
                 }
 
                 $alternatives = array();
-                if ($this->levenshtein) {
-                    foreach (array_keys($this->services) as $key) {
-                        $lev = levenshtein($id, $key);
-                        if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {
-                            $alternatives[] = $key;
-                        }
+                foreach (array_keys($this->services) as $key) {
+                    $lev = levenshtein($id, $key);
+                    if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {
+                        $alternatives[] = $key;
                     }
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -75,6 +75,7 @@ class Container implements IntrospectableContainerInterface
     protected $scopedServices = array();
     protected $scopeStacks = array();
     protected $loading = array();
+    protected $levenshtein = true;
 
     /**
      * Constructor.
@@ -293,10 +294,12 @@ class Container implements IntrospectableContainerInterface
                 }
 
                 $alternatives = array();
-                foreach (array_keys($this->services) as $key) {
-                    $lev = levenshtein($id, $key);
-                    if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {
-                        $alternatives[] = $key;
+                if ($levenshtein) {
+                    foreach (array_keys($this->services) as $key) {
+                        $lev = levenshtein($id, $key);
+                        if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {
+                            $alternatives[] = $key;
+                        }
                     }
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -294,7 +294,7 @@ class Container implements IntrospectableContainerInterface
                 }
 
                 $alternatives = array();
-                if ($levenshtein) {
+                if ($this->levenshtein) {
                     foreach (array_keys($this->services) as $key) {
                         $lev = levenshtein($id, $key);
                         if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -461,43 +461,41 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         $id = strtolower($id);
         if ($service = parent::get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE)) {
           return $service;
-        } else {
-            if (isset($this->loading[$id])) {
-                throw new LogicException(sprintf('The service "%s" has a circular reference to itself.', $id), 0, $e);
+        if (isset($this->loading[$id])) {
+            throw new LogicException(sprintf('The service "%s" has a circular reference to itself.', $id), 0, $e);
+        }
+
+        if (!$this->hasDefinition($id) && isset($this->aliasDefinitions[$id])) {
+            return $this->get($this->aliasDefinitions[$id]);
+        }
+
+        try {
+            $definition = $this->getDefinition($id);
+        } catch (InvalidArgumentException $e) {
+            if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
+                return null;
             }
 
-            if (!$this->hasDefinition($id) && isset($this->aliasDefinitions[$id])) {
-                return $this->get($this->aliasDefinitions[$id]);
-            }
+            throw $e;
+        }
 
-            try {
-                $definition = $this->getDefinition($id);
-            } catch (InvalidArgumentException $e) {
-                if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
-                    return null;
-                }
+        $this->loading[$id] = true;
 
-                throw $e;
-            }
-
-            $this->loading[$id] = true;
-
-            try {
-                $service = $this->createService($definition, $id);
-            } catch (\Exception $e) {
-                unset($this->loading[$id]);
-
-                if ($e instanceof InactiveScopeException && self::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
-                    return null;
-                }
-
-                throw $e;
-            }
-
+        try {
+            $service = $this->createService($definition, $id);
+        } catch (\Exception $e) {
             unset($this->loading[$id]);
 
-            return $service;
+            if ($e instanceof InactiveScopeException && self::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
+                return null;
+            }
+
+            throw $e;
         }
+
+        unset($this->loading[$id]);
+
+        return $service;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -461,8 +461,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         $id = strtolower($id);
         if ($service = parent::get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE)) {
           return $service;
-        }
-        else {
+        } else {
             if (isset($this->loading[$id])) {
                 throw new LogicException(sprintf('The service "%s" has a circular reference to itself.', $id), 0, $e);
             }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -84,6 +84,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     private $expressionLanguage;
 
+    protected $levenshtein = false;
+
     /**
      * Sets the track resources flag.
      *

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -84,8 +84,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     private $expressionLanguage;
 
-    protected $levenshtein = false;
-
     /**
      * Sets the track resources flag.
      *
@@ -461,16 +459,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     public function get($id, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
     {
         $id = strtolower($id);
-
-        try {
-            return parent::get($id, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
-        } catch (InactiveScopeException $e) {
-            if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
-                return null;
-            }
-
-            throw $e;
-        } catch (InvalidArgumentException $e) {
+        if ($service = parent::get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE)) {
+          return $service;
+        }
+        else {
             if (isset($this->loading[$id])) {
                 throw new LogicException(sprintf('The service "%s" has a circular reference to itself.', $id), 0, $e);
             }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -461,6 +461,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         $id = strtolower($id);
         if ($service = parent::get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE)) {
           return $service;
+        }
         if (isset($this->loading[$id])) {
             throw new LogicException(sprintf('The service "%s" has a circular reference to itself.', $id), 0, $e);
         }


### PR DESCRIPTION
[DependencyInjection] ContainerBuilder catches exceptions when a service isn't found by Container::get().

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

In the process of building the exception message, I saw over 13k calls to levenshtein() when profiling a Drupal request where there's no compiled container yet, this adds around 36ms+ to the request for the function calls themselves, more for the overall logic.

Made the levenshtein calls optional based on a property on the class, then ContainerBuilder can set that to false and skip the suggestions.

![lev-before](https://f.cloud.github.com/assets/116285/2525110/d6dd3a90-b4eb-11e3-934a-a3726e0f8f09.png)
![lev-after](https://f.cloud.github.com/assets/116285/2525114/dd2de0fc-b4eb-11e3-8df0-598cadf2286b.png)
