### PR TITLE
Fixed incompatibility of x509 auth with nginx

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
@@ -44,21 +44,12 @@ class X509AuthenticationListener extends AbstractPreAuthenticatedListener
         $user = null;
         if ($request->server->has($this->userKey)) {
             $user = $request->server->get($this->userKey);
-        } elseif ($request->server->has($this->credentialKey)) {
-            $dnEmailPreg = '#/emailAddress=(.+\@.+\..+)(/|$)#';
-            if (preg_match($dnEmailPreg, $request->server->get($this->credentialKey), $matches)) {
-                $user = $matches[1];
-            }
+        } elseif ($request->server->has($this->credentialKey) && preg_match('#/emailAddress=(.+\@.+\..+)(/|$)#', $request->server->get($this->credentialKey), $matches)) {
+            $user = $matches[1];
         }
 
-        if ($user === null) {
-            throw new BadCredentialsException(
-                sprintf(
-                    'SSL credentials not found: %s, %s',
-                    $this->userKey,
-                    $this->credentialKey
-                )
-            );
+        if (null === $user) {
+            throw new BadCredentialsException(sprintf('SSL credentials not found: %s, %s', $this->userKey, $this->credentialKey));
         }
 
         return array($user, $request->server->get($this->credentialKey, ''));

--- a/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
@@ -41,10 +41,26 @@ class X509AuthenticationListener extends AbstractPreAuthenticatedListener
      */
     protected function getPreAuthenticatedData(Request $request)
     {
-        if (!$request->server->has($this->userKey)) {
-            throw new BadCredentialsException(sprintf('SSL key was not found: %s', $this->userKey));
+        $user = null;
+        if ($request->server->has($this->userKey)) {
+            $user = $request->server->get($this->userKey);
+        } elseif ($request->server->has($this->credentialKey)) {
+            $dnEmailPreg = '#/emailAddress=([\w\d\-\.]+@[\w\d\-\.]+\.[\w\d]+)(/|$)#';
+            if (preg_match($dnEmailPreg, $request->server->get($this->credentialKey), $matches)) {
+                $user = $matches[1];
+            }
         }
 
-        return array($request->server->get($this->userKey), $request->server->get($this->credentialKey, ''));
+        if ($user === null) {
+            throw new BadCredentialsException(
+                sprintf(
+                    'SSL credentials not found: %s, %s',
+                    $this->userKey,
+                    $this->credentialKey
+                )
+            );
+        }
+
+        return array($user, $request->server->get($this->credentialKey, ''));
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
@@ -45,7 +45,7 @@ class X509AuthenticationListener extends AbstractPreAuthenticatedListener
         if ($request->server->has($this->userKey)) {
             $user = $request->server->get($this->userKey);
         } elseif ($request->server->has($this->credentialKey)) {
-            $dnEmailPreg = '#/emailAddress=([\w\d\-\.]+@[\w\d\-\.]+\.[\w\d]+)(/|$)#';
+            $dnEmailPreg = '#/emailAddress=(.+\@.+\..+)(/|$)#';
             if (preg_match($dnEmailPreg, $request->server->get($this->credentialKey), $matches)) {
                 $user = $matches[1];
             }

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/X509AuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/X509AuthenticationListenerTest.php
@@ -63,10 +63,32 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGetPreAuthenticatedDataNoUser()
+    {
+        $credentials = 'CN=Sample certificate DN/emailAddress=cert@example.com';
+        $request = new Request(array(), array(), array(), array(), array(), array('SSL_CLIENT_S_DN' => $credentials));
+
+        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+
+        $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
+
+        $listener = new X509AuthenticationListener(
+            $context,
+            $authenticationManager,
+            'TheProviderKey'
+        );
+
+        $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs($listener, array($request));
+        $this->assertSame($result, array('cert@example.com', $credentials));
+    }
+
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
      */
-    public function testGetPreAuthenticatedDataNoUser()
+    public function testGetPreAuthenticatedDataNoData()
     {
         $request = new Request(array(), array(), array(), array(), array(), array());
 

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/X509AuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/X509AuthenticationListenerTest.php
@@ -63,9 +63,12 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testGetPreAuthenticatedDataNoUser()
+    /**
+     * @dataProvider dataProviderGetPreAuthenticatedDataNoUser
+     */
+    public function testGetPreAuthenticatedDataNoUser($emailAddress)
     {
-        $credentials = 'CN=Sample certificate DN/emailAddress=cert@example.com';
+        $credentials = 'CN=Sample certificate DN/emailAddress=' . $emailAddress;
         $request = new Request(array(), array(), array(), array(), array(), array('SSL_CLIENT_S_DN' => $credentials));
 
         $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
@@ -82,7 +85,15 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
 
         $result = $method->invokeArgs($listener, array($request));
-        $this->assertSame($result, array('cert@example.com', $credentials));
+        $this->assertSame($result, array($emailAddress, $credentials));
+    }
+
+    public static function dataProviderGetPreAuthenticatedDataNoUser()
+    {
+        return array(
+            'basicEmailAddress' => array('cert@example.com'),
+            'emailAddressWithPlusSign' => array('cert+something@example.com'),
+        );
     }
 
     /**

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/X509AuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/X509AuthenticationListenerTest.php
@@ -42,11 +42,7 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new X509AuthenticationListener(
-            $context,
-            $authenticationManager,
-            'TheProviderKey'
-        );
+        $listener = new X509AuthenticationListener($context, $authenticationManager, 'TheProviderKey');
 
         $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
         $method->setAccessible(true);
@@ -68,18 +64,14 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPreAuthenticatedDataNoUser($emailAddress)
     {
-        $credentials = 'CN=Sample certificate DN/emailAddress=' . $emailAddress;
+        $credentials = 'CN=Sample certificate DN/emailAddress='.$emailAddress;
         $request = new Request(array(), array(), array(), array(), array(), array('SSL_CLIENT_S_DN' => $credentials));
 
         $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new X509AuthenticationListener(
-            $context,
-            $authenticationManager,
-            'TheProviderKey'
-        );
+        $listener = new X509AuthenticationListener($context, $authenticationManager, 'TheProviderKey');
 
         $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
         $method->setAccessible(true);
@@ -107,11 +99,7 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new X509AuthenticationListener(
-            $context,
-            $authenticationManager,
-            'TheProviderKey'
-        );
+        $listener = new X509AuthenticationListener($context, $authenticationManager, 'TheProviderKey');
 
         $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
         $method->setAccessible(true);
@@ -131,13 +119,7 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new X509AuthenticationListener(
-            $context,
-            $authenticationManager,
-            'TheProviderKey',
-            'TheUserKey',
-            'TheCredentialsKey'
-        );
+        $listener = new X509AuthenticationListener($context, $authenticationManager, 'TheProviderKey', 'TheUserKey', 'TheCredentialsKey');
 
         $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
         $method->setAccessible(true);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This commit fixes x509 authentication when using nginx as web server.
X509AuthenticationListener depends on the SSL_CLIENT_S_DN_Email field being set.
As is, this field is specific to Apache and cannot be provided by nginx. nginx
can provide the DN of the certificate in SSL_CLIENT_S_DN. If the email field is
not set, the listener tries to extract the email address from the DN.
