### PR TITLE
[Form] Fix #6325 : Rename "always_empty" in PasswordType to "reset_on_submit"

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -23,7 +23,7 @@ class PasswordType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if ($options['always_empty'] || !$form->isSubmitted()) {
+        if ($options['reset_on_submit'] || !$form->isSubmitted()) {
             $view->vars['value'] = '';
         }
     }
@@ -34,7 +34,7 @@ class PasswordType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'always_empty' => true,
+            'reset_on_submit' => true,
             'trim'         => false,
         ));
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -41,7 +41,7 @@ class PasswordType extends AbstractType
 
         $resolver->setDefaults(array(
             'reset_on_submit' => $resetOnSubmit,
-            'always_empty' => true, // Deprecated use reset_on_submit unstead
+            'always_empty' => true, // Deprecated use reset_on_submit instead
             'trim'         => false,
         ));
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class PasswordType extends AbstractType
@@ -33,8 +34,14 @@ class PasswordType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        // BC with old "always_empty" option
+        $resetOnSubmit = function (Options $options) {
+            return $options['always_empty'];
+        };
+
         $resolver->setDefaults(array(
-            'reset_on_submit' => true,
+            'reset_on_submit' => $resetOnSubmit,
+            'always_empty' => true, // Deprecated use reset_on_submit unstead
             'trim'         => false,
         ));
     }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1404,7 +1404,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testPasswordSubmittedWithNotAlwaysEmpty()
     {
         $form = $this->factory->createNamed('name', 'password', null, array(
-            'always_empty' => false,
+            'reset_on_submit' => false,
         ));
         $form->submit('foo&bar');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -33,7 +33,7 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotEmptyIfSubmittedAndNotAlwaysEmpty()
     {
-        $form = $this->factory->create('password', null, array('always_empty' => false));
+        $form = $this->factory->create('password', null, array('reset_on_submit' => false));
         $form->submit('pAs5w0rd');
         $view = $form->createView();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #6325 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3781 |
