### PR TITLE
[DependencyInjection] Fixed YamlFileLoader imports path

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -51,7 +51,7 @@ class YamlFileLoader extends FileLoader
         }
 
         // imports
-        $this->parseImports($content, $file);
+        $this->parseImports($content, $path);
 
         // parameters
         if (isset($content['parameters'])) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services4.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services4.yml
@@ -1,6 +1,7 @@
 imports:
     - { resource: services2.yml }
     - { resource: services3.yml }
+    - { resource: "../php/simple.php" }
     - { resource: "../ini/parameters.ini", class: Symfony\Component\DependencyInjection\Loader\IniFileLoader }
     - { resource: "../ini/parameters2.ini" }
     - { resource: "../xml/services13.xml" }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\FileLocator;
 
@@ -93,6 +94,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $resolver = new LoaderResolver(array(
             new IniFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml')),
             new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml')),
+            new PhpFileLoader($container, new FileLocator(self::$fixturesPath.'/php')),
             $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml')),
         ));
         $loader->setResolver($resolver);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10516 |
| License | MIT |
| Doc PR | http://symfony.com/doc/current/book/service_container.html#importing-configuration-with-imports |

YamlFileLoader used the resource name as the current directory during import, which can cause a failed import when using a relative path. Using the $path variable output from the locator is consistent with other loaders and fixes the bug.
