### PR TITLE
[FrameworkBundle] tada animated exceptions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
@@ -49,6 +49,9 @@
 }
 .sf-reset .block-exception-detected .illustration-exception {
     width: 152px;
+    animation-name: sf-illustration-exception;
+    animation-duration: 0.9s;
+    animation-fill-mode: both;
 }
 .sf-reset .block-exception-detected .text-exception {
     width: 670px;
@@ -110,4 +113,33 @@
     white-space: pre;
     font-size: 12px;
     font-family: monospace;
+}
+
+/*
+Keyframes from Animate.css
+http://daneden.me/animate
+Licensed under the MIT license
+Copyright (c) 2013 Daniel Eden
+*/
+
+@keyframes sf-illustration-exception {
+    0% {
+        transform: scale(1);
+    }
+
+    10%, 20% {
+        transform: scale(0.9) rotate(-3deg);
+    }
+
+    30%, 50%, 70%, 90% {
+        transform: scale(1.4) rotate(3deg);
+    }
+
+    40%, 60%, 80% {
+        transform: scale(1.4) rotate(-3deg);
+    }
+
+    100% {
+        transform: scale(1) rotate(0);
+    }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.css.twig
@@ -47,6 +47,9 @@
 }
 .sf-reset .block-exception-detected .illustration-exception {
     width: 152px;
+    animation-name: sf-illustration-exception;
+    animation-duration: 0.9s;
+    animation-fill-mode: both;
 }
 .sf-reset .block-exception-detected .text-exception {
     width: 670px;
@@ -101,4 +104,33 @@
 .sf-reset #output-content {
     color: #000;
     font-size: 12px;
+}
+
+/*
+Keyframes from Animate.css
+http://daneden.me/animate
+Licensed under the MIT license
+Copyright (c) 2013 Daniel Eden
+*/
+
+@keyframes sf-illustration-exception {
+    0% {
+        transform: scale(1);
+    }
+
+    10%, 20% {
+        transform: scale(0.9) rotate(-3deg);
+    }
+
+    30%, 50%, 70%, 90% {
+        transform: scale(1.4) rotate(3deg);
+    }
+
+    40%, 60%, 80% {
+        transform: scale(1.4) rotate(-3deg);
+    }
+
+    100% {
+        transform: scale(1) rotate(0);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Tagged as bug fix because it should have been this way since the beginning ;-)
Although the screenshot below shows an infinite loop, the proposed animation is run once naturally.

![oghost](https://cloud.githubusercontent.com/assets/243674/2731514/1c90ccc0-c62e-11e3-975a-e9d3c68aef80.gif)
