### PR TITLE
[WIP]REFS #10487 - [Console] Fixed Options arguments behaviour

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -938,7 +938,7 @@ class Application
 
             new InputOption('--help',           '-h', InputOption::VALUE_NONE, 'Display this help message.'),
             new InputOption('--quiet',          '-q', InputOption::VALUE_NONE, 'Do not output any message.'),
-            new InputOption('--verbose',        '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
+            new InputOption('--verbose',        '-v|vv|vvv', InputOption::VALUE_OPTIONAL, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version',        '-V', InputOption::VALUE_NONE, 'Display this application version.'),
             new InputOption('--ansi',           '',   InputOption::VALUE_NONE, 'Force ANSI output.'),
             new InputOption('--no-ansi',        '',   InputOption::VALUE_NONE, 'Disable ANSI output.'),

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -227,14 +227,16 @@ class ArgvInput extends Input
         if (null === $value && $option->acceptValue() && count($this->parsed)) {
             // if option accepts an optional or mandatory argument
             // let's see if there is one provided
-            $next = array_shift($this->parsed);
-            if (isset($next[0]) && '-' !== $next[0]) {
-                $value = $next;
-            } elseif (empty($next)) {
-                $value = '';
-            } else {
-                array_unshift($this->parsed, $next);
-            }
+            /* [This code should not be used]
+                $next = array_shift($this->parsed);
+                if (isset($next[0]) && '-' !== $next[0]) {
+                    $value = $next;
+                } elseif (empty($next)) {
+                    $value = '';
+                } else {
+                    array_unshift($this->parsed, $next);
+                }
+            */
         }
 
         if (null === $value) {
@@ -313,7 +315,7 @@ class ArgvInput extends Input
         $tokens = $this->tokens;
         while ($token = array_shift($tokens)) {
             foreach ($values as $value) {
-                if ($token === $value || 0 === strpos($token, $value.'=')) {
+                if (substr($token, 0, strpos($token, '=')) === $value || 0 === strpos($token, $value.'=')) {
                     if (false !== $pos = strpos($token, '=')) {
                         return substr($token, $pos + 1);
                     }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -638,6 +638,20 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->run($input, $output);
     }
 
+    public function testVerboseLongValueInArgv()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->add(new \FooCommand());
+
+        $output = new StreamOutput(fopen('php://memory', 'w', false));
+
+        $input = new ArgvInput(array('cli.php', '--verbose=3', 'foo:bar'));
+        $application->run($input, $output);
+        $this->assertEquals(Output::VERBOSITY_DEBUG, $output->getVerbosity());
+    }
+
     public function testRunReturnsIntegerExitCode()
     {
         $exception = new \Exception('', 4);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #10487, #9576 |
| License | MIT |
| Doc PR | no |

Hi,

I'm actualy working on it.
The main problem is that we can actualy do:
`php app/console --foo bar` and foo value is bar.

This behavior is not correct with the actual documentation: http://symfony.com/doc/2.3/components/console/introduction.html#using-command-arguments

The options values should be passed with the `=` operator and don't accept "space" notation described before.

That's why a call like `php app/console -v foo bar` crashes becauses the actual behavior try to use the next arguments as a value for the current option.

So... do we have to fix the behavior on `verbose` or remove the "space" notation ?

Regards,
