### PR TITLE
fixed the profiler when an uncalled listener throws an exception when instantiated

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -36,9 +36,9 @@
         {% endfor %}
     </table>
 
-    {% if collector.notcalledlisteners %}
-        <h2>Not Called Listeners</h2>
+    <h2>Not Called Listeners</h2>
 
+    {% if collector.notcalledlisteners %}
         <table>
             <tr>
                 <th>Event name</th>
@@ -52,6 +52,17 @@
                 </tr>
             {% endfor %}
         </table>
+    {% else %}
+        <p>
+            <strong>No uncalled listeners</strong>.
+        </p>
+        <p>
+
+            All listeners were called for this request or an error occurred
+            when trying to collect uncalled listeners (in which case check the
+            logs to get more information).
+
+        </p>
     {% endif %}
 {% endblock %}
 

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -160,9 +160,19 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
      */
     public function getNotCalledListeners()
     {
-        $notCalled = array();
+        try {
+            $allListeners = $this->getListeners();
+        } catch (\Exception $e) {
+            if (null !== $this->logger) {
+                $this->logger->info(sprintf('An exception was thrown while getting the uncalled listeners (%s)', $e->getMessage()), array('exception' => $e));
+            }
 
-        foreach ($this->getListeners() as $name => $listeners) {
+            // unable to retrieve the uncalled listeners
+            return array();
+        }
+
+        $notCalled = array();
+        foreach ($allListeners as $name => $listeners) {
             foreach ($listeners as $listener) {
                 $info = $this->getListenerInfo($listener, null, $name);
                 if (!isset($this->called[$name.'.'.$info['pretty']])) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10371 |
| License | MIT |
| Doc PR | n/a |

When the profiler gets the uncalled listeners, the current page is broken without a very clear message. That happens when a listener is a service that depends for instance on the request; creating this service throws an exception.

After this patch, if we cannot get the listeners, we give up and add a log message about the problem (the error message is an info as the problem is not really related to the toolbar but more about how things work).
