### PR TITLE
[Debug] Fixed ClassNotFoundFatalErrorHandler on windows.

### DIFF
--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -150,7 +150,7 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
      */
     private function convertFileToClass($path, $file)
     {
-        $namespacedClass = str_replace(array($path.'/', '.php', '/'), array('', '', '\\'), $file);
+        $namespacedClass = str_replace(array($path.DIRECTORY_SEPARATOR, '.php', '/'), array('', '', '\\'), $file);
         $pearClass = str_replace('\\', '_', $namespacedClass);
 
         // We cannot use the autoloader here as most of them use require; but if the class


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |

Because `$path` is `realpath`'ed. So we have to use `DIRECTORY_SEPARATOR`
instead of `/` because the default directory separator on windows is
`\`. And so the `str_replace` can not work and can lead to a fatal error
because class could already be loaded. For example, the `Response` class
in symfony full stack is in the `bootstrap.php.cache`.

ping @nicolas-grekas
