### PR TITLE
[2.3] Use `Filesystem::chmod` instead of `chmod` when dumping file

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CompilerDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CompilerDebugDumpPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 class CompilerDebugDumpPass implements CompilerPassInterface
@@ -24,8 +25,11 @@ class CompilerDebugDumpPass implements CompilerPassInterface
 
         $filesystem = new Filesystem();
         $filesystem->dumpFile($filename, implode("\n", $container->getCompiler()->getLog()), null);
-        // discard chmod failure (some filesystem may not support it)
-        @chmod($filename, 0666 & ~umask());
+        try {
+            $filesystem->chmod($filename, 0666, umask());
+        } catch (IOException $e) {
+            // discard chmod failure (some filesystem may not support it)
+        }
     }
 
     public static function getCompilerLogFilename(ContainerInterface $container)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\XmlDumper;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -31,7 +32,10 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
         $filename = $container->getParameter('debug.container.dump');
         $filesystem = new Filesystem();
         $filesystem->dumpFile($filename, $dumper->dump(), null);
-        // discard chmod failure (some filesystem may not support it)
-        @chmod($filename, 0666 & ~umask());
+        try {
+            $filesystem->chmod($filename, 0666, umask());
+        } catch (IOException $e) {
+            // discard chmod failure (some filesystem may not support it)
+        }
     }
 }

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config;
 
 use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -93,14 +94,23 @@ class ConfigCache
      */
     public function write($content, array $metadata = null)
     {
-        $mode = 0666 & ~umask();
+        $mode = 0666;
+        $umask = umask();
         $filesystem = new Filesystem();
         $filesystem->dumpFile($this->file, $content, null);
-        @chmod($this->file, $mode);
+        try {
+            $filesystem->chmod($this->file, $mode, $umask);
+        } catch (IOException $e) {
+            // discard chmod failure (some filesystem may not support it)
+        }
 
         if (null !== $metadata && true === $this->debug) {
             $filesystem->dumpFile($this->getMetaFile(), serialize($metadata), null);
-            @chmod($this->getMetaFile(), $mode);
+            try {
+                $filesystem->chmod($this->getMetaFile(), $mode, $umask);
+            } catch (IOException $e) {
+                // discard chmod failure (some filesystem may not support it)
+            }
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This adds consistency as discussed in https://github.com/symfony/symfony/commit/ca5eea5c1922688685d104f962bc5d16626ce05d#commitcomment-5804089
