### PR TITLE
[OptionsResolver] Implemented policies for treating unknown/missing options

### DIFF
--- a/UPGRADE-2.5.md
+++ b/UPGRADE-2.5.md
@@ -45,6 +45,38 @@ Form
    {
    ```
 
+OptionsResolver
+---------------
+
+ * A new parameter `$flags` was added to `OptionsResolverInterface::resolve()`.
+   The parameter takes a bitwise combination of the new flag constants in that
+   interface.
+
+   If you implement the interface in your code, you should add the parameter as
+   well.
+
+   Before:
+
+   ```
+   public function resolve(array $options = array())
+   {
+       // ...
+   }
+   ```
+
+   After:
+
+   ```
+   public function resolve(array $options = array(), $flags = 0)
+   {
+       if ($flags & self::FORBID_UNKNOWN) {
+           // ...
+       }
+
+       // ...
+   }
+   ```
+
 Validator
 ---------
 
@@ -56,7 +88,7 @@ Validator
 
    After:
 
-   Default email validation is now done via a simple regex which may cause invalid emails (not RFC compilant) to be 
+   Default email validation is now done via a simple regex which may cause invalid emails (not RFC compilant) to be
    valid. This is the default behaviour.
 
    Strict email validation has to be explicitly activated in the configuration file by adding

--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -4,5 +4,6 @@ CHANGELOG
 2.5.0
 -----
 
+ * [BC BREAK] added parameter $flags to OptionsResolverInterface::resolve()
  * added flags FORBID_UNKNOWN, REMOVE_UNKNOWN, IGNORE_UNKNOWN, FORBID_MISSING
    and IGNORE_MISSING to OptionsResolverInterface

--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,0 +1,8 @@
+CHANGELOG
+=========
+
+2.5.0
+-----
+
+ * added flags FORBID_UNKNOWN, REMOVE_UNKNOWN, IGNORE_UNKNOWN, FORBID_MISSING
+   and IGNORE_MISSING to OptionsResolverInterface

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -224,10 +224,6 @@ class OptionsResolver implements OptionsResolverInterface
             $flags |= self::FORBID_MISSING;
         }
 
-        if (($flags & self::REMOVE_UNKNOWN) && ($flags & self::IGNORE_UNKNOWN)) {
-            throw new \InvalidArgumentException('self::REMOVE_UNKNOWN and self::IGNORE_UNKNOWN are mutually exclusive');
-        }
-
         if ($flags & self::FORBID_UNKNOWN) {
             $this->validateOptionsExistence($options);
         } elseif ($flags & self::REMOVE_UNKNOWN) {

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -234,7 +234,7 @@ class OptionsResolver implements OptionsResolverInterface
             $options = array_intersect_key($options, $this->knownOptions);
         }
 
-        if  ($flags & self::FORBID_MISSING) {
+        if ($flags & self::FORBID_MISSING) {
             $this->validateOptionsCompleteness($options);
         }
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -17,6 +17,18 @@ namespace Symfony\Component\OptionsResolver;
 interface OptionsResolverInterface
 {
     /**
+     * Remove unknown options passed to the resolve() method
+     * Is mutually exclusive with IGNORE_UNKNOWN
+     */
+    const REMOVE_UNKNOWN = 1;
+
+    /**
+     * Ignore unknown options passed to the resolve() method
+     * Is mutually exclusive with REMOVE_UNKNOWN
+     */
+    const IGNORE_UNKNOWN = 2;
+
+    /**
      * Sets default option values.
      *
      * The options can either be values of any types or closures that
@@ -196,6 +208,7 @@ interface OptionsResolverInterface
      * Returns the combination of the default and the passed options.
      *
      * @param array $options The custom option values.
+     * @param int   $flags   Can be REMOVE_UNKNOWN or IGNORE_UNKNOWN
      *
      * @return array A list of options and their values.
      *
@@ -206,5 +219,5 @@ interface OptionsResolverInterface
      * @throws Exception\OptionDefinitionException If a cyclic dependency is detected
      *                                             between two lazy options.
      */
-    public function resolve(array $options = array());
+    public function resolve(array $options = array(), $flags = 0);
 }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -17,16 +17,29 @@ namespace Symfony\Component\OptionsResolver;
 interface OptionsResolverInterface
 {
     /**
-     * Remove unknown options passed to the resolve() method
-     * Is mutually exclusive with IGNORE_UNKNOWN
+     * Throw an exception if unknown options are passed to {@link resolve()}.
      */
-    const REMOVE_UNKNOWN = 1;
+    const FORBID_UNKNOWN = 1;
 
     /**
-     * Ignore unknown options passed to the resolve() method
-     * Is mutually exclusive with REMOVE_UNKNOWN
+     * Remove unknown options passed to {@link resolve()}.
      */
-    const IGNORE_UNKNOWN = 2;
+    const REMOVE_UNKNOWN = 2;
+
+    /**
+     * Ignore unknown options passed to {@link resolve()}.
+     */
+    const IGNORE_UNKNOWN = 4;
+
+    /**
+     * Throw an exception if a required option is missing in {@link resolve()}.
+     */
+    const FORBID_MISSING = 32;
+
+    /**
+     * Ignore missing required options in {@link resolve()}.
+     */
+    const IGNORE_MISSING = 64;
 
     /**
      * Sets default option values.
@@ -207,8 +220,9 @@ interface OptionsResolverInterface
     /**
      * Returns the combination of the default and the passed options.
      *
-     * @param array $options The custom option values.
-     * @param int   $flags   Can be REMOVE_UNKNOWN or IGNORE_UNKNOWN
+     * @param array   $options The custom option values.
+     * @param integer $flags   A combination of the flag constants in this
+     *                         interface.
      *
      * @return array A list of options and their values.
      *

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\OptionsResolver\Tests;
 
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
 
@@ -716,5 +717,53 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
             'one' => '1',
             'three' => '3',
         ), $clone->resolve());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRemoveUnknownAndIgnoreUnknownAreMutuallyExclusive()
+    {
+        $this->resolver->resolve(array(
+            'one' => 'one',
+            'two' => 'two'
+        ), OptionsResolverInterface::REMOVE_UNKNOWN | OptionsResolverInterface::IGNORE_UNKNOWN);
+    }
+
+    public function testRemoveUnknownOption()
+    {
+        $this->resolver->setDefaults(array(
+            'one' => 'default',
+            'two' => 'default'
+        ));
+
+        $options = $this->resolver->resolve(array(
+            'one' => 'keep',
+            'three' => 'remove'
+        ), OptionsResolverInterface::REMOVE_UNKNOWN);
+
+        $this->assertEquals($options, array(
+            'one' => 'keep',
+            'two' => 'default'
+        ));
+    }
+
+    public function testIgnoreUnknownOption()
+    {
+        $this->resolver->setDefaults(array(
+            'one' => 'default',
+            'two' => 'default'
+        ));
+
+        $options = $this->resolver->resolve(array(
+            'one' => 'keep',
+            'three' => 'ignored'
+        ), OptionsResolverInterface::IGNORE_UNKNOWN);
+
+        $this->assertEquals($options, array(
+            'one' => 'keep',
+            'two' => 'default',
+            'three' => 'ignored'
+        ));
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -789,17 +789,6 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         ), $clone->resolve());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testRemoveUnknownAndIgnoreUnknownAreMutuallyExclusive()
-    {
-        $this->resolver->resolve(array(
-            'one' => 'one',
-            'two' => 'two'
-        ), OptionsResolverInterface::REMOVE_UNKNOWN | OptionsResolverInterface::IGNORE_UNKNOWN);
-    }
-
     public function testRemoveUnknownOption()
     {
         $this->resolver->setDefaults(array(

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -176,7 +176,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
-    public function testResolveFailsIfNonExistingOption()
+    public function testResolveFailsIfUnknownOption()
     {
         $this->resolver->setDefaults(array(
             'one' => '1',
@@ -195,6 +195,57 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testResolveRemovesUnknownOptionIfFlagIsSet()
+    {
+        $this->resolver->setDefaults(array(
+            'one' => '1',
+        ));
+
+        $this->resolver->setRequired(array(
+            'two',
+        ));
+
+        $this->resolver->setOptional(array(
+            'three',
+        ));
+
+        $options = $this->resolver->resolve(array(
+            'foo' => 'bar',
+            'two' => '20',
+        ), OptionsResolverInterface::REMOVE_UNKNOWN);
+
+        $this->assertEquals(array(
+            'one' => '1',
+            'two' => '20'
+        ), $options);
+    }
+
+    public function testResolveIgnoresUnknownOptionsIfFlagIsSet()
+    {
+        $this->resolver->setDefaults(array(
+            'one' => '1',
+        ));
+
+        $this->resolver->setRequired(array(
+            'two',
+        ));
+
+        $this->resolver->setOptional(array(
+            'three',
+        ));
+
+        $options = $this->resolver->resolve(array(
+            'foo' => 'bar',
+            'two' => '20',
+        ), OptionsResolverInterface::IGNORE_UNKNOWN);
+
+        $this->assertEquals(array(
+            'one' => '1',
+            'foo' => 'bar',
+            'two' => '20',
+        ), $options);
+    }
+
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
      */
@@ -211,6 +262,25 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->resolve(array(
             'two' => '20',
         ));
+    }
+
+    public function testResolveIgnoresMissingRequiredOptionIfFlagIsSet()
+    {
+        $this->resolver->setRequired(array(
+            'one',
+        ));
+
+        $this->resolver->setDefaults(array(
+            'two' => '2',
+        ));
+
+        $options = $this->resolver->resolve(array(
+            'two' => '20',
+        ), OptionsResolverInterface::IGNORE_MISSING);
+
+        $this->assertEquals(array(
+            'two' => '20',
+        ), $options);
     }
 
     public function testResolveSucceedsIfOptionValueAllowed()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7979, replaces #9754 |
| License | MIT |
| Doc PR | symfony/symfony-docs#3731 |

replacement for #10574 which was closed by accident
