### PR TITLE
[Config] Fix NodeBuilderTest::testNumericNodeCreation.

### DIFF
--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
@@ -79,7 +79,7 @@ class NodeBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testNumericNodeCreation()
     {
-        $builder = new NodeBuilder();
+        $builder = new BaseNodeBuilder();
 
         $node = $builder->integerNode('foo')->min(3)->max(5);
         $this->assertInstanceOf('Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition', $node);


### PR DESCRIPTION
[Config] Fixes a test failure, under both php and hhvm.

```
PHP Fatal error:  Class 'Symfony\Component\Config\Tests\Definition\Builder\NodeBuilder' not found in /home/d/dev-fork/symfony-fork/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php on line 82
```

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
