### PR TITLE
[Validator] Fix #10648 : Incorrect validation for maxSize option in the FileValidator

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -100,7 +100,7 @@ abstract class Helper implements HelperInterface
         }
 
         if ($memory >= 1024) {
-            return sprintf('%d kB', $memory / 1024);
+            return sprintf('%d KB', $memory / 1024);
         }
 
         return sprintf('%d B', $memory);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -372,12 +372,12 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
             $this->generateOutput(
                 " \033[44;37m Looks good to me...                   \033[0m\n".
                 "  4/15 ".str_repeat($done, 7).$progress.str_repeat($empty, 19)."  26%\n".
-                " 🏁  1 sec                        \033[41;37m 97 kB \033[0m"
+                " 🏁  1 sec                        \033[41;37m 97 KB \033[0m"
             ).
             $this->generateOutput(
                 " \033[44;37m Thanks, bye                           \033[0m\n".
                 " 15/15 ".str_repeat($done, 28)." 100%\n".
-                " 🏁  1 sec                       \033[41;37m 195 kB \033[0m"
+                " 🏁  1 sec                       \033[41;37m 195 KB \033[0m"
             ),
             stream_get_contents($output->getStream())
         );

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -291,7 +291,7 @@ class UploadedFile extends File
     public function getErrorMessage()
     {
         static $errors = array(
-            UPLOAD_ERR_INI_SIZE   => 'The file "%s" exceeds your upload_max_filesize ini directive (limit is %d kb).',
+            UPLOAD_ERR_INI_SIZE   => 'The file "%s" exceeds your upload_max_filesize ini directive (limit is %d KB).',
             UPLOAD_ERR_FORM_SIZE  => 'The file "%s" exceeds the upload limit defined in your form.',
             UPLOAD_ERR_PARTIAL    => 'The file "%s" was only partially uploaded.',
             UPLOAD_ERR_NO_FILE    => 'No file was uploaded.',

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -117,11 +117,11 @@ class FileValidator extends ConstraintValidator
                 $limit = (int) $constraint->maxSize;
                 $suffix = 'bytes';
             } elseif (preg_match('/^\d++k$/', $constraint->maxSize)) {
-                $size = round(filesize($path) / 1000, 2);
+                $size = round(filesize($path) / 1024, 2);
                 $limit = (int) $constraint->maxSize;
                 $suffix = 'kB';
             } elseif (preg_match('/^\d++M$/', $constraint->maxSize)) {
-                $size = round(filesize($path) / 1000000, 2);
+                $size = round(filesize($path) / (1024 * 1024), 2);
                 $limit = (int) $constraint->maxSize;
                 $suffix = 'MB';
             } else {

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -119,7 +119,7 @@ class FileValidator extends ConstraintValidator
             } elseif (preg_match('/^\d++k$/', $constraint->maxSize)) {
                 $size = round(filesize($path) / 1024, 2);
                 $limit = (int) $constraint->maxSize;
-                $suffix = 'kB';
+                $suffix = 'KB';
             } elseif (preg_match('/^\d++M$/', $constraint->maxSize)) {
                 $size = round(filesize($path) / (1024 * 1024), 2);
                 $limit = (int) $constraint->maxSize;

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -47,7 +47,7 @@ class FileValidator extends ConstraintValidator
                         } elseif (preg_match('/^\d++k$/', $constraint->maxSize)) {
                             $maxSize = $constraint->maxSize * 1024;
                         } elseif (preg_match('/^\d++M$/', $constraint->maxSize)) {
-                            $maxSize = $constraint->maxSize * 1048576;
+                            $maxSize = $constraint->maxSize * 1024 * 1024;
                         } else {
                             throw new ConstraintDefinitionException(sprintf('"%s" is not a valid maximum size', $constraint->maxSize));
                         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -119,7 +119,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ size }}'    => '1.37',
                 '{{ suffix }}'  => 'KB',
                 '{{ file }}'    => $this->path,
-        ));
+            ));
 
         $this->validator->validate($this->getFile($this->path), $constraint);
     }
@@ -155,7 +155,6 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->context->expects($this->never())->method('addViolation');
         $this->validator->validate($this->getFile($this->path), $constraint);
-
     }
 
     public function testMaxSizeMegaBytes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -117,7 +117,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->with('myMessage', array(
                 '{{ limit }}'   => '1',
                 '{{ size }}'    => '1.37',
-                '{{ suffix }}'  => 'kB',
+                '{{ suffix }}'  => 'KB',
                 '{{ file }}'    => $this->path,
         ));
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -116,10 +116,10 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage', array(
                 '{{ limit }}'   => '1',
-                '{{ size }}'    => '1.4',
+                '{{ size }}'    => '1.37',
                 '{{ suffix }}'  => 'kB',
                 '{{ file }}'    => $this->path,
-            ));
+        ));
 
         $this->validator->validate($this->getFile($this->path), $constraint);
     }
@@ -137,11 +137,36 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage', array(
                 '{{ limit }}'   => '1',
-                '{{ size }}'    => '1.4',
+                '{{ size }}'    => '1.34',
                 '{{ suffix }}'  => 'MB',
                 '{{ file }}'    => $this->path,
             ));
 
+        $this->validator->validate($this->getFile($this->path), $constraint);
+    }
+
+    public function testMaxSizeKiloBytes()
+    {
+        fwrite($this->file, str_repeat('0', 1010));
+
+        $constraint = new File(array(
+            'maxSize' => '1k',
+        ));
+
+        $this->context->expects($this->never())->method('addViolation');
+        $this->validator->validate($this->getFile($this->path), $constraint);
+
+    }
+
+    public function testMaxSizeMegaBytes()
+    {
+        fwrite($this->file, str_repeat('0', (1024 * 1022)));
+
+        $constraint = new File(array(
+            'maxSize' => '1M',
+        ));
+
+        $this->context->expects($this->never())->method('addViolation');
         $this->validator->validate($this->getFile($this->path), $constraint);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10648 |
| License | MIT |
| Doc PR | N/A |
