### PR TITLE
[PropertyAccessor] Wrong number of parameters

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -570,7 +570,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     }
 
     /**
-     * Returns whether a method is public and has a specific number of required parameters.
+     * Returns whether a method is public and has the number of required parameters.
      *
      * @param  \ReflectionClass $class      The class of the method
      * @param  string           $methodName The method name
@@ -584,7 +584,9 @@ class PropertyAccessor implements PropertyAccessorInterface
         if ($class->hasMethod($methodName)) {
             $method = $class->getMethod($methodName);
 
-            if ($method->isPublic() && $method->getNumberOfRequiredParameters() === $parameters) {
+            if ($method->isPublic()
+                && $method->getNumberOfRequiredParameters() <= $parameters
+                && $method->getNumberOfParameters() >= $parameters) {
                 return true;
             }
         }

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
@@ -18,6 +18,9 @@ class TestClass
     private $privateProperty;
 
     private $publicAccessor;
+    private $publicAccessorWithDefaultValue;
+    private $publicAccessorWithRequiredAndDefaultValue;
+    private $publicAccessorWithMoreRequiredParameters;
     private $publicIsAccessor;
     private $publicHasAccessor;
 
@@ -25,6 +28,9 @@ class TestClass
     {
         $this->publicProperty = $value;
         $this->publicAccessor = $value;
+        $this->publicAccessorWithDefaultValue = $value;
+        $this->publicAccessorWithRequiredAndDefaultValue = $value;
+        $this->publicAccessorWithMoreRequiredParameters = $value;
         $this->publicIsAccessor = $value;
         $this->publicHasAccessor = $value;
     }
@@ -34,9 +40,39 @@ class TestClass
         $this->publicAccessor = $value;
     }
 
+    public function setPublicAccessorWithDefaultValue($value = null)
+    {
+        $this->publicAccessorWithDefaultValue = $value;
+    }
+
+    public function setPublicAccessorWithRequiredAndDefaultValue($value, $optional = null)
+    {
+        $this->publicAccessorWithRequiredAndDefaultValue = $value;
+    }
+
+    public function setPublicAccessorWithMoreRequiredParameters($value, $needed)
+    {
+        $this->publicAccessorWithMoreRequiredParameters = $value;
+    }
+
     public function getPublicAccessor()
     {
         return $this->publicAccessor;
+    }
+
+    public function getPublicAccessorWithDefaultValue()
+    {
+        return $this->publicAccessorWithDefaultValue;
+    }
+
+    public function getPublicAccessorWithRequiredAndDefaultValue()
+    {
+        return $this->publicAccessorWithRequiredAndDefaultValue;
+    }
+
+    public function getPublicAccessorWithMoreRequiredParameters()
+    {
+        return $this->publicAccessorWithMoreRequiredParameters;
     }
 
     public function setPublicIsAccessor($value)

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -43,6 +43,8 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
             // Accessor methods
             array(new TestClass('Bernhard'), 'publicProperty', 'Bernhard'),
             array(new TestClass('Bernhard'), 'publicAccessor', 'Bernhard'),
+            array(new TestClass('Bernhard'), 'publicAccessorWithDefaultValue', 'Bernhard'),
+            array(new TestClass('Bernhard'), 'publicAccessorWithRequiredAndDefaultValue', 'Bernhard'),
             array(new TestClass('Bernhard'), 'publicIsAccessor', 'Bernhard'),
             array(new TestClass('Bernhard'), 'publicHasAccessor', 'Bernhard'),
 
@@ -248,6 +250,14 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->propertyAccessor->setValue($author, 'magicProperty', 'Updated');
 
         $this->assertEquals('Updated', $author->__get('magicProperty'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     */
+    public function testSetValueThrowsExceptionIfThereAreMissingParameters()
+    {
+        $this->propertyAccessor->setValue(new TestClass('Bernhard'), 'publicAccessorWithMoreRequiredParameters', 'Updated');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Since [6d2af217aafd03e3f1600ce0ebc9c30cf0a7fc70#diff-3e45cf556c0330623c0167841d303dff](https://github.com/symfony/symfony/commit/6d2af217aafd03e3f1600ce0ebc9c30cf0a7fc70#diff-3e45cf556c0330623c0167841d303dff) the PropertyAccessor is failing on setters with default values because  [ReflectionFunctionAbstract::getNumberOfRequiredParameters](http://www.php.net/manual/es/reflectionfunctionabstract.getnumberofparameters.php) only count the parameters without default values.
