### PR TITLE
[DomCrawler] Textarea value should default to empty string instead of null.

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
@@ -31,7 +31,7 @@ class TextareaFormField extends FormField
             throw new \LogicException(sprintf('A TextareaFormField can only be created from a textarea tag (%s given).', $this->node->nodeName));
         }
 
-        $this->value = null;
+        $this->value = '';
         foreach ($this->node->childNodes as $node) {
             $this->value .= $node->wholeText;
         }

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -853,4 +853,21 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
         return $dom;
     }
+
+    public function testgetPhpValuesWithEmptyTextarea()
+    {
+      $dom = new \DOMDocument();
+      $dom->loadHTML('
+              <html>
+                  <form>
+                      <textarea name="example"></textarea>
+                  </form>
+              </html>
+          ');
+
+      $nodes = $dom->getElementsByTagName('form');
+      $form = new Form($nodes->item(0), 'http://example.com');
+      $this->assertEquals($form->getPhpValues(), array('example' => ''));
+    }
+
 }


### PR DESCRIPTION
Noticed this when working on Updating Behat/Mink/Goutte to Guzzle 4, see https://github.com/fabpot/Goutte/pull/140 and https://github.com/Behat/MinkGoutteDriver/pull/34. 

Testing this with Drupal 8, trying to submit a Form which has empty form elements, the $value in a TextArea form elements defaults to null, then we end up with those in getValues() and then http_build_query() creates an empty string for those. That results in array keys like ['' => false]. This is then passed through to Guzzle, which ends up in MessageFactory::addPostData(), goes into the else creates and tries to create file with those values, which will throw an exception in GuzzleHttp\Stream::create(): with "Invalid resource type false".

I think the correct fix is to default to an empty string instead of null.

Will also need tests, 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
