### PR TITLE
[FrameworkBundle] tada animated exceptions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
@@ -49,6 +49,10 @@
 }
 .sf-reset .block-exception-detected .illustration-exception {
     width: 152px;
+    animation-name: sf-illustration-exception;
+    animation-delay: 2s;
+    animation-duration: 2s;
+    animation-fill-mode: both;
 }
 .sf-reset .block-exception-detected .text-exception {
     width: 670px;
@@ -110,4 +114,43 @@
     white-space: pre;
     font-size: 12px;
     font-family: monospace;
+}
+
+/*
+Keyframes from Animate.css
+http://daneden.me/animate
+Licensed under the MIT license
+Copyright (c) 2013 Daniel Eden
+*/
+
+@keyframes sf-illustration-exception {
+    0% {
+      transform: rotate(0);
+      transform-origin: top left;
+      animation-timing-function: ease-in-out;
+    }
+
+    20%, 60% {
+      transform: rotate(60deg);
+      transform-origin: top left;
+      animation-timing-function: ease-in-out;
+    }
+
+    40% {
+      transform: rotate(40deg);
+      transform-origin: top left;
+      animation-timing-function: ease-in-out;
+    }
+
+    80% {
+      transform: rotate(40deg) translateY(0);
+      transform-origin: top left;
+      animation-timing-function: ease-in-out;
+      opacity: 1;
+    }
+
+    100% {
+      transform: translateY(700px);
+      opacity: 0;
+    }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.css.twig
@@ -47,6 +47,10 @@
 }
 .sf-reset .block-exception-detected .illustration-exception {
     width: 152px;
+    animation-name: sf-illustration-exception;
+    animation-delay: 2s;
+    animation-duration: 2s;
+    animation-fill-mode: both;
 }
 .sf-reset .block-exception-detected .text-exception {
     width: 670px;
@@ -101,4 +105,43 @@
 .sf-reset #output-content {
     color: #000;
     font-size: 12px;
+}
+
+/*
+Keyframes from Animate.css
+http://daneden.me/animate
+Licensed under the MIT license
+Copyright (c) 2013 Daniel Eden
+*/
+
+@keyframes sf-illustration-exception {
+  0% {
+    transform: rotate(0);
+    transform-origin: top left;
+    animation-timing-function: ease-in-out;
+  }
+
+  20%, 60% {
+    transform: rotate(60deg);
+    transform-origin: top left;
+    animation-timing-function: ease-in-out;
+  }
+
+  40% {
+    transform: rotate(40deg);
+    transform-origin: top left;
+    animation-timing-function: ease-in-out;
+  }
+
+  80% {
+    transform: rotate(40deg) translateY(0);
+    transform-origin: top left;
+    animation-timing-function: ease-in-out;
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateY(700px);
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

I totally agree that changes proposed in #10729 are much needed and to be honest, I'm a bit annoyed that nobody fixed that earlier. But the fix is obviously wrong and still buggy. So, after a lot of hard work, I finally fixed the thing with a much better alternative that should make everyone happy and will make debugging Symfony issues much easier for everyone. YMMV of course.

![untitled](https://cloud.githubusercontent.com/assets/47313/2747994/43050b44-c79d-11e3-8cf2-9ae534abb1f3.gif)
