### PR TITLE
[TwigBridge] Removed strict check when found variables inside a translation

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -36,7 +36,7 @@ class TransNode extends \Twig_Node
             $defaults = $this->getNode('vars');
             $vars = null;
         }
-        list($msg, $defaults) = $this->compileString($this->getNode('body'), $defaults);
+        list($msg, $defaults) = $this->compileString($this->getNode('body'), $defaults, (boolean) $vars);
 
         $method = null === $this->getNode('count') ? 'trans' : 'transChoice';
 
@@ -83,7 +83,7 @@ class TransNode extends \Twig_Node
         $compiler->raw(");\n");
     }
 
-    protected function compileString(\Twig_NodeInterface $body, \Twig_Node_Expression_Array $vars)
+    protected function compileString(\Twig_NodeInterface $body, \Twig_Node_Expression_Array $vars, $ignoreStrictCheck = false)
     {
         if ($body instanceof \Twig_Node_Expression_Constant) {
             $msg = $body->getAttribute('value');
@@ -98,7 +98,9 @@ class TransNode extends \Twig_Node
         foreach ($matches[1] as $var) {
             $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
             if (!$vars->hasElement($key)) {
-                $vars->addElement(new \Twig_Node_Expression_Name($var, $body->getLine()), $key);
+                $varExpr = new \Twig_Node_Expression_Name($var, $body->getLine());
+                $varExpr->setAttribute('ignore_strict_check', $ignoreStrictCheck);
+                $vars->addElement($varExpr, $key);
             }
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Node;
+
+use Symfony\Bridge\Twig\Node\TransNode;
+
+/**
+ *
+ * @author Asmir Mustafic <goetas@gmail.com>
+ *
+ */
+class TransNodeTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testCompileStrict()
+    {
+        $body = new \Twig_Node_Text('trans %var%', 0);
+        $vars = new \Twig_Node_Expression_Name('foo', 0);
+        $node = new TransNode($body, null, null, $vars);
+
+        $env = new \Twig_Environment(null, array(
+            'strict_variables' => true,
+        ));
+        $compiler = new \Twig_Compiler($env);
+
+        $this->assertEquals(
+            sprintf(
+                'echo $this->env->getExtension(\'translator\')->getTranslator()->trans("trans %%var%%", array_merge(array("%%var%%" => %s), %s), "messages");',
+                $this->getVariableGetterWithoutStrictCheck('var'),
+                $this->getVariableGetterWithStrictCheck('foo')
+             ),
+             trim($compiler->compile($node)->getSource())
+        );
+    }
+    protected function getVariableGetterWithoutStrictCheck($name)
+    {
+        if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
+            return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
+        }
+
+        return sprintf('$this->getContext($context, "%s", true)', $name);
+    }
+    protected function getVariableGetterWithStrictCheck($name)
+    {
+        if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
+            return sprintf('(isset($context["%s"]) ? $context["%s"] : $this->getContext($context, "%s"))', $name, $name, $name);
+        }
+
+        return sprintf('$this->getContext($context, "%s")', $name);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no? |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10638 |
| License | MIT |
