### PR TITLE
[Finder] Marked test skipped when ftp stream wrapper is not available

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -824,6 +824,10 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
     public function testNonSeekableStream()
     {
+        if (!in_array('ftp', stream_get_wrappers())) {
+            $this->markTestSkipped(sprintf('Unavailable stream "%s".', 'ftp'));
+        }
+
         try {
             $i = Finder::create()->in('ftp://ftp.mozilla.org/')->depth(0)->getIterator();
         } catch (\UnexpectedValueException $e) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This should prevent test from failing on hhvm as ftp stream wrapper is not currently implemented.
See https://github.com/facebook/hhvm/issues/2108 for more details.
