### PR TITLE
[Templating] PhpEngine should propagate charset to its helpers

### DIFF
--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -32,6 +32,9 @@ class PhpEngine implements EngineInterface, \ArrayAccess
 {
     protected $loader;
     protected $current;
+    /**
+     * @var HelperInterface[]
+     */
     protected $helpers;
     protected $parents;
     protected $stack;
@@ -368,6 +371,10 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     public function setCharset($charset)
     {
         $this->charset = $charset;
+
+        foreach ($this->helpers as $helper) {
+            $helper->setCharset($this->charset);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Templating\Tests;
 
 use Symfony\Component\Templating\PhpEngine;
 use Symfony\Component\Templating\Loader\Loader;
-use Symfony\Component\Templating\Storage\Storage;
 use Symfony\Component\Templating\Storage\StringStorage;
 use Symfony\Component\Templating\Helper\SlotsHelper;
 use Symfony\Component\Templating\TemplateNameParser;
@@ -126,10 +125,14 @@ class PhpEngineTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSetCharset()
     {
-        $engine = new ProjectTemplateEngine(new TemplateNameParser(), $this->loader);
-        $this->assertEquals('UTF-8', $engine->getCharset(), '->getCharset() returns UTF-8 by default');
+        $helper = new SlotsHelper();
+        $engine = new ProjectTemplateEngine(new TemplateNameParser(), $this->loader, array($helper));
+        $this->assertEquals('UTF-8', $engine->getCharset(), 'EngineInterface::getCharset() returns UTF-8 by default');
+        $this->assertEquals('UTF-8', $helper->getCharset(), 'HelperInterface::getCharset() returns UTF-8 by default');
+
         $engine->setCharset('ISO-8859-1');
-        $this->assertEquals('ISO-8859-1', $engine->getCharset(), '->setCharset() changes the default charset to use');
+        $this->assertEquals('ISO-8859-1', $engine->getCharset(), 'EngineInterface::setCharset() changes the default charset to use');
+        $this->assertEquals('ISO-8859-1', $helper->getCharset(), 'EngineInterface::setCharset() changes the default charset of helper');
     }
 
     public function testGlobalVariables()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10666 |
| License | MIT |
