### PR TITLE
[HttpFoundation] factorize out the way output buffers should be closed

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -70,17 +70,13 @@ class ExceptionController
      */
     protected function getAndCleanOutputBuffering($startObLevel)
     {
-        // ob_get_level() never returns 0 on some Windows configurations, so if
-        // the level is the same two times in a row, the loop should be stopped.
-        $previousObLevel = null;
-        $currentContent = '';
-
-        while (($obLevel = ob_get_level()) > $startObLevel && $obLevel !== $previousObLevel) {
-            $previousObLevel = $obLevel;
-            $currentContent .= ob_get_clean();
+        if (ob_get_level() <= $startObLevel) {
+            return '';
         }
 
-        return $currentContent;
+        Response::closeOutputBuffers($startObLevel + 1, true);
+
+        return ob_get_clean();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -376,24 +376,7 @@ class Response
         if (function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();
         } elseif ('cli' !== PHP_SAPI) {
-            // ob_get_level() never returns 0 on some Windows configurations, so if
-            // the level is the same two times in a row, the loop should be stopped.
-            $previous = null;
-            $obStatus = ob_get_status(1);
-            while (($level = ob_get_level()) > 0 && $level !== $previous) {
-                $previous = $level;
-                if ($obStatus[$level - 1]) {
-                    if (version_compare(PHP_VERSION, '5.4', '>=')) {
-                        if (isset($obStatus[$level - 1]['flags']) && ($obStatus[$level - 1]['flags'] & PHP_OUTPUT_HANDLER_REMOVABLE)) {
-                            ob_end_flush();
-                        }
-                    } else {
-                        if (isset($obStatus[$level - 1]['del']) && $obStatus[$level - 1]['del']) {
-                            ob_end_flush();
-                        }
-                    }
-                }
-            }
+            static::closeOutputBuffers(0, true);
             flush();
         }
 
@@ -1247,7 +1230,36 @@ class Response
     }
 
     /**
-     * Check if we need to remove Cache-Control for SSL encrypted downloads when using IE < 9
+     * Cleans or flushes output buffers up to target level.
+     *
+     * Resulting level can be greater than target level if a non-removable buffer has been encountered.
+     *
+     * @param int  $targetLevel The target output buffering level
+     * @param bool $flush       Whether to flush or clean the buffers
+     */
+    public static function closeOutputBuffers($targetLevel, $flush)
+    {
+        $status = ob_get_status(true);
+        $level = count($status);
+
+        while ($level-- > $targetLevel
+            && (!empty($status[$level]['del'])
+                || (isset($status[$level]['flags'])
+                    && ($status[$level]['flags'] & PHP_OUTPUT_HANDLER_REMOVABLE)
+                    && ($status[$level]['flags'] & ($flush ? PHP_OUTPUT_HANDLER_FLUSHABLE : PHP_OUTPUT_HANDLER_CLEANABLE))
+                )
+            )
+        ) {
+            if ($flush) {
+                ob_end_flush();
+            } else {
+                ob_end_clean();
+            }
+        }
+    }
+
+    /**
+     * Checks if we need to remove Cache-Control for SSL encrypted downloads when using IE < 9
      *
      * @link http://support.microsoft.com/kb/323308
      */

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -93,9 +93,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
             }
 
             // let's clean up the output buffers that were created by the sub-request
-            while (ob_get_level() > $level) {
-                ob_get_clean();
-            }
+            Response::closeOutputBuffers($level, false);
 
             if (isset($options['alt'])) {
                 $alt = $options['alt'];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Closing output buffers was done in three different files, but not exactly the same way, with subtle differences.
This PR factorizes out the best way to do this in a new public static function of the Response class.
