### PR TITLE
[DomCrawler] Added support for slicing nodes

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -351,14 +351,7 @@ class Crawler extends \SplObjectStorage
      */
     public function slice($offset = 0, $length = -1)
     {
-    	$nodes = array();
-
-        $iterator = new \LimitIterator($this, $offset, $length);
-        foreach($iterator as $i => $node) {
-            $nodes[] = $node;
-        }
-
-        return new static($nodes, $this->uri);
+        return new static(iterator_to_array(new \LimitIterator($this, $offset, $length)), $this->uri);
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -346,8 +346,6 @@ class Crawler extends \SplObjectStorage
      * @param integer $length
      * 
      * @return Crawler A Crawler instance with the sliced nodes.
-     * 
-     * @api
      */
     public function slice($offset = 0, $length = -1)
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -342,8 +342,8 @@ class Crawler extends \SplObjectStorage
     /**
      * Slices the list of nodes by $offset and $length.
      *
-     * @param integer $offset
-     * @param integer $length
+     * @param int     $offset
+     * @param int     $length
      *
      * @return Crawler A Crawler instance with the sliced nodes.
      */

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -340,6 +340,28 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
+     * Slices the list of nodes by $offset and $length.
+     * 
+     * @param integer $offset 
+     * @param integer $length
+     * 
+     * @return Crawler A Crawler instance with the sliced nodes.
+     * 
+     * @api
+     */
+    public function slice($offset = 0, $length = -1)
+    {
+    	$nodes = array();
+
+        $iterator = new \LimitIterator($this, $offset, $length);
+        foreach($iterator as $i => $node) {
+            $nodes[] = $node;
+        }
+
+        return new static($nodes, $this->uri);
+    }
+
+    /**
      * Reduces the list of nodes by calling an anonymous function.
      *
      * To remove a node from the list, the anonymous function must return false.

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -107,7 +107,7 @@ class Crawler extends \SplObjectStorage
 
         // DOM only for HTML/XML content
         if (!preg_match('/(x|ht)ml/i', $type, $xmlMatches)) {
-            return null;
+            return;
         }
 
         $charset = null;
@@ -294,7 +294,7 @@ class Crawler extends \SplObjectStorage
     /**
      * Returns a node given its position in the node list.
      *
-     * @param integer $position The position
+     * @param int     $position The position
      *
      * @return Crawler A new instance of the Crawler with the selected node, or an empty Crawler if it does not exist.
      *
@@ -341,10 +341,10 @@ class Crawler extends \SplObjectStorage
 
     /**
      * Slices the list of nodes by $offset and $length.
-     * 
-     * @param integer $offset 
+     *
+     * @param integer $offset
      * @param integer $length
-     * 
+     *
      * @return Crawler A Crawler instance with the sliced nodes.
      */
     public function slice($offset = 0, $length = -1)
@@ -819,7 +819,7 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
-     * @param integer $position
+     * @param int     $position
      *
      * @return \DOMElement|null
      */
@@ -831,7 +831,7 @@ class Crawler extends \SplObjectStorage
             }
         }
 
-        return null;
+        return;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -309,6 +309,16 @@ EOF
         $this->assertEquals(array('0-One', '1-Two', '2-Three'), $data, '->each() executes an anonymous function on each node of the list');
     }
 
+    public function testSlice()
+    {
+        $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');
+        $this->assertNotSame($crawler->slice(), $crawler, '->slice() returns a new instance of a crawler');
+        $this->assertInstanceOf('Symfony\\Component\\DomCrawler\\Crawler', $crawler->slice(), '->slice() returns a new instance of a crawler');
+
+        $this->assertCount(3, $crawler->slice(), '->slice() does not slice the nodes in the list if any param is entered');
+        $this->assertCount(1, $crawler->slice(1, 1), '->slice() slices the nodes in the list');
+    }
+
     public function testReduce()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

There are no easy way to slice nodes in specific range. I created a method using \LimitIterator. Works fine for me.

An example using is:

``` php
     $crawler->filter('h1')->slice(5, 10)->each(function ($node, $i) {
         return $node->text();
     });
```
