### PR TITLE
bug #10612 [Debug] Always ignore error_reporting value

### DIFF
--- a/src/Symfony/Component/Debug/Debug.php
+++ b/src/Symfony/Component/Debug/Debug.php
@@ -39,9 +39,10 @@ class Debug
 
         static::$enabled = true;
 
+        ErrorHandler::register($errorReportingLevel, $displayErrors);
+
         error_reporting(-1);
 
-        ErrorHandler::register($errorReportingLevel, $displayErrors);
         if ('cli' !== php_sapi_name()) {
             ExceptionHandler::register();
         // CLI - display errors only if they're not already logged to STDERR


### PR DESCRIPTION
## Discussion

[Debug] Always ignore error_reporting value

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | symfony/symfony#10612 |
| License | MIT |
| Doc PR | no |

Debug component ignored error_reporting from php.ini.
