### PR TITLE
[Form] Fix #10658 Deprecate "read_only" option

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -374,7 +374,6 @@
 {% block widget_attributes %}
 {% spaceless %}
     id="{{ id }}" name="{{ full_name }}"
-    {%- if read_only %} readonly="readonly"{% endif -%}
     {%- if disabled %} disabled="disabled"{% endif -%}
     {%- if required %} required="required"{% endif -%}
     {%- for attrname, attrvalue in attr -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -1,5 +1,4 @@
-id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($read_only): ?>readonly="readonly" <?php endif ?>
-<?php if ($disabled): ?>disabled="disabled" <?php endif ?>
+id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($disabled): ?>disabled="disabled" <?php endif ?>
 <?php if ($required): ?>required="required" <?php endif ?>
 <?php foreach ($attr as $k => $v): ?>
 <?php if (in_array($v, array('placeholder', 'title'), true)): ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -1,4 +1,5 @@
-id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($disabled): ?>disabled="disabled" <?php endif ?>
+id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>"
+<?php if ($disabled): ?>disabled="disabled" <?php endif ?>
 <?php if ($required): ?>required="required" <?php endif ?>
 <?php foreach ($attr as $k => $v): ?>
 <?php if (in_array($v, array('placeholder', 'title'), true)): ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -73,7 +73,7 @@ class FormType extends BaseType
 
         $name = $form->getName();
 
-        $readOnly =  isset($view->vars['attr']['readonly']) && in_array($view->vars['attr']['readonly'], array('readonly', true));
+        $readOnly = isset($view->vars['attr']['readonly']) && false !== $view->vars['attr']['readonly'];
 
         if ($view->parent) {
             if ('' === $name) {
@@ -81,7 +81,7 @@ class FormType extends BaseType
             }
 
             // Complex fields are read-only if they themselves or their parents are.
-            if (!$readOnly && (isset($view->parent->vars['attr']['readonly']) && in_array($view->parent->vars['attr']['readonly'], array('readonly', true)))) {
+            if (!$readOnly && (isset($view->parent->vars['attr']['readonly']) && false !== $view->parent->vars['attr']['readonly'])) {
                 $view->vars['attr']['readonly'] = 'readonly';
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -87,7 +87,7 @@ class FormType extends BaseType
         }
 
         $view->vars = array_replace($view->vars, array(
-            'read_only' => $readOnly,
+            'read_only'  => $readOnly,
             'errors'     => $form->getErrors(),
             'valid'      => $form->isSubmitted() ? $form->isValid() : true,
             'value'      => $form->getViewData(),
@@ -193,7 +193,7 @@ class FormType extends BaseType
             'empty_data'         => $emptyData,
             'trim'               => true,
             'required'           => true,
-            'read_only'          => false, //Deprecated use attr['readonly'] instead
+            'read_only'          => false, // Deprecated use attr['readonly'] instead
             'max_length'         => null,
             'pattern'            => null,
             'property_path'      => null,

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -87,6 +87,7 @@ class FormType extends BaseType
         }
 
         $view->vars = array_replace($view->vars, array(
+            'read_only' => $readOnly,
             'errors'     => $form->getErrors(),
             'valid'      => $form->isSubmitted() ? $form->isValid() : true,
             'value'      => $form->getViewData(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -73,22 +73,19 @@ class FormType extends BaseType
 
         $name = $form->getName();
 
-        $readOnly = isset($view->vars['attr']['readonly']) && false !== $view->vars['attr']['readonly'];
-
         if ($view->parent) {
             if ('' === $name) {
                 throw new LogicException('Form node with empty name can be used only as root form node.');
             }
 
             // Complex fields are read-only if they themselves or their parents are.
-            if (!$readOnly && (isset($view->parent->vars['attr']['readonly']) && false !== $view->parent->vars['attr']['readonly'])) {
-                $view->vars['attr']['readonly'] = 'readonly';
-                $readOnly = true;
+            if (!$view->vars['attr']['readonly'] && (isset($view->parent->vars['attr']['readonly']) && false !== $view->parent->vars['attr']['readonly'])) {
+                $view->vars['attr']['readonly'] = true;
             }
         }
 
         $view->vars = array_replace($view->vars, array(
-            'read_only'  => $readOnly,
+            'read_only'  => $view->vars['attr']['readonly'],
             'errors'     => $form->getErrors(),
             'valid'      => $form->isSubmitted() ? $form->isValid() : true,
             'value'      => $form->getViewData(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -84,7 +84,6 @@ class FormType extends BaseType
             if (!$readOnly && (isset($view->parent->vars['attr']['readonly']) && in_array($view->parent->vars['attr']['readonly'], array('readonly', true)))) {
                 $view->vars['attr']['readonly'] = 'readonly';
             }
-
         }
 
         $view->vars = array_replace($view->vars, array(
@@ -183,10 +182,7 @@ class FormType extends BaseType
             if (null !== $options['pattern']) {
                 $attributes['pattern'] = $options['pattern'];
             }
-
-            if (false !== $options['read_only']) {
-                $attributes['readonly'] = $options['read_only'];
-            }
+            $attributes['readonly'] = $options['read_only'];
 
             return $attributes;
         };

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -83,6 +83,7 @@ class FormType extends BaseType
             // Complex fields are read-only if they themselves or their parents are.
             if (!$readOnly && (isset($view->parent->vars['attr']['readonly']) && false !== $view->parent->vars['attr']['readonly'])) {
                 $view->vars['attr']['readonly'] = 'readonly';
+                $readOnly = true;
             }
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -72,7 +72,8 @@ class FormType extends BaseType
         parent::buildView($view, $form, $options);
 
         $name = $form->getName();
-        $readOnly = $options['read_only'];
+
+        $readOnly =  isset($view->vars['attr']['readonly']) && in_array($view->vars['attr']['readonly'], array('readonly', true));
 
         if ($view->parent) {
             if ('' === $name) {
@@ -80,13 +81,13 @@ class FormType extends BaseType
             }
 
             // Complex fields are read-only if they themselves or their parents are.
-            if (!$readOnly) {
-                $readOnly = $view->parent->vars['read_only'];
+            if (!$readOnly && (isset($view->parent->vars['attr']['readonly']) && in_array($view->parent->vars['attr']['readonly'], array('readonly', true)))) {
+                $view->vars['attr']['readonly'] = 'readonly';
             }
+
         }
 
         $view->vars = array_replace($view->vars, array(
-            'read_only'  => $readOnly,
             'errors'     => $form->getErrors(),
             'valid'      => $form->isSubmitted() ? $form->isValid() : true,
             'value'      => $form->getViewData(),
@@ -170,7 +171,7 @@ class FormType extends BaseType
             'data',
         ));
 
-        // BC clause for the "max_length" and "pattern" option
+        // BC clause for the "max_length", "pattern" and "read_only" option
         // Add these values to the "attr" option instead
         $defaultAttr = function (Options $options) {
             $attributes = array();
@@ -183,6 +184,10 @@ class FormType extends BaseType
                 $attributes['pattern'] = $options['pattern'];
             }
 
+            if (false !== $options['read_only']) {
+                $attributes['readonly'] = $options['read_only'];
+            }
+
             return $attributes;
         };
 
@@ -191,7 +196,7 @@ class FormType extends BaseType
             'empty_data'         => $emptyData,
             'trim'               => true,
             'required'           => true,
-            'read_only'          => false,
+            'read_only'          => false, //Deprecated use attr['read_only'] instead
             'max_length'         => null,
             'pattern'            => null,
             'property_path'      => null,

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -196,7 +196,7 @@ class FormType extends BaseType
             'empty_data'         => $emptyData,
             'trim'               => true,
             'required'           => true,
-            'read_only'          => false, //Deprecated use attr['read_only'] instead
+            'read_only'          => false, //Deprecated use attr['readonly'] instead
             'max_length'         => null,
             'pattern'            => null,
             'property_path'      => null,

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1291,6 +1291,21 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
+    public function testReadOnlyBc()
+    {
+        $form = $this->factory->createNamed('name', 'text', null, array(
+            'read_only' => true,
+        ));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+            '/input
+    [@type="text"]
+    [@name="name"]
+    [@readonly="readonly"]
+'
+        );
+    }
+
     public function testReadOnly()
     {
         $form = $this->factory->createNamed('name', 'text', null, array(

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1294,7 +1294,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testReadOnly()
     {
         $form = $this->factory->createNamed('name', 'text', null, array(
-            'read_only' => true,
+            'attr' => array('readonly' => 'readonly'),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1899,8 +1899,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $form = $this->factory->createNamed('text', 'text', 'value', array(
             'required' => true,
             'disabled' => true,
-            'read_only' => true,
-            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
+            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar', 'readonly' => true),
         ));
 
         $html = $this->renderWidget($form->createView());

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1309,7 +1309,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testReadOnly()
     {
         $form = $this->factory->createNamed('name', 'text', null, array(
-            'attr' => array('readonly' => 'readonly'),
+            'attr' => array('readonly' => true),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -107,7 +107,7 @@ class FormTypeTest extends BaseTypeTest
             ->getForm()
             ->createView();
 
-        $this->assertEquals('readonly', $view['child']->vars['attr']['readonly']);
+        $this->assertSame('readonly', $view['child']->vars['attr']['readonly']);
     }
 
     public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
@@ -117,7 +117,7 @@ class FormTypeTest extends BaseTypeTest
             ->getForm()
             ->createView();
 
-        $this->assertEquals('readonly', $view['child']->vars['attr']['readonly']);
+        $this->assertSame('readonly', $view['child']->vars['attr']['readonly']);
     }
 
     public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
@@ -127,7 +127,7 @@ class FormTypeTest extends BaseTypeTest
                 ->getForm()
                 ->createView();
 
-        $this->assertEquals(false, $view['child']->vars['attr']['readonly']);
+        $this->assertFalse($view['child']->vars['attr']['readonly']);
     }
 
     public function testPassMaxLengthToView()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -102,22 +102,22 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('read_only' => true))
+        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('attr' => array('readonly' => 'readonly')))
             ->add('child', 'form')
             ->getForm()
             ->createView();
 
-        $this->assertTrue($view['child']->vars['read_only']);
+        $this->assertEquals('readonly', $view['child']->vars['attr']['readonly']);
     }
 
     public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
         $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form', array('read_only' => true))
+            ->add('child', 'form', array('attr' => array('readonly' => 'readonly')))
             ->getForm()
             ->createView();
 
-        $this->assertTrue($view['child']->vars['read_only']);
+        $this->assertEquals('readonly', $view['child']->vars['attr']['readonly']);
     }
 
     public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
@@ -127,7 +127,7 @@ class FormTypeTest extends BaseTypeTest
                 ->getForm()
                 ->createView();
 
-        $this->assertFalse($view['child']->vars['read_only']);
+        $this->assertArrayNotHasKey('readonly', $view['child']->vars['attr']);
     }
 
     public function testPassMaxLengthToView()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -127,7 +127,7 @@ class FormTypeTest extends BaseTypeTest
                 ->getForm()
                 ->createView();
 
-        $this->assertArrayNotHasKey('readonly', $view['child']->vars['attr']);
+        $this->assertEquals(false, $view['child']->vars['attr']['readonly']);
     }
 
     public function testPassMaxLengthToView()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\PropertyAccess\PropertyPath;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\FixedDataTransformer;
@@ -102,22 +101,22 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('attr' => array('readonly' => 'readonly')))
+        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('attr' => array('readonly' => true)))
             ->add('child', 'form')
             ->getForm()
             ->createView();
 
-        $this->assertSame('readonly', $view['child']->vars['attr']['readonly']);
+        $this->assertTrue($view['child']->vars['attr']['readonly']);
     }
 
     public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
         $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form', array('attr' => array('readonly' => 'readonly')))
+            ->add('child', 'form', array('attr' => array('readonly' => true)))
             ->getForm()
             ->createView();
 
-        $this->assertSame('readonly', $view['child']->vars['attr']['readonly']);
+        $this->assertTrue($view['child']->vars['attr']['readonly']);
     }
 
     public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #10658 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3782 |
