### PR TITLE
[Form] Fixed bug in ChoiceType triggering a warning when not using utf-8

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -166,7 +166,7 @@ class ChoiceType extends AbstractType
             $choices = null !== $options['choices'] ? $options['choices'] : array();
 
             // Reuse existing choice lists in order to increase performance
-            $hash = hash('sha256', json_encode(array($choices, $options['preferred_choices'])));
+            $hash = hash('sha256', serialize(array($choices, $options['preferred_choices'])));
 
             if (!isset($choiceListCache[$hash])) {
                 $choiceListCache[$hash] = new SimpleChoiceList($choices, $options['preferred_choices']);


### PR DESCRIPTION
[Form] [Extension] [ChoiceType] This fixes issue #10409 by not using json_encode() anymore, but serialize() instead. See issue for more information or this forum post I found: 
http://forum.symfony-project.org/viewtopic.php?f=23&t=70133

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10409 |
| License | MIT |
| Doc PR | N/A |
