### PR TITLE
[Security] Replace exception mocks with actual exception instances.

### DIFF
--- a/src/Symfony/Component/Security/Tests/Core/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/AuthenticationProviderManagerTest.php
@@ -129,7 +129,7 @@ class AuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
         } elseif (null !== $exception) {
             $provider->expects($this->once())
                      ->method('authenticate')
-                     ->will($this->throwException($this->getMock($exception, null, array(), '', false)))
+                     ->will($this->throwException($this->getMock($exception, null, array(), '', true)))
             ;
         }
 

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Tests\Core\Authentication\Provider;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 
 use Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
 class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -37,7 +38,7 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $userProvider = $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface');
         $userProvider->expects($this->once())
                      ->method('loadUserByUsername')
-                     ->will($this->throwException($this->getMock('Symfony\\Component\\Security\\Core\\Exception\\UsernameNotFoundException', null, array(), '', false)))
+                     ->will($this->throwException(new UsernameNotFoundException()))
         ;
 
         $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));
@@ -55,7 +56,7 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $userProvider = $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface');
         $userProvider->expects($this->once())
                      ->method('loadUserByUsername')
-                     ->will($this->throwException($this->getMock('RuntimeException', null, array(), '', false)))
+                     ->will($this->throwException(new \RuntimeException()))
         ;
 
         $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Tests\Core\Authentication\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\PreAuthenticatedAuthenticationProvider;
+use Symfony\Component\Security\Core\Exception\LockedException;
 
 class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -79,7 +80,7 @@ class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_Test
         $userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
         $userChecker->expects($this->once())
                     ->method('checkPostAuth')
-                    ->will($this->throwException($this->getMock('Symfony\Component\Security\Core\Exception\LockedException', null, array(), '', false)))
+                    ->will($this->throwException(new LockedException()))
         ;
 
         $provider = $this->getProvider($user, $userChecker);

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Tests\Core\Authentication\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider;
-use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\Exception\AccountExpiredException;
 use Symfony\Component\Security\Core\Role\Role;
 
 class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
@@ -52,7 +52,7 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
         $userChecker->expects($this->once())
                     ->method('checkPostAuth')
-                    ->will($this->throwException($this->getMock('Symfony\Component\Security\Core\Exception\AccountExpiredException', null, array(), '', false)))
+                    ->will($this->throwException(new AccountExpiredException()))
         ;
 
         $provider = $this->getProvider($userChecker);

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Security\Tests\Core\Authentication\Provider;
 
-use Symfony\Component\Security\Core\Authentication\Provider\UserAuthenticationProvider;
+use Symfony\Component\Security\Core\Exception\AccountExpiredException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Role\SwitchUserRole;
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
 class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -41,7 +43,7 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $provider = $this->getProvider(false, false);
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->throwException($this->getMock('Symfony\Component\Security\Core\Exception\UsernameNotFoundException', null, array(), '', false)))
+                 ->will($this->throwException(new UsernameNotFoundException()))
         ;
 
         $provider->authenticate($this->getSupportedToken());
@@ -55,7 +57,7 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $provider = $this->getProvider(false, true);
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->throwException($this->getMock('Symfony\Component\Security\Core\Exception\UsernameNotFoundException', null, array(), '', false)))
+                 ->will($this->throwException(new UsernameNotFoundException()))
         ;
 
         $provider->authenticate($this->getSupportedToken());
@@ -83,7 +85,7 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
         $userChecker->expects($this->once())
                     ->method('checkPreAuth')
-                    ->will($this->throwException($this->getMock('Symfony\Component\Security\Core\Exception\CredentialsExpiredException', null, array(), '', false)))
+                    ->will($this->throwException(new CredentialsExpiredException()))
         ;
 
         $provider = $this->getProvider($userChecker);
@@ -103,7 +105,7 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
         $userChecker->expects($this->once())
                     ->method('checkPostAuth')
-                    ->will($this->throwException($this->getMock('Symfony\Component\Security\Core\Exception\AccountExpiredException', null, array(), '', false)))
+                    ->will($this->throwException(new AccountExpiredException()))
         ;
 
         $provider = $this->getProvider($userChecker);
@@ -128,7 +130,7 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         ;
         $provider->expects($this->once())
                  ->method('checkAuthentication')
-                 ->will($this->throwException($this->getMock('Symfony\Component\Security\Core\Exception\BadCredentialsException', null, array(), '', false)))
+                 ->will($this->throwException(new BadCredentialsException()))
         ;
 
         $provider->authenticate($this->getSupportedToken());


### PR DESCRIPTION
It is done for two reasons:
- consistency - we use real exception objects in most of the code
- latest phpunit does not like the way we were creating mocks for exceptions (it could be also fixed by letting phpunit to call the original constructor)
