### PR TITLE
Made types used by Symfony compatible with the ones of Hack

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -60,7 +60,7 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param integer $level
+     * @param int     $level
      * @param string  $message
      *
      * @return array Record

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
@@ -39,7 +39,7 @@ class LazyServiceProjectServiceContainer extends Container
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @param boolean $lazyLoad whether to try lazy-loading the service with a proxy
+     * @param bool    $lazyLoad whether to try lazy-loading the service with a proxy
      *
      * @return stdClass A stdClass instance.
      */

--- a/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
+++ b/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
@@ -34,7 +34,7 @@ class MessageDataCollector extends DataCollector
      * to avoid the creation of these objects when no emails are sent.
      *
      * @param ContainerInterface $container A ContainerInterface instance
-     * @param Boolean            $isSpool
+     * @param bool               $isSpool
      */
     public function __construct(ContainerInterface $container, $isSpool)
     {

--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -157,7 +157,7 @@ class CodeExtension extends \Twig_Extension
      * Formats a file path.
      *
      * @param string  $file An absolute file path
-     * @param integer $line The line number
+     * @param int     $line The line number
      * @param string  $text Use this text for the link rather than the file path
      *
      * @return string
@@ -186,7 +186,7 @@ class CodeExtension extends \Twig_Extension
      * Returns the link for a given file/line pair.
      *
      * @param string  $file An absolute file path
-     * @param integer $line The line number
+     * @param int     $line The line number
      *
      * @return string A link of false
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -412,7 +412,7 @@ EOF
      * Renders list of tagged services grouped by tag
      *
      * @param OutputInterface $output
-     * @param Boolean         $showPrivate
+     * @param bool            $showPrivate
      */
     protected function outputTags(OutputInterface $output, $showPrivate = false)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -38,7 +38,7 @@ class Controller extends ContainerAware
      *
      * @param string         $route         The name of the route
      * @param mixed          $parameters    An array of parameters
-     * @param Boolean|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     * @param bool|string    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The generated URL
      *
@@ -70,7 +70,7 @@ class Controller extends ContainerAware
      * Returns a RedirectResponse to the given URL.
      *
      * @param string  $url    The URL to redirect to
-     * @param integer $status The status code to use for the Response
+     * @param int     $status The status code to use for the Response
      *
      * @return RedirectResponse
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -36,8 +36,8 @@ class RedirectController extends ContainerAware
      *
      * @param Request       $request          The request instance
      * @param string        $route            The route name to redirect to
-     * @param Boolean       $permanent        Whether the redirection is permanent
-     * @param Boolean|array $ignoreAttributes Whether to ignore attributes or an array of attributes to ignore
+     * @param bool          $permanent        Whether the redirection is permanent
+     * @param bool|array    $ignoreAttributes Whether to ignore attributes or an array of attributes to ignore
      *
      * @return Response A Response instance
      *
@@ -72,10 +72,10 @@ class RedirectController extends ContainerAware
      *
      * @param Request      $request   The request instance
      * @param string       $path      The absolute path or URL to redirect to
-     * @param Boolean      $permanent Whether the redirect is permanent or not
+     * @param bool         $permanent Whether the redirect is permanent or not
      * @param string|null  $scheme    The URL scheme (null to keep the current one)
-     * @param integer|null $httpPort  The HTTP port (null to keep the current one for the same scheme or the configured port in the container)
-     * @param integer|null $httpsPort The HTTPS port (null to keep the current one for the same scheme or the configured port in the container)
+     * @param int    |null $httpPort  The HTTP port (null to keep the current one for the same scheme or the configured port in the container)
+     * @param int    |null $httpsPort The HTTPS port (null to keep the current one for the same scheme or the configured port in the container)
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -27,7 +27,7 @@ class TemplateController extends ContainerAware
      * @param string       $template  The template name
      * @param int|null     $maxAge    Max age for client caching
      * @param int|null     $sharedAge Max age for shared (proxy) caching
-     * @param Boolean|null $private   Whether or not caching should apply for client caches only
+     * @param bool|null    $private   Whether or not caching should apply for client caches only
      *
      * @return Response A Response instance
      */

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -46,7 +46,7 @@ abstract class HttpCache extends BaseHttpCache
      * Forwards the Request to the backend and returns the Response.
      *
      * @param Request  $request A Request instance
-     * @param Boolean  $raw     Whether to catch exceptions or not
+     * @param bool     $raw     Whether to catch exceptions or not
      * @param Response $entry   A Response instance (the stale entry if present, null otherwise)
      *
      * @return Response A Response instance

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -112,6 +112,6 @@ class GlobalVariables
      */
     public function getDebug()
     {
-        return (Boolean) $this->container->getParameter('kernel.debug');
+        return (bool) $this->container->getParameter('kernel.debug');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -151,7 +151,7 @@ class CodeHelper extends Helper
      * Formats a file path.
      *
      * @param string  $file An absolute file path
-     * @param integer $line The line number
+     * @param int     $line The line number
      * @param string  $text Use this text for the link rather than the file path
      *
      * @return string
@@ -180,7 +180,7 @@ class CodeHelper extends Helper
      * Returns the link for a given file/line pair.
      *
      * @param string  $file An absolute file path
-     * @param integer $line The line number
+     * @param int     $line The line number
      *
      * @return string A link of false
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
@@ -38,7 +38,7 @@ class RouterHelper extends Helper
      *
      * @param string         $name          The name of the route
      * @param mixed          $parameters    An array of parameters
-     * @param Boolean|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     * @param bool|string    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The generated URL
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
@@ -57,7 +57,7 @@ class FilesystemLoader implements LoaderInterface
      * Returns true if the template is still fresh.
      *
      * @param TemplateReferenceInterface $template The template name as an array
-     * @param integer                    $time     The last modification time of the cached template (timestamp)
+     * @param int                        $time     The last modification time of the cached template (timestamp)
      *
      * @return Boolean
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -56,7 +56,7 @@ class TemplateLocator implements FileLocatorInterface
      *
      * @param TemplateReferenceInterface $template    A template
      * @param string                     $currentPath Unused
-     * @param Boolean                    $first       Unused
+     * @param bool                       $first       Unused
      *
      * @return string The full path for the file
      *

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -82,7 +82,7 @@ class LogoutUrlHelper extends Helper
      * Generates the logout URL for the firewall.
      *
      * @param string         $key           The firewall key
-     * @param Boolean|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     * @param bool|string    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The logout URL
      *

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -64,7 +64,7 @@ class ExceptionController
     }
 
     /**
-     * @param integer $startObLevel
+     * @param int     $startObLevel
      *
      * @return string
      */
@@ -86,8 +86,8 @@ class ExceptionController
     /**
      * @param Request $request
      * @param string  $format
-     * @param integer $code       An HTTP response status code
-     * @param Boolean $debug
+     * @param int     $code       An HTTP response status code
+     * @param bool    $debug
      *
      * @return TemplateReference
      */

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -41,8 +41,8 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     public function __construct(\Twig_Environment $twig, $interceptRedirects = false, $mode = self::ENABLED, $position = 'bottom')
     {
         $this->twig = $twig;
-        $this->interceptRedirects = (Boolean) $interceptRedirects;
-        $this->mode = (integer) $mode;
+        $this->interceptRedirects = (bool) $interceptRedirects;
+        $this->mode = (int) $mode;
         $this->position = $position;
     }
 

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -76,7 +76,7 @@ abstract class Client
      */
     public function followRedirects($followRedirect = true)
     {
-        $this->followRedirects = (Boolean) $followRedirect;
+        $this->followRedirects = (bool) $followRedirect;
     }
 
     /**
@@ -107,7 +107,7 @@ abstract class Client
             // @codeCoverageIgnoreEnd
         }
 
-        $this->insulated = (Boolean) $insulated;
+        $this->insulated = (bool) $insulated;
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -70,7 +70,7 @@ abstract class Client
     /**
      * Sets whether to automatically follow redirects or not.
      *
-     * @param Boolean $followRedirect Whether to follow redirects
+     * @param bool    $followRedirect Whether to follow redirects
      *
      * @api
      */
@@ -82,7 +82,7 @@ abstract class Client
     /**
      * Sets the maximum number of requests that crawler can follow.
      *
-     * @param integer $maxRedirects
+     * @param int     $maxRedirects
      */
     public function setMaxRedirects($maxRedirects)
     {
@@ -93,7 +93,7 @@ abstract class Client
     /**
      * Sets the insulated flag.
      *
-     * @param Boolean $insulated Whether to insulate the requests or not
+     * @param bool    $insulated Whether to insulate the requests or not
      *
      * @throws \RuntimeException When Symfony Process Component is not installed
      *
@@ -287,7 +287,7 @@ abstract class Client
      * @param array   $files         The files
      * @param array   $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
      * @param string  $content       The raw body data
-     * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     * @param bool    $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
      *
      * @return Crawler
      *
@@ -601,7 +601,7 @@ abstract class Client
      * Makes a request from a Request object directly.
      *
      * @param Request $request       A Request instance
-     * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     * @param bool    $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
      *
      * @return Crawler
      */

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -53,9 +53,9 @@ class Cookie
      * @param string  $expires      The time the cookie expires
      * @param string  $path         The path on the server in which the cookie will be available on
      * @param string  $domain       The domain that the cookie is available
-     * @param Boolean $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param Boolean $httponly     The cookie httponly flag
-     * @param Boolean $encodedValue Whether the value is encoded or not
+     * @param bool    $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param bool    $httponly     The cookie httponly flag
+     * @param bool    $encodedValue Whether the value is encoded or not
      *
      * @api
      */

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -69,11 +69,11 @@ class Cookie
             $this->rawValue = urlencode($value);
         }
         $this->name     = $name;
-        $this->expires  = null === $expires ? null : (integer) $expires;
+        $this->expires  = null === $expires ? null : (int) $expires;
         $this->path     = empty($path) ? '/' : $path;
         $this->domain   = $domain;
-        $this->secure   = (Boolean) $secure;
-        $this->httponly = (Boolean) $httponly;
+        $this->secure   = (bool) $secure;
+        $this->httponly = (bool) $httponly;
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -201,7 +201,7 @@ class CookieJar
      * Returns not yet expired cookie values for the given URI.
      *
      * @param string  $uri             A URI
-     * @param Boolean $returnsRawValue Returns raw value or urldecoded value
+     * @param bool    $returnsRawValue Returns raw value or urldecoded value
      *
      * @return array An array of cookie values
      */

--- a/src/Symfony/Component/BrowserKit/Response.php
+++ b/src/Symfony/Component/BrowserKit/Response.php
@@ -31,7 +31,7 @@ class Response
      * then the value is an array of all the values.
      *
      * @param string  $content The content of the response
-     * @param integer $status  The response status code
+     * @param int     $status  The response status code
      * @param array   $headers An array of headers
      *
      * @api
@@ -117,7 +117,7 @@ class Response
      * Gets a response header.
      *
      * @param string  $header The header name
-     * @param Boolean $first  Whether to return the first value or all header values
+     * @param bool    $first  Whether to return the first value or all header values
      *
      * @return string|array The first header value if $first is true, an array of values otherwise
      */

--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -79,7 +79,7 @@ class ApcClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param bool    $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -28,8 +28,8 @@ class ClassCollectionLoader
      * @param array   $classes    An array of classes to load
      * @param string  $cacheDir   A cache directory
      * @param string  $name       The cache name prefix
-     * @param Boolean $autoReload Whether to flush the cache when the cache is stale or not
-     * @param Boolean $adaptive   Whether to remove already declared classes or not
+     * @param bool    $autoReload Whether to flush the cache when the cache is stale or not
+     * @param bool    $adaptive   Whether to remove already declared classes or not
      * @param string  $extension  File extension of the resulting file
      *
      * @throws \InvalidArgumentException When class can't be loaded

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -200,7 +200,7 @@ class ClassCollectionLoader
      */
     public static function enableTokenizer($bool)
     {
-        self::$useTokenizer = (Boolean) $bool;
+        self::$useTokenizer = (bool) $bool;
     }
 
     /**

--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -103,7 +103,7 @@ class ClassLoader
     /**
      * Turns on searching the include for class files.
      *
-     * @param Boolean $useIncludePath
+     * @param bool    $useIncludePath
      */
     public function setUseIncludePath($useIncludePath)
     {
@@ -124,7 +124,7 @@ class ClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param bool    $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {

--- a/src/Symfony/Component/ClassLoader/MapClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/MapClassLoader.php
@@ -33,7 +33,7 @@ class MapClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param bool    $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {

--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -70,7 +70,7 @@ class UniversalClassLoader
      * Turns on searching the include for class files. Allows easy loading
      * of installed PEAR packages
      *
-     * @param Boolean $useIncludePath
+     * @param bool    $useIncludePath
      */
     public function useIncludePath($useIncludePath)
     {
@@ -229,7 +229,7 @@ class UniversalClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param bool    $prepend Whether to prepend the autoloader or not
      *
      * @api
      */

--- a/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
@@ -76,7 +76,7 @@ class WinCacheClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param bool    $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {

--- a/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
@@ -73,7 +73,7 @@ class XcacheClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param bool    $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -32,7 +32,7 @@ class ConfigCache
      * Constructor.
      *
      * @param string  $file  The absolute cache path
-     * @param Boolean $debug Whether debugging is enabled or not
+     * @param bool    $debug Whether debugging is enabled or not
      */
     public function __construct($file, $debug)
     {

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -37,7 +37,7 @@ class ConfigCache
     public function __construct($file, $debug)
     {
         $this->file = $file;
-        $this->debug = (Boolean) $debug;
+        $this->debug = (bool) $debug;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -109,7 +109,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      * Sets whether to add default values for this array if it has not been
      * defined in any of the configuration files.
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      */
     public function setAddIfNotSet($boolean)
     {
@@ -119,7 +119,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets whether false is allowed as value indicating that the array should be unset.
      *
-     * @param Boolean $allow
+     * @param bool    $allow
      */
     public function setAllowFalse($allow)
     {
@@ -129,7 +129,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets whether new keys can be defined in subsequent configurations.
      *
-     * @param Boolean $allow
+     * @param bool    $allow
      */
     public function setAllowNewKeys($allow)
     {
@@ -139,7 +139,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets if deep merging should occur.
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      */
     public function setPerformDeepMerging($boolean)
     {
@@ -149,7 +149,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Whether extra keys should just be ignore without an exception.
      *
-     * @param Boolean $boolean To allow extra keys
+     * @param bool    $boolean To allow extra keys
      */
     public function setIgnoreExtraKeys($boolean)
     {

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -53,7 +53,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
     public function setNormalizeKeys($normalizeKeys)
     {
-        $this->normalizeKeys = (Boolean) $normalizeKeys;
+        $this->normalizeKeys = (bool) $normalizeKeys;
     }
 
     /**
@@ -113,7 +113,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      */
     public function setAddIfNotSet($boolean)
     {
-        $this->addIfNotSet = (Boolean) $boolean;
+        $this->addIfNotSet = (bool) $boolean;
     }
 
     /**
@@ -123,7 +123,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      */
     public function setAllowFalse($allow)
     {
-        $this->allowFalse = (Boolean) $allow;
+        $this->allowFalse = (bool) $allow;
     }
 
     /**
@@ -133,7 +133,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      */
     public function setAllowNewKeys($allow)
     {
-        $this->allowNewKeys = (Boolean) $allow;
+        $this->allowNewKeys = (bool) $allow;
     }
 
     /**
@@ -143,7 +143,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      */
     public function setPerformDeepMerging($boolean)
     {
-        $this->performDeepMerging = (Boolean) $boolean;
+        $this->performDeepMerging = (bool) $boolean;
     }
 
     /**
@@ -153,7 +153,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      */
     public function setIgnoreExtraKeys($boolean)
     {
-        $this->ignoreExtraKeys = (Boolean) $boolean;
+        $this->ignoreExtraKeys = (bool) $boolean;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -138,7 +138,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Set this node as required.
      *
-     * @param Boolean $boolean Required node
+     * @param bool    $boolean Required node
      */
     public function setRequired($boolean)
     {
@@ -148,7 +148,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Sets if this node can be overridden.
      *
-     * @param Boolean $allow
+     * @param bool    $allow
      */
     public function setAllowOverwrite($allow)
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -142,7 +142,7 @@ abstract class BaseNode implements NodeInterface
      */
     public function setRequired($boolean)
     {
-        $this->required = (Boolean) $boolean;
+        $this->required = (bool) $boolean;
     }
 
     /**
@@ -152,7 +152,7 @@ abstract class BaseNode implements NodeInterface
      */
     public function setAllowOverwrite($allow)
     {
-        $this->allowOverwrite = (Boolean) $allow;
+        $this->allowOverwrite = (bool) $allow;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -309,7 +309,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      */
     public function normalizeKeys($bool)
     {
-        $this->normalizeKeys = (Boolean) $bool;
+        $this->normalizeKeys = (bool) $bool;
 
         return $this;
     }

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -105,7 +105,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     /**
      * Adds children with a default value when none are defined.
      *
-     * @param integer|string|array|null $children The number of children|The child name|The children names to be added
+     * @param int    |string|array|null $children The number of children|The child name|The children names to be added
      *
      * This method is applicable to prototype nodes only.
      *
@@ -185,7 +185,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      * This method is applicable to prototype nodes only.
      *
      * @param string  $name          The name of the key
-     * @param Boolean $removeKeyItem Whether or not the key item should be removed.
+     * @param bool    $removeKeyItem Whether or not the key item should be removed.
      *
      * @return ArrayNodeDefinition
      */
@@ -200,7 +200,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     /**
      * Sets whether the node can be unset.
      *
-     * @param Boolean $allow
+     * @param bool    $allow
      *
      * @return ArrayNodeDefinition
      */
@@ -303,7 +303,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     /**
      * Sets key normalization.
      *
-     * @param Boolean $bool Whether to enable key normalization
+     * @param bool    $bool Whether to enable key normalization
      *
      * @return ArrayNodeDefinition
      */

--- a/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
@@ -37,7 +37,7 @@ class MergeBuilder
     /**
      * Sets whether the node can be unset.
      *
-     * @param Boolean $allow
+     * @param bool    $allow
      *
      * @return MergeBuilder
      */
@@ -51,7 +51,7 @@ class MergeBuilder
     /**
      * Sets whether the node can be overwritten.
      *
-     * @param Boolean $deny Whether the overwriting is forbidden or not
+     * @param bool    $deny Whether the overwriting is forbidden or not
      *
      * @return MergeBuilder
      */

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -120,7 +120,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Creates the node.
      *
-     * @param Boolean $forceRootNode Whether to force this node as the root node
+     * @param bool    $forceRootNode Whether to force this node as the root node
      *
      * @return NodeInterface
      */
@@ -282,7 +282,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Sets whether the node can be overwritten.
      *
-     * @param Boolean $deny Whether the overwriting is forbidden or not
+     * @param bool    $deny Whether the overwriting is forbidden or not
      *
      * @return NodeDefinition
      */

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -48,7 +48,7 @@ class PrototypedArrayNode extends ArrayNode
      * Sets the minimum number of elements that a prototype based node must
      * contain. By default this is zero, meaning no elements.
      *
-     * @param integer $number
+     * @param int     $number
      */
     public function setMinNumberOfElements($number)
     {
@@ -77,7 +77,7 @@ class PrototypedArrayNode extends ArrayNode
      * array, then you can set the second argument of this method to false.
      *
      * @param string  $attribute The name of the attribute which value is to be used as a key
-     * @param Boolean $remove    Whether or not to remove the key
+     * @param bool    $remove    Whether or not to remove the key
      */
     public function setKeyAttribute($attribute, $remove = true)
     {
@@ -124,7 +124,7 @@ class PrototypedArrayNode extends ArrayNode
     /**
      * Adds default children when none are set.
      *
-     * @param integer|string|array|null $children The number of children|The child name|The children names to be added
+     * @param int    |string|array|null $children The number of children|The child name|The children names to be added
      */
     public function setAddChildrenIfNoneSet($children = array('defaults'))
     {

--- a/src/Symfony/Component/Config/Definition/ReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/ReferenceDumper.php
@@ -39,7 +39,7 @@ class ReferenceDumper
 
     /**
      * @param NodeInterface $node
-     * @param integer       $depth
+     * @param int           $depth
      */
     private function writeNode(NodeInterface $node, $depth = 0)
     {

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -55,7 +55,7 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets if this node is allowed to have an empty value.
      *
-     * @param Boolean $boolean True if this entity will accept empty values.
+     * @param bool    $boolean True if this entity will accept empty values.
      */
     public function setAllowEmptyValue($boolean)
     {

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -59,7 +59,7 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
      */
     public function setAllowEmptyValue($boolean)
     {
-        $this->allowEmptyValue = (Boolean) $boolean;
+        $this->allowEmptyValue = (bool) $boolean;
     }
 
     /**

--- a/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
@@ -21,7 +21,7 @@ class FileLoaderLoadException extends \Exception
     /**
      * @param string     $resource       The resource that could not be imported
      * @param string     $sourceResource The original resource importing the new resource
-     * @param integer    $code           The error code
+     * @param int        $code           The error code
      * @param \Exception $previous       A previous exception
      */
     public function __construct($resource, $sourceResource = null, $code = null, $previous = null)

--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -35,7 +35,7 @@ class FileLocator implements FileLocatorInterface
      *
      * @param mixed   $name        The file name to locate
      * @param string  $currentPath The current path
-     * @param Boolean $first       Whether to return the first occurrence or an array of filenames
+     * @param bool    $first       Whether to return the first occurrence or an array of filenames
      *
      * @return string|array The full path to the file|An array of file paths
      *

--- a/src/Symfony/Component/Config/FileLocatorInterface.php
+++ b/src/Symfony/Component/Config/FileLocatorInterface.php
@@ -21,7 +21,7 @@ interface FileLocatorInterface
      *
      * @param mixed   $name        The file name to locate
      * @param string  $currentPath The current path
-     * @param Boolean $first       Whether to return the first occurrence or an array of filenames
+     * @param bool    $first       Whether to return the first occurrence or an array of filenames
      *
      * @return string|array The full path to the file|An array of file paths
      *

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -53,7 +53,7 @@ abstract class FileLoader extends Loader
      *
      * @param mixed   $resource       A Resource
      * @param string  $type           The resource type
-     * @param Boolean $ignoreErrors   Whether to ignore import errors or not
+     * @param bool    $ignoreErrors   Whether to ignore import errors or not
      * @param string  $sourceResource The original resource importing the new resource
      *
      * @return mixed

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -61,7 +61,7 @@ class DirectoryResource implements ResourceInterface, \Serializable
     /**
      * Returns true if the resource has not been updated since the given timestamp.
      *
-     * @param integer $timestamp The last time the resource was loaded
+     * @param int     $timestamp The last time the resource was loaded
      *
      * @return Boolean true if the resource has not been updated, false otherwise
      */

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -55,7 +55,7 @@ class FileResource implements ResourceInterface, \Serializable
     /**
      * Returns true if the resource has not been updated since the given timestamp.
      *
-     * @param integer $timestamp The last time the resource was loaded
+     * @param int     $timestamp The last time the resource was loaded
      *
      * @return Boolean true if the resource has not been updated, false otherwise
      */

--- a/src/Symfony/Component/Config/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Config/Resource/ResourceInterface.php
@@ -28,7 +28,7 @@ interface ResourceInterface
     /**
      * Returns true if the resource has not been updated since the given timestamp.
      *
-     * @param integer $timestamp The last time the resource was loaded
+     * @param int     $timestamp The last time the resource was loaded
      *
      * @return Boolean true if the resource has not been updated, false otherwise
      */

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -117,7 +117,7 @@ class XmlUtils
      *  * The nested-tags are converted to keys (<foo><foo>bar</foo></foo>)
      *
      * @param \DomElement $element     A \DomElement instance
-     * @param Boolean     $checkPrefix Check prefix in an element or an attribute name
+     * @param bool        $checkPrefix Check prefix in an element or an attribute name
      *
      * @return array A PHP array
      */

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -276,7 +276,7 @@ class Application
      */
     public function setCatchExceptions($boolean)
     {
-        $this->catchExceptions = (Boolean) $boolean;
+        $this->catchExceptions = (bool) $boolean;
     }
 
     /**
@@ -288,7 +288,7 @@ class Application
      */
     public function setAutoExit($boolean)
     {
-        $this->autoExit = (Boolean) $boolean;
+        $this->autoExit = (bool) $boolean;
     }
 
     /**

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -270,7 +270,7 @@ class Application
     /**
      * Sets whether to catch exceptions or not during commands execution.
      *
-     * @param Boolean $boolean Whether to catch exceptions or not during commands execution
+     * @param bool    $boolean Whether to catch exceptions or not during commands execution
      *
      * @api
      */
@@ -282,7 +282,7 @@ class Application
     /**
      * Sets whether to automatically exit after a command execution or not.
      *
-     * @param Boolean $boolean Whether to automatically exit after a command execution or not
+     * @param bool    $boolean Whether to automatically exit after a command execution or not
      *
      * @api
      */
@@ -675,7 +675,7 @@ class Application
      * Returns a text representation of the Application.
      *
      * @param string  $namespace An optional namespace name
-     * @param boolean $raw       Whether to return raw command list
+     * @param bool    $raw       Whether to return raw command list
      *
      * @return string A string representing the Application
      *
@@ -692,7 +692,7 @@ class Application
      * Returns an XML representation of the Application.
      *
      * @param string  $namespace An optional namespace name
-     * @param Boolean $asDom     Whether to return a DOM or an XML string
+     * @param bool    $asDom     Whether to return a DOM or an XML string
      *
      * @return string|\DOMDocument An XML string representing the Application
      *

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -279,7 +279,7 @@ class Command
      *
      * This method is not part of public API and should not be used directly.
      *
-     * @param Boolean $mergeArgs Whether to merge or not the Application definition arguments to Command definition arguments
+     * @param bool    $mergeArgs Whether to merge or not the Application definition arguments to Command definition arguments
      */
     public function mergeApplicationDefinition($mergeArgs = true)
     {
@@ -354,7 +354,7 @@ class Command
      * Adds an argument.
      *
      * @param string  $name        The argument name
-     * @param integer $mode        The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
+     * @param int     $mode        The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
      * @param string  $description A description text
      * @param mixed   $default     The default value (for InputArgument::OPTIONAL mode only)
      *
@@ -374,7 +374,7 @@ class Command
      *
      * @param string  $name        The option name
      * @param string  $shortcut    The shortcut (can be null)
-     * @param integer $mode        The option mode: One of the InputOption::VALUE_* constants
+     * @param int     $mode        The option mode: One of the InputOption::VALUE_* constants
      * @param string  $description A description text
      * @param mixed   $default     The default value (must be null for InputOption::VALUE_REQUIRED or InputOption::VALUE_NONE)
      *
@@ -583,7 +583,7 @@ class Command
     /**
      * Returns an XML representation of the command.
      *
-     * @param Boolean $asDom Whether to return a DOM or an XML string
+     * @param bool    $asDom Whether to return a DOM or an XML string
      *
      * @return string|\DOMDocument An XML string representing the command
      *

--- a/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
@@ -39,7 +39,7 @@ class ConsoleTerminateEvent extends ConsoleEvent
     /**
      * Sets the exit code.
      *
-     * @param integer $exitCode The command exit code
+     * @param int     $exitCode The command exit code
      */
     public function setExitCode($exitCode)
     {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -39,7 +39,7 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Initializes console output formatter.
      *
-     * @param Boolean          $decorated Whether this formatter should actually decorate strings
+     * @param bool             $decorated Whether this formatter should actually decorate strings
      * @param OutputFormatterStyleInterface[] $styles    Array of "name => FormatterStyle" instances
      *
      * @api
@@ -63,7 +63,7 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Sets the decorated flag.
      *
-     * @param Boolean $decorated Whether to decorate the messages or not
+     * @param bool    $decorated Whether to decorate the messages or not
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -46,7 +46,7 @@ class OutputFormatter implements OutputFormatterInterface
      */
     public function __construct($decorated = false, array $styles = array())
     {
-        $this->decorated = (Boolean) $decorated;
+        $this->decorated = (bool) $decorated;
 
         $this->setStyle('error', new OutputFormatterStyle('white', 'red'));
         $this->setStyle('info', new OutputFormatterStyle('green'));
@@ -69,7 +69,7 @@ class OutputFormatter implements OutputFormatterInterface
      */
     public function setDecorated($decorated)
     {
-        $this->decorated = (Boolean) $decorated;
+        $this->decorated = (bool) $decorated;
     }
 
     /**

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
@@ -23,7 +23,7 @@ interface OutputFormatterInterface
     /**
      * Sets the decorated flag.
      *
-     * @param Boolean $decorated Whether to decorate the messages or not
+     * @param bool    $decorated Whether to decorate the messages or not
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Helper/DescriptorHelper.php
+++ b/src/Symfony/Component/Console/Helper/DescriptorHelper.php
@@ -49,7 +49,7 @@ class DescriptorHelper extends Helper
      * @param OutputInterface $output
      * @param object          $object
      * @param string          $format
-     * @param boolean         $raw
+     * @param bool            $raw
      */
     public function describe(OutputInterface $output, $object, $format = null, $raw = false, $namespace = null)
     {

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -31,10 +31,10 @@ class DialogHelper extends Helper
      * @param OutputInterface $output       An Output instance
      * @param string|array    $question     The question to ask
      * @param array           $choices      List of choices to pick from
-     * @param Boolean|string  $default      The default answer if the user enters nothing
-     * @param Boolean|integer $attempts Max number of times to ask before giving up (false by default, which means infinite)
+     * @param bool|string     $default      The default answer if the user enters nothing
+     * @param bool|integer    $attempts Max number of times to ask before giving up (false by default, which means infinite)
      * @param string          $errorMessage Message which will be shown if invalid value from choice list would be picked
-     * @param Boolean         $multiselect  Select more than one value separated by comma
+     * @param bool            $multiselect  Select more than one value separated by comma
      *
      * @return integer|string|array The selected value or values (the key of the choices array)
      *
@@ -223,7 +223,7 @@ class DialogHelper extends Helper
      *
      * @param OutputInterface $output   An Output instance
      * @param string|array    $question The question to ask
-     * @param Boolean         $default  The default answer if the user enters nothing
+     * @param bool            $default  The default answer if the user enters nothing
      *
      * @return Boolean true if the user has confirmed, false otherwise
      */
@@ -246,7 +246,7 @@ class DialogHelper extends Helper
      *
      * @param OutputInterface $output   An Output instance
      * @param string|array    $question The question
-     * @param Boolean         $fallback In case the response can not be hidden, whether to fallback on non-hidden question or not
+     * @param bool            $fallback In case the response can not be hidden, whether to fallback on non-hidden question or not
      *
      * @return string         The answer
      *
@@ -321,7 +321,7 @@ class DialogHelper extends Helper
      * @param OutputInterface $output       An Output instance
      * @param string|array    $question     The question to ask
      * @param callable        $validator    A PHP callback
-     * @param integer         $attempts     Max number of times to ask before giving up (false by default, which means infinite)
+     * @param int             $attempts     Max number of times to ask before giving up (false by default, which means infinite)
      * @param string          $default      The default answer if none is given by the user
      * @param array           $autocomplete List of values to autocomplete
      *
@@ -350,8 +350,8 @@ class DialogHelper extends Helper
      * @param OutputInterface $output    An Output instance
      * @param string|array    $question  The question to ask
      * @param callable        $validator A PHP callback
-     * @param integer         $attempts  Max number of times to ask before giving up (false by default, which means infinite)
-     * @param Boolean         $fallback  In case the response can not be hidden, whether to fallback on non-hidden question or not
+     * @param int             $attempts  Max number of times to ask before giving up (false by default, which means infinite)
+     * @param bool            $fallback  In case the response can not be hidden, whether to fallback on non-hidden question or not
      *
      * @return string         The response
      *
@@ -444,7 +444,7 @@ class DialogHelper extends Helper
      * @param callable         $interviewer  A callable that will ask for a question and return the result
      * @param OutputInterface  $output       An Output instance
      * @param callable         $validator    A PHP callback
-     * @param integer          $attempts     Max number of times to ask before giving up ; false will ask infinitely
+     * @param int              $attempts     Max number of times to ask before giving up ; false will ask infinitely
      *
      * @return string   The validated response
      *

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -39,7 +39,7 @@ class FormatterHelper extends Helper
      *
      * @param string|array $messages The message to write in the block
      * @param string       $style    The style to apply to the whole block
-     * @param Boolean      $large    Whether to return a large block
+     * @param bool         $large    Whether to return a large block
      *
      * @return string The formatter message
      */

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -178,7 +178,7 @@ class ProgressHelper extends Helper
      * Starts the progress output.
      *
      * @param OutputInterface $output An Output instance
-     * @param integer|null    $max    Maximum steps
+     * @param int    |null    $max    Maximum steps
      */
     public function start(OutputInterface $output, $max = null)
     {
@@ -220,8 +220,8 @@ class ProgressHelper extends Helper
     /**
      * Advances the progress output X steps.
      *
-     * @param integer $step   Number of steps to advance
-     * @param Boolean $redraw Whether to redraw or not
+     * @param int     $step   Number of steps to advance
+     * @param bool    $redraw Whether to redraw or not
      *
      * @throws \LogicException
      */
@@ -248,8 +248,8 @@ class ProgressHelper extends Helper
     /**
      * Sets the current progress.
      *
-     * @param integer $current The current progress
-     * @param Boolean $redraw  Whether to redraw or not
+     * @param int     $current The current progress
+     * @param bool    $redraw  Whether to redraw or not
      *
      * @throws \LogicException
      */
@@ -282,7 +282,7 @@ class ProgressHelper extends Helper
     /**
      * Outputs the current progress string.
      *
-     * @param Boolean $finish Forces the end result
+     * @param bool    $finish Forces the end result
      *
      * @throws \LogicException
      */
@@ -343,7 +343,7 @@ class ProgressHelper extends Helper
     /**
      * Generates the array map of format variables to values.
      *
-     * @param Boolean $finish Forces the end result
+     * @param bool    $finish Forces the end result
      *
      * @return array Array of format vars and values
      */
@@ -401,7 +401,7 @@ class ProgressHelper extends Helper
     /**
      * Converts seconds into human-readable format.
      *
-     * @param integer $secs Number of seconds
+     * @param int     $secs Number of seconds
      *
      * @return string Time in readable format
      */

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -277,7 +277,7 @@ class TableHelper extends Helper
     /**
      * Sets cell padding type.
      *
-     * @param integer $padType STR_PAD_*
+     * @param int     $padType STR_PAD_*
      *
      * @return TableHelper
      */
@@ -376,7 +376,7 @@ class TableHelper extends Helper
      * Renders table cell with padding.
      *
      * @param array   $row
-     * @param integer $column
+     * @param int     $column
      * @param string  $cellFormat
      */
     private function renderCell(array $row, $column, $cellFormat)
@@ -425,7 +425,7 @@ class TableHelper extends Helper
     /**
      * Gets column width.
      *
-     * @param integer $column
+     * @param int     $column
      *
      * @return int
      */
@@ -448,7 +448,7 @@ class TableHelper extends Helper
      * Gets cell width.
      *
      * @param array   $row
-     * @param integer $column
+     * @param int     $column
      *
      * @return int
      */

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -94,7 +94,7 @@ abstract class Input implements InputInterface
      */
     public function setInteractive($interactive)
     {
-        $this->interactive = (Boolean) $interactive;
+        $this->interactive = (bool) $interactive;
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -90,7 +90,7 @@ abstract class Input implements InputInterface
     /**
      * Sets the input interactivity.
      *
-     * @param Boolean $interactive If the input should be interactive
+     * @param bool    $interactive If the input should be interactive
      */
     public function setInteractive($interactive)
     {

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -33,7 +33,7 @@ class InputArgument
      * Constructor.
      *
      * @param string  $name        The argument name
-     * @param integer $mode        The argument mode: self::REQUIRED or self::OPTIONAL
+     * @param int     $mode        The argument mode: self::REQUIRED or self::OPTIONAL
      * @param string  $description A description text
      * @param mixed   $default     The default value (for self::OPTIONAL mode only)
      *

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -433,7 +433,7 @@ class InputDefinition
     /**
      * Returns an XML representation of the InputDefinition.
      *
-     * @param Boolean $asDom Whether to return a DOM or an XML string
+     * @param bool    $asDom Whether to return a DOM or an XML string
      *
      * @return string|\DOMDocument An XML string representing the InputDefinition
      *

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -146,7 +146,7 @@ interface InputInterface
     /**
      * Sets the input interactivity.
      *
-     * @param Boolean $interactive If the input should be interactive
+     * @param bool    $interactive If the input should be interactive
      */
     public function setInteractive($interactive);
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -36,7 +36,7 @@ class InputOption
      *
      * @param string       $name        The option name
      * @param string|array $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param integer      $mode        The option mode: One of the VALUE_* constants
+     * @param int          $mode        The option mode: One of the VALUE_* constants
      * @param string       $description A description text
      * @param mixed        $default     The default value (must be null for self::VALUE_REQUIRED or self::VALUE_NONE)
      *

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -35,8 +35,8 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
     /**
      * Constructor.
      *
-     * @param integer                       $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
-     * @param Boolean|null                  $decorated Whether to decorate messages (null for auto-guessing)
+     * @param int                           $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
+     * @param bool|null                     $decorated Whether to decorate messages (null for auto-guessing)
      * @param OutputFormatterInterface|null $formatter Output formatter instance (null to use default OutputFormatter)
      *
      * @api

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -37,8 +37,8 @@ abstract class Output implements OutputInterface
     /**
      * Constructor.
      *
-     * @param integer                       $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
-     * @param Boolean                       $decorated Whether to decorate messages
+     * @param int                           $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
+     * @param bool                          $decorated Whether to decorate messages
      * @param OutputFormatterInterface|null $formatter Output formatter instance (null to use default OutputFormatter)
      *
      * @api
@@ -139,7 +139,7 @@ abstract class Output implements OutputInterface
      * Writes a message to the output.
      *
      * @param string  $message A message to write to the output
-     * @param Boolean $newline Whether to add a newline or not
+     * @param bool    $newline Whether to add a newline or not
      */
     abstract protected function doWrite($message, $newline);
 }

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -36,8 +36,8 @@ interface OutputInterface
      * Writes a message to the output.
      *
      * @param string|array $messages The message as an array of lines or a single string
-     * @param Boolean      $newline  Whether to add a newline
-     * @param integer      $type     The type of output (one of the OUTPUT constants)
+     * @param bool         $newline  Whether to add a newline
+     * @param int          $type     The type of output (one of the OUTPUT constants)
      *
      * @throws \InvalidArgumentException When unknown output type is given
      *
@@ -49,7 +49,7 @@ interface OutputInterface
      * Writes a message to the output and adds a newline at the end.
      *
      * @param string|array $messages The message as an array of lines of a single string
-     * @param integer      $type     The type of output (one of the OUTPUT constants)
+     * @param int          $type     The type of output (one of the OUTPUT constants)
      *
      * @throws \InvalidArgumentException When unknown output type is given
      *
@@ -60,7 +60,7 @@ interface OutputInterface
     /**
      * Sets the verbosity of the output.
      *
-     * @param integer $level The level of verbosity (one of the VERBOSITY constants)
+     * @param int     $level The level of verbosity (one of the VERBOSITY constants)
      *
      * @api
      */
@@ -78,7 +78,7 @@ interface OutputInterface
     /**
      * Sets the decorated flag.
      *
-     * @param Boolean $decorated Whether to decorate the messages
+     * @param bool    $decorated Whether to decorate the messages
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -36,8 +36,8 @@ class StreamOutput extends Output
      * Constructor.
      *
      * @param mixed                         $stream    A stream resource
-     * @param integer                       $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
-     * @param Boolean|null                  $decorated Whether to decorate messages (null for auto-guessing)
+     * @param int                           $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
+     * @param bool|null                     $decorated Whether to decorate messages (null for auto-guessing)
      * @param OutputFormatterInterface|null $formatter Output formatter instance (null to use default OutputFormatter)
      *
      * @throws \InvalidArgumentException When first argument is not a real stream

--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -220,7 +220,7 @@ EOF;
 
     public function setProcessIsolation($processIsolation)
     {
-        $this->processIsolation = (Boolean) $processIsolation;
+        $this->processIsolation = (bool) $processIsolation;
 
         if ($this->processIsolation && !class_exists('Symfony\\Component\\Process\\Process')) {
             throw new \RuntimeException('Unable to isolate processes as the Symfony Process Component is not installed.');

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -78,7 +78,7 @@ class ApplicationTester
     /**
      * Gets the display returned by the last execution of the application.
      *
-     * @param Boolean $normalize Whether to normalize end of lines to \n or not
+     * @param bool    $normalize Whether to normalize end of lines to \n or not
      *
      * @return string The display
      */

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -73,7 +73,7 @@ class CommandTester
     /**
      * Gets the display returned by the last execution of the command.
      *
-     * @param Boolean $normalize Whether to normalize end of lines to \n or not
+     * @param bool    $normalize Whether to normalize end of lines to \n or not
      *
      * @return string The display
      */

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -169,7 +169,7 @@ class Parser implements ParserInterface
      * Parses next simple node (hash, class, pseudo, negation).
      *
      * @param TokenStream $stream
-     * @param boolean     $insideNegation
+     * @param bool        $insideNegation
      *
      * @throws SyntaxErrorException
      *

--- a/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
@@ -46,8 +46,8 @@ class FunctionExtension extends AbstractExtension
     /**
      * @param XPathExpr    $xpath
      * @param FunctionNode $function
-     * @param boolean      $last
-     * @param boolean      $addNameTest
+     * @param bool         $last
+     * @param bool         $addNameTest
      *
      * @return XPathExpr
      *

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -53,7 +53,7 @@ class NodeExtension extends AbstractExtension
 
     /**
      * @param int     $flag
-     * @param boolean $on
+     * @param bool    $on
      *
      * @return NodeExtension
      */

--- a/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
@@ -40,7 +40,7 @@ class XPathExpr
      * @param string  $path
      * @param string  $element
      * @param string  $condition
-     * @param boolean $starPrefix
+     * @param bool    $starPrefix
      */
     public function __construct($path = '', $element = '*', $condition = '', $starPrefix = false)
     {

--- a/src/Symfony/Component/Debug/Debug.php
+++ b/src/Symfony/Component/Debug/Debug.php
@@ -30,8 +30,8 @@ class Debug
      * If the Symfony ClassLoader component is available, a special
      * class loader is also registered.
      *
-     * @param integer $errorReportingLevel The level of error reporting you want
-     * @param Boolean $displayErrors       Whether to display errors (for development) or just log them (for production)
+     * @param int     $errorReportingLevel The level of error reporting you want
+     * @param bool    $displayErrors       Whether to display errors (for development) or just log them (for production)
      */
     public static function enable($errorReportingLevel = null, $displayErrors = true)
     {

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -56,8 +56,8 @@ class ErrorHandler
     /**
      * Registers the error handler.
      *
-     * @param integer $level The level at which the conversion to Exception is done (null to use the error_reporting() value and 0 to disable)
-     * @param Boolean $displayErrors Display errors (for dev environment) or just log they (production usage)
+     * @param int     $level The level at which the conversion to Exception is done (null to use the error_reporting() value and 0 to disable)
+     * @param bool    $displayErrors Display errors (for dev environment) or just log they (production usage)
      *
      * @return ErrorHandler The registered error handler
      */

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -43,7 +43,7 @@ class ExceptionHandler
     /**
      * Registers the exception handler.
      *
-     * @param Boolean $debug
+     * @param bool    $debug
      *
      * @return ExceptionHandler The registered exception handler
      */

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -54,7 +54,7 @@ class Alias
      */
     public function setPublic($boolean)
     {
-        $this->public = (Boolean) $boolean;
+        $this->public = (bool) $boolean;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -23,7 +23,7 @@ class Alias
      * Constructor.
      *
      * @param string  $id     Alias identifier
-     * @param Boolean $public If this alias is public
+     * @param bool    $public If this alias is public
      *
      * @api
      */
@@ -48,7 +48,7 @@ class Alias
     /**
      * Sets if this Alias is public.
      *
-     * @param Boolean $boolean If this Alias should be public
+     * @param bool    $boolean If this Alias should be public
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -36,7 +36,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
     /**
      * Constructor.
      *
-     * @param Boolean $onlyConstructorArguments Sets this Service Reference pass to ignore method calls
+     * @param bool    $onlyConstructorArguments Sets this Service Reference pass to ignore method calls
      */
     public function __construct($onlyConstructorArguments = false)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -40,7 +40,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
      */
     public function __construct($onlyConstructorArguments = false)
     {
-        $this->onlyConstructorArguments = (Boolean) $onlyConstructorArguments;
+        $this->onlyConstructorArguments = (bool) $onlyConstructorArguments;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -127,7 +127,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
                 throw new RuntimeException(sprintf('Invalid argument key "%s" found.', $k));
             }
 
-            $index = (integer) substr($k, strlen('index_'));
+            $index = (int) substr($k, strlen('index_'));
             $def->replaceArgument($index, $v);
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -70,7 +70,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
      * Processes arguments to determine invalid references.
      *
      * @param array   $arguments    An array of Reference objects
-     * @param Boolean $inMethodCall
+     * @param bool    $inMethodCall
      *
      * @return array
      *

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -254,7 +254,7 @@ class Container implements IntrospectableContainerInterface
      * with a get{$id}Service() method, the former has always precedence.
      *
      * @param string  $id              The service identifier
-     * @param integer $invalidBehavior The behavior when the service does not exist
+     * @param int     $invalidBehavior The behavior when the service does not exist
      *
      * @return object The associated service
      *

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -88,7 +88,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function setResourceTracking($track)
     {
-        $this->trackResources = (Boolean) $track;
+        $this->trackResources = (bool) $track;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -84,7 +84,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * If you are not using the loaders and therefore don't want
      * to depend on the Config component, set this flag to false.
      *
-     * @param Boolean $track true if you want to track resources, false otherwise
+     * @param bool    $track true if you want to track resources, false otherwise
      */
     public function setResourceTracking($track)
     {
@@ -445,7 +445,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * Gets a service.
      *
      * @param string  $id              The service identifier
-     * @param integer $invalidBehavior The behavior when the service does not exist
+     * @param int     $invalidBehavior The behavior when the service does not exist
      *
      * @return object The associated service
      *
@@ -901,7 +901,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param Definition $definition A service definition instance
      * @param string     $id         The service identifier
-     * @param Boolean    $tryProxy   Whether to try proxying the service with a lazy proxy
+     * @param bool       $tryProxy   Whether to try proxying the service with a lazy proxy
      *
      * @return object The service described by the service definition
      *

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -240,7 +240,7 @@ class Definition
     /**
      * Sets a specific argument
      *
-     * @param integer $index
+     * @param int     $index
      * @param mixed   $argument
      *
      * @return Definition The current instance
@@ -275,7 +275,7 @@ class Definition
     /**
      * Gets an argument to pass to the service constructor/factory method.
      *
-     * @param integer $index
+     * @param int     $index
      *
      * @return mixed The argument value
      *
@@ -548,7 +548,7 @@ class Definition
     /**
      * Sets the visibility of this service.
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      *
      * @return Definition The current instance
      *
@@ -576,7 +576,7 @@ class Definition
     /**
      * Sets the synchronized flag of this service.
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      *
      * @return Definition The current instance
      *
@@ -604,7 +604,7 @@ class Definition
     /**
      * Sets the lazy flag of this service.
      *
-     * @param Boolean $lazy
+     * @param bool    $lazy
      *
      * @return Definition The current instance
      */
@@ -629,7 +629,7 @@ class Definition
      * Sets whether this definition is synthetic, that is not constructed by the
      * container, but dynamically injected.
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      *
      * @return Definition the current instance
      *
@@ -659,7 +659,7 @@ class Definition
      * Whether this definition is abstract, that means it merely serves as a
      * template for other definitions.
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      *
      * @return Definition the current instance
      *

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -556,7 +556,7 @@ class Definition
      */
     public function setPublic($boolean)
     {
-        $this->public = (Boolean) $boolean;
+        $this->public = (bool) $boolean;
 
         return $this;
     }
@@ -584,7 +584,7 @@ class Definition
      */
     public function setSynchronized($boolean)
     {
-        $this->synchronized = (Boolean) $boolean;
+        $this->synchronized = (bool) $boolean;
 
         return $this;
     }
@@ -610,7 +610,7 @@ class Definition
      */
     public function setLazy($lazy)
     {
-        $this->lazy = (Boolean) $lazy;
+        $this->lazy = (bool) $lazy;
 
         return $this;
     }
@@ -637,7 +637,7 @@ class Definition
      */
     public function setSynthetic($boolean)
     {
-        $this->synthetic = (Boolean) $boolean;
+        $this->synthetic = (bool) $boolean;
 
         return $this;
     }
@@ -667,7 +667,7 @@ class Definition
      */
     public function setAbstract($boolean)
     {
-        $this->abstract = (Boolean) $boolean;
+        $this->abstract = (bool) $boolean;
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -167,7 +167,7 @@ class DefinitionDecorator extends Definition
      * If replaceArgument() has been used to replace an argument, this method
      * will return the replacement value.
      *
-     * @param integer $index
+     * @param int     $index
      *
      * @return mixed The argument value
      *
@@ -198,7 +198,7 @@ class DefinitionDecorator extends Definition
      * certain conventions when you want to overwrite the arguments of the
      * parent definition, otherwise your arguments will only be appended.
      *
-     * @param integer $index
+     * @param int     $index
      * @param mixed   $value
      *
      * @return DefinitionDecorator the current instance

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -123,7 +123,7 @@ class GraphvizDumper extends Dumper
      *
      * @param string  $id        The service id used to find edges
      * @param array   $arguments An array of arguments
-     * @param Boolean $required
+     * @param bool    $required
      * @param string  $name
      *
      * @return array An array of edges

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -544,7 +544,7 @@ EOF;
 
         if ($definition->isLazy()) {
             $lazyInitialization    = '$lazyLoad = true';
-            $lazyInitializationDoc = "\n     * @param boolean \$lazyLoad whether to try lazy-loading the service with a proxy\n     *";
+            $lazyInitializationDoc = "\n     * @param bool    \$lazyLoad whether to try lazy-loading the service with a proxy\n     *";
         } else {
             $lazyInitialization    = '';
             $lazyInitializationDoc = '';
@@ -955,7 +955,7 @@ EOF;
      *
      * @param array   $parameters
      * @param string  $path
-     * @param integer $indent
+     * @param int     $indent
      *
      * @return string
      *
@@ -1104,7 +1104,7 @@ EOF;
      *
      * @param string  $id
      * @param array   $arguments
-     * @param Boolean $deep
+     * @param bool    $deep
      * @param array   $visited
      *
      * @return Boolean
@@ -1141,7 +1141,7 @@ EOF;
      * Dumps values.
      *
      * @param array   $value
-     * @param Boolean $interpolate
+     * @param bool    $interpolate
      *
      * @return string
      *

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -275,7 +275,7 @@ class YamlDumper extends Dumper
      * Prepares parameters.
      *
      * @param array   $parameters
-     * @param Boolean $escape
+     * @param bool    $escape
      *
      * @return array
      */

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -121,6 +121,6 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
             throw new InvalidArgumentException("The config array has no 'enabled' key.");
         }
 
-        return (Boolean) $container->getParameterBag()->resolveValue($config['enabled']);
+        return (bool) $container->getParameterBag()->resolveValue($config['enabled']);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -102,7 +102,7 @@ class XmlFileLoader extends FileLoader
 
         foreach ($imports as $import) {
             $this->setCurrentDir(dirname($file));
-            $this->import((string) $import['resource'], null, (Boolean) $import->getAttributeAsPhp('ignore-errors'), $file);
+            $this->import((string) $import['resource'], null, (bool) $import->getAttributeAsPhp('ignore-errors'), $file);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -94,7 +94,7 @@ class YamlFileLoader extends FileLoader
 
         foreach ($content['imports'] as $import) {
             $this->setCurrentDir(dirname($file));
-            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (Boolean) $import['ignore_errors'] : false, $file);
+            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (bool) $import['ignore_errors'] : false, $file);
         }
     }
 
@@ -131,7 +131,7 @@ class YamlFileLoader extends FileLoader
 
             return;
         } elseif (isset($service['alias'])) {
-            $public = !array_key_exists('public', $service) || (Boolean) $service['public'];
+            $public = !array_key_exists('public', $service) || (bool) $service['public'];
             $this->container->setAlias($id, new Alias($service['alias'], $public));
 
             return;

--- a/src/Symfony/Component/DependencyInjection/Reference.php
+++ b/src/Symfony/Component/DependencyInjection/Reference.php
@@ -29,7 +29,7 @@ class Reference
      *
      * @param string  $id              The service identifier
      * @param int     $invalidBehavior The behavior when the service does not exist
-     * @param Boolean $strict          Sets how this reference is validated
+     * @param bool    $strict          Sets how this reference is validated
      *
      * @see Container
      */

--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -36,7 +36,7 @@ class SimpleXMLElement extends \SimpleXMLElement
      * Returns arguments as valid PHP types.
      *
      * @param string  $name
-     * @param Boolean $lowercase
+     * @param bool    $lowercase
      *
      * @return mixed
      */

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -280,7 +280,7 @@ class Crawler extends \SplObjectStorage
     /**
      * Returns a node given its position in the node list.
      *
-     * @param integer $position The position
+     * @param int     $position The position
      *
      * @return Crawler A new instance of the Crawler with the selected node, or an empty Crawler if it does not exist.
      *
@@ -772,7 +772,7 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
-     * @param integer $position
+     * @param int     $position
      *
      * @return \DOMElement|null
      */

--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -23,7 +23,7 @@ class FileFormField extends FormField
     /**
      * Sets the PHP error code associated with the field.
      *
-     * @param integer $error The error code (one of UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE, UPLOAD_ERR_PARTIAL, UPLOAD_ERR_NO_FILE, UPLOAD_ERR_NO_TMP_DIR, UPLOAD_ERR_CANT_WRITE, or UPLOAD_ERR_EXTENSION)
+     * @param int     $error The error code (one of UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE, UPLOAD_ERR_PARTIAL, UPLOAD_ERR_NO_FILE, UPLOAD_ERR_NO_TMP_DIR, UPLOAD_ERR_CANT_WRITE, or UPLOAD_ERR_EXTENSION)
      *
      * @throws \InvalidArgumentException When error code doesn't exist
      */

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -105,7 +105,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     public function hasListeners($eventName = null)
     {
         if (null === $eventName) {
-            return (Boolean) count($this->listenerIds) || (Boolean) count($this->listeners);
+            return (bool) count($this->listenerIds) || (bool) count($this->listeners);
         }
 
         if (isset($this->listenerIds[$eventName])) {

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -57,7 +57,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
      * @param string $eventName Event for which the listener is added
      * @param array  $callback  The service ID of the listener service & the method
      *                            name that has to be called
-     * @param integer $priority The higher this value, the earlier an event listener
+     * @param int     $priority The higher this value, the earlier an event listener
      *                            will be triggered in the chain.
      *                            Defaults to 0.
      *

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -82,7 +82,7 @@ class EventDispatcher implements EventDispatcherInterface
      */
     public function hasListeners($eventName = null)
     {
-        return (Boolean) count($this->getListeners($eventName));
+        return (bool) count($this->getListeners($eventName));
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -42,7 +42,7 @@ interface EventDispatcherInterface
      *
      * @param string   $eventName The event to listen on
      * @param callable $listener  The listener
-     * @param integer  $priority  The higher this value, the earlier an event
+     * @param int      $priority  The higher this value, the earlier an event
      *                            listener will be triggered in the chain (defaults to 0)
      *
      * @api

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -29,7 +29,7 @@ class Filesystem
      *
      * @param string  $originFile The original filename
      * @param string  $targetFile The target filename
-     * @param boolean $override   Whether to override an existing file or not
+     * @param bool    $override   Whether to override an existing file or not
      *
      * @throws IOException When copy fails
      */
@@ -66,7 +66,7 @@ class Filesystem
      * Creates a directory recursively.
      *
      * @param string|array|\Traversable $dirs The directory path
-     * @param integer                   $mode The directory mode
+     * @param int                       $mode The directory mode
      *
      * @throws IOException On any directory creation failure
      */
@@ -105,8 +105,8 @@ class Filesystem
      * Sets access and modification time of file.
      *
      * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to create
-     * @param integer                   $time  The touch time as a Unix timestamp
-     * @param integer                   $atime The access time as a Unix timestamp
+     * @param int                       $time  The touch time as a Unix timestamp
+     * @param int                       $atime The access time as a Unix timestamp
      *
      * @throws IOException When touch fails
      */
@@ -161,9 +161,9 @@ class Filesystem
      * Change mode for an array of files or directories.
      *
      * @param string|array|\Traversable $files     A filename, an array of files, or a \Traversable instance to change mode
-     * @param integer                   $mode      The new mode (octal)
-     * @param integer                   $umask     The mode mask (octal)
-     * @param Boolean                   $recursive Whether change the mod recursively or not
+     * @param int                       $mode      The new mode (octal)
+     * @param int                       $umask     The mode mask (octal)
+     * @param bool                      $recursive Whether change the mod recursively or not
      *
      * @throws IOException When the change fail
      */
@@ -184,7 +184,7 @@ class Filesystem
      *
      * @param string|array|\Traversable $files     A filename, an array of files, or a \Traversable instance to change owner
      * @param string                    $user      The new owner user name
-     * @param Boolean                   $recursive Whether change the owner recursively or not
+     * @param bool                      $recursive Whether change the owner recursively or not
      *
      * @throws IOException When the change fail
      */
@@ -211,7 +211,7 @@ class Filesystem
      *
      * @param string|array|\Traversable $files     A filename, an array of files, or a \Traversable instance to change group
      * @param string                    $group     The group name
-     * @param Boolean                   $recursive Whether change the group recursively or not
+     * @param bool                      $recursive Whether change the group recursively or not
      *
      * @throws IOException When the change fail
      */
@@ -238,7 +238,7 @@ class Filesystem
      *
      * @param string  $origin    The origin filename or directory
      * @param string  $target    The new filename or directory
-     * @param Boolean $overwrite Whether to overwrite the target if it already exists
+     * @param bool    $overwrite Whether to overwrite the target if it already exists
      *
      * @throws IOException When target file or directory already exists
      * @throws IOException When origin cannot be renamed
@@ -260,7 +260,7 @@ class Filesystem
      *
      * @param string  $originDir     The origin directory path
      * @param string  $targetDir     The symbolic link name
-     * @param Boolean $copyOnWindows Whether to copy files if on Windows
+     * @param bool    $copyOnWindows Whether to copy files if on Windows
      *
      * @throws IOException When symlink fails
      */

--- a/src/Symfony/Component/Finder/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractAdapter.php
@@ -216,7 +216,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function ignoreUnreadableDirs($ignore = true)
     {
-        $this->ignoreUnreadableDirs = (Boolean) $ignore;
+        $this->ignoreUnreadableDirs = (bool) $ignore;
 
         return $this;
     }

--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -148,7 +148,7 @@ abstract class AbstractFindAdapter extends AbstractAdapter
     /**
      * @param Command  $command
      * @param string[] $names
-     * @param Boolean  $not
+     * @param bool     $not
      */
     private function buildNamesFiltering(Command $command, array $names, $not = false)
     {
@@ -196,7 +196,7 @@ abstract class AbstractFindAdapter extends AbstractAdapter
      * @param Command  $command
      * @param string   $dir
      * @param string[] $paths
-     * @param Boolean  $not
+     * @param bool     $not
      */
     private function buildPathsFiltering(Command $command, $dir, array $paths, $not = false)
     {
@@ -321,7 +321,7 @@ abstract class AbstractFindAdapter extends AbstractAdapter
     /**
      * @param Command $command
      * @param array   $contains
-     * @param Boolean $not
+     * @param bool    $not
      */
     abstract protected function buildContentFiltering(Command $command, array $contains, $not = false);
 }

--- a/src/Symfony/Component/Finder/Adapter/AdapterInterface.php
+++ b/src/Symfony/Component/Finder/Adapter/AdapterInterface.php
@@ -17,14 +17,14 @@ namespace Symfony\Component\Finder\Adapter;
 interface AdapterInterface
 {
     /**
-     * @param Boolean $followLinks
+     * @param bool    $followLinks
      *
      * @return AdapterInterface Current instance
      */
     public function setFollowLinks($followLinks);
 
     /**
-     * @param integer $mode
+     * @param int     $mode
      *
      * @return AdapterInterface Current instance
      */
@@ -115,7 +115,7 @@ interface AdapterInterface
     public function setNotPath(array $notPaths);
 
     /**
-     * @param boolean $ignore
+     * @param bool    $ignore
      *
      * @return AdapterInterface Current instance
      */

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -638,7 +638,7 @@ class Finder implements \IteratorAggregate, \Countable
      */
     public function ignoreUnreadableDirs($ignore = true)
     {
-        $this->ignoreUnreadableDirs = (Boolean) $ignore;
+        $this->ignoreUnreadableDirs = (bool) $ignore;
 
         return $this;
     }

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -90,7 +90,7 @@ class Finder implements \IteratorAggregate, \Countable
      * Registers a finder engine implementation.
      *
      * @param AdapterInterface $adapter  An adapter instance
-     * @param integer          $priority Highest is selected first
+     * @param int              $priority Highest is selected first
      *
      * @return Finder The current Finder instance
      */
@@ -415,7 +415,7 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Excludes "hidden" directories and files (starting with a dot).
      *
-     * @param Boolean $ignoreDotFiles Whether to exclude "hidden" files or not
+     * @param bool    $ignoreDotFiles Whether to exclude "hidden" files or not
      *
      * @return Finder The current Finder instance
      *
@@ -437,7 +437,7 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Forces the finder to ignore version control directories.
      *
-     * @param Boolean $ignoreVCS Whether to exclude VCS files or not
+     * @param bool    $ignoreVCS Whether to exclude VCS files or not
      *
      * @return Finder The current Finder instance
      *
@@ -632,7 +632,7 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * By default, scanning unreadable directories content throws an AccessDeniedException.
      *
-     * @param boolean $ignore
+     * @param bool    $ignore
      *
      * @return Finder The current Finder instance
      */

--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -39,8 +39,8 @@ class Glob
      * Returns a regexp which is the equivalent of the glob pattern.
      *
      * @param string  $glob                The glob pattern
-     * @param Boolean $strictLeadingDot
-     * @param Boolean $strictWildcardSlash
+     * @param bool    $strictLeadingDot
+     * @param bool    $strictWildcardSlash
      *
      * @return string regex The regexp
      */

--- a/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
@@ -27,7 +27,7 @@ class FileTypeFilterIterator extends FilterIterator
      * Constructor.
      *
      * @param \Iterator $iterator The Iterator to filter
-     * @param integer   $mode     The mode (self::ONLY_FILES or self::ONLY_DIRECTORIES)
+     * @param int       $mode     The mode (self::ONLY_FILES or self::ONLY_DIRECTORIES)
      */
     public function __construct(\Iterator $iterator, $mode)
     {

--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -36,7 +36,7 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
      *
      * @param string  $path
      * @param int     $flags
-     * @param boolean $ignoreUnreadableDirs
+     * @param bool    $ignoreUnreadableDirs
      *
      * @throws \RuntimeException
      */

--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -31,7 +31,7 @@ class SortableIterator implements \IteratorAggregate
      * Constructor.
      *
      * @param \Traversable     $iterator The Iterator to filter
-     * @param integer|callback $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a PHP callback)
+     * @param int    |callback $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a PHP callback)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Finder/Shell/Command.php
+++ b/src/Symfony/Component/Finder/Shell/Command.php
@@ -283,7 +283,7 @@ class Command
      * Insert a string or a Command instance before the bit at given position $index (index starts from 0).
      *
      * @param string|Command $bit
-     * @param integer        $index
+     * @param int            $index
      *
      * @return Command The current Command instance
      */

--- a/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
@@ -19,8 +19,8 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
      * @dataProvider getPaths
      *
      * @param string  $path
-     * @param Boolean $seekable
-     * @param Boolean $supports
+     * @param bool    $seekable
+     * @param bool    $supports
      * @param string  $message
      */
     public function testRewind($path, $seekable, $contains, $message = null)
@@ -40,8 +40,8 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
      * @dataProvider getPaths
      *
      * @param string  $path
-     * @param Boolean $seekable
-     * @param Boolean $supports
+     * @param bool    $seekable
+     * @param bool    $supports
      * @param string  $message
      */
     public function testSeek($path, $seekable, $contains, $message = null)

--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -146,7 +146,7 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
      *                                     themes.
      * @param array    $blockNameHierarchy The block hierarchy, with the most
      *                                     specific block name at the end.
-     * @param integer  $hierarchyLevel     The level in the block hierarchy that
+     * @param int      $hierarchyLevel     The level in the block hierarchy that
      *                                     should be loaded.
      *
      * @return Boolean True if the resource could be loaded, false otherwise.

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -374,7 +374,7 @@ class Button implements \IteratorAggregate, FormInterface
      * Submits data to the button.
      *
      * @param null|string $submittedData The data.
-     * @param Boolean     $clearMissing  Not used.
+     * @param bool        $clearMissing  Not used.
      *
      * @return Button The button instance
      *

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -169,7 +169,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * @param string   $eventName
      * @param callable $listener
-     * @param integer  $priority
+     * @param int      $priority
      *
      * @throws BadMethodCallException
      */
@@ -198,7 +198,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      * This method should not be invoked.
      *
      * @param DataTransformerInterface $viewTransformer
-     * @param Boolean                  $forcePrepend
+     * @param bool                     $forcePrepend
      *
      * @throws BadMethodCallException
      */
@@ -225,7 +225,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      * This method should not be invoked.
      *
      * @param DataTransformerInterface $modelTransformer
-     * @param Boolean                  $forceAppend
+     * @param bool                     $forceAppend
      *
      * @throws BadMethodCallException
      */
@@ -283,7 +283,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Set whether the button is disabled.
      *
-     * @param Boolean $disabled Whether the button is disabled
+     * @param bool    $disabled Whether the button is disabled
      *
      * @return ButtonBuilder The button builder.
      */
@@ -313,7 +313,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param Boolean $errorBubbling
+     * @param bool    $errorBubbling
      *
      * @throws BadMethodCallException
      */
@@ -327,7 +327,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param Boolean $required
+     * @param bool    $required
      *
      * @throws BadMethodCallException
      */
@@ -355,7 +355,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param Boolean $mapped
+     * @param bool    $mapped
      *
      * @throws BadMethodCallException
      */
@@ -369,7 +369,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param Boolean $byReference
+     * @param bool    $byReference
      *
      * @throws BadMethodCallException
      */
@@ -383,7 +383,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param Boolean $virtual
+     * @param bool    $virtual
      *
      * @throws BadMethodCallException
      */
@@ -397,7 +397,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param Boolean $compound
+     * @param bool    $compound
      *
      * @throws BadMethodCallException
      */
@@ -439,7 +439,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param Boolean $locked
+     * @param bool    $locked
      *
      * @throws BadMethodCallException
      */
@@ -503,7 +503,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * @param Boolean $initialize
+     * @param bool    $initialize
      *
      * @throws BadMethodCallException
      */
@@ -519,7 +519,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * @param Boolean $inheritData
+     * @param bool    $inheritData
      *
      * @throws BadMethodCallException
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -41,7 +41,7 @@ class BooleanToStringTransformer implements DataTransformerInterface
     /**
      * Transforms a Boolean into a string.
      *
-     * @param Boolean $value Boolean value.
+     * @param bool    $value Boolean value.
      *
      * @return string String value.
      *

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -28,7 +28,7 @@ class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
      * Constructor.
      *
      * @param ChoiceListInterface $choiceList
-     * @param Boolean             $placeholderPresent
+     * @param bool                $placeholderPresent
      */
     public function __construct(ChoiceListInterface $choiceList, $placeholderPresent)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -45,7 +45,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         }
 
         $this->fields = $fields;
-        $this->pad = (Boolean) $pad;
+        $this->pad = (bool) $pad;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -32,7 +32,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
      * @param string  $inputTimezone  The input timezone
      * @param string  $outputTimezone The output timezone
      * @param array   $fields         The date fields
-     * @param Boolean $pad            Whether to use padding
+     * @param bool    $pad            Whether to use padding
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -34,9 +34,9 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
      *
      * @param string  $inputTimezone  The name of the input timezone
      * @param string  $outputTimezone The name of the output timezone
-     * @param integer $dateFormat     The date format
-     * @param integer $timeFormat     The time format
-     * @param integer $calendar       One of the \IntlDateFormatter calendar constants
+     * @param int     $dateFormat     The date format
+     * @param int     $timeFormat     The time format
+     * @param int     $calendar       One of the \IntlDateFormatter calendar constants
      * @param string  $pattern        A pattern to pass to \IntlDateFormatter
      *
      * @throws UnexpectedTypeException If a format is not supported or if a timezone is not a string

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -56,7 +56,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
      * @param string  $inputTimezone  The name of the input timezone
      * @param string  $outputTimezone The name of the output timezone
      * @param string  $format         The date format
-     * @param Boolean $parseUsingPipe Whether to parse by appending a pipe "|" to the parse format
+     * @param bool    $parseUsingPipe Whether to parse by appending a pipe "|" to the parse format
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -55,7 +55,7 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
     /**
      * Transforms a number type into localized number.
      *
-     * @param integer|float $value Number value.
+     * @param int    |float $value Number value.
      *
      * @return string Localized value.
      *

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -40,7 +40,7 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
      *
      * @see self::$types for a list of supported types
      *
-     * @param integer $precision The precision
+     * @param int     $precision The precision
      * @param string  $type      One of the supported types
      *
      * @throws UnexpectedTypeException if the given value of type is unknown

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -32,7 +32,7 @@ class FixRadioInputListener implements EventSubscriberInterface
      * Constructor.
      *
      * @param ChoiceListInterface $choiceList
-     * @param Boolean             $placeholderPresent
+     * @param bool                $placeholderPresent
      */
     public function __construct(ChoiceListInterface $choiceList, $placeholderPresent)
     {

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -36,9 +36,9 @@ class MergeCollectionListener implements EventSubscriberInterface
     /**
      * Creates a new listener.
      *
-     * @param Boolean $allowAdd Whether values might be added to the
+     * @param bool    $allowAdd Whether values might be added to the
      *                                collection.
-     * @param Boolean $allowDelete Whether values might be removed from the
+     * @param bool    $allowDelete Whether values might be removed from the
      *                                collection.
      */
     public function __construct($allowAdd = false, $allowDelete = false)

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapperInterface.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapperInterface.php
@@ -26,7 +26,7 @@ interface ViolationMapperInterface
      * @param ConstraintViolation $violation The violation to map.
      * @param FormInterface       $form      The root form of the tree
      *                                       to map it to.
-     * @param Boolean             $allowNonSynchronized Whether to allow
+     * @param bool                $allowNonSynchronized Whether to allow
      *                                       mapping to non-synchronized forms.
      */
     public function mapViolation(ConstraintViolation $violation, FormInterface $form, $allowNonSynchronized = false);

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -198,7 +198,7 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
      * In this example, "address" and "office" map to forms, while
      * "street does not.
      *
-     * @param  integer $index The element index.
+     * @param  int     $index The element index.
      *
      * @return Boolean Whether the element maps to a form.
      *

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -784,7 +784,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * This method should only be used to help debug a form.
      *
-     * @param integer $level The indentation level (used internally)
+     * @param int     $level The indentation level (used internally)
      *
      * @return string A string representation of all errors
      */

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -603,7 +603,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
             throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
-        $this->disabled = (Boolean) $disabled;
+        $this->disabled = (bool) $disabled;
 
         return $this;
     }
@@ -631,7 +631,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
             throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
-        $this->errorBubbling = null === $errorBubbling ? null : (Boolean) $errorBubbling;
+        $this->errorBubbling = null === $errorBubbling ? null : (bool) $errorBubbling;
 
         return $this;
     }
@@ -645,7 +645,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
             throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
-        $this->required = (Boolean) $required;
+        $this->required = (bool) $required;
 
         return $this;
     }
@@ -855,7 +855,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public function setAutoInitialize($initialize)
     {
-        $this->autoInitialize = (Boolean) $initialize;
+        $this->autoInitialize = (bool) $initialize;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -713,7 +713,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * Alias of {@link setInheritData()}.
      *
-     * @param Boolean $inheritData Whether the form should inherit its parent's data.
+     * @param bool    $inheritData Whether the form should inherit its parent's data.
      *
      * @return FormConfigBuilder The configuration object.
      *

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -23,7 +23,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      *
      * @param string   $eventName The name of the event to listen to.
      * @param callable $listener  The listener to execute.
-     * @param integer  $priority  The priority of the listener. Listeners
+     * @param int      $priority  The priority of the listener. Listeners
      *                            with a higher priority are called before
      *                            listeners with a lower priority.
      *
@@ -49,7 +49,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * view to the normalized format.
      *
      * @param DataTransformerInterface $viewTransformer
-     * @param Boolean                  $forcePrepend if set to true, prepend instead of appending
+     * @param bool                     $forcePrepend if set to true, prepend instead of appending
      *
      * @return self The configuration object.
      */
@@ -71,7 +71,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * normalized to the model format.
      *
      * @param DataTransformerInterface $modelTransformer
-     * @param Boolean                  $forceAppend if set to true, append instead of prepending
+     * @param bool                     $forceAppend if set to true, append instead of prepending
      *
      * @return self The configuration object.
      */
@@ -115,7 +115,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Set whether the form is disabled.
      *
-     * @param Boolean $disabled Whether the form is disabled
+     * @param bool    $disabled Whether the form is disabled
      *
      * @return self The configuration object.
      */
@@ -133,7 +133,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets whether errors bubble up to the parent.
      *
-     * @param Boolean $errorBubbling
+     * @param bool    $errorBubbling
      *
      * @return self The configuration object.
      */
@@ -142,7 +142,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets whether this field is required to be filled out when submitted.
      *
-     * @param Boolean $required
+     * @param bool    $required
      *
      * @return self The configuration object.
      */
@@ -163,7 +163,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * Sets whether the form should be mapped to an element of its
      * parent's data.
      *
-     * @param Boolean $mapped Whether the form should be mapped.
+     * @param bool    $mapped Whether the form should be mapped.
      *
      * @return self The configuration object.
      */
@@ -172,7 +172,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets whether the form's data should be modified by reference.
      *
-     * @param Boolean $byReference Whether the data should be
+     * @param bool    $byReference Whether the data should be
      *                              modified by reference.
      *
      * @return self The configuration object.
@@ -182,7 +182,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets whether the form should read and write the data of its parent.
      *
-     * @param Boolean $inheritData Whether the form should inherit its parent's data.
+     * @param bool    $inheritData Whether the form should inherit its parent's data.
      *
      * @return self The configuration object.
      */
@@ -191,7 +191,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets whether the form should be compound.
      *
-     * @param Boolean $compound Whether the form should be compound.
+     * @param bool    $compound Whether the form should be compound.
      *
      * @return self The configuration object.
      *
@@ -224,7 +224,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * this configuration. The data can only be modified then by
      * submitting the form.
      *
-     * @param Boolean $locked Whether to lock the default data.
+     * @param bool    $locked Whether to lock the default data.
      *
      * @return self The configuration object.
      */
@@ -269,7 +269,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      *
      * Should be set to true only for root forms.
      *
-     * @param Boolean $initialize True to initialize the form automatically,
+     * @param bool    $initialize True to initialize the form automatically,
      *                            false to suppress automatic initialization.
      *                            In the second case, you need to call
      *                            {@link FormInterface::initialize()} manually.

--- a/src/Symfony/Component/Form/FormError.php
+++ b/src/Symfony/Component/Form/FormError.php
@@ -51,7 +51,7 @@ class FormError
      * @param string|null  $messageTemplate      The template for the error message
      * @param array        $messageParameters    The parameters that should be
      *                                           substituted in the message template.
-     * @param integer|null $messagePluralization The value for error message pluralization
+     * @param int    |null $messagePluralization The value for error message pluralization
      *
      * @see \Symfony\Component\Translation\Translator
      */

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -253,7 +253,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * Submits data to the form, transforms and validates it.
      *
      * @param null|string|array $submittedData The submitted data.
-     * @param Boolean           $clearMissing  Whether to set fields to NULL
+     * @param bool              $clearMissing  Whether to set fields to NULL
      *                                         when they are missing in the
      *                                         submitted data.
      *

--- a/src/Symfony/Component/Form/FormRendererEngineInterface.php
+++ b/src/Symfony/Component/Form/FormRendererEngineInterface.php
@@ -78,7 +78,7 @@ interface FormRendererEngineInterface
      *                                              its parent etc.
      * @param array             $blockNameHierarchy The block name hierarchy, with
      *                                              the root block at the beginning.
-     * @param integer           $hierarchyLevel     The level in the hierarchy at
+     * @param int               $hierarchyLevel     The level in the hierarchy at
      *                                              which to start looking. Level 0
      *                                              indicates the root block, i.e.
      *                                              the first element of
@@ -122,7 +122,7 @@ interface FormRendererEngineInterface
      *                                              its parent etc.
      * @param array             $blockNameHierarchy The block name hierarchy, with
      *                                              the root block at the beginning.
-     * @param integer           $hierarchyLevel     The level in the hierarchy at
+     * @param int               $hierarchyLevel     The level in the hierarchy at
      *                                              which to start looking. Level 0
      *                                              indicates the root block, i.e.
      *                                              the first element of

--- a/src/Symfony/Component/Form/Guess/Guess.php
+++ b/src/Symfony/Component/Form/Guess/Guess.php
@@ -86,7 +86,7 @@ abstract class Guess
     /**
      * Constructor.
      *
-     * @param integer $confidence The confidence
+     * @param int     $confidence The confidence
      *
      * @throws InvalidArgumentException if the given value of confidence is unknown
      */

--- a/src/Symfony/Component/Form/Guess/TypeGuess.php
+++ b/src/Symfony/Component/Form/Guess/TypeGuess.php
@@ -37,7 +37,7 @@ class TypeGuess extends Guess
      * @param string $type    The guessed field type
      * @param array  $options The options for creating instances of the
      *                              guessed class
-     * @param integer $confidence The confidence that the guessed class name
+     * @param int     $confidence The confidence that the guessed class name
      *                              is correct
      */
     public function __construct($type, array $options, $confidence)

--- a/src/Symfony/Component/Form/Guess/ValueGuess.php
+++ b/src/Symfony/Component/Form/Guess/ValueGuess.php
@@ -28,7 +28,7 @@ class ValueGuess extends Guess
      * Constructor
      *
      * @param string  $value      The guessed value
-     * @param integer $confidence The confidence that the guessed class name
+     * @param int     $confidence The confidence that the guessed class name
      *                              is correct
      */
     public function __construct($value, $confidence)

--- a/src/Symfony/Component/Form/SubmitButton.php
+++ b/src/Symfony/Component/Form/SubmitButton.php
@@ -35,7 +35,7 @@ class SubmitButton extends Button implements ClickableInterface
      * Submits data to the button.
      *
      * @param null|string $submittedData The data.
-     * @param Boolean     $clearMissing  Not used.
+     * @param bool        $clearMissing  Not used.
      *
      * @return SubmitButton The button instance
      *

--- a/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
@@ -47,7 +47,7 @@ abstract class FormPerformanceTestCase extends FormIntegrationTestCase
     }
 
     /**
-     * @param  integer $maxRunningTime
+     * @param  int     $maxRunningTime
      * @throws \InvalidArgumentException
      */
     public function setMaxRunningTime($maxRunningTime)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -61,7 +61,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param FormConfigInterface $config
-     * @param Boolean $synchronized
+     * @param bool    $synchronized
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getForm(FormConfigInterface $config, $synchronized = true, $submitted = true)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -40,7 +40,7 @@ class MoneyTypeTest extends TypeTestCase
 
         $form = $this->factory->create('money', null, array('currency' => 'JPY'));
         $view = $form->createView();
-        $this->assertTrue((Boolean) strstr($view->vars['money_pattern'], '¥'));
+        $this->assertTrue((bool) strstr($view->vars['money_pattern'], '¥'));
     }
 
     // https://github.com/symfony/symfony/issues/5458

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -35,12 +35,12 @@ class BinaryFileResponse extends Response
      * Constructor.
      *
      * @param \SplFileInfo|string $file               The file to stream
-     * @param integer             $status             The response status code
+     * @param int                 $status             The response status code
      * @param array               $headers            An array of response headers
-     * @param boolean             $public             Files are public by default
+     * @param bool                $public             Files are public by default
      * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
-     * @param boolean             $autoEtag           Whether the ETag header should be automatically set
-     * @param boolean             $autoLastModified   Whether the Last-Modified header should be automatically set
+     * @param bool                $autoEtag           Whether the ETag header should be automatically set
+     * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
      */
     public function __construct($file, $status = 200, $headers = array(), $public = true, $contentDisposition = null, $autoEtag = false, $autoLastModified = true)
     {
@@ -55,12 +55,12 @@ class BinaryFileResponse extends Response
 
     /**
      * @param \SplFileInfo|string $file               The file to stream
-     * @param integer             $status             The response status code
+     * @param int                 $status             The response status code
      * @param array               $headers            An array of response headers
-     * @param boolean             $public             Files are public by default
+     * @param bool                $public             Files are public by default
      * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
-     * @param boolean             $autoEtag           Whether the ETag header should be automatically set
-     * @param boolean             $autoLastModified   Whether the Last-Modified header should be automatically set
+     * @param bool                $autoEtag           Whether the ETag header should be automatically set
+     * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
      */
     public static function create($file = null, $status = 200, $headers = array(), $public = true, $contentDisposition = null, $autoEtag = false, $autoLastModified = true)
     {
@@ -72,8 +72,8 @@ class BinaryFileResponse extends Response
      *
      * @param \SplFileInfo|string $file The file to stream
      * @param string              $contentDisposition
-     * @param Boolean             $autoEtag
-     * @param Boolean             $autoLastModified
+     * @param bool                $autoEtag
+     * @param bool                $autoLastModified
      *
      * @return BinaryFileResponse
      *

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -70,8 +70,8 @@ class Cookie
         $this->domain = $domain;
         $this->expire = $expire;
         $this->path = empty($path) ? '/' : $path;
-        $this->secure = (Boolean) $secure;
-        $this->httpOnly = (Boolean) $httpOnly;
+        $this->secure = (bool) $secure;
+        $this->httpOnly = (bool) $httpOnly;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -33,11 +33,11 @@ class Cookie
      *
      * @param string                   $name     The name of the cookie
      * @param string                   $value    The value of the cookie
-     * @param integer|string|\DateTime $expire   The time the cookie expires
+     * @param int    |string|\DateTime $expire   The time the cookie expires
      * @param string                   $path     The path on the server in which the cookie will be available on
      * @param string                   $domain   The domain that the cookie is available to
-     * @param Boolean                  $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param Boolean                  $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
+     * @param bool                     $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param bool                     $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      *
      * @throws \InvalidArgumentException
      *

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -29,7 +29,7 @@ class File extends \SplFileInfo
      * Constructs a new file from the given path.
      *
      * @param string  $path      The path to the file
-     * @param Boolean $checkPath Whether to check the path or not
+     * @param bool    $checkPath Whether to check the path or not
      *
      * @throws FileNotFoundException If the given path is not a file
      *

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -95,7 +95,7 @@ class UploadedFile extends File
         $this->mimeType = $mimeType ?: 'application/octet-stream';
         $this->size = $size;
         $this->error = $error ?: UPLOAD_ERR_OK;
-        $this->test = (Boolean) $test;
+        $this->test = (bool) $test;
 
         parent::__construct($path, UPLOAD_ERR_OK === $this->error);
     }

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -80,9 +80,9 @@ class UploadedFile extends File
      * @param string  $path         The full temporary path to the file
      * @param string  $originalName The original file name
      * @param string  $mimeType     The type of the file as provided by PHP
-     * @param integer $size         The file size
-     * @param integer $error        The error constant of the upload (one of PHP's UPLOAD_ERR_XXX constants)
-     * @param Boolean $test         Whether the test mode is active
+     * @param int     $size         The file size
+     * @param int     $error        The error constant of the upload (one of PHP's UPLOAD_ERR_XXX constants)
+     * @param bool    $test         Whether the test mode is active
      *
      * @throws FileException         If file_uploads is disabled
      * @throws FileNotFoundException If the file does not exist

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -119,7 +119,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      *
      * @param string  $key     The header name
      * @param mixed   $default The default value
-     * @param Boolean $first   Whether to return the first value or all header values
+     * @param bool    $first   Whether to return the first value or all header values
      *
      * @return string|array The first header value if $first is true, an array of values otherwise
      *
@@ -149,7 +149,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      *
      * @param string       $key     The key
      * @param string|array $values  The value or an array of values
-     * @param Boolean      $replace Whether to replace the actual value or not (true by default)
+     * @param bool         $replace Whether to replace the actual value or not (true by default)
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -31,7 +31,7 @@ class JsonResponse extends Response
      * Constructor.
      *
      * @param mixed   $data    The response data
-     * @param integer $status  The response status code
+     * @param int     $status  The response status code
      * @param array   $headers An array of response headers
      */
     public function __construct($data = null, $status = 200, $headers = array())

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -92,7 +92,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string  $path    The key
      * @param mixed   $default The default value if the parameter key does not exist
-     * @param boolean $deep    If true, a path like foo[bar] will find deeper items
+     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return mixed
      *
@@ -193,7 +193,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string  $key     The parameter key
      * @param mixed   $default The default value if the parameter key does not exist
-     * @param boolean $deep    If true, a path like foo[bar] will find deeper items
+     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      *
@@ -209,7 +209,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string  $key     The parameter key
      * @param mixed   $default The default value if the parameter key does not exist
-     * @param boolean $deep    If true, a path like foo[bar] will find deeper items
+     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      *
@@ -225,7 +225,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string  $key     The parameter key
      * @param mixed   $default The default value if the parameter key does not exist
-     * @param boolean $deep    If true, a path like foo[bar] will find deeper items
+     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      *
@@ -242,7 +242,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string  $key     The parameter key
      * @param mixed   $default The default value if the parameter key does not exist
-     * @param boolean $deep    If true, a path like foo[bar] will find deeper items
+     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return integer The filtered value
      *
@@ -258,8 +258,8 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string  $key     Key.
      * @param mixed   $default Default = null.
-     * @param boolean $deep    Default = false.
-     * @param integer $filter  FILTER_* constant.
+     * @param bool    $deep    Default = false.
+     * @param int     $filter  FILTER_* constant.
      * @param mixed   $options Filter options.
      *
      * @see http://php.net/manual/en/function.filter-var.php

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -26,7 +26,7 @@ class RedirectResponse extends Response
      * Creates a redirect response so that it conforms to the rules defined for a redirect status code.
      *
      * @param string  $url     The URL to redirect to
-     * @param integer $status  The status code (302 by default)
+     * @param int     $status  The status code (302 by default)
      * @param array   $headers The headers (Location is always set to the given URL)
      *
      * @throws \InvalidArgumentException

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -680,7 +680,7 @@ class Request
      *
      * @param string  $key     the key
      * @param mixed   $default the default value
-     * @param Boolean $deep    is parameter deep in multidimensional array
+     * @param bool    $deep    is parameter deep in multidimensional array
      *
      * @return mixed
      */
@@ -1398,7 +1398,7 @@ class Request
     /**
      * Returns the request body content.
      *
-     * @param Boolean $asResource If true, a resource will be returned
+     * @param bool    $asResource If true, a resource will be returned
      *
      * @return string|resource The request body content or a resource to read the body stream.
      *

--- a/src/Symfony/Component/HttpFoundation/Resources/stubs/SessionHandlerInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Resources/stubs/SessionHandlerInterface.php
@@ -90,7 +90,7 @@ interface SessionHandlerInterface
      *
      * @see http://php.net/sessionhandlerinterface.gc
      *
-     * @param integer $lifetime Max lifetime in seconds to keep sessions stored.
+     * @param int     $lifetime Max lifetime in seconds to keep sessions stored.
      *
      * @throws \RuntimeException On fatal error.
      *

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -128,7 +128,7 @@ class Response
      * Constructor.
      *
      * @param string  $content The response content
-     * @param integer $status  The response status code
+     * @param int     $status  The response status code
      * @param array   $headers An array of response headers
      *
      * @throws \InvalidArgumentException When the HTTP status code is not valid
@@ -155,7 +155,7 @@ class Response
      *         ->setSharedMaxAge(300);
      *
      * @param string  $content The response content
-     * @param integer $status  The response status code
+     * @param int     $status  The response status code
      * @param array   $headers An array of response headers
      *
      * @return Response
@@ -406,7 +406,7 @@ class Response
     /**
      * Sets the response status code.
      *
-     * @param integer $code HTTP status code
+     * @param int     $code HTTP status code
      * @param mixed   $text HTTP status text
      *
      * If the status text is null it will be automatically populated for the known
@@ -723,7 +723,7 @@ class Response
      *
      * This methods sets the Cache-Control max-age directive.
      *
-     * @param integer $value Number of seconds
+     * @param int     $value Number of seconds
      *
      * @return Response
      *
@@ -741,7 +741,7 @@ class Response
      *
      * This methods sets the Cache-Control s-maxage directive.
      *
-     * @param integer $value Number of seconds
+     * @param int     $value Number of seconds
      *
      * @return Response
      *
@@ -781,7 +781,7 @@ class Response
      *
      * This method adjusts the Cache-Control/s-maxage directive.
      *
-     * @param integer $seconds Number of seconds
+     * @param int     $seconds Number of seconds
      *
      * @return Response
      *
@@ -799,7 +799,7 @@ class Response
      *
      * This method adjusts the Cache-Control/max-age directive.
      *
-     * @param integer $seconds Number of seconds
+     * @param int     $seconds Number of seconds
      *
      * @return Response
      *
@@ -866,7 +866,7 @@ class Response
      * Sets the ETag value.
      *
      * @param string|null $etag The ETag unique identifier or null to remove the header
-     * @param Boolean     $weak Whether you want a weak ETag or not
+     * @param bool        $weak Whether you want a weak ETag or not
      *
      * @return Response
      *
@@ -1003,7 +1003,7 @@ class Response
      * Sets the Vary header.
      *
      * @param string|array $headers
-     * @param Boolean      $replace Whether to replace the actual value of not (true by default)
+     * @param bool         $replace Whether to replace the actual value of not (true by default)
      *
      * @return Response
      *

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
@@ -100,7 +100,7 @@ class NamespacedAttributeBag extends AttributeBag
      * This method allows structured namespacing of session attributes.
      *
      * @param string  $name         Key name
-     * @param boolean $writeContext Write context, default false
+     * @param bool    $writeContext Write context, default false
      *
      * @return array
      */

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -73,7 +73,7 @@ interface SessionInterface
      * Clears all session attributes and flashes and regenerates the
      * session and deletes the old session from persistence.
      *
-     * @param integer $lifetime Sets the cookie lifetime for the session cookie. A null value
+     * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
      *                          will leave the system settings unchanged, 0 sets the cookie
      *                          to expire with browser session. Time is in seconds, and is
      *                          not a Unix timestamp.
@@ -88,8 +88,8 @@ interface SessionInterface
      * Migrates the current session to a new session id while maintaining all
      * session attributes.
      *
-     * @param Boolean $destroy  Whether to delete the old session or leave it to garbage collection.
-     * @param integer $lifetime Sets the cookie lifetime for the session cookie. A null value
+     * @param bool    $destroy  Whether to delete the old session or leave it to garbage collection.
+     * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
      *                          will leave the system settings unchanged, 0 sets the cookie
      *                          to expire with browser session. Time is in seconds, and is
      *                          not a Unix timestamp.

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
@@ -87,7 +87,7 @@ class MetadataBag implements SessionBagInterface
     /**
      * Stamps a new session's metadata.
      *
-     * @param integer $lifetime Sets the cookie lifetime for the session cookie. A null value
+     * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
      *                          will leave the system settings unchanged, 0 sets the cookie
      *                          to expire with browser session. Time is in seconds, and is
      *                          not a Unix timestamp.

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
@@ -87,7 +87,7 @@ abstract class AbstractProxy
      *
      * @internal
      *
-     * @param Boolean $flag
+     * @param bool    $flag
      *
      * @throws \LogicException
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
@@ -88,8 +88,8 @@ interface SessionStorageInterface
      * Note regenerate+destroy should not clear the session data in memory
      * only delete the session data from persistent storage.
      *
-     * @param Boolean $destroy  Destroy session when regenerating?
-     * @param integer $lifetime Sets the cookie lifetime for the session cookie. A null value
+     * @param bool    $destroy  Destroy session when regenerating?
+     * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
      *                          will leave the system settings unchanged, 0 sets the cookie
      *                          to expire with browser session. Time is in seconds, and is
      *                          not a Unix timestamp.

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -35,7 +35,7 @@ class StreamedResponse extends Response
      * Constructor.
      *
      * @param mixed   $callback A valid PHP callback
-     * @param integer $status   The response status code
+     * @param int     $status   The response status code
      * @param array   $headers  An array of response headers
      *
      * @api

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -324,7 +324,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
      * Updates the stopwatch data in the profile hierarchy.
      *
      * @param string  $token          Profile token
-     * @param Boolean $updateChildren Whether to update the children altogether
+     * @param bool    $updateChildren Whether to update the children altogether
      */
     private function updateProfiles($token, $updateChildren)
     {
@@ -339,7 +339,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
      * Update the profiles with the timing and events information and saves them.
      *
      * @param Profile $profile        The root profile
-     * @param Boolean $updateChildren Whether to update the children altogether
+     * @param bool    $updateChildren Whether to update the children altogether
      */
     private function saveInfoInProfile(Profile $profile, $updateChildren)
     {

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -93,7 +93,7 @@ class ExceptionListener implements EventSubscriberInterface
      *
      * @param \Exception $exception The original \Exception instance
      * @param string     $message   The error message to log
-     * @param Boolean    $original  False when the handling of the exception thrown another exception
+     * @param bool       $original  False when the handling of the exception thrown another exception
      */
     protected function logException(\Exception $exception, $message, $original = true)
     {

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -49,8 +49,8 @@ class ProfilerListener implements EventSubscriberInterface
     {
         $this->profiler = $profiler;
         $this->matcher = $matcher;
-        $this->onlyException = (Boolean) $onlyException;
-        $this->onlyMasterRequests = (Boolean) $onlyMasterRequests;
+        $this->onlyException = (bool) $onlyException;
+        $this->onlyMasterRequests = (bool) $onlyMasterRequests;
         $this->children = new \SplObjectStorage();
         $this->profiles = array();
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -42,8 +42,8 @@ class ProfilerListener implements EventSubscriberInterface
      *
      * @param Profiler                $profiler           A Profiler instance
      * @param RequestMatcherInterface $matcher            A RequestMatcher instance
-     * @param Boolean                 $onlyException      true if the profiler only collects data when an exception occurs, false otherwise
-     * @param Boolean                 $onlyMasterRequests true if the profiler only collects data when the request is a master request, false otherwise
+     * @param bool                    $onlyException      true if the profiler only collects data when an exception occurs, false otherwise
+     * @param bool                    $onlyMasterRequests true if the profiler only collects data when the request is a master request, false otherwise
      */
     public function __construct(Profiler $profiler, RequestMatcherInterface $matcher = null, $onlyException = false, $onlyMasterRequests = false)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
@@ -24,7 +24,7 @@ class AccessDeniedHttpException extends HttpException
      *
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
-     * @param integer    $code     The internal exception code
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
@@ -23,7 +23,7 @@ class BadRequestHttpException extends HttpException
      *
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
@@ -23,7 +23,7 @@ class ConflictHttpException extends HttpException
      *
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
@@ -23,7 +23,7 @@ class GoneHttpException extends HttpException
      *
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
@@ -23,7 +23,7 @@ class LengthRequiredHttpException extends HttpException
      *
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
@@ -24,7 +24,7 @@ class MethodNotAllowedHttpException extends HttpException
      * @param array      $allow    An array of allowed methods
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
-     * @param integer    $code     The internal exception code
+     * @param int        $code     The internal exception code
      */
     public function __construct(array $allow, $message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
@@ -23,7 +23,7 @@ class NotAcceptableHttpException extends HttpException
      *
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
@@ -23,7 +23,7 @@ class NotFoundHttpException extends HttpException
      *
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
-     * @param integer    $code     The internal exception code
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
@@ -23,7 +23,7 @@ class PreconditionFailedHttpException extends HttpException
      *
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
@@ -24,7 +24,7 @@ class PreconditionRequiredHttpException extends HttpException
      *
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
@@ -24,7 +24,7 @@ class ServiceUnavailableHttpException extends HttpException
      * @param int|string  $retryAfter The number of seconds or HTTP-date after which the request may be retried
      * @param string      $message    The internal exception message
      * @param \Exception  $previous   The previous exception
-     * @param integer     $code       The internal exception code
+     * @param int         $code       The internal exception code
      */
     public function __construct($retryAfter = null, $message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
@@ -22,10 +22,10 @@ class TooManyRequestsHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param integer|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
+     * @param int    |string $retryAfter The number of seconds or HTTP-date after which the request may be retried
      * @param string         $message    The internal exception message
      * @param \Exception     $previous   The previous exception
-     * @param integer        $code       The internal exception code
+     * @param int            $code       The internal exception code
      */
     public function __construct($retryAfter = null, $message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
@@ -24,7 +24,7 @@ class UnauthorizedHttpException extends HttpException
      * @param string     $challenge WWW-Authenticate challenge string
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($challenge, $message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
@@ -23,7 +23,7 @@ class UnsupportedMediaTypeHttpException extends HttpException
      *
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
-     * @param integer    $code      The internal exception code
+     * @param int        $code      The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
@@ -36,7 +36,7 @@ class FragmentHandler
      * Constructor.
      *
      * @param FragmentRendererInterface[] $renderers An array of FragmentRendererInterface instances
-     * @param Boolean                     $debug     Whether the debug mode is enabled or not
+     * @param bool                        $debug     Whether the debug mode is enabled or not
      */
     public function __construct(array $renderers = array(), $debug = false)
     {

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -41,7 +41,7 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
      *
      * @param ControllerReference  $reference A ControllerReference instance
      * @param Request              $request   A Request instance
-     * @param Boolean              $absolute  Whether to generate an absolute URL or not
+     * @param bool                 $absolute  Whether to generate an absolute URL or not
      *
      * @return string A fragment URI
      */

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -115,7 +115,7 @@ class Esi
      *
      * @param string  $uri          A URI
      * @param string  $alt          An alternate URI
-     * @param Boolean $ignoreErrors Whether to ignore errors or not
+     * @param bool    $ignoreErrors Whether to ignore errors or not
      * @param string  $comment      A comment to add as an esi:include tag
      *
      * @return string
@@ -185,7 +185,7 @@ class Esi
      * @param HttpCache $cache        An HttpCache instance
      * @param string    $uri          The main URI
      * @param string    $alt          An alternative URI
-     * @param Boolean   $ignoreErrors Whether to ignore errors or not
+     * @param bool      $ignoreErrors Whether to ignore errors or not
      *
      * @return string
      *

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -107,7 +107,7 @@ class Esi
             return false;
         }
 
-        return (Boolean) preg_match('#content="[^"]*ESI/1.0[^"]*"#', $control);
+        return (bool) preg_match('#content="[^"]*ESI/1.0[^"]*"#', $control);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -232,7 +232,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * Forwards the Request to the backend without storing the Response in the cache.
      *
      * @param Request $request A Request instance
-     * @param Boolean $catch   Whether to process exceptions
+     * @param bool    $catch   Whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -247,7 +247,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * Invalidates non-safe methods (like POST, PUT, and DELETE).
      *
      * @param Request $request A Request instance
-     * @param Boolean $catch   Whether to process exceptions
+     * @param bool    $catch   Whether to process exceptions
      *
      * @return Response A Response instance
      *
@@ -296,7 +296,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * it triggers "miss" processing.
      *
      * @param Request $request A Request instance
-     * @param Boolean $catch   whether to process exceptions
+     * @param bool    $catch   whether to process exceptions
      *
      * @return Response A Response instance
      *
@@ -350,7 +350,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param Request  $request A Request instance
      * @param Response $entry   A Response instance to validate
-     * @param Boolean  $catch   Whether to process exceptions
+     * @param bool     $catch   Whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -411,7 +411,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * This methods is triggered when the cache missed or a reload is required.
      *
      * @param Request $request A Request instance
-     * @param Boolean $catch   whether to process exceptions
+     * @param bool    $catch   whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -445,7 +445,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * Forwards the Request to the backend and returns the Response.
      *
      * @param Request  $request A Request instance
-     * @param Boolean  $catch   Whether to catch exceptions or not
+     * @param bool     $catch   Whether to catch exceptions or not
      * @param Response $entry   A Response instance (the stale entry if present, null otherwise)
      *
      * @return Response A Response instance

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -84,7 +84,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      * Exceptions are not caught.
      *
      * @param Request $request A Request instance
-     * @param integer $type    The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param int     $type    The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
      *
      * @return Response A Response instance
      *
@@ -144,7 +144,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      *
      * @param Response $response A Response instance
      * @param Request  $request  An error message in case the response is not a Response object
-     * @param integer  $type     The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param int      $type     The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
      *
      * @return Response The filtered Response instance
      *
@@ -164,7 +164,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      *
      * @param \Exception $e       An \Exception instance
      * @param Request    $request A Request instance
-     * @param integer    $type    The type of the request
+     * @param int        $type    The type of the request
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -33,9 +33,9 @@ interface HttpKernelInterface
      * and do its best to convert them to a Response instance.
      *
      * @param Request $request A Request instance
-     * @param integer $type    The type of the request
+     * @param int     $type    The type of the request
      *                          (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
-     * @param Boolean $catch Whether to catch exceptions or not
+     * @param bool    $catch Whether to catch exceptions or not
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -77,7 +77,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     public function __construct($environment, $debug)
     {
         $this->environment = $environment;
-        $this->debug = (Boolean) $debug;
+        $this->debug = (bool) $debug;
         $this->booted = false;
         $this->rootDir = $this->getRootDir();
         $this->name = $this->getName();

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -70,7 +70,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      * Constructor.
      *
      * @param string  $environment The environment
-     * @param Boolean $debug       Whether to enable debugging or not
+     * @param bool    $debug       Whether to enable debugging or not
      *
      * @api
      */
@@ -262,7 +262,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param string  $name  A resource name to locate
      * @param string  $dir   A directory where to look for the resource first
-     * @param Boolean $first Whether to return the first path or paths for all matching bundles
+     * @param bool    $first Whether to return the first path or paths for all matching bundles
      *
      * @return string|array The absolute path of the resource or an array if $first is false
      *

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -84,7 +84,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      * Returns a bundle and optionally its descendants by its name.
      *
      * @param string  $name  Bundle name
-     * @param Boolean $first Whether to return the first bundle only or together with its descendants
+     * @param bool    $first Whether to return the first bundle only or together with its descendants
      *
      * @return BundleInterface|BundleInterface[] A BundleInterface instance or an array of BundleInterface instances if $first is false
      *
@@ -113,7 +113,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      *
      * @param string  $name  A resource name to locate
      * @param string  $dir   A directory where to look for the resource first
-     * @param Boolean $first Whether to return the first path or paths for all matching bundles
+     * @param bool    $first Whether to return the first path or paths for all matching bundles
      *
      * @return string|array The absolute path of the resource or an array if $first is false
      *

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -23,7 +23,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
      * @param string  $dsn      A data source name
      * @param string  $username Not used
      * @param string  $password Not used
-     * @param integer $lifetime The lifetime to use for the purge
+     * @param int     $lifetime The lifetime to use for the purge
      */
     public function __construct($dsn, $username = '', $password = '', $lifetime = 86400)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -31,7 +31,7 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
      * @param string  $dsn      A data source name
      * @param string  $username The username for the database
      * @param string  $password The password for the database
-     * @param integer $lifetime The lifetime to use for the purge
+     * @param int     $lifetime The lifetime to use for the purge
      */
     public function __construct($dsn, $username = '', $password = '', $lifetime = 86400)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -59,7 +59,7 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
         $criteria = $criteria ? 'WHERE '.implode(' AND ', $criteria) : '';
 
         $db = $this->initDb();
-        $tokens = $this->fetch($db, 'SELECT token, ip, method, url, time, parent FROM sf_profiler_data '.$criteria.' ORDER BY time DESC LIMIT '.((integer) $limit), $args);
+        $tokens = $this->fetch($db, 'SELECT token, ip, method, url, time, parent FROM sf_profiler_data '.$criteria.' ORDER BY time DESC LIMIT '.((int) $limit), $args);
         $this->close($db);
 
         return $tokens;

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -49,6 +49,6 @@ class KernelForTest extends Kernel
 
     public function setIsBooted($value)
     {
-        $this->booted = (Boolean) $value;
+        $this->booted = (bool) $value;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcacheMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcacheMock.php
@@ -31,8 +31,8 @@ class MemcacheMock
      * Open memcached server connection
      *
      * @param string  $host
-     * @param integer $port
-     * @param integer $timeout
+     * @param int     $port
+     * @param int     $timeout
      *
      * @return boolean
      */
@@ -51,8 +51,8 @@ class MemcacheMock
      * Open memcached server persistent connection
      *
      * @param string  $host
-     * @param integer $port
-     * @param integer $timeout
+     * @param int     $port
+     * @param int     $timeout
      *
      * @return boolean
      */
@@ -71,14 +71,14 @@ class MemcacheMock
      * Add a memcached server to connection pool
      *
      * @param string   $host
-     * @param integer  $port
-     * @param boolean  $persistent
-     * @param integer  $weight
-     * @param integer  $timeout
-     * @param integer  $retry_interval
-     * @param boolean  $status
+     * @param int      $port
+     * @param bool     $persistent
+     * @param int      $weight
+     * @param int      $timeout
+     * @param int      $retry_interval
+     * @param bool     $status
      * @param callable $failure_callback
-     * @param integer  $timeoutms
+     * @param int      $timeoutms
      *
      * @return boolean
      */
@@ -98,8 +98,8 @@ class MemcacheMock
      *
      * @param string  $key
      * @param mixed   $var
-     * @param integer $flag
-     * @param integer $expire
+     * @param int     $flag
+     * @param int     $expire
      *
      * @return boolean
      */
@@ -123,8 +123,8 @@ class MemcacheMock
      *
      * @param string  $key
      * @param string  $var
-     * @param integer $flag
-     * @param integer $expire
+     * @param int     $flag
+     * @param int     $expire
      *
      * @return boolean
      */
@@ -144,8 +144,8 @@ class MemcacheMock
      *
      * @param string  $key
      * @param mixed   $var
-     * @param integer $flag
-     * @param integer $expire
+     * @param int     $flag
+     * @param int     $expire
      *
      * @return boolean
      */
@@ -168,7 +168,7 @@ class MemcacheMock
      * Retrieve item from the server.
      *
      * @param string|array  $key
-     * @param integer|array $flags
+     * @param int    |array $flags
      *
      * @return mixed
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcachedMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcachedMock.php
@@ -30,7 +30,7 @@ class MemcachedMock
     /**
      * Set a Memcached option
      *
-     * @param integer $option
+     * @param int     $option
      * @param mixed   $value
      *
      * @return boolean
@@ -44,8 +44,8 @@ class MemcachedMock
      * Add a memcached server to connection pool
      *
      * @param string  $host
-     * @param integer $port
-     * @param integer $weight
+     * @param int     $port
+     * @param int     $weight
      *
      * @return boolean
      */
@@ -65,7 +65,7 @@ class MemcachedMock
      *
      * @param string  $key
      * @param mixed   $value
-     * @param integer $expiration
+     * @param int     $expiration
      *
      * @return boolean
      */
@@ -89,7 +89,7 @@ class MemcachedMock
      *
      * @param string  $key
      * @param mixed   $value
-     * @param integer $expiration
+     * @param int     $expiration
      *
      * @return boolean
      */
@@ -109,7 +109,7 @@ class MemcachedMock
      *
      * @param string  $key
      * @param mixed   $value
-     * @param integer $expiration
+     * @param int     $expiration
      *
      * @return boolean
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
@@ -32,7 +32,7 @@ class RedisMock
      * Add a server to connection pool
      *
      * @param string  $host
-     * @param integer $port
+     * @param int     $port
      * @param float   $timeout
      *
      * @return boolean
@@ -51,8 +51,8 @@ class RedisMock
     /**
      * Set client option.
      *
-     * @param integer $name
-     * @param integer $value
+     * @param int     $name
+     * @param int     $value
      *
      * @return boolean
      */
@@ -85,7 +85,7 @@ class RedisMock
      * Store data at the server with expiration time.
      *
      * @param string  $key
-     * @param integer $ttl
+     * @param int     $ttl
      * @param mixed   $value
      *
      * @return boolean
@@ -105,7 +105,7 @@ class RedisMock
      * Sets an expiration time on an item.
      *
      * @param string  $key
-     * @param integer $ttl
+     * @param int     $ttl
      *
      * @return boolean
      */

--- a/src/Symfony/Component/Intl/Collator/Collator.php
+++ b/src/Symfony/Component/Intl/Collator/Collator.php
@@ -99,7 +99,7 @@ class Collator
      * Sort array maintaining index association
      *
      * @param array   &$array    Input array
-     * @param integer $sortFlag  Flags for sorting, can be one of the following:
+     * @param int     $sortFlag  Flags for sorting, can be one of the following:
      *                           Collator::SORT_REGULAR - compare items normally (don't change types)
      *                           Collator::SORT_NUMERIC - compare items numerically
      *                           Collator::SORT_STRING - compare items as strings

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -187,7 +187,7 @@ class IntlDateFormatter
     /**
      * Format the date/time value (timestamp) as a string
      *
-     * @param integer|\DateTime $timestamp The timestamp to format. \DateTime objects
+     * @param int    |\DateTime $timestamp The timestamp to format. \DateTime objects
      *                                     are supported as of PHP 5.3.4.
      *
      * @return string|Boolean The formatted value or false if formatting failed.
@@ -489,7 +489,7 @@ class IntlDateFormatter
      * patterns, parsing as much as possible to obtain a value. Extra space, unrecognized tokens, or
      * invalid values ("February 30th") are not accepted.
      *
-     * @param Boolean $lenient Sets whether the parser is lenient or not. Currently
+     * @param bool    $lenient Sets whether the parser is lenient or not. Currently
      *                         only false (strict) is supported.
      *
      * @return Boolean true on success or false on failure

--- a/src/Symfony/Component/Intl/Globals/IntlGlobals.php
+++ b/src/Symfony/Component/Intl/Globals/IntlGlobals.php
@@ -67,7 +67,7 @@ abstract class IntlGlobals
     /**
      * Returns whether the error code indicates a failure
      *
-     * @param integer $errorCode The error code returned by IntlGlobals::getErrorCode()
+     * @param int     $errorCode The error code returned by IntlGlobals::getErrorCode()
      *
      * @return Boolean
      */
@@ -104,7 +104,7 @@ abstract class IntlGlobals
     /**
      * Returns the symbolic name for a given error code
      *
-     * @param integer $code The error code returned by IntlGlobals::getErrorCode()
+     * @param int     $code The error code returned by IntlGlobals::getErrorCode()
      *
      * @return string
      */
@@ -120,7 +120,7 @@ abstract class IntlGlobals
     /**
      * Sets the current error
      *
-     * @param integer $code    One of the error constants in this class
+     * @param int     $code    One of the error constants in this class
      * @param string  $message The ICU class error message
      *
      * @throws \InvalidArgumentException If the code is not one of the error constants in this class

--- a/src/Symfony/Component/Intl/Locale/Locale.php
+++ b/src/Symfony/Component/Intl/Locale/Locale.php
@@ -76,7 +76,7 @@ class Locale
      *
      * @param string  $langtag      The language tag to check
      * @param string  $locale       The language range to check against
-     * @param Boolean $canonicalize
+     * @param bool    $canonicalize
      *
      * @return string The corresponding locale code
      *
@@ -271,7 +271,7 @@ class Locale
      *
      * @param array   $langtag      A list of the language tags to compare to locale
      * @param string  $locale       The locale to use as the language range when matching
-     * @param Boolean $canonicalize If true, the arguments will be converted to canonical form before matching
+     * @param bool    $canonicalize If true, the arguments will be converted to canonical form before matching
      * @param string  $default      The locale to use if no match is found
      *
      * @see http://www.php.net/manual/en/locale.lookup.php

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -693,7 +693,7 @@ class NumberFormatter
     /**
      * Rounds a value.
      *
-     * @param integer|float $value     The value to round
+     * @param int    |float $value     The value to round
      * @param int           $precision The number of decimal digits to round to
      *
      * @return integer|float The rounded value
@@ -711,7 +711,7 @@ class NumberFormatter
     /**
      * Formats a number.
      *
-     * @param integer|float $value     The numeric value to format
+     * @param int    |float $value     The numeric value to format
      * @param int           $precision The number of decimal digits to use
      *
      * @return string The formatted number
@@ -726,7 +726,7 @@ class NumberFormatter
     /**
      * Returns the precision value if the DECIMAL style is being used and the FRACTION_DIGITS attribute is unitialized.
      *
-     * @param integer|float $value     The value to get the precision from if the FRACTION_DIGITS attribute is unitialized
+     * @param int    |float $value     The value to get the precision from if the FRACTION_DIGITS attribute is unitialized
      * @param int           $precision The precision value to returns if the FRACTION_DIGITS attribute is initialized
      *
      * @return int The precision value

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -870,7 +870,7 @@ class NumberFormatter
      */
     private function normalizeGroupingUsedValue($value)
     {
-        return (int) (Boolean) (int) $value;
+        return (int) (bool) (int) $value;
     }
 
     /**

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/BufferedBundleReader.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/BufferedBundleReader.php
@@ -29,7 +29,7 @@ class BufferedBundleReader implements BundleReaderInterface
      * Buffers a given reader.
      *
      * @param BundleReaderInterface $reader     The reader to buffer.
-     * @param integer               $bufferSize The number of entries to store
+     * @param int                   $bufferSize The number of entries to store
      *                                          in the buffer.
      */
     public function __construct(BundleReaderInterface $reader, $bufferSize)

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/StructuredBundleReaderInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/StructuredBundleReaderInterface.php
@@ -36,7 +36,7 @@ interface StructuredBundleReaderInterface extends BundleReaderInterface
      * @param string   $path     The path to the resource bundle.
      * @param string   $locale   The locale to read.
      * @param string[] $indices  The indices to read from the bundle.
-     * @param Boolean  $fallback Whether to merge the value with the value from
+     * @param bool     $fallback Whether to merge the value with the value from
      *                           the fallback locale (e.g. "en" for "en_GB").
      *                           Only applicable if the result is multivalued
      *                           (i.e. array or \ArrayAccess) or cannot be found

--- a/src/Symfony/Component/Intl/ResourceBundle/Writer/TextBundleWriter.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Writer/TextBundleWriter.php
@@ -58,8 +58,8 @@ class TextBundleWriter implements BundleWriterInterface
      *
      * @param resource $file          The file handle to write to.
      * @param mixed    $value         The value of the node.
-     * @param integer  $indentation   The number of levels to indent.
-     * @param Boolean  $requireBraces Whether to require braces to be printed
+     * @param int      $indentation   The number of levels to indent.
+     * @param bool     $requireBraces Whether to require braces to be printed
      *                                around the value.
      *
      * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
@@ -103,7 +103,7 @@ class TextBundleWriter implements BundleWriterInterface
      * Writes an "integer" node.
      *
      * @param resource $file  The file handle to write to.
-     * @param integer  $value The value of the node.
+     * @param int      $value The value of the node.
      *
      * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
      */
@@ -117,7 +117,7 @@ class TextBundleWriter implements BundleWriterInterface
      *
      * @param resource $file        The file handle to write to.
      * @param array    $value       The value of the node.
-     * @param integer  $indentation The number of levels to indent.
+     * @param int      $indentation The number of levels to indent.
      *
      * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
      */
@@ -137,7 +137,7 @@ class TextBundleWriter implements BundleWriterInterface
      *
      * @param resource $file         The file handle to write to.
      * @param string   $value        The value of the node.
-     * @param Boolean  $requireBraces Whether to require braces to be printed
+     * @param bool     $requireBraces Whether to require braces to be printed
      *                                around the value.
      *
      * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
@@ -158,7 +158,7 @@ class TextBundleWriter implements BundleWriterInterface
      *
      * @param resource $file        The file handle to write to.
      * @param array    $value       The value of the node.
-     * @param integer  $indentation The number of levels to indent.
+     * @param int      $indentation The number of levels to indent.
      *
      * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
      */
@@ -182,7 +182,7 @@ class TextBundleWriter implements BundleWriterInterface
      *
      * @param resource $file        The file handle to write to.
      * @param array    $value       The value of the node.
-     * @param integer  $indentation The number of levels to indent.
+     * @param int      $indentation The number of levels to indent.
      */
     private function writeTable($file, array $value, $indentation)
     {

--- a/src/Symfony/Component/Intl/Resources/stubs/functions.php
+++ b/src/Symfony/Component/Intl/Resources/stubs/functions.php
@@ -19,7 +19,7 @@ if (!function_exists('intl_is_failure')) {
      *
      * @author Bernhard Schussek <bschussek@gmail.com>
      *
-     * @param integer $errorCode  The error code returned by intl_get_error_code().
+     * @param int     $errorCode  The error code returned by intl_get_error_code().
      *
      * @return Boolean Whether the error code indicates an error.
      *
@@ -66,7 +66,7 @@ if (!function_exists('intl_is_failure')) {
      * Stub implementation for the {@link intl_error_name()} function of the intl
      * extension.
      *
-     * @param integer $errorCode The error code.
+     * @param int     $errorCode The error code.
      *
      * @return string The name of the error code constant.
      *

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -924,7 +924,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     abstract protected function getIntlErrorCode();
 
     /**
-     * @param integer $errorCode
+     * @param int     $errorCode
      *
      * @return Boolean
      */

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -734,7 +734,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
     abstract protected function getIntlErrorCode();
 
     /**
-     * @param integer $errorCode
+     * @param int     $errorCode
      *
      * @return Boolean
      */

--- a/src/Symfony/Component/Intl/Util/IcuVersion.php
+++ b/src/Symfony/Component/Intl/Util/IcuVersion.php
@@ -46,7 +46,7 @@ class IcuVersion
      * @param string       $version1  A version string.
      * @param string       $version2  A version string to compare.
      * @param string       $operator  The comparison operator.
-     * @param integer|null $precision The number of components to compare. Pass
+     * @param int    |null $precision The number of components to compare. Pass
      *                                NULL to compare the versions unchanged.
      *
      * @return Boolean Whether the comparison succeeded.
@@ -81,7 +81,7 @@ class IcuVersion
      *     // => '12.3'
      *
      * @param string       $version   An ICU version string.
-     * @param integer|null $precision The number of components to include. Pass
+     * @param int    |null $precision The number of components to include. Pass
      *                                NULL to return the version unchanged.
      *
      * @return string|null The normalized ICU version or NULL if it couldn't be

--- a/src/Symfony/Component/Intl/Util/Version.php
+++ b/src/Symfony/Component/Intl/Util/Version.php
@@ -36,7 +36,7 @@ class Version
      * @param string       $version1  A version string.
      * @param string       $version2  A version string to compare.
      * @param string       $operator  The comparison operator.
-     * @param integer|null $precision The number of components to compare. Pass
+     * @param int    |null $precision The number of components to compare. Pass
      *                                NULL to compare the versions unchanged.
      *
      * @return Boolean Whether the comparison succeeded.
@@ -64,7 +64,7 @@ class Version
      *     // => '1.2'
      *
      * @param string       $version   A version string.
-     * @param integer|null $precision The number of components to include. Pass
+     * @param int    |null $precision The number of components to include. Pass
      *                                NULL to return the version unchanged.
      *
      * @return string|null The normalized version or NULL if it couldn't be

--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -34,7 +34,7 @@ class PhpProcess extends Process
      * @param string  $script  The PHP script to run (as a string)
      * @param string  $cwd     The working directory
      * @param array   $env     The environment variables
-     * @param integer $timeout The timeout in seconds
+     * @param int     $timeout The timeout in seconds
      * @param array   $options An array of options for proc_open
      *
      * @api

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -776,7 +776,7 @@ class Process
      */
     public function setTty($tty)
     {
-        $this->tty = (Boolean) $tty;
+        $this->tty = (bool) $tty;
 
         return $this;
     }
@@ -928,7 +928,7 @@ class Process
      */
     public function setEnhanceWindowsCompatibility($enhance)
     {
-        $this->enhanceWindowsCompatibility = (Boolean) $enhance;
+        $this->enhanceWindowsCompatibility = (bool) $enhance;
 
         return $this;
     }
@@ -956,7 +956,7 @@ class Process
      */
     public function setEnhanceSigchildCompatibility($enhance)
     {
-        $this->enhanceSigchildCompatibility = (Boolean) $enhance;
+        $this->enhanceSigchildCompatibility = (bool) $enhance;
 
         return $this;
     }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -123,7 +123,7 @@ class Process
      * @param string|null        $cwd         The working directory or null to use the working dir of the current PHP process
      * @param array|null         $env         The environment variables or null to inherit
      * @param string|null        $stdin       The STDIN content
-     * @param integer|float|null $timeout     The timeout in seconds or null to disable
+     * @param int    |float|null $timeout     The timeout in seconds or null to disable
      * @param array              $options     An array of options for proc_open
      *
      * @throws RuntimeException When proc_open is not installed
@@ -351,7 +351,7 @@ class Process
     /**
      * Sends a POSIX signal to the process.
      *
-     * @param  integer $signal A valid POSIX signal (see http://www.php.net/manual/en/pcntl.constants.php)
+     * @param  int     $signal A valid POSIX signal (see http://www.php.net/manual/en/pcntl.constants.php)
      *
      * @return Process
      *
@@ -646,8 +646,8 @@ class Process
     /**
      * Stops the process.
      *
-     * @param integer|float $timeout The timeout in seconds
-     * @param integer       $signal  A POSIX signal to send in case the process has not stop at timeout, default is SIGKILL
+     * @param int    |float $timeout The timeout in seconds
+     * @param int           $signal  A POSIX signal to send in case the process has not stop at timeout, default is SIGKILL
      *
      * @return integer The exit-code of the process
      *
@@ -746,7 +746,7 @@ class Process
      *
      * To disable the timeout, set this value to null.
      *
-     * @param integer|float|null $timeout The timeout in seconds
+     * @param int    |float|null $timeout The timeout in seconds
      *
      * @return self The current Process instance
      *
@@ -770,7 +770,7 @@ class Process
     /**
      * Enables or disables the TTY mode.
      *
-     * @param boolean $tty True to enabled and false to disable
+     * @param bool    $tty True to enabled and false to disable
      *
      * @return self The current Process instance
      */
@@ -922,7 +922,7 @@ class Process
     /**
      * Sets whether or not Windows compatibility is enabled.
      *
-     * @param Boolean $enhance
+     * @param bool    $enhance
      *
      * @return self The current Process instance
      */
@@ -950,7 +950,7 @@ class Process
      * determine the success of a process when PHP has been compiled with
      * the --enable-sigchild option
      *
-     * @param Boolean $enhance
+     * @param bool    $enhance
      *
      * @return self The current Process instance
      */
@@ -1035,7 +1035,7 @@ class Process
     /**
      * Updates the status of the process, reads pipes.
      *
-     * @param Boolean $blocking Whether to use a blocking read call.
+     * @param bool    $blocking Whether to use a blocking read call.
      */
     protected function updateStatus($blocking)
     {
@@ -1077,8 +1077,8 @@ class Process
     /**
      * Reads pipes, executes callback.
      *
-     * @param Boolean $blocking Whether to use blocking calls or not.
-     * @param Boolean $close    Whether to close file handles or not.
+     * @param bool    $blocking Whether to use blocking calls or not.
+     * @param bool    $close    Whether to close file handles or not.
      */
     private function readPipes($blocking, $close)
     {
@@ -1155,8 +1155,8 @@ class Process
     /**
      * Sends a POSIX signal to the process.
      *
-     * @param  integer $signal         A valid POSIX signal (see http://www.php.net/manual/en/pcntl.constants.php)
-     * @param  Boolean $throwException Whether to throw exception in case signal failed
+     * @param  int     $signal         A valid POSIX signal (see http://www.php.net/manual/en/pcntl.constants.php)
+     * @param  bool    $throwException Whether to throw exception in case signal failed
      *
      * @return Boolean True if the signal was sent successfully, false otherwise
      *

--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -151,7 +151,7 @@ class ProcessPipes
     /**
      * Reads data in file handles and pipes.
      *
-     * @param Boolean $blocking Whether to use blocking calls or not.
+     * @param bool    $blocking Whether to use blocking calls or not.
      *
      * @return array An array of read data indexed by their fd.
      */
@@ -163,7 +163,7 @@ class ProcessPipes
     /**
      * Reads data in file handles and pipes, closes them if EOF is reached.
      *
-     * @param Boolean $blocking Whether to use blocking calls or not.
+     * @param bool    $blocking Whether to use blocking calls or not.
      *
      * @return array An array of read data indexed by their fd.
      */
@@ -189,7 +189,7 @@ class ProcessPipes
     /**
      * Writes stdin data.
      *
-     * @param Boolean     $blocking Whether to use blocking calls or not.
+     * @param bool        $blocking Whether to use blocking calls or not.
      * @param string|null $stdin    The data to write.
      */
     public function write($blocking, $stdin)
@@ -240,7 +240,7 @@ class ProcessPipes
     /**
      * Reads data in file handles.
      *
-     * @param Boolean $close Whether to close file handles or not.
+     * @param bool    $close Whether to close file handles or not.
      *
      * @return array An array of read data indexed by their fd.
      */
@@ -276,8 +276,8 @@ class ProcessPipes
     /**
      * Reads data in file pipes streams.
      *
-     * @param Boolean $blocking Whether to use blocking calls or not.
-     * @param Boolean $close    Whether to close file handles or not.
+     * @param bool    $blocking Whether to use blocking calls or not.
+     * @param bool    $close    Whether to close file handles or not.
      *
      * @return array An array of read data indexed by their fd.
      */

--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -35,8 +35,8 @@ class ProcessPipes
 
     public function __construct($useFiles, $ttyMode)
     {
-        $this->useFiles = (Boolean) $useFiles;
-        $this->ttyMode = (Boolean) $ttyMode;
+        $this->useFiles = (bool) $useFiles;
+        $this->ttyMode = (bool) $ttyMode;
 
         // Fix for PHP bug #51800: reading from STDOUT pipe hangs forever on Windows if the output is too big.
         // Workaround for this problem is to use temporary files instead of pipes on Windows platform.
@@ -180,10 +180,10 @@ class ProcessPipes
     public function hasOpenHandles()
     {
         if (!$this->useFiles) {
-            return (Boolean) $this->pipes;
+            return (bool) $this->pipes;
         }
 
-        return (Boolean) $this->pipes && (Boolean) $this->fileHandles;
+        return (bool) $this->pipes && (bool) $this->fileHandles;
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -779,7 +779,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
      * @param null    $cwd
      * @param array   $env
      * @param null    $stdin
-     * @param integer $timeout
+     * @param int     $timeout
      * @param array   $options
      *
      * @return Process

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -100,7 +100,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @param object|array          $objectOrArray The object or array to read from
      * @param PropertyPathInterface $propertyPath  The property path to read
-     * @param integer               $lastIndex     The index up to which should be read
+     * @param int                   $lastIndex     The index up to which should be read
      *
      * @return array The values read in the path.
      *
@@ -424,7 +424,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @param  \ReflectionClass $class      The class of the method
      * @param  string           $methodName The method name
-     * @param  integer          $parameters The number of parameters
+     * @param  int              $parameters The number of parameters
      *
      * @return Boolean Whether the method is public and has $parameters
      *                                      required parameters

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -45,9 +45,9 @@ class PropertyPathBuilder
      * Appends a (sub-) path to the current path.
      *
      * @param PropertyPathInterface|string $path   The path to append.
-     * @param integer                      $offset The offset where the appended
+     * @param int                          $offset The offset where the appended
      *                                             piece starts in $path.
-     * @param integer                      $length The length of the appended piece.
+     * @param int                          $length The length of the appended piece.
      *                                             If 0, the full path is appended.
      */
     public function append($path, $offset = 0, $length = 0)
@@ -93,8 +93,8 @@ class PropertyPathBuilder
     /**
      * Removes elements from the current path.
      *
-     * @param integer $offset The offset at which to remove
-     * @param integer $length The length of the removed piece
+     * @param int     $offset The offset at which to remove
+     * @param int     $length The length of the removed piece
      *
      * @throws OutOfBoundsException if offset is invalid
      */
@@ -110,12 +110,12 @@ class PropertyPathBuilder
     /**
      * Replaces a sub-path by a different (sub-) path.
      *
-     * @param integer                      $offset     The offset at which to replace.
-     * @param integer                      $length     The length of the piece to replace.
+     * @param int                          $offset     The offset at which to replace.
+     * @param int                          $length     The length of the piece to replace.
      * @param PropertyPathInterface|string $path       The path to insert.
-     * @param integer                      $pathOffset The offset where the inserted piece
+     * @param int                          $pathOffset The offset where the inserted piece
      *                                                 starts in $path.
-     * @param integer                      $pathLength The length of the inserted piece.
+     * @param int                          $pathLength The length of the inserted piece.
      *                                                 If 0, the full path is inserted.
      *
      * @throws OutOfBoundsException If the offset is invalid
@@ -147,7 +147,7 @@ class PropertyPathBuilder
     /**
      * Replaces a property element by an index element.
      *
-     * @param integer $offset The offset at which to replace
+     * @param int     $offset The offset at which to replace
      * @param string  $name   The new name of the element. Optional.
      *
      * @throws OutOfBoundsException If the offset is invalid
@@ -168,7 +168,7 @@ class PropertyPathBuilder
     /**
      * Replaces an index element by a property element.
      *
-     * @param integer $offset The offset at which to replace
+     * @param int     $offset The offset at which to replace
      * @param string  $name   The new name of the element. Optional.
      *
      * @throws OutOfBoundsException If the offset is invalid
@@ -235,9 +235,9 @@ class PropertyPathBuilder
      * removed at $offset and another chunk of length $insertionLength
      * can be inserted.
      *
-     * @param  integer $offset          The offset where the removed chunk starts
-     * @param  integer $cutLength       The length of the removed chunk
-     * @param  integer $insertionLength The length of the inserted chunk
+     * @param  int     $offset          The offset where the removed chunk starts
+     * @param  int     $cutLength       The length of the removed chunk
+     * @param  int     $insertionLength The length of the inserted chunk
      */
     private function resize($offset, $cutLength, $insertionLength)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -54,7 +54,7 @@ interface PropertyPathInterface extends \Traversable
     /**
      * Returns the element at the given index in the property path
      *
-     * @param  integer $index The index key
+     * @param  int     $index The index key
      *
      * @return string A property or index name
      *
@@ -65,7 +65,7 @@ interface PropertyPathInterface extends \Traversable
     /**
      * Returns whether the element at the given index is a property
      *
-     * @param  integer $index The index in the property path
+     * @param  int     $index The index in the property path
      *
      * @return Boolean Whether the element at this index is a property
      *
@@ -76,7 +76,7 @@ interface PropertyPathInterface extends \Traversable
     /**
      * Returns whether the element at the given index is an array index
      *
-     * @param  integer $index The index in the property path
+     * @param  int     $index The index in the property path
      *
      * @return Boolean Whether the element at this index is an array index
      *

--- a/src/Symfony/Component/Routing/Generator/ConfigurableRequirementsInterface.php
+++ b/src/Symfony/Component/Routing/Generator/ConfigurableRequirementsInterface.php
@@ -41,7 +41,7 @@ interface ConfigurableRequirementsInterface
      * Enables or disables the exception on incorrect parameters.
      * Passing null will deactivate the requirements check completely.
      *
-     * @param Boolean|null $enabled
+     * @param bool|null    $enabled
      */
     public function setStrictRequirements($enabled);
 

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -114,7 +114,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
      */
     public function setStrictRequirements($enabled)
     {
-        $this->strictRequirements = null === $enabled ? null : (Boolean) $enabled;
+        $this->strictRequirements = null === $enabled ? null : (bool) $enabled;
     }
 
     /**

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -72,7 +72,7 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      *
      * @param string         $name          The name of the route
      * @param mixed          $parameters    An array of parameters
-     * @param Boolean|string $referenceType The type of reference to be generated (one of the constants)
+     * @param bool|string    $referenceType The type of reference to be generated (one of the constants)
      *
      * @return string The generated URL
      *

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -78,7 +78,7 @@ EOF;
     /**
      * Generates the code for the match method implementing UrlMatcherInterface.
      *
-     * @param Boolean $supportsRedirections Whether redirections are supported by the base class
+     * @param bool    $supportsRedirections Whether redirections are supported by the base class
      *
      * @return string Match method as PHP code
      */
@@ -103,7 +103,7 @@ EOF;
      * Generates PHP code to match a RouteCollection with all its routes.
      *
      * @param RouteCollection $routes               A RouteCollection instance
-     * @param Boolean         $supportsRedirections Whether redirections are supported by the base class
+     * @param bool            $supportsRedirections Whether redirections are supported by the base class
      *
      * @return string PHP code
      */
@@ -144,7 +144,7 @@ EOF;
      * Generates PHP code recursively to match a tree of routes
      *
      * @param DumperPrefixCollection $collection           A DumperPrefixCollection instance
-     * @param Boolean                $supportsRedirections Whether redirections are supported by the base class
+     * @param bool                   $supportsRedirections Whether redirections are supported by the base class
      * @param string                 $parentPrefix         Prefix of the parent collection
      *
      * @return string PHP code
@@ -184,7 +184,7 @@ EOF;
      *
      * @param Route       $route                A Route instance
      * @param string      $name                 The name of the Route
-     * @param Boolean     $supportsRedirections Whether redirections are supported by the base class
+     * @param bool        $supportsRedirections Whether redirections are supported by the base class
      * @param string|null $parentPrefix         The prefix of the parent collection used to optimize the code
      *
      * @return string PHP code

--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -43,8 +43,8 @@ class RequestContext
      * @param string  $method       The HTTP method
      * @param string  $host         The HTTP host name
      * @param string  $scheme       The HTTP scheme
-     * @param integer $httpPort     The HTTP port
-     * @param integer $httpsPort    The HTTPS port
+     * @param int     $httpPort     The HTTP port
+     * @param int     $httpsPort    The HTTPS port
      * @param string  $path         The path
      * @param string  $queryString  The query string
      *

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -196,8 +196,8 @@ class RouteCompiler implements RouteCompilerInterface
      * Computes the regexp used to match a specific token. It can be static text or a subpattern.
      *
      * @param array   $tokens        The route tokens
-     * @param integer $index         The index of the current token
-     * @param integer $firstOptional The index of the first optional token
+     * @param int     $index         The index of the current token
+     * @param int     $firstOptional The index of the first optional token
      *
      * @return string The regexp pattern for a single token
      */

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -554,7 +554,7 @@ QUERY;
                     $oidCache[$oidLookupKey] = new ObjectIdentity($objectIdentifier, $classType);
                 }
 
-                $acl = new Acl((integer) $aclId, $oidCache[$oidLookupKey], $permissionGrantingStrategy, $emptyArray, !!$entriesInheriting);
+                $acl = new Acl((int) $aclId, $oidCache[$oidLookupKey], $permissionGrantingStrategy, $emptyArray, !!$entriesInheriting);
 
                 // keep a local, and global reference to this ACL
                 $loadedAcls[$classType][$objectIdentifier] = $acl;
@@ -596,9 +596,9 @@ QUERY;
                     }
 
                     if (null === $fieldName) {
-                        $loadedAces[$aceId] = new Entry((integer) $aceId, $acl, $sids[$key], $grantingStrategy, (integer) $mask, !!$granting, !!$auditFailure, !!$auditSuccess);
+                        $loadedAces[$aceId] = new Entry((int) $aceId, $acl, $sids[$key], $grantingStrategy, (int) $mask, !!$granting, !!$auditFailure, !!$auditSuccess);
                     } else {
-                        $loadedAces[$aceId] = new FieldEntry((integer) $aceId, $acl, $fieldName, $sids[$key], $grantingStrategy, (integer) $mask, !!$granting, !!$auditFailure, !!$auditSuccess);
+                        $loadedAces[$aceId] = new FieldEntry((int) $aceId, $acl, $fieldName, $sids[$key], $grantingStrategy, (int) $mask, !!$granting, !!$auditFailure, !!$auditSuccess);
                     }
                 }
                 $ace = $loadedAces[$aceId];

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -318,7 +318,7 @@ SELECTCLAUSE;
      * object identities.
      *
      * @param ObjectIdentityInterface $oid
-     * @param Boolean                 $directChildrenOnly
+     * @param bool                    $directChildrenOnly
      * @return string
      */
     protected function getFindChildrenSql(ObjectIdentityInterface $oid, $directChildrenOnly)

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -354,7 +354,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for deleting access control entries.
      *
-     * @param integer $oidPK
+     * @param int     $oidPK
      * @return string
      */
     protected function getDeleteAccessControlEntriesSql($oidPK)
@@ -369,7 +369,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for deleting a specific ACE.
      *
-     * @param integer $acePK
+     * @param int     $acePK
      * @return string
      */
     protected function getDeleteAccessControlEntrySql($acePK)
@@ -384,7 +384,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for deleting an object identity.
      *
-     * @param integer $pk
+     * @param int     $pk
      * @return string
      */
     protected function getDeleteObjectIdentitySql($pk)
@@ -399,7 +399,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for deleting relation entries.
      *
-     * @param integer $pk
+     * @param int     $pk
      * @return string
      */
     protected function getDeleteObjectIdentityRelationsSql($pk)
@@ -414,16 +414,16 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for inserting an ACE.
      *
-     * @param integer      $classId
-     * @param integer|null $objectIdentityId
+     * @param int          $classId
+     * @param int    |null $objectIdentityId
      * @param string|null  $field
-     * @param integer      $aceOrder
-     * @param integer      $securityIdentityId
+     * @param int          $aceOrder
+     * @param int          $securityIdentityId
      * @param string       $strategy
-     * @param integer      $mask
-     * @param Boolean      $granting
-     * @param Boolean      $auditSuccess
-     * @param Boolean      $auditFailure
+     * @param int          $mask
+     * @param bool         $granting
+     * @param bool         $auditSuccess
+     * @param bool         $auditFailure
      * @return string
      */
     protected function getInsertAccessControlEntrySql($classId, $objectIdentityId, $field, $aceOrder, $securityIdentityId, $strategy, $mask, $granting, $auditSuccess, $auditFailure)
@@ -478,8 +478,8 @@ QUERY;
     /**
      * Constructs the SQL for inserting a relation entry.
      *
-     * @param integer $objectIdentityId
-     * @param integer $ancestorId
+     * @param int     $objectIdentityId
+     * @param int     $ancestorId
      * @return string
      */
     protected function getInsertObjectIdentityRelationSql($objectIdentityId, $ancestorId)
@@ -496,8 +496,8 @@ QUERY;
      * Constructs the SQL for inserting an object identity.
      *
      * @param string  $identifier
-     * @param integer $classId
-     * @param Boolean $entriesInheriting
+     * @param int     $classId
+     * @param bool    $entriesInheriting
      * @return string
      */
     protected function getInsertObjectIdentitySql($identifier, $classId, $entriesInheriting)
@@ -546,10 +546,10 @@ QUERY;
     /**
      * Constructs the SQL for selecting an ACE.
      *
-     * @param integer $classId
-     * @param integer $oid
+     * @param int     $classId
+     * @param int     $oid
      * @param string  $field
-     * @param integer $order
+     * @param int     $order
      * @return string
      */
     protected function getSelectAccessControlEntryIdSql($classId, $oid, $field, $order)
@@ -614,7 +614,7 @@ QUERY;
     /**
      * Constructs the SQL for updating an object identity.
      *
-     * @param integer $pk
+     * @param int     $pk
      * @param array   $changes
      * @throws \InvalidArgumentException
      * @return string
@@ -636,7 +636,7 @@ QUERY;
     /**
      * Constructs the SQL for updating an ACE.
      *
-     * @param integer $pk
+     * @param int     $pk
      * @param array   $sets
      * @throws \InvalidArgumentException
      * @return string
@@ -709,7 +709,7 @@ QUERY;
     /**
      * Deletes all ACEs for the given object identity primary key.
      *
-     * @param integer $oidPK
+     * @param int     $oidPK
      */
     private function deleteAccessControlEntries($oidPK)
     {
@@ -719,7 +719,7 @@ QUERY;
     /**
      * Deletes the object identity from the database.
      *
-     * @param integer $pk
+     * @param int     $pk
      */
     private function deleteObjectIdentity($pk)
     {
@@ -729,7 +729,7 @@ QUERY;
     /**
      * Deletes all entries from the relations table from the database.
      *
-     * @param integer $pk
+     * @param int     $pk
      */
     private function deleteObjectIdentityRelations($pk)
     {

--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -49,11 +49,11 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Constructor
      *
-     * @param integer                             $id
+     * @param int                                 $id
      * @param ObjectIdentityInterface             $objectIdentity
      * @param PermissionGrantingStrategyInterface $permissionGrantingStrategy
      * @param array                               $loadedSids
-     * @param Boolean                             $entriesInheriting
+     * @param bool                                $entriesInheriting
      */
     public function __construct($id, ObjectIdentityInterface $objectIdentity, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $loadedSids = array(), $entriesInheriting)
     {
@@ -398,7 +398,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * Deletes an ACE
      *
      * @param string  $property
-     * @param integer $index
+     * @param int     $index
      * @throws \OutOfBoundsException
      */
     private function deleteAce($property, $index)
@@ -422,7 +422,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * Deletes a field-based ACE
      *
      * @param string  $property
-     * @param integer $index
+     * @param int     $index
      * @param string  $field
      * @throws \OutOfBoundsException
      */
@@ -447,10 +447,10 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * Inserts an ACE
      *
      * @param string                    $property
-     * @param integer                   $index
-     * @param integer                   $mask
+     * @param int                       $index
+     * @param int                       $mask
      * @param SecurityIdentityInterface $sid
-     * @param Boolean                   $granting
+     * @param bool                      $granting
      * @param string                    $strategy
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
@@ -495,11 +495,11 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * Inserts a field-based ACE
      *
      * @param string                    $property
-     * @param integer                   $index
+     * @param int                       $index
      * @param string                    $field
-     * @param integer                   $mask
+     * @param int                       $mask
      * @param SecurityIdentityInterface $sid
-     * @param Boolean                   $granting
+     * @param bool                      $granting
      * @param string                    $strategy
      * @throws \InvalidArgumentException
      * @throws \OutOfBoundsException
@@ -552,8 +552,8 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * Updates an ACE
      *
      * @param string  $property
-     * @param integer $index
-     * @param integer $mask
+     * @param int     $index
+     * @param int     $mask
      * @param string  $strategy
      * @throws \OutOfBoundsException
      */
@@ -579,9 +579,9 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * Updates auditing for an ACE
      *
      * @param array   &$aces
-     * @param integer $index
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param int     $index
+     * @param bool    $auditSuccess
+     * @param bool    $auditFailure
      * @throws \OutOfBoundsException
      */
     private function updateAuditing(array &$aces, $index, $auditSuccess, $auditFailure)
@@ -605,9 +605,9 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * Updates a field-based ACE
      *
      * @param string  $property
-     * @param integer $index
+     * @param int     $index
      * @param string  $field
-     * @param integer $mask
+     * @param int     $mask
      * @param string  $strategy
      * @throws \InvalidArgumentException
      * @throws \OutOfBoundsException

--- a/src/Symfony/Component/Security/Acl/Domain/AuditLogger.php
+++ b/src/Symfony/Component/Security/Acl/Domain/AuditLogger.php
@@ -25,7 +25,7 @@ abstract class AuditLogger implements AuditLoggerInterface
     /**
      * Performs some checks if logging was requested
      *
-     * @param Boolean        $granted
+     * @param bool           $granted
      * @param EntryInterface $ace
      */
     public function logIfNeeded($granted, EntryInterface $ace)
@@ -44,7 +44,7 @@ abstract class AuditLogger implements AuditLoggerInterface
     /**
      * This method is only called when logging is needed
      *
-     * @param Boolean        $granted
+     * @param bool           $granted
      * @param EntryInterface $ace
      */
     abstract protected function doLog($granted, EntryInterface $ace);

--- a/src/Symfony/Component/Security/Acl/Domain/Entry.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Entry.php
@@ -34,14 +34,14 @@ class Entry implements AuditableEntryInterface
     /**
      * Constructor
      *
-     * @param integer                   $id
+     * @param int                       $id
      * @param AclInterface              $acl
      * @param SecurityIdentityInterface $sid
      * @param string                    $strategy
-     * @param integer                   $mask
-     * @param Boolean                   $granting
-     * @param Boolean                   $auditFailure
-     * @param Boolean                   $auditSuccess
+     * @param int                       $mask
+     * @param bool                      $granting
+     * @param bool                      $auditFailure
+     * @param bool                      $auditSuccess
      */
     public function __construct($id, AclInterface $acl, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
     {
@@ -125,7 +125,7 @@ class Entry implements AuditableEntryInterface
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      */
     public function setAuditFailure($boolean)
     {
@@ -138,7 +138,7 @@ class Entry implements AuditableEntryInterface
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      */
     public function setAuditSuccess($boolean)
     {
@@ -151,7 +151,7 @@ class Entry implements AuditableEntryInterface
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
      *
-     * @param integer $mask
+     * @param int     $mask
      */
     public function setMask($mask)
     {

--- a/src/Symfony/Component/Security/Acl/Domain/FieldEntry.php
+++ b/src/Symfony/Component/Security/Acl/Domain/FieldEntry.php
@@ -27,15 +27,15 @@ class FieldEntry extends Entry implements FieldEntryInterface
     /**
      * Constructor
      *
-     * @param integer                   $id
+     * @param int                       $id
      * @param AclInterface              $acl
      * @param string                    $field
      * @param SecurityIdentityInterface $sid
      * @param string                    $strategy
-     * @param integer                   $mask
-     * @param Boolean                   $granting
-     * @param Boolean                   $auditFailure
-     * @param Boolean                   $auditSuccess
+     * @param int                       $mask
+     * @param bool                      $granting
+     * @param bool                      $auditFailure
+     * @param bool                      $auditSuccess
      */
     public function __construct($id, AclInterface $acl, $field, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
     {

--- a/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
@@ -128,7 +128,7 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      * @param EntryInterface[]            $aces               An array of ACE to check against
      * @param array                       $masks              An array of permission masks
      * @param SecurityIdentityInterface[] $sids               An array of SecurityIdentityInterface implementations
-     * @param Boolean                     $administrativeMode True turns off audit logging
+     * @param bool                        $administrativeMode True turns off audit logging
      *
      * @return Boolean true, or false; either granting, or denying access respectively.
      *
@@ -188,7 +188,7 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      * Strategy EQUAL:
      * The ACE will be considered applicable when the bitmasks are equal.
      *
-     * @param integer        $requiredMask
+     * @param int            $requiredMask
      * @param EntryInterface $ace
      *
      * @return Boolean

--- a/src/Symfony/Component/Security/Acl/Model/AclCacheInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclCacheInterface.php
@@ -37,7 +37,7 @@ interface AclCacheInterface
     /**
      * Retrieves an ACL for the given object identity primary key from the cache
      *
-     * @param integer $primaryKey
+     * @param int     $primaryKey
      * @return AclInterface
      */
     public function getFromCacheById($primaryKey);

--- a/src/Symfony/Component/Security/Acl/Model/AclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclInterface.php
@@ -82,7 +82,7 @@ interface AclInterface extends \Serializable
      * @param string  $field
      * @param array   $masks
      * @param array   $securityIdentities
-     * @param Boolean $administrativeMode
+     * @param bool    $administrativeMode
      * @return Boolean
      */
     public function isFieldGranted($field, array $masks, array $securityIdentities, $administrativeMode = false);
@@ -93,7 +93,7 @@ interface AclInterface extends \Serializable
      * @throws NoAceFoundException when no ACE was applicable for this request
      * @param array   $masks
      * @param array   $securityIdentities
-     * @param Boolean $administrativeMode
+     * @param bool    $administrativeMode
      * @return Boolean
      */
     public function isGranted(array $masks, array $securityIdentities, $administrativeMode = false);

--- a/src/Symfony/Component/Security/Acl/Model/AclProviderInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclProviderInterface.php
@@ -24,7 +24,7 @@ interface AclProviderInterface
      * Retrieves all child object identities from the database
      *
      * @param ObjectIdentityInterface $parentOid
-     * @param Boolean                 $directChildrenOnly
+     * @param bool                    $directChildrenOnly
      *
      * @return array returns an array of child 'ObjectIdentity's
      */

--- a/src/Symfony/Component/Security/Acl/Model/AuditLoggerInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AuditLoggerInterface.php
@@ -22,7 +22,7 @@ interface AuditLoggerInterface
      * This method is called whenever access is granted, or denied, and
      * administrative mode is turned off.
      *
-     * @param Boolean        $granted
+     * @param bool           $granted
      * @param EntryInterface $ace
      */
     public function logIfNeeded($granted, EntryInterface $ace);

--- a/src/Symfony/Component/Security/Acl/Model/AuditableAclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AuditableAclInterface.php
@@ -21,38 +21,38 @@ interface AuditableAclInterface extends MutableAclInterface
     /**
      * Updates auditing for class-based ACE
      *
-     * @param integer $index
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param int     $index
+     * @param bool    $auditSuccess
+     * @param bool    $auditFailure
      */
     public function updateClassAuditing($index, $auditSuccess, $auditFailure);
 
     /**
      * Updates auditing for class-field-based ACE
      *
-     * @param integer $index
+     * @param int     $index
      * @param string  $field
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param bool    $auditSuccess
+     * @param bool    $auditFailure
      */
     public function updateClassFieldAuditing($index, $field, $auditSuccess, $auditFailure);
 
     /**
      * Updates auditing for object-based ACE
      *
-     * @param integer $index
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param int     $index
+     * @param bool    $auditSuccess
+     * @param bool    $auditFailure
      */
     public function updateObjectAuditing($index, $auditSuccess, $auditFailure);
 
     /**
      * Updates auditing for object-field-based ACE
      *
-     * @param integer $index
+     * @param int     $index
      * @param string  $field
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param bool    $auditSuccess
+     * @param bool    $auditFailure
      */
     public function updateObjectFieldAuditing($index, $field, $auditSuccess, $auditFailure);
 }

--- a/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
@@ -24,14 +24,14 @@ interface MutableAclInterface extends AclInterface
     /**
      * Deletes a class-based ACE
      *
-     * @param integer $index
+     * @param int     $index
      */
     public function deleteClassAce($index);
 
     /**
      * Deletes a class-field-based ACE
      *
-     * @param integer $index
+     * @param int     $index
      * @param string  $field
      */
     public function deleteClassFieldAce($index, $field);
@@ -39,14 +39,14 @@ interface MutableAclInterface extends AclInterface
     /**
      * Deletes an object-based ACE
      *
-     * @param integer $index
+     * @param int     $index
      */
     public function deleteObjectAce($index);
 
     /**
      * Deletes an object-field-based ACE
      *
-     * @param integer $index
+     * @param int     $index
      * @param string  $field
      */
     public function deleteObjectFieldAce($index, $field);
@@ -62,9 +62,9 @@ interface MutableAclInterface extends AclInterface
      * Inserts a class-based ACE
      *
      * @param SecurityIdentityInterface $sid
-     * @param integer                   $mask
-     * @param integer                   $index
-     * @param Boolean                   $granting
+     * @param int                       $mask
+     * @param int                       $index
+     * @param bool                      $granting
      * @param string                    $strategy
      */
     public function insertClassAce(SecurityIdentityInterface $sid, $mask, $index = 0, $granting = true, $strategy = null);
@@ -74,9 +74,9 @@ interface MutableAclInterface extends AclInterface
      *
      * @param string                    $field
      * @param SecurityIdentityInterface $sid
-     * @param integer                   $mask
-     * @param integer                   $index
-     * @param Boolean                   $granting
+     * @param int                       $mask
+     * @param int                       $index
+     * @param bool                      $granting
      * @param string                    $strategy
      */
     public function insertClassFieldAce($field, SecurityIdentityInterface $sid, $mask, $index = 0, $granting = true, $strategy = null);
@@ -85,9 +85,9 @@ interface MutableAclInterface extends AclInterface
      * Inserts an object-based ACE
      *
      * @param SecurityIdentityInterface $sid
-     * @param integer                   $mask
-     * @param integer                   $index
-     * @param Boolean                   $granting
+     * @param int                       $mask
+     * @param int                       $index
+     * @param bool                      $granting
      * @param string                    $strategy
      */
     public function insertObjectAce(SecurityIdentityInterface $sid, $mask, $index = 0, $granting = true, $strategy = null);
@@ -97,9 +97,9 @@ interface MutableAclInterface extends AclInterface
      *
      * @param string                    $field
      * @param SecurityIdentityInterface $sid
-     * @param integer                   $mask
-     * @param integer                   $index
-     * @param Boolean                   $granting
+     * @param int                       $mask
+     * @param int                       $index
+     * @param bool                      $granting
      * @param string                    $strategy
      */
     public function insertObjectFieldAce($field, SecurityIdentityInterface $sid, $mask, $index = 0, $granting = true, $strategy = null);
@@ -107,7 +107,7 @@ interface MutableAclInterface extends AclInterface
     /**
      * Sets whether entries are inherited
      *
-     * @param Boolean $boolean
+     * @param bool    $boolean
      */
     public function setEntriesInheriting($boolean);
 
@@ -121,8 +121,8 @@ interface MutableAclInterface extends AclInterface
     /**
      * Updates a class-based ACE
      *
-     * @param integer $index
-     * @param integer $mask
+     * @param int     $index
+     * @param int     $mask
      * @param string  $strategy if null the strategy should not be changed
      */
     public function updateClassAce($index, $mask, $strategy = null);
@@ -130,9 +130,9 @@ interface MutableAclInterface extends AclInterface
     /**
      * Updates a class-field-based ACE
      *
-     * @param integer $index
+     * @param int     $index
      * @param string  $field
-     * @param integer $mask
+     * @param int     $mask
      * @param string  $strategy if null the strategy should not be changed
      */
     public function updateClassFieldAce($index, $field, $mask, $strategy = null);
@@ -140,8 +140,8 @@ interface MutableAclInterface extends AclInterface
     /**
      * Updates an object-based ACE
      *
-     * @param integer $index
-     * @param integer $mask
+     * @param int     $index
+     * @param int     $mask
      * @param string  $strategy if null the strategy should not be changed
      */
     public function updateObjectAce($index, $mask, $strategy = null);
@@ -149,9 +149,9 @@ interface MutableAclInterface extends AclInterface
     /**
      * Updates an object-field-based ACE
      *
-     * @param integer $index
+     * @param int     $index
      * @param string  $field
-     * @param integer $mask
+     * @param int     $mask
      * @param string  $strategy if null the strategy should not be changed
      */
     public function updateObjectFieldAce($index, $field, $mask, $strategy = null);

--- a/src/Symfony/Component/Security/Acl/Model/PermissionGrantingStrategyInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/PermissionGrantingStrategyInterface.php
@@ -24,7 +24,7 @@ interface PermissionGrantingStrategyInterface
      * @param AclInterface $acl
      * @param array        $masks
      * @param array        $sids
-     * @param Boolean      $administrativeMode
+     * @param bool         $administrativeMode
      * @return Boolean
      */
     public function isGranted(AclInterface $acl, array $masks, array $sids, $administrativeMode = false);
@@ -36,7 +36,7 @@ interface PermissionGrantingStrategyInterface
      * @param string       $field
      * @param array        $masks
      * @param array        $sids
-     * @param Boolean      $administrativeMode
+     * @param bool         $administrativeMode
      *
      * @return Boolean
      */

--- a/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
+++ b/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
@@ -72,7 +72,7 @@ class MaskBuilder
     /**
      * Constructor
      *
-     * @param integer $mask optional; defaults to 0
+     * @param int     $mask optional; defaults to 0
      *
      * @throws \InvalidArgumentException
      */
@@ -178,7 +178,7 @@ class MaskBuilder
     /**
      * Returns the code for the passed mask
      *
-     * @param integer $mask
+     * @param int     $mask
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      * @return string

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -38,7 +38,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * Constructor.
      *
      * @param AuthenticationProviderInterface[] $providers        An array of AuthenticationProviderInterface instances
-     * @param Boolean                           $eraseCredentials Whether to erase credentials after authentication or not
+     * @param bool                              $eraseCredentials Whether to erase credentials after authentication or not
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -49,7 +49,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
         }
 
         $this->providers = $providers;
-        $this->eraseCredentials = (Boolean) $eraseCredentials;
+        $this->eraseCredentials = (bool) $eraseCredentials;
     }
 
     public function setEventDispatcher(EventDispatcherInterface $dispatcher)

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -38,7 +38,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
      * @param UserCheckerInterface    $userChecker                An UserCheckerInterface instance
      * @param string                  $providerKey                The provider key
      * @param EncoderFactoryInterface $encoderFactory             An EncoderFactoryInterface instance
-     * @param Boolean                 $hideUserNotFoundExceptions Whether to hide user not found exception or not
+     * @param bool                    $hideUserNotFoundExceptions Whether to hide user not found exception or not
      */
     public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, $providerKey, EncoderFactoryInterface $encoderFactory, $hideUserNotFoundExceptions = true)
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -37,7 +37,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
      *
      * @param UserCheckerInterface $userChecker                An UserCheckerInterface interface
      * @param string               $providerKey                A provider key
-     * @param Boolean              $hideUserNotFoundExceptions Whether to hide user not found exception or not
+     * @param bool                 $hideUserNotFoundExceptions Whether to hide user not found exception or not
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -131,7 +131,7 @@ abstract class AbstractToken implements TokenInterface
      */
     public function setAuthenticated($authenticated)
     {
-        $this->authenticated = (Boolean) $authenticated;
+        $this->authenticated = (bool) $authenticated;
     }
 
     /**
@@ -251,7 +251,7 @@ abstract class AbstractToken implements TokenInterface
         }
 
         if ($this->user instanceof EquatableInterface) {
-            return ! (Boolean) $this->user->isEqualTo($user);
+            return ! (bool) $this->user->isEqualTo($user);
         }
 
         if ($this->user->getPassword() !== $user->getPassword()) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -76,7 +76,7 @@ interface TokenInterface extends \Serializable
     /**
      * Sets the authenticated flag.
      *
-     * @param Boolean $isAuthenticated The authenticated flag
+     * @param bool    $isAuthenticated The authenticated flag
      */
     public function setAuthenticated($isAuthenticated);
 

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -45,8 +45,8 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
 
         $this->voters = $voters;
         $this->strategy = 'decide'.ucfirst($strategy);
-        $this->allowIfAllAbstainDecisions = (Boolean) $allowIfAllAbstainDecisions;
-        $this->allowIfEqualGrantedDeniedDecisions = (Boolean) $allowIfEqualGrantedDeniedDecisions;
+        $this->allowIfAllAbstainDecisions = (bool) $allowIfAllAbstainDecisions;
+        $this->allowIfEqualGrantedDeniedDecisions = (bool) $allowIfEqualGrantedDeniedDecisions;
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -32,8 +32,8 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      *
      * @param VoterInterface[] $voters                             An array of VoterInterface instances
      * @param string           $strategy                           The vote strategy
-     * @param Boolean          $allowIfAllAbstainDecisions         Whether to grant access if all voters abstained or not
-     * @param Boolean          $allowIfEqualGrantedDeniedDecisions Whether to grant access if result are equals
+     * @param bool             $allowIfAllAbstainDecisions         Whether to grant access if all voters abstained or not
+     * @param bool             $allowIfEqualGrantedDeniedDecisions Whether to grant access if result are equals
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -27,7 +27,7 @@ class BCryptPasswordEncoder extends BasePasswordEncoder
     /**
      * Constructor.
      *
-     * @param integer $cost The algorithmic cost that should be used
+     * @param int     $cost The algorithmic cost that should be used
      *
      * @throws \RuntimeException When no BCrypt encoder is available
      * @throws \InvalidArgumentException if cost is out of range

--- a/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
@@ -28,8 +28,8 @@ class MessageDigestPasswordEncoder extends BasePasswordEncoder
      * Constructor.
      *
      * @param string  $algorithm          The digest algorithm to use
-     * @param Boolean $encodeHashAsBase64 Whether to base64 encode the password hash
-     * @param integer $iterations         The number of iterations to use to stretch the password hash
+     * @param bool    $encodeHashAsBase64 Whether to base64 encode the password hash
+     * @param int     $iterations         The number of iterations to use to stretch the password hash
      */
     public function __construct($algorithm = 'sha512', $encodeHashAsBase64 = true, $iterations = 5000)
     {

--- a/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
@@ -37,9 +37,9 @@ class Pbkdf2PasswordEncoder extends BasePasswordEncoder
      * Constructor.
      *
      * @param string  $algorithm          The digest algorithm to use
-     * @param Boolean $encodeHashAsBase64 Whether to base64 encode the password hash
-     * @param integer $iterations         The number of iterations to use to stretch the password hash
-     * @param integer $length             Length of derived key to create
+     * @param bool    $encodeHashAsBase64 Whether to base64 encode the password hash
+     * @param int     $iterations         The number of iterations to use to stretch the password hash
+     * @param int     $length             Length of derived key to create
      */
     public function __construct($algorithm = 'sha512', $encodeHashAsBase64 = true, $iterations = 1000, $length = 40)
     {

--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -25,7 +25,7 @@ class PlaintextPasswordEncoder extends BasePasswordEncoder
     /**
      * Constructor.
      *
-     * @param Boolean $ignorePasswordCase Compare password case-insensitive
+     * @param bool    $ignorePasswordCase Compare password case-insensitive
      */
     public function __construct($ignorePasswordCase = false)
     {

--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -36,7 +36,7 @@ class SecurityContext implements SecurityContextInterface
      *
      * @param AuthenticationManagerInterface      $authenticationManager An AuthenticationManager instance
      * @param AccessDecisionManagerInterface|null $accessDecisionManager An AccessDecisionManager instance
-     * @param Boolean                             $alwaysAuthenticate
+     * @param bool                                $alwaysAuthenticate
      */
     public function __construct(AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager, $alwaysAuthenticate = false)
     {

--- a/src/Symfony/Component/Security/Core/Util/SecureRandomInterface.php
+++ b/src/Symfony/Component/Security/Core/Util/SecureRandomInterface.php
@@ -21,7 +21,7 @@ interface SecureRandomInterface
     /**
      * Generates the specified number of secure random bytes.
      *
-     * @param integer $nbBytes
+     * @param int     $nbBytes
      *
      * @return string
      */

--- a/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
@@ -34,7 +34,7 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
      * @param HttpKernelInterface $kernel
      * @param HttpUtils           $httpUtils  An HttpUtils instance
      * @param string              $loginPath  The path to the login form
-     * @param Boolean             $useForward Whether to forward or redirect to the login form
+     * @param bool                $useForward Whether to forward or redirect to the login form
      */
     public function __construct(HttpKernelInterface $kernel, HttpUtils $httpUtils, $loginPath, $useForward = false)
     {

--- a/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
@@ -41,7 +41,7 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
         $this->httpKernel = $kernel;
         $this->httpUtils = $httpUtils;
         $this->loginPath = $loginPath;
-        $this->useForward = (Boolean) $useForward;
+        $this->useForward = (bool) $useForward;
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -53,7 +53,7 @@ class HttpUtils
      *
      * @param Request $request A Request instance
      * @param string  $path    A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
-     * @param integer $status  The status code
+     * @param int     $status  The status code
      *
      * @return RedirectResponse A RedirectResponse instance
      */

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -116,7 +116,7 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      *
      * @param string  $class
      * @param string  $username The username
-     * @param integer $expires  The Unix timestamp when the cookie expires
+     * @param int     $expires  The Unix timestamp when the cookie expires
      * @param string  $password The encoded password
      *
      * @throws \RuntimeException if username contains invalid chars
@@ -138,7 +138,7 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      *
      * @param string  $class
      * @param string  $username The username
-     * @param integer $expires  The Unix timestamp when the cookie expires
+     * @param int     $expires  The Unix timestamp when the cookie expires
      * @param string  $password The encoded password
      *
      * @throws \RuntimeException when the private key is empty

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -38,8 +38,8 @@ class JsonDecode implements DecoderInterface
     /**
      * Constructs a new JsonDecode instance.
      *
-     * @param Boolean  $associative True to return the result associative array, false for a nested stdClass hierarchy
-     * @param integer  $depth       Specifies the recursion depth
+     * @param bool     $associative True to return the result associative array, false for a nested stdClass hierarchy
+     * @param int      $depth       Specifies the recursion depth
      */
     public function __construct($associative = false, $depth = 512)
     {

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -213,7 +213,7 @@ class StopwatchEvent
     /**
      * Formats a time.
      *
-     * @param integer|float $time A raw time
+     * @param int    |float $time A raw time
      *
      * @return float The formatted time
      *

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -25,8 +25,8 @@ class StopwatchPeriod
     /**
      * Constructor
      *
-     * @param integer $start The relative time of the start of the period
-     * @param integer $end   The relative time of the end of the period
+     * @param int     $start The relative time of the start of the period
+     * @param int     $end   The relative time of the end of the period
      */
     public function __construct($start, $end)
     {

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -30,8 +30,8 @@ class StopwatchPeriod
      */
     public function __construct($start, $end)
     {
-        $this->start = (integer) $start;
-        $this->end = (integer) $end;
+        $this->start = (int) $start;
+        $this->end = (int) $end;
         $this->memory = memory_get_usage(true);
     }
 

--- a/src/Symfony/Component/Templating/Helper/SlotsHelper.php
+++ b/src/Symfony/Component/Templating/Helper/SlotsHelper.php
@@ -84,7 +84,7 @@ class SlotsHelper extends Helper
      * Gets the slot value.
      *
      * @param string         $name    The slot name
-     * @param Boolean|string $default The default slot content
+     * @param bool|string    $default The default slot content
      *
      * @return string The slot content
      *
@@ -112,7 +112,7 @@ class SlotsHelper extends Helper
      * Outputs a slot.
      *
      * @param string         $name    The slot name
-     * @param Boolean|string $default The default slot content
+     * @param bool|string    $default The default slot content
      *
      * @return Boolean true if the slot is defined or if a default content has been provided, false otherwise
      *

--- a/src/Symfony/Component/Templating/Loader/CacheLoader.php
+++ b/src/Symfony/Component/Templating/Loader/CacheLoader.php
@@ -86,7 +86,7 @@ class CacheLoader extends Loader
      * Returns true if the template is still fresh.
      *
      * @param TemplateReferenceInterface $template A template
-     * @param integer                    $time     The last modification time of the cached template (timestamp)
+     * @param int                        $time     The last modification time of the cached template (timestamp)
      *
      * @return Boolean
      */

--- a/src/Symfony/Component/Templating/Loader/ChainLoader.php
+++ b/src/Symfony/Component/Templating/Loader/ChainLoader.php
@@ -68,7 +68,7 @@ class ChainLoader extends Loader
      * Returns true if the template is still fresh.
      *
      * @param TemplateReferenceInterface $template A template
-     * @param integer                    $time     The last modification time of the cached template (timestamp)
+     * @param int                        $time     The last modification time of the cached template (timestamp)
      *
      * @return Boolean
      */

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -88,7 +88,7 @@ class FilesystemLoader extends Loader
      * Returns true if the template is still fresh.
      *
      * @param TemplateReferenceInterface $template A template
-     * @param integer                    $time     The last modification time of the cached template (timestamp)
+     * @param int                        $time     The last modification time of the cached template (timestamp)
      *
      * @return Boolean true if the template is still fresh, false otherwise
      *

--- a/src/Symfony/Component/Templating/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Templating/Loader/LoaderInterface.php
@@ -38,7 +38,7 @@ interface LoaderInterface
      * Returns true if the template is still fresh.
      *
      * @param TemplateReferenceInterface $template A template
-     * @param integer                    $time     The last modification time of the cached template (timestamp)
+     * @param int                        $time     The last modification time of the cached template (timestamp)
      *
      * @return Boolean
      *

--- a/src/Symfony/Component/Translation/Interval.php
+++ b/src/Symfony/Component/Translation/Interval.php
@@ -36,7 +36,7 @@ class Interval
     /**
      * Tests if the given number is in the math interval.
      *
-     * @param integer $number   A number
+     * @param int     $number   A number
      * @param string  $interval An interval
      *
      * @return Boolean

--- a/src/Symfony/Component/Translation/Loader/MoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/MoFileLoader.php
@@ -177,6 +177,6 @@ class MoFileLoader extends ArrayLoader implements LoaderInterface
         $result = unpack($isBigEndian ? 'N1' : 'V1', fread($stream, 4));
         $result = current($result);
 
-        return (integer) substr($result, -8);
+        return (int) substr($result, -8);
     }
 }

--- a/src/Symfony/Component/Translation/Loader/MoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/MoFileLoader.php
@@ -169,7 +169,7 @@ class MoFileLoader extends ArrayLoader implements LoaderInterface
      * Reads an unsigned long from stream respecting endianess.
      *
      * @param  resource $stream
-     * @param  boolean  $isBigEndian
+     * @param  bool     $isBigEndian
      * @return integer
      */
     private function readLong($stream, $isBigEndian)

--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -134,7 +134,7 @@ class PoFileLoader extends ArrayLoader implements LoaderInterface
                 $item['ids']['plural'] = substr($line, 14, -1);
             } elseif (substr($line, 0, 7) === 'msgstr[') {
                 $size = strpos($line, ']');
-                $item['translated'][(integer) substr($line, 7, 1)] = substr($line, $size + 3, -1);
+                $item['translated'][(int) substr($line, 7, 1)] = substr($line, $size + 3, -1);
             }
 
         }

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -124,7 +124,7 @@ class XliffFileLoader implements LoaderInterface
     /**
      * Returns the XML errors of the internal XML parser
      *
-     * @param Boolean $internalErrors
+     * @param bool    $internalErrors
      *
      * @return array An array of errors
      */

--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -40,7 +40,7 @@ class MessageSelector
      *     {0} There are no apples|one: There is one apple|more: There are %count% apples
      *
      * @param string  $message The message being translated
-     * @param integer $number  The number of items represented for the message
+     * @param int     $number  The number of items represented for the message
      * @param string  $locale  The locale to use for choosing
      *
      * @return string

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -24,7 +24,7 @@ class PluralizationRules
     /**
      * Returns the plural position to use for the given locale and number.
      *
-     * @param integer $number The number
+     * @param int     $number The number
      * @param string  $locale The locale
      *
      * @return integer The plural position

--- a/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
+++ b/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
@@ -95,7 +95,7 @@ class PluralizationRulesTest  extends \PHPUnit_Framework_TestCase
      *
      * @param string  $nplural       plural expected
      * @param array   $matrix        containing langcodes and their plural index values.
-     * @param boolean $expectSuccess
+     * @param bool    $expectSuccess
      */
     protected function validateMatrix($nplural, $matrix, $expectSuccess = true)
     {

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -38,7 +38,7 @@ interface TranslatorInterface
      * Translates the given choice message by choosing a translation according to a number.
      *
      * @param string  $id         The message id (may also be an object that can be cast to string)
-     * @param integer $number     The number to use to find the indice of the message
+     * @param int     $number     The number to use to find the indice of the message
      * @param array   $parameters An array of parameters for the message
      * @param string  $domain     The domain for the message
      * @param string  $locale     The locale

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -72,7 +72,7 @@ class ConstraintViolation implements ConstraintViolationInterface
      *                                            value.
      * @param mixed        $invalidValue          The invalid value causing the
      *                                            violation.
-     * @param integer|null $messagePluralization  The pluralization parameter.
+     * @param int    |null $messagePluralization  The pluralization parameter.
      * @param mixed        $code                  The error code of the
      *                                            violation, if any.
      */

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -41,7 +41,7 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
     /**
      * Returns the violation at a given offset.
      *
-     * @param  integer $offset The offset of the violation.
+     * @param  int     $offset The offset of the violation.
      *
      * @return ConstraintViolationInterface The violation.
      *
@@ -54,7 +54,7 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
     /**
      * Returns whether the given offset exists.
      *
-     * @param  integer $offset The violation offset.
+     * @param  int     $offset The violation offset.
      *
      * @return Boolean Whether the offset exists.
      *
@@ -65,7 +65,7 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
     /**
      * Sets a violation at a given offset.
      *
-     * @param integer                      $offset    The violation offset.
+     * @param int                          $offset    The violation offset.
      * @param ConstraintViolationInterface $violation The violation.
      *
      * @api
@@ -75,7 +75,7 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
     /**
      * Removes a violation at a given offset.
      *
-     * @param integer $offset The offset to remove.
+     * @param int     $offset The offset to remove.
      *
      * @api
      */

--- a/src/Symfony/Component/Validator/DefaultTranslator.php
+++ b/src/Symfony/Component/Validator/DefaultTranslator.php
@@ -118,7 +118,7 @@ class DefaultTranslator implements TranslatorInterface
      *     // -> These are 3 donkeys.
      *
      * @param string  $id         The message id
-     * @param integer $number     The number to use to find the index of the message
+     * @param int     $number     The number to use to find the index of the message
      * @param array   $parameters An array of parameters for the message
      * @param string  $domain     Ignored
      * @param string  $locale     Ignored

--- a/src/Symfony/Component/Validator/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/ExecutionContextInterface.php
@@ -91,8 +91,8 @@ interface ExecutionContextInterface
      * @param string       $message       The error message.
      * @param array        $params        The parameters substituted in the error message.
      * @param mixed        $invalidValue  The invalid, validated value.
-     * @param integer|null $pluralization The number to use to pluralize of the message.
-     * @param integer|null $code          The violation code.
+     * @param int    |null $pluralization The number to use to pluralize of the message.
+     * @param int    |null $code          The violation code.
      *
      * @api
      */
@@ -106,8 +106,8 @@ interface ExecutionContextInterface
      * @param string       $message       The error message.
      * @param array        $params        The parameters substituted in the error message.
      * @param mixed        $invalidValue  The invalid, validated value.
-     * @param integer|null $pluralization The number to use to pluralize of the message.
-     * @param integer|null $code          The violation code.
+     * @param int    |null $pluralization The number to use to pluralize of the message.
+     * @param int    |null $code          The violation code.
      *
      * @api
      */
@@ -147,9 +147,9 @@ interface ExecutionContextInterface
      * @param null|string|string[] $groups   The groups to validate in. If you don't pass any
      *                                       groups here, the current group of the context
      *                                       will be used.
-     * @param Boolean              $traverse Whether to traverse the value if it is an array
+     * @param bool                 $traverse Whether to traverse the value if it is an array
      *                                       or an instance of <tt>\Traversable</tt>.
-     * @param Boolean              $deep     Whether to traverse the value recursively if
+     * @param bool                 $deep     Whether to traverse the value recursively if
      *                                       it is a collection of collections.
      */
     public function validate($value, $subPath = '', $groups = null, $traverse = false, $deep = false);

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -392,7 +392,7 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
     /**
      * Sets whether a group sequence provider should be used.
      *
-     * @param Boolean $active
+     * @param bool    $active
      *
      * @throws GroupDefinitionException
      */

--- a/src/Symfony/Component/Validator/ValidationVisitorInterface.php
+++ b/src/Symfony/Component/Validator/ValidationVisitorInterface.php
@@ -57,8 +57,8 @@ interface ValidationVisitorInterface
      * @param mixed   $value        The value to validate.
      * @param string  $group        The validation group to validate.
      * @param string  $propertyPath The current property path in the validation graph.
-     * @param Boolean $traverse     Whether to traverse the value if it is traversable.
-     * @param Boolean $deep         Whether to traverse nested traversable values recursively.
+     * @param bool    $traverse     Whether to traverse the value if it is traversable.
+     * @param bool    $deep         Whether to traverse nested traversable values recursively.
      *
      * @throws Exception\NoSuchMetadataException If no metadata can be found for
      *                                           the given value.

--- a/src/Symfony/Component/Validator/ValidatorInterface.php
+++ b/src/Symfony/Component/Validator/ValidatorInterface.php
@@ -28,8 +28,8 @@ interface ValidatorInterface
      *
      * @param mixed      $value    The value to validate
      * @param array|null $groups   The validation groups to validate.
-     * @param Boolean    $traverse Whether to traverse the value if it is traversable.
-     * @param Boolean    $deep     Whether to traverse nested traversable values recursively.
+     * @param bool       $traverse Whether to traverse the value if it is traversable.
+     * @param bool       $deep     Whether to traverse nested traversable values recursively.
      *
      * @return ConstraintViolationListInterface A list of constraint violations. If the
      *                                          list is empty, validation succeeded.

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -28,7 +28,7 @@ class Dumper
     /**
      * Sets the indentation.
      *
-     * @param integer $num The amount of spaces to use for indentation of nested nodes.
+     * @param int     $num The amount of spaces to use for indentation of nested nodes.
      */
     public function setIndentation($num)
     {
@@ -39,10 +39,10 @@ class Dumper
      * Dumps a PHP value to YAML.
      *
      * @param mixed   $input                  The PHP value
-     * @param integer $inline                 The level where you switch to inline YAML
-     * @param integer $indent                 The level of indentation (used internally)
-     * @param Boolean $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param Boolean $objectSupport          true if object support is enabled, false otherwise
+     * @param int     $inline                 The level where you switch to inline YAML
+     * @param int     $indent                 The level of indentation (used internally)
+     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool    $objectSupport          true if object support is enabled, false otherwise
      *
      * @return string  The YAML representation of the PHP value
      */

--- a/src/Symfony/Component/Yaml/Exception/ParseException.php
+++ b/src/Symfony/Component/Yaml/Exception/ParseException.php
@@ -34,8 +34,8 @@ class ParseException extends RuntimeException
      * Constructor.
      *
      * @param string    $message    The error message
-     * @param integer   $parsedLine The line where the error occurred
-     * @param integer   $snippet    The snippet of code near the problem
+     * @param int       $parsedLine The line where the error occurred
+     * @param int       $snippet    The snippet of code near the problem
      * @param string    $parsedFile The file name where the error occurred
      * @param \Exception $previous   The previous exception
      */
@@ -110,7 +110,7 @@ class ParseException extends RuntimeException
     /**
      * Sets the line where the error occurred.
      *
-     * @param integer $parsedLine The file line
+     * @param int     $parsedLine The file line
      */
     public function setParsedLine($parsedLine)
     {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -30,8 +30,8 @@ class Inline
      * Converts a YAML string to a PHP array.
      *
      * @param string  $value                  A YAML string
-     * @param Boolean $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param Boolean $objectSupport          true if object support is enabled, false otherwise
+     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool    $objectSupport          true if object support is enabled, false otherwise
      *
      * @return array A PHP array representing the YAML string
      *
@@ -83,8 +83,8 @@ class Inline
      * Dumps a given PHP variable to a YAML string.
      *
      * @param mixed   $value                  The PHP variable to convert
-     * @param Boolean $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param Boolean $objectSupport          true if object support is enabled, false otherwise
+     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool    $objectSupport          true if object support is enabled, false otherwise
      *
      * @return string The YAML string representing the PHP array
      *
@@ -149,8 +149,8 @@ class Inline
      * Dumps a PHP array to a YAML string.
      *
      * @param array   $value                  The PHP array to dump
-     * @param Boolean $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param Boolean $objectSupport          true if object support is enabled, false otherwise
+     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool    $objectSupport          true if object support is enabled, false otherwise
      *
      * @return string The YAML string representing the PHP array
      */
@@ -184,8 +184,8 @@ class Inline
      * @param scalar $scalar
      * @param string $delimiters
      * @param array  $stringDelimiters
-     * @param integer &$i
-     * @param Boolean $evaluate
+     * @param int     &$i
+     * @param bool    $evaluate
      *
      * @return string A YAML string
      *
@@ -232,7 +232,7 @@ class Inline
      * Parses a quoted scalar to YAML.
      *
      * @param string $scalar
-     * @param integer &$i
+     * @param int     &$i
      *
      * @return string A YAML string
      *
@@ -262,7 +262,7 @@ class Inline
      * Parses a sequence to a YAML string.
      *
      * @param string $sequence
-     * @param integer &$i
+     * @param int     &$i
      *
      * @return string A YAML string
      *
@@ -318,7 +318,7 @@ class Inline
      * Parses a mapping to a YAML string.
      *
      * @param string $mapping
-     * @param integer &$i
+     * @param int     &$i
      *
      * @return string A YAML string
      *

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -159,7 +159,7 @@ class Inline
         // array
         $keys = array_keys($value);
         if ((1 == count($keys) && '0' == $keys[0])
-            || (count($keys) > 1 && array_reduce($keys, function ($v, $w) { return (integer) $v + $w; }, 0) == count($keys) * (count($keys) - 1) / 2)
+            || (count($keys) > 1 && array_reduce($keys, function ($v, $w) { return (int) $v + $w; }, 0) == count($keys) * (count($keys) - 1) / 2)
         ) {
             $output = array();
             foreach ($value as $val) {

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -31,7 +31,7 @@ class Parser
     /**
      * Constructor
      *
-     * @param integer $offset The offset of YAML document (used for line numbers in error messages)
+     * @param int     $offset The offset of YAML document (used for line numbers in error messages)
      */
     public function __construct($offset = 0)
     {
@@ -42,8 +42,8 @@ class Parser
      * Parses a YAML string to a PHP value.
      *
      * @param string  $value                  A YAML string
-     * @param Boolean $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param Boolean $objectSupport          true if object support is enabled, false otherwise
+     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool    $objectSupport          true if object support is enabled, false otherwise
      *
      * @return mixed  A PHP value
      *
@@ -281,7 +281,7 @@ class Parser
     /**
      * Returns the next embed block of YAML.
      *
-     * @param integer $indentation The indent level at which the block is to be read, or null for default
+     * @param int     $indentation The indent level at which the block is to be read, or null for default
      *
      * @return string A YAML string
      *
@@ -374,8 +374,8 @@ class Parser
      * Parses a YAML value.
      *
      * @param string  $value                  A YAML value
-     * @param Boolean $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
-     * @param Boolean $objectSupport          True if object support is enabled, false otherwise
+     * @param bool    $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
+     * @param bool    $objectSupport          True if object support is enabled, false otherwise
      *
      * @return mixed  A PHP value
      *
@@ -418,7 +418,7 @@ class Parser
      *
      * @param string  $separator   The separator that was used to begin this folded scalar (| or >)
      * @param string  $indicator   The indicator that was used to begin this folded scalar (+ or -)
-     * @param integer $indentation The indentation that was used to begin this folded scalar
+     * @param int     $indentation The indentation that was used to begin this folded scalar
      *
      * @return string  The text value
      */

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -39,8 +39,8 @@ class Yaml
      * as an input is a deprecated feature and will be removed in 3.0.
      *
      * @param string  $input                  Path to a YAML file or a string containing YAML
-     * @param Boolean $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
-     * @param Boolean $objectSupport          True if object support is enabled, false otherwise
+     * @param bool    $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
+     * @param bool    $objectSupport          True if object support is enabled, false otherwise
      *
      * @return array The YAML converted to a PHP array
      *
@@ -81,10 +81,10 @@ class Yaml
      * to convert the array into friendly YAML.
      *
      * @param array   $array                  PHP array
-     * @param integer $inline                 The level where you switch to inline YAML
-     * @param integer $indent                 The amount of spaces to use for indentation of nested nodes.
-     * @param Boolean $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param Boolean $objectSupport          true if object support is enabled, false otherwise
+     * @param int     $inline                 The level where you switch to inline YAML
+     * @param int     $indent                 The amount of spaces to use for indentation of nested nodes.
+     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool    $objectSupport          true if object support is enabled, false otherwise
      *
      * @return string A YAML string representing the original PHP array
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#3802 |

PHP supports several ways to express types: like Boolean/bool or integer/int. Hack only supports one of them, so this PR proposes to use the Hack type to make Symfony a bit more "compatible" with Hack (gradual upgrade ;)).
