### PR TITLE
[FrameworkBundle] Fix tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -277,6 +277,23 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(array('loadClassMetadata'), $calls[4][1]);
         $this->assertSame('setMetadataCache', $calls[5][0]);
         $this->assertEquals(array(new Reference('validator.mapping.cache.apc')), $calls[5][1]);
+    }
+
+    public function testFullyConfiguredValidationService()
+    {
+        if (!extension_loaded('apc')) {
+            $this->markTestSkipped('The apc extension is not available.');
+        }
+
+        $container = $this->createContainerFromFile('full');
+
+        $this->assertInstanceOf('Symfony\Component\Validator\ValidatorInterface', $container->get('validator'));
+    }
+
+    public function testValidationService()
+    {
+        $container = $this->createContainerFromFile('validation_annotations');
+
         $this->assertInstanceOf('Symfony\Component\Validator\ValidatorInterface', $container->get('validator'));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10622 |
| License | MIT |
| Doc PR | - |

This [fixes the build](https://travis-ci.org/jakzal/symfony/builds/22199535) [![Build Status](https://travis-ci.org/jakzal/symfony.svg?branch=framework-bundle-tests-fix)](https://travis-ci.org/jakzal/symfony) by only initializing a fully configured validation service if APC is available. At the moment we only provide ApcCache for mapping' caching (out of the box). DoctrineCache is available but not configured. I also added an additional test case to verify that a validation service can be created on php >=5.5.
