### PR TITLE
[ExpressionLanguage] Strict in_array check in Parser.php

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -190,7 +190,7 @@ class Parser
 
                             $node = new Node\FunctionNode($token->value, $this->parseArguments());
                         } else {
-                            if (!in_array($token->value, $this->names)) {
+                            if (!in_array($token->value, $this->names, true)) {
                                 throw new SyntaxError(sprintf('Variable "%s" is not valid', $token->value), $token->cursor);
                             }
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -29,6 +29,17 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException        \Symfony\Component\ExpressionLanguage\SyntaxError
+     * @expectedExceptionMessage Variable "foo" is not valid around position 1.
+     */
+    public function testParseWithZeroInNames()
+    {
+        $lexer = new Lexer();
+        $parser = new Parser(array());
+        $parser->parse($lexer->tokenize('foo'), array(0));
+    }
+
+    /**
      * @dataProvider getParseData
      */
     public function testParse($node, $expression, $names = array())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Otherwise it doesn't throw an exception for the cases when passed parameters array includes zero key (and that will result in the PHP Notice down the road).
