### PR TITLE
Fix URI replacement when ['HTTP_HOST'] starts with a number

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -297,7 +297,7 @@ abstract class Client
         $uri = $this->getAbsoluteUri($uri);
 
         if (isset($server['HTTP_HOST'])) {
-            $uri = preg_replace('{^(https?\://)'.parse_url($uri, PHP_URL_HOST).'}', '\\1'.$server['HTTP_HOST'], $uri);
+            $uri = preg_replace('{^(https?\://)'.parse_url($uri, PHP_URL_HOST).'}', '${1}'.$server['HTTP_HOST'], $uri);
         }
 
         if (isset($server['HTTPS'])) {

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -421,6 +421,16 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($headers, $client->getRequest()->getServer());
     }
 
+    public function testFollowRedirectWithIpHost()
+    {
+        $client = new TestClient();
+        $client->request('GET', 'http://127.0.0.1/foo', array(), array(), array(
+            'HTTP_HOST' => "127.0.0.1",
+        ));
+
+        $this->assertEquals('http://127.0.0.1/foo', $client->getRequest()->getUri());
+    }
+
     public function testFollowRedirectWithPort()
     {
         $headers = array(


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

---

I had an issue with the BrowserKit while doing functional testing with Behat. Actually, the URI generated had an IP address in place of the host. Because the host starts with a number, preg_replace tries to replace a backreference that selects nothing in the regexp pattern.

The previous bug is repeatable with the following code: 

```
<?php
$uri = 'http://127.0.0.1/login';
$server_http_host = '227.0.0.7';
echo preg_replace('{^(https?\://)'.parse_url($uri, PHP_URL_HOST).'}', '\\1'.$server_http_host, $uri);
// outputs "27.0.0.7/login" instead of "http://127.0.0.1/login"
```

Here is the php.net documentation related to this issue:

When working with a replacement pattern where a backreference is immediately followed by another number (i.e.: placing a literal number immediately after a matched pattern), you cannot use the familiar \1 notation for your backreference. \11, for example, would confuse preg_replace() since it does not know whether you want the \1 backreference followed by a literal 1, or the \11 backreference followed by nothing. In this case the solution is to use \${1}1. This creates an isolated $1 backreference, leaving the 1 as a literal.
