### PR TITLE
Fixing Yaml Loader/Dumper to use underscores instead of dashes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -143,7 +143,7 @@ class YamlDumper extends Dumper
             list ($decorated, $renamedId) = $decorated;
             $code .= sprintf("        decorates: %s\n", $decorated);
             if (null !== $renamedId) {
-                $code .= sprintf("        decoration-inner-name: %s\n", $renamedId);
+                $code .= sprintf("        decoration_inner_name: %s\n", $renamedId);
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -235,7 +235,7 @@ class YamlFileLoader extends FileLoader
         }
 
         if (isset($service['decorates'])) {
-            $renameId = isset($service['decoration-inner-name']) ? $service['decoration-inner-name'] : null;
+            $renameId = isset($service['decoration_inner_name']) ? $service['decoration_inner_name'] : null;
             $definition->setDecoratedService($service['decorates'], $renameId);
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -34,4 +34,4 @@ services:
         decorates: decorated
     decorator_service_with_name:
         decorates: decorated
-        decoration-inner-name: decorated.pif-pouf
+        decoration_inner_name: decorated.pif-pouf

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -87,6 +87,6 @@ services:
     decorator_service_with_name:
         class: stdClass
         decorates: decorated
-        decoration-inner-name: decorated.pif-pouf
+        decoration_inner_name: decorated.pif-pouf
     alias_for_foo: @foo
     alias_for_alias: @foo


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
