### PR TITLE
Changed the typehint of the EsiFragmentRenderer to the interface

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/EsiFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/EsiFragmentRenderer.php
@@ -32,10 +32,10 @@ class EsiFragmentRenderer extends RoutableFragmentRenderer
      * The "fallback" strategy when ESI is not available should always be an
      * instance of InlineFragmentRenderer.
      *
-     * @param Esi                    $esi            An Esi instance
-     * @param InlineFragmentRenderer $inlineStrategy The inline strategy to use when ESI is not supported
+     * @param Esi                       $esi            An Esi instance
+     * @param FragmentRendererInterface $inlineStrategy The inline strategy to use when ESI is not supported
      */
-    public function __construct(Esi $esi = null, InlineFragmentRenderer $inlineStrategy)
+    public function __construct(Esi $esi = null, FragmentRendererInterface $inlineStrategy)
     {
         $this->esi = $esi;
         $this->inlineStrategy = $inlineStrategy;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | maybe |
| New feature? | maybe |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

While it is true that passing a different core renderer implementation as inline strategy does not make any sense. Typehint the inline strategy here makes it much more complex to decorate the inline strategy (your decorator has to extend the class and overwrite all public methods instead of implementing the interface directly just to pass the typehint). And I have a valid use case for it (which is the reason why I submitted it now), or rather @lolautruche has one in EZPublish: https://github.com/ezsystems/ezpublish-kernel/pull/793

I don't know exactly whether this change should be considered as a bugfix (merged in the upcoming 2.3.13) or a new feature (merged in 2.5). I guess @lolautruche will like us if it goes its way to 2.3.x (EZPublish could bump its requirement to run on 2.3.13+ instead of 2.3.0+ and use a simpler code).

I remember suggesting the change in the initial PR btw, but it was rejecting sayign it does not make sense to use other strategies at that time.
