### PR TITLE
Fixed wrong typehint in documentation for XmlEncoder

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -231,11 +231,11 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
     }
 
     /**
-     * Parse the input DOMNode into an array.
+     * Parse the input DOMNode into an array or a string.
      *
      * @param \DOMNode $node xml to parse
      *
-     * @return array
+     * @return array|string
      */
     private function parseXml(\DOMNode $node)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Method documentation correction.
See https://github.com/symfony/symfony/pull/10668#discussion_r11477618
