### PR TITLE
No need to use mb functions here

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -105,16 +105,8 @@ class WebDebugToolbarListener implements EventSubscriberInterface
      */
     protected function injectToolbar(Response $response)
     {
-        if (function_exists('mb_stripos')) {
-            $posrFunction   = 'mb_strripos';
-            $substrFunction = 'mb_substr';
-        } else {
-            $posrFunction   = 'strripos';
-            $substrFunction = 'substr';
-        }
-
         $content = $response->getContent();
-        $pos = $posrFunction($content, '</body>');
+        $pos = strripos($content, '</body>');
 
         if (false !== $pos) {
             $toolbar = "\n".str_replace("\n", '', $this->twig->render(
@@ -124,7 +116,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
                     'token' => $response->headers->get('X-Debug-Token'),
                 )
             ))."\n";
-            $content = $substrFunction($content, 0, $pos).$toolbar.$substrFunction($content, $pos);
+            $content = substr($content, 0, $pos).$toolbar.substr($content, $pos);
             $response->setContent($content);
         }
     }


### PR DESCRIPTION
When mb functions are used and a large response is given the OOM happens as mb functions will use large quantities of memory.

In my example the response is approximately 27M in size and a php has a memory consumption of about 150M... When mb functions are used the memory shoots over 250M
