### PR TITLE
[Validator][Email] - When standalone "Fatal error: Class 'validator.email' not found"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -73,7 +73,7 @@
 
         <service id="validator.email" class="%validator.email.class%">
             <argument></argument>
-            <tag name="validator.constraint_validator" alias="validator.email" />
+            <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -26,12 +26,4 @@ class Email extends Constraint
     public $checkMX = false;
     public $checkHost = false;
     public $strict = null;
-
-    /**
-     * {@inheritDoc}
-     */
-    public function validatedBy()
-    {
-        return 'validator.email';
-    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/silexphp/Silex/issues/932 |
| License | MIT |
| Doc PR | no |

When using the validator as an standalone component a bug was introduced by overriding the `validatedBy()` method in the `Email` constraint.
This PR removes the override and implements a way for the DI to get the right validator.

Another way would be modifying the definition of validator to change the alias instead of having the FQCN in the xml
