### PR TITLE
[PropertyAccess] array_keys does not work for ArrayAccess objects

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -232,16 +232,17 @@ class PropertyAccessor implements PropertyAccessorInterface
             if ($isIndex && $isArrayAccess && !isset($objectOrArray[$property])) {
                 if (!$ignoreInvalidIndices) {
                     $message = sprintf('Cannot read property "%s".', $property);
+                    $keys = 'not available';
                     if (is_array($objectOrArray)) {
-                        $message .= sprintf(' Available properties are "%s"', print_r(array_keys($objectOrArray), true));
+                        $keys = '"' . print_r(array_keys($objectOrArray), true) . '"';
                     } elseif ($objectOrArray instanceof \Traversable) {
-                        $keys = [];
+                        $list = [];
                         foreach ($objectOrArray as $key => &$value) {
-                            $keys[] = $key;
+                            $list[] = $key;
                         }
-                        $message .= sprintf(' Available properties are "%s"', print_r($keys, true));
+                        $keys = '"' . print_r($list, true) . '"';
                     }
-                    throw new NoSuchIndexException($message);
+                    throw new NoSuchIndexException(sprintf('Cannot read property "%s". Available properties are %s', $property, $keys));
                 }
 
                 $objectOrArray[$property] = $i + 1 < $propertyPath->getLength() ? array() : null;

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -231,7 +231,11 @@ class PropertyAccessor implements PropertyAccessorInterface
             // Create missing nested arrays on demand
             if ($isIndex && $isArrayAccess && !isset($objectOrArray[$property])) {
                 if (!$ignoreInvalidIndices) {
-                    throw new NoSuchIndexException(sprintf('Cannot read property "%s". Available properties are "%s"', $property, print_r(array_keys($objectOrArray), true)));
+                    $message = sprintf('Cannot read property "%s".', $property);
+                    if (is_array($objectOrArray)) {
+                        $message .= sprintf(' Available properties are "%s"', print_r(array_keys($objectOrArray), true));
+                    }
+                    throw new NoSuchIndexException($message);
                 }
 
                 $objectOrArray[$property] = $i + 1 < $propertyPath->getLength() ? array() : null;

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -234,6 +234,12 @@ class PropertyAccessor implements PropertyAccessorInterface
                     $message = sprintf('Cannot read property "%s".', $property);
                     if (is_array($objectOrArray)) {
                         $message .= sprintf(' Available properties are "%s"', print_r(array_keys($objectOrArray), true));
+                    } elseif ($objectOrArray instanceof \Traversable) {
+                        $keys = [];
+                        foreach ($objectOrArray as $key => &$value) {
+                            $keys[] = $key;
+                        }
+                        $message .= sprintf(' Available properties are "%s"', print_r($keys, true));
                     }
                     throw new NoSuchIndexException($message);
                 }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -234,13 +234,13 @@ class PropertyAccessor implements PropertyAccessorInterface
                     $message = sprintf('Cannot read property "%s".', $property);
                     $keys = 'not available';
                     if (is_array($objectOrArray)) {
-                        $keys = '"' . print_r(array_keys($objectOrArray), true) . '"';
+                        $keys = '"'.print_r(array_keys($objectOrArray), true).'"';
                     } elseif ($objectOrArray instanceof \Traversable) {
-                        $list = [];
+                        $list = array();
                         foreach ($objectOrArray as $key => &$value) {
                             $list[] = $key;
                         }
-                        $keys = '"' . print_r($list, true) . '"';
+                        $keys = '"'.print_r($list, true).'"';
                     }
                     throw new NoSuchIndexException(sprintf('Cannot read property "%s". Available properties are %s', $property, $keys));
                 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCustomArrayObjectTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCustomArrayObjectTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\PropertyAccess\Tests;
 
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\CustomArrayObject;
 
 class PropertyAccessorCustomArrayObjectTest extends PropertyAccessorCollectionTest
@@ -18,5 +19,16 @@ class PropertyAccessorCustomArrayObjectTest extends PropertyAccessorCollectionTe
     protected function getCollection(array $array)
     {
         return new CustomArrayObject($array);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
+     */
+    public function testGetNoSuchIndex()
+    {
+        $arrayObject = new CustomArrayObject(array('foo', 'bar'));
+        $propertyAccessor = new PropertyAccessor(false, true);
+
+        $propertyAccessor->getValue($arrayObject, '[2]');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The array_keys() function does not work on objects implementing \ArrayAccess. Skip listing the known properties for such objects.
