### PR TITLE
bug #10675 [Validator] Fix constraint violation message parameterization

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -37,7 +37,7 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
 
         if (!$this->compareValues($value, $constraint->value)) {
             $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->valueToString($constraint->value),
+                '{{ value }}' => $this->valueToString($value),
                 '{{ compared_value }}' => $this->valueToString($constraint->value),
                 '{{ compared_value_type }}' => $this->valueToType($constraint->value)
             ));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10675 |
| License | MIT |

This PR fixes an error during the constraint violation message parametrization, more information on the related ticket.
