### PR TITLE
unified return null usages

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -291,8 +291,6 @@ abstract class AbstractDoctrineExtension extends Extension
         if (is_dir($dir.'/'.$this->getMappingObjectDefaultName())) {
             return 'annotation';
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -88,7 +88,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
         $classMetadatas = $this->getMetadata($class);
 
         if (!$classMetadatas) {
-            return null;
+            return;
         }
 
         /* @var ClassMetadataInfo $classMetadata */
@@ -116,8 +116,6 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
 
             return new ValueGuess(!$mapping['joinColumns'][0]['nullable'], Guess::HIGH_CONFIDENCE);
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -69,8 +69,6 @@ abstract class DoctrineType extends AbstractType
             if (null !== $options['query_builder']) {
                 return $type->getLoader($options['em'], $options['query_builder'], $options['class']);
             }
-
-            return null;
         };
 
         $choiceList = function (Options $options) use (&$choiceListCache, $propertyAccessor) {

--- a/src/Symfony/Bridge/Propel1/Tests/Fixtures/ItemQuery.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Fixtures/ItemQuery.php
@@ -66,8 +66,6 @@ class ItemQuery
         if ($this->hasColumn($column)) {
             return new Column($column, $this->map[$column]);
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
@@ -111,7 +111,7 @@ class TranslationNodeVisitor implements \Twig_NodeVisitorInterface
         } elseif ($arguments->hasNode($index)) {
             $argument = $arguments->getNode($index);
         } else {
-            return null;
+            return;
         }
 
         return $this->getReadDomainFromNode($argument);
@@ -125,7 +125,7 @@ class TranslationNodeVisitor implements \Twig_NodeVisitorInterface
     private function getReadDomainFromNode(\Twig_Node $node = null)
     {
         if (null === $node) {
-            return null;
+            return;
         }
 
         if ($node instanceof \Twig_Node_Expression_Constant) {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -218,11 +218,11 @@ class Controller extends ContainerAware
         }
 
         if (null === $token = $this->container->get('security.context')->getToken()) {
-            return null;
+            return;
         }
 
         if (!is_object($user = $token->getUser())) {
-            return null;
+            return;
         }
 
         return $user;

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -441,7 +441,7 @@ abstract class Client
     protected function createCrawlerFromContent($uri, $content, $type)
     {
         if (!class_exists('Symfony\Component\DomCrawler\Crawler')) {
-            return null;
+            return;
         }
 
         $crawler = new Crawler(null, $uri);

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -73,7 +73,7 @@ class CookieJar
                 }
             }
 
-            return null;
+            return;
         }
 
         // avoid relying on this behavior that is mainly here for BC reasons
@@ -82,8 +82,6 @@ class CookieJar
                 return $cookies[$path][$name];
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -186,7 +186,7 @@ class XmlUtils
 
         switch (true) {
             case 'null' === $lowercaseValue:
-                return null;
+                return;
             case ctype_digit($value):
                 $raw = $value;
                 $cast = intval($value);

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -162,7 +162,7 @@ class TokenStream
         }
 
         if ($next->isDelimiter(array('*'))) {
-            return null;
+            return;
         }
 
         throw SyntaxErrorException::unexpectedToken('identifier or "*"', $next);

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -132,7 +132,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
         }
 
         if (!$this->container->hasDefinition($id)) {
-            return null;
+            return;
         }
 
         return $id;

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -159,7 +159,7 @@ class CheckReferenceValidityPass implements CompilerPassInterface
     private function getDefinition($id)
     {
         if (!$this->container->hasDefinition($id)) {
-            return null;
+            return;
         }
 
         return $this->container->getDefinition($id);

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -310,7 +310,7 @@ class Container implements IntrospectableContainerInterface
                 throw new ServiceNotFoundException($id, null, null, $alternatives);
             }
 
-            return null;
+            return;
         }
 
         $this->loading[$id] = true;
@@ -325,7 +325,7 @@ class Container implements IntrospectableContainerInterface
             }
 
             if ($e instanceof InactiveScopeException && self::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
-                return null;
+                return;
             }
 
             throw $e;

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -478,7 +478,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             $definition = $this->getDefinition($id);
         } catch (InvalidArgumentException $e) {
             if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
-                return null;
+                return;
             }
 
             throw $e;
@@ -492,7 +492,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             unset($this->loading[$id]);
 
             if ($e instanceof InactiveScopeException && self::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
-                return null;
+                return;
             }
 
             throw $e;

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -96,8 +96,6 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
                 return $configuration;
             }
         }
-
-        return null;
     }
 
     final protected function processConfiguration(ConfigurationInterface $configuration, array $configs)

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/ProjectExtension.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/ProjectExtension.php
@@ -36,6 +36,5 @@ class ProjectExtension implements ExtensionInterface
 
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
-        return null;
     }
 }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -97,7 +97,7 @@ class Crawler extends \SplObjectStorage
 
         // DOM only for HTML/XML content
         if (!preg_match('/(x|ht)ml/i', $type, $xmlMatches)) {
-            return null;
+            return;
         }
 
         $charset = null;
@@ -784,8 +784,6 @@ class Crawler extends \SplObjectStorage
             }
         // @codeCoverageIgnoreStart
         }
-
-        return null;
         // @codeCoverageIgnoreEnd
     }
 

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -136,7 +136,6 @@ abstract class AbstractExtension implements FormExtensionInterface
      */
     protected function loadTypeGuesser()
     {
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -211,7 +211,6 @@ class Button implements \IteratorAggregate, FormInterface
      */
     public function getData()
     {
-        return null;
     }
 
     /**
@@ -221,7 +220,6 @@ class Button implements \IteratorAggregate, FormInterface
      */
     public function getNormData()
     {
-        return null;
     }
 
     /**
@@ -231,7 +229,6 @@ class Button implements \IteratorAggregate, FormInterface
      */
     public function getViewData()
     {
-        return null;
     }
 
     /**
@@ -281,7 +278,6 @@ class Button implements \IteratorAggregate, FormInterface
      */
     public function getPropertyPath()
     {
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -549,7 +549,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getEventDispatcher()
     {
-        return null;
     }
 
     /**
@@ -567,7 +566,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getPropertyPath()
     {
-        return null;
     }
 
     /**
@@ -647,7 +645,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getDataMapper()
     {
-        return null;
     }
 
     /**
@@ -687,7 +684,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getEmptyData()
     {
-        return null;
     }
 
     /**
@@ -732,7 +728,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getData()
     {
-        return null;
     }
 
     /**
@@ -742,7 +737,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getDataClass()
     {
-        return null;
     }
 
     /**
@@ -762,7 +756,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getFormFactory()
     {
-        return null;
     }
 
     /**
@@ -772,7 +765,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getAction()
     {
-        return null;
     }
 
     /**
@@ -782,7 +774,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getMethod()
     {
-        return null;
     }
 
     /**
@@ -792,7 +783,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getRequestHandler()
     {
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
@@ -73,7 +73,7 @@ class ArrayToPartsTransformer implements DataTransformerInterface
         if (count($emptyKeys) > 0) {
             if (count($emptyKeys) === count($this->partMapping)) {
                 // All parts empty
-                return null;
+                return;
             }
 
             throw new TransformationFailedException(

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -50,7 +50,7 @@ class BooleanToStringTransformer implements DataTransformerInterface
     public function transform($value)
     {
         if (null === $value) {
-            return null;
+            return;
         }
 
         if (!is_bool($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -106,13 +106,11 @@ class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
                 if (isset($choices[$i])) {
                     return $choices[$i] === '' ? null : $choices[$i];
                 } elseif ($this->placeholderPresent && 'placeholder' === $i) {
-                    return null;
+                    return;
                 } else {
                     throw new TransformationFailedException(sprintf('The choice "%s" does not exist', $i));
                 }
             }
         }
-
-        return null;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
@@ -46,7 +46,7 @@ class ChoiceToValueTransformer implements DataTransformerInterface
         // These are now valid ChoiceList values, so we can return null
         // right away
         if ('' === $value || null === $value) {
-            return null;
+            return;
         }
 
         $choices = $this->choiceList->getChoicesForValues(array($value));

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -119,7 +119,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
     public function reverseTransform($value)
     {
         if (null === $value) {
-            return null;
+            return;
         }
 
         if (!is_array($value)) {
@@ -127,7 +127,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         }
 
         if ('' === implode('', $value)) {
-            return null;
+            return;
         }
 
         $emptyFields = array();

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -121,7 +121,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         }
 
         if ('' === $value) {
-            return null;
+            return;
         }
 
         $timestamp = $this->getIntlDateFormatter()->parse($value);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
@@ -49,7 +49,7 @@ class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
         }
 
         if ('' === $rfc3339) {
-            return null;
+            return;
         }
 
         try {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -131,7 +131,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
     public function reverseTransform($value)
     {
         if (empty($value)) {
-            return null;
+            return;
         }
 
         if (!is_string($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
@@ -35,7 +35,7 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
     public function transform($value)
     {
         if (null === $value) {
-            return null;
+            return;
         }
 
         if (!$value instanceof \DateTime) {
@@ -65,7 +65,7 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
     public function reverseTransform($value)
     {
         if (null === $value) {
-            return null;
+            return;
         }
 
         if (!is_numeric($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
@@ -31,7 +31,7 @@ class IntegerToLocalizedStringTransformer extends NumberToLocalizedStringTransfo
         }
 
         if ('' === $value) {
-            return null;
+            return;
         }
 
         if ('NaN' === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -102,7 +102,7 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
         }
 
         if ('' === $value) {
-            return null;
+            return;
         }
 
         if ('NaN' === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -115,7 +115,7 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
         }
 
         if ('' === $value) {
-            return null;
+            return;
         }
 
         $formatter = $this->getNumberFormatter();

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -78,7 +78,7 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
         if (count($emptyKeys) > 0) {
             if (count($emptyKeys) == count($this->keys)) {
                 // All keys empty
-                return null;
+                return;
             }
 
             throw new TransformationFailedException(

--- a/src/Symfony/Component/Form/Extension/Core/Type/ButtonType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ButtonType.php
@@ -26,7 +26,6 @@ class ButtonType extends BaseType implements ButtonTypeInterface
      */
     public function getParent()
     {
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -190,10 +190,10 @@ class ChoiceType extends AbstractType
         $emptyValueNormalizer = function (Options $options, $emptyValue) {
             if ($options['multiple']) {
                 // never use an empty value for this case
-                return null;
+                return;
             } elseif (false === $emptyValue) {
                 // an empty value should be added but the user decided otherwise
-                return null;
+                return;
             } elseif ($options['expanded'] && '' === $emptyValue) {
                 // never use an empty label for radio buttons
                 return 'None';

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -201,7 +201,6 @@ class FormType extends BaseType
      */
     public function getParent()
     {
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/Type/BaseValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/BaseValidatorExtension.php
@@ -35,7 +35,7 @@ abstract class BaseValidatorExtension extends AbstractTypeExtension
             }
 
             if (empty($groups)) {
-                return null;
+                return;
             }
 
             if (is_callable($groups)) {

--- a/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
@@ -26,7 +26,7 @@ class ServerParams
         $iniMax = strtolower($this->getNormalizedIniPostMaxSize());
 
         if ('' === $iniMax) {
-            return null;
+            return;
         }
 
         $max = ltrim($iniMax, '+');

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -159,8 +159,6 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\False':
                 return new TypeGuess('checkbox', array(), Guess::MEDIUM_CONFIDENCE);
         }
-
-        return null;
     }
 
     /**
@@ -178,8 +176,6 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\True':
                 return new ValueGuess(true, Guess::HIGH_CONFIDENCE);
         }
-
-        return null;
     }
 
     /**
@@ -210,8 +206,6 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 }
                 break;
         }
-
-        return null;
     }
 
     /**
@@ -250,8 +244,6 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 }
                 break;
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
@@ -64,8 +64,6 @@ class MappingRule
         if ($propertyPath === (string) $this->propertyPath) {
             return $this->getTarget();
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -172,7 +172,7 @@ class ViolationMapper implements ViolationMapperInterface
         // Make the path longer until we find a matching child
         while (true) {
             if (!$it->valid()) {
-                return null;
+                return;
             }
 
             if ($it->isIndex()) {
@@ -223,8 +223,6 @@ class ViolationMapper implements ViolationMapperInterface
                 return $foundChild;
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -127,7 +127,7 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
     public function getParent()
     {
         if ($this->length <= 1) {
-            return null;
+            return;
         }
 
         $parent = clone $this;

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -209,7 +209,7 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         if (null === $this->getName() || '' === $this->getName()) {
-            return null;
+            return;
         }
 
         $parent = $this->parent;
@@ -767,8 +767,6 @@ class Form implements \IteratorAggregate, FormInterface
         if ($this->parent && method_exists($this->parent, 'getClickedButton')) {
             return $this->parent->getClickedButton();
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -180,7 +180,7 @@ class NativeRequestHandler implements RequestHandlerInterface
 
         if (self::$fileKeys === $keys) {
             if (UPLOAD_ERR_NO_FILE === $data['error']) {
-                return null;
+                return;
             }
 
             return $data;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTest.php
@@ -64,7 +64,7 @@ abstract class BaseValidatorExtensionTest extends TypeTestCase
     public function testValidationGroupsCanBeSetToClosure()
     {
         $form = $this->createForm(array(
-            'validation_groups' => function (FormInterface $form) { return null; },
+            'validation_groups' => function (FormInterface $form) { return; },
         ));
 
         $this->assertTrue(is_callable($form->getConfig()->getOption('validation_groups')));

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
@@ -27,6 +27,5 @@ class FooType extends AbstractType
 
     public function getParent()
     {
-        return null;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
@@ -62,7 +62,7 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
         }
 
         if (!self::isSupported()) {
-            return null;
+            return;
         }
 
         ob_start();
@@ -72,14 +72,14 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
         if ($return > 0) {
             ob_end_clean();
 
-            return null;
+            return;
         }
 
         $type = trim(ob_get_clean());
 
         if (!preg_match('#^([a-z0-9\-]+/[a-z0-9\-\.]+)#i', $type, $match)) {
             // it's not a type, but an error message
-            return null;
+            return;
         }
 
         return $match[1];

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php
@@ -59,11 +59,11 @@ class FileinfoMimeTypeGuesser implements MimeTypeGuesserInterface
         }
 
         if (!self::isSupported()) {
-            return null;
+            return;
         }
 
         if (!$finfo = new \finfo(FILEINFO_MIME_TYPE, $this->magicFile)) {
-            return null;
+            return;
         }
 
         return $finfo->file($path);

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1264,8 +1264,6 @@ class Request
                 return $format;
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -714,8 +714,6 @@ class Response
         if (null !== $this->getExpires()) {
             return $this->getExpires()->format('U') - $this->getDate()->format('U');
         }
-
-        return null;
     }
 
     /**
@@ -772,8 +770,6 @@ class Response
         if (null !== $maxAge = $this->getMaxAge()) {
             return $maxAge - $this->getAge();
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -239,7 +239,5 @@ class PdoSessionHandler implements \SessionHandlerInterface
             case 'sqlite':
                 return "INSERT OR REPLACE INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time)";
         }
-
-        return null;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -141,7 +141,6 @@ abstract class Bundle extends ContainerAware implements BundleInterface
      */
     public function getParent()
     {
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -121,7 +121,7 @@ class Store implements StoreInterface
         $key = $this->getCacheKey($request);
 
         if (!$entries = $this->getMetadata($key)) {
-            return null;
+            return;
         }
 
         // find a cached entry that matches the request.
@@ -135,7 +135,7 @@ class Store implements StoreInterface
         }
 
         if (null === $match) {
-            return null;
+            return;
         }
 
         list($req, $headers) = $match;
@@ -146,7 +146,6 @@ class Store implements StoreInterface
         // TODO the metaStore referenced an entity that doesn't exist in
         // the entityStore. We definitely want to return nil but we should
         // also purge the entry from the meta-store when this is detected.
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -116,7 +116,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
     public function read($token)
     {
         if (!$token || !file_exists($file = $this->getFilename($token))) {
-            return null;
+            return;
         }
 
         return $this->createProfileFromData($token, unserialize(file_get_contents($file)));
@@ -215,7 +215,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         $position = ftell($file);
 
         if (0 === $position) {
-            return null;
+            return;
         }
 
         while (true) {

--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -77,8 +77,6 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
         if (isset($data[0]['data'])) {
             return $this->createProfileFromData($token, $data[0]);
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -273,13 +273,13 @@ class Profiler
     private function getTimestamp($value)
     {
         if (null === $value || '' == $value) {
-            return null;
+            return;
         }
 
         try {
             $value = new \DateTime(is_numeric($value) ? '@'.$value : $value);
         } catch (\Exception $e) {
-            return null;
+            return;
         }
 
         return $value->getTimestamp();

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -379,8 +379,6 @@ class IntlDateFormatter
         if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
             return date_default_timezone_get();
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
@@ -28,7 +28,7 @@ class LanguageBundle extends AbstractBundle implements LanguageBundleInterface
         }
 
         if (null === ($languages = $this->readEntry($locale, array('Languages'), true))) {
-            return null;
+            return;
         }
 
         // Some languages are translated together with their region,
@@ -87,7 +87,7 @@ class LanguageBundle extends AbstractBundle implements LanguageBundleInterface
 
         // "af" (Afrikaans) has no "Scripts" block
         if (!isset($data['Scripts'][$script])) {
-            return null;
+            return;
         }
 
         return $data['Scripts'][$script];

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/StructuredBundleReader.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/StructuredBundleReader.php
@@ -105,7 +105,7 @@ class StructuredBundleReader implements StructuredBundleReaderInterface
     private function getFallbackLocale($locale)
     {
         if (false === $pos = strrpos($locale, '_')) {
-            return null;
+            return;
         }
 
         return substr($locale, 0, $pos);

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/LocaleBundleTransformationRule.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/LocaleBundleTransformationRule.php
@@ -195,7 +195,7 @@ class LocaleBundleTransformationRule implements TransformationRuleInterface
         // Currently the only available variant is POSIX, which we don't want
         // to include in the list
         if (count($variants) > 0) {
-            return null;
+            return;
         }
 
         // Some languages are translated together with their region,
@@ -207,7 +207,7 @@ class LocaleBundleTransformationRule implements TransformationRuleInterface
         // Some languages are simply not translated
         // Example: "az" (Azerbaijani) has no translation in "af" (Afrikaans)
         if (null === ($name = $this->languageBundle->getLanguageName($lang, null, $displayLocale))) {
-            return null;
+            return;
         }
 
         // "as" (Assamese) has no "Variants" block
@@ -222,7 +222,7 @@ class LocaleBundleTransformationRule implements TransformationRuleInterface
         if ($script) {
             // Some scripts are not translated into every language
             if (null === ($scriptName = $this->languageBundle->getScriptName($script, $lang, $displayLocale))) {
-                return null;
+                return;
             }
 
             $extras[] = $scriptName;
@@ -233,7 +233,7 @@ class LocaleBundleTransformationRule implements TransformationRuleInterface
         if ($region) {
             // Some regions are not translated into every language
             if (null === ($regionName = $this->regionBundle->getCountryName($region, $displayLocale))) {
-                return null;
+                return;
             }
 
             $extras[] = $regionName;

--- a/src/Symfony/Component/Intl/ResourceBundle/Util/RecursiveArrayAccess.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Util/RecursiveArrayAccess.php
@@ -20,7 +20,7 @@ class RecursiveArrayAccess
     {
         foreach ($indices as $index) {
             if (!$array instanceof \ArrayAccess && !is_array($array)) {
-                return null;
+                return;
             }
 
             $array = $array[$index];

--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -62,7 +62,7 @@ function get_icu_version_from_genrb($genrb)
     }
 
     if (!preg_match('/ICU version ([\d\.]+)/', implode('', $output), $matches)) {
-        return null;
+        return;
     }
 
     return $matches[1];

--- a/src/Symfony/Component/Intl/Util/Version.php
+++ b/src/Symfony/Component/Intl/Util/Version.php
@@ -83,7 +83,7 @@ class Version
         }
 
         if (!preg_match('/^' . $pattern . '/', $version, $matches)) {
-            return null;
+            return;
         }
 
         return $matches[0];

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -183,7 +183,7 @@ class Locale extends \Locale
     protected static function getFallbackLocale($locale)
     {
         if (false === $pos = strrpos($locale, '_')) {
-            return null;
+            return;
         }
 
         return substr($locale, 0, $pos);

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -415,8 +415,6 @@ class PropertyAccessor implements PropertyAccessorInterface
                 ));
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -155,7 +155,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     public function getParent()
     {
         if ($this->length <= 1) {
-            return null;
+            return;
         }
 
         $parent = clone $this;

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -171,7 +171,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                             $this->logger->error($message);
                         }
 
-                        return null;
+                        return;
                     }
 
                     $url = $token[1].$mergedParams[$token[3]].$url;
@@ -224,7 +224,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                                 $this->logger->error($message);
                             }
 
-                            return null;
+                            return;
                         }
 
                         $routeHost = $token[1].$mergedParams[$token[3]].$routeHost;

--- a/src/Symfony/Component/Security/Acl/Domain/DoctrineAclCache.php
+++ b/src/Symfony/Component/Security/Acl/Domain/DoctrineAclCache.php
@@ -96,14 +96,14 @@ class DoctrineAclCache implements AclCacheInterface
     {
         $lookupKey = $this->getAliasKeyForIdentity($aclId);
         if (!$this->cache->contains($lookupKey)) {
-            return null;
+            return;
         }
 
         $key = $this->cache->fetch($lookupKey);
         if (!$this->cache->contains($key)) {
             $this->cache->delete($lookupKey);
 
-            return null;
+            return;
         }
 
         return $this->unserializeAcl($this->cache->fetch($key));
@@ -116,7 +116,7 @@ class DoctrineAclCache implements AclCacheInterface
     {
         $key = $this->getDataKeyByIdentity($oid);
         if (!$this->cache->contains($key)) {
-            return null;
+            return;
         }
 
         return $this->unserializeAcl($this->cache->fetch($key));
@@ -154,7 +154,7 @@ class DoctrineAclCache implements AclCacheInterface
             $parentAcl = $this->getFromCacheById($parentId);
 
             if (null === $parentAcl) {
-                return null;
+                return;
             }
 
             $acl->setParentAcl($parentAcl);

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentityRetrievalStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentityRetrievalStrategy.php
@@ -29,7 +29,7 @@ class ObjectIdentityRetrievalStrategy implements ObjectIdentityRetrievalStrategy
         try {
             return ObjectIdentity::fromDomainObject($domainObject);
         } catch (InvalidDomainObjectException $failed) {
-            return null;
+            return;
         }
     }
 }

--- a/src/Symfony/Component/Security/Acl/Permission/BasicPermissionMap.php
+++ b/src/Symfony/Component/Security/Acl/Permission/BasicPermissionMap.php
@@ -92,7 +92,7 @@ class BasicPermissionMap implements PermissionMapInterface
     public function getMasks($permission, $object)
     {
         if (!isset($this->map[$permission])) {
-            return null;
+            return;
         }
 
         return $this->map[$permission];

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/AnonymousAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/AnonymousAuthenticationProvider.php
@@ -40,7 +40,7 @@ class AnonymousAuthenticationProvider implements AuthenticationProviderInterface
     public function authenticate(TokenInterface $token)
     {
         if (!$this->supports($token)) {
-            return null;
+            return;
         }
 
         if ($this->key !== $token->getKey()) {

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
@@ -53,7 +53,7 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
      public function authenticate(TokenInterface $token)
      {
          if (!$this->supports($token)) {
-             return null;
+             return;
          }
 
         if (!$user = $token->getUser()) {

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -58,7 +58,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
     public function authenticate(TokenInterface $token)
     {
         if (!$this->supports($token)) {
-            return null;
+            return;
         }
 
         $username = $token->getUsername();

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -64,7 +64,6 @@ final class User implements AdvancedUserInterface
      */
     public function getSalt()
     {
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -171,7 +171,7 @@ class ContextListener implements ListenerInterface
                     $this->logger->warning(sprintf('Username "%s" could not be found.', $notFound->getUsername()));
                 }
 
-                return null;
+                return;
             }
         }
 

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -142,8 +142,6 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
         }
 
         $this->cancelCookie($request);
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -144,7 +144,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
             array(
                 array(
                     'bar' => function ($bar) {
-                        return null;
+                        return;
                     },
                 ),
                 'baz',

--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -190,8 +190,6 @@ class Section
                 return $child;
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -253,8 +253,6 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
                 return $this->metadata[$domain][$key];
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -168,7 +168,6 @@ abstract class Constraint
      */
     public function getDefaultOption()
     {
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -78,7 +78,7 @@ class Regex extends Constraint
     {
         // If match = false, pattern should not be added to HTML5 validation
         if (!$this->match) {
-            return null;
+            return;
         }
 
         if (preg_match('/^(.)(\^?)(.*?)(\$?)\1$/', $this->pattern, $matches)) {
@@ -92,7 +92,5 @@ class Regex extends Constraint
 
             return $start.$pattern.$end;
         }
-
-        return null;
     }
 }

--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -168,8 +168,6 @@ class ExecutionContext implements ExecutionContextInterface
         if ($this->metadata instanceof ClassBasedInterface) {
             return $this->metadata->getClassName();
         }
-
-        return null;
     }
 
     /**
@@ -180,8 +178,6 @@ class ExecutionContext implements ExecutionContextInterface
         if ($this->metadata instanceof PropertyMetadataInterface) {
             return $this->metadata->getPropertyName();
         }
-
-        return null;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintAValidator.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintAValidator.php
@@ -33,7 +33,5 @@ class ConstraintAValidator extends ConstraintValidator
 
             return;
         }
-
-        return;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FailingConstraintValidator.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FailingConstraintValidator.php
@@ -19,7 +19,5 @@ class FailingConstraintValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         $this->context->addViolation($constraint->message, array());
-
-        return;
     }
 }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -393,7 +393,7 @@ class Inline
             case 'null' === $scalarLower:
             case '' === $scalar:
             case '~' === $scalar:
-                return null;
+                return;
             case 'true' === $scalarLower:
                 return true;
             case 'false' === $scalarLower:
@@ -414,7 +414,7 @@ class Inline
                             throw new ParseException('Object support when parsing a YAML file has been disabled.');
                         }
 
-                        return null;
+                        return;
                     case ctype_digit($scalar):
                         $raw = $scalar;
                         $cast = intval($scalar);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| License | MIT |

This PR unifies the way we return `null` from a function or method:
- always use `return;` instead of `return null;` (the current code base uses both);
- never use `return;` at the end of a function/method.
