### PR TITLE
[Translation] Make IcuDatFileLoader/IcuResFileLoader::load invalid resource compatible with HHVM.

### DIFF
--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/BinaryBundleReader.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/BinaryBundleReader.php
@@ -28,7 +28,12 @@ class BinaryBundleReader extends AbstractBundleReader implements BundleReaderInt
     {
         // Point for future extension: Modify this class so that it works also
         // if the \ResourceBundle class is not available.
-        $bundle = new \ResourceBundle($locale, $path);
+        try {
+            $bundle = new \ResourceBundle($locale, $path);
+        } catch (\Exception $e) {
+            // HHVM compatibility: constructor throws on invalid resource
+            $bundle = null;
+        }
 
         if (null === $bundle) {
             throw new RuntimeException(sprintf(

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/LocaleBundleTransformationRule.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/LocaleBundleTransformationRule.php
@@ -119,7 +119,12 @@ class LocaleBundleTransformationRule implements TransformationRuleInterface
             }
 
             // Delete locales that have no content (i.e. only "Version" key)
-            $bundle = new \ResourceBundle($locale, $tempDir);
+            try {
+                $bundle = new \ResourceBundle($locale, $tempDir);
+            } catch (\Exception $e) {
+                // HHVM compatibility: constructor throws on invalid resource
+                $bundle = null;
+            }
 
             if (null === $bundle) {
                 throw new RuntimeException('The resource bundle for locale ' . $locale . ' could not be loaded from directory ' . $tempDir);

--- a/src/Symfony/Component/Translation/Loader/IcuDatFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IcuDatFileLoader.php
@@ -36,7 +36,12 @@ class IcuDatFileLoader extends IcuResFileLoader
             throw new NotFoundResourceException(sprintf('File "%s" not found.', $resource));
         }
 
-        $rb = new \ResourceBundle($locale, $resource);
+        try {
+            $rb = new \ResourceBundle($locale, $resource);
+        } catch (\Exception $e) {
+            // HHVM compatibility: constructor throws on invalid resource
+            $rb = null;
+        }
 
         if (!$rb) {
             throw new InvalidResourceException(sprintf('Cannot load resource "%s"', $resource));

--- a/src/Symfony/Component/Translation/Loader/IcuResFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IcuResFileLoader.php
@@ -36,7 +36,12 @@ class IcuResFileLoader implements LoaderInterface
             throw new NotFoundResourceException(sprintf('File "%s" not found.', $resource));
         }
 
-        $rb = new \ResourceBundle($locale, $resource);
+        try {
+            $rb = new \ResourceBundle($locale, $resource);
+        } catch (\Exception $e) {
+            // HHVM compatibility: constructor throws on invalid resource
+            $rb = false;
+        }
 
         if (!$rb) {
             throw new InvalidResourceException(sprintf('Cannot load resource "%s"', $resource));

--- a/src/Symfony/Component/Translation/Loader/IcuResFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IcuResFileLoader.php
@@ -40,7 +40,7 @@ class IcuResFileLoader implements LoaderInterface
             $rb = new \ResourceBundle($locale, $resource);
         } catch (\Exception $e) {
             // HHVM compatibility: constructor throws on invalid resource
-            $rb = false;
+            $rb = null;
         }
 
         if (!$rb) {


### PR DESCRIPTION
[Translation] HHVM throws when an invalid ResourceBundle is constructed, while zend returns FALSE from the constructor. This patch makes IcuResFileLoader and IcuDatFileLoader compatible with HHVM.

The following tests now pass on HHVM:
https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Translation/Tests/Loader/IcuDatFileLoaderTest.php#L33
https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Translation/Tests/Loader/IcuResFileLoaderTest.php#L54

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
