### PR TITLE
[ConfigCache] Use non-local files resources

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Config/Resource/Refresher/ContainerAwareRefresher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Config/Resource/Refresher/ContainerAwareRefresher.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Config\Resource\Refresher;
+
+use Symfony\Component\Config\Resource\Refresher\RefresherInterface;
+use Symfony\Component\Config\Resource\MutableResourceInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author Luc Vieillescazes <luc@vieillescazes.net>
+ */
+class ContainerAwareRefresher implements RefresherInterface
+{
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function refresh(MutableResourceInterface $resource)
+    {
+        if ($resource instanceof ContainerAwareInterface) {
+            $resource->setContainer($this->container);
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ConfigResourceRefresherPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ConfigResourceRefresherPass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class ConfigResourceRefresherPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('config.resource.chain_refresher')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('config.resource.chain_refresher');
+
+        foreach ($container->findTaggedServiceIds('config.resource_refresher') as $id => $attributes) {
+            $definition->addMethodCall('addRefresher', array(new Reference($id)));
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -47,6 +47,7 @@ class FrameworkExtension extends Extension
         $loader->load('web.xml');
         $loader->load('services.xml');
         $loader->load('fragment_renderer.xml');
+        $loader->load('config.xml');
 
         // A translator must always be registered (as support is included by
         // default in the Form component). If disabled, an identity translator

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -27,6 +27,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationExtra
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationDumperPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FragmentRendererPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SerializerPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigResourceRefresherPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Scope;
@@ -81,6 +82,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new TranslationDumperPass());
         $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new SerializerPass());
+        $container->addCompilerPass(new ConfigResourceRefresherPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="config.resource.chain_refresher.class">Symfony\Component\Config\Resource\Refresher\ChainRefresher</parameter>
+        <parameter key="config.resource.container_aware_refresher.class">Symfony\Bundle\FrameworkBundle\Config\Resource\Refresher\ContainerAwareRefresher</parameter>
+    </parameters>
+
+    <services>
+        <service id="config.resource.chain_refresher" class="%config.resource.chain_refresher.class%">
+        </service>
+        <service id="config.resource.container_aware_refresher" class="%config.resource.container_aware_refresher.class%">
+            <argument type="service" id="service_container" />
+            <tag name="config.resource_refresher" />
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -44,6 +44,7 @@
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>
                 <argument key="debug">%kernel.debug%</argument>
             </argument>
+            <argument type="service" id="config.resource.chain_refresher" />
         </service>
 
         <service id="translator" class="%translator.identity.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -15,6 +15,7 @@ use Symfony\Component\Translation\Translator as BaseTranslator;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\Resource\Refresher\RefresherInterface;
 
 /**
  * Translator.
@@ -29,6 +30,7 @@ class Translator extends BaseTranslator
         'debug'     => false,
     );
     protected $loaderIds;
+    protected $refresher;
 
     /**
      * Constructor.
@@ -45,10 +47,11 @@ class Translator extends BaseTranslator
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array())
+    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array(), RefresherInterface $refresher = null)
     {
         $this->container = $container;
         $this->loaderIds = $loaderIds;
+        $this->refresher = $refresher;
 
         // check option names
         if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
@@ -88,7 +91,7 @@ class Translator extends BaseTranslator
         }
 
         $cache = new ConfigCache($this->options['cache_dir'].'/catalogue.'.$locale.'.php', $this->options['debug']);
-        if (!$cache->isFresh()) {
+        if (!$cache->isFresh($this->refresher)) {
             $this->initialize();
 
             parent::loadCatalogue($locale);

--- a/src/Symfony/Component/Config/Resource/MutableResourceInterface.php
+++ b/src/Symfony/Component/Config/Resource/MutableResourceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Resource;
+
+/**
+ * MutableResourceInterface is the interface that must be implemented by all Resource classes.
+ *
+ * @author Luc Vieillescazes <luc@vieillescazes.net>
+ */
+interface MutableResourceInterface extends ResourceInterface
+{
+    public function isMutable();
+}

--- a/src/Symfony/Component/Config/Resource/Refresher/ChainRefresher.php
+++ b/src/Symfony/Component/Config/Resource/Refresher/ChainRefresher.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Resource\Refresher;
+
+use Symfony\Component\Config\Resource\MutableResourceInterface;
+
+/**
+ * @author Luc Vieillescazes <luc@vieillescazes.net>
+ */
+class ChainRefresher implements RefresherInterface
+{
+    private $refreshers = array();
+
+    public function addRefresher(RefresherInterface $refresher)
+    {
+        $this->refreshers[] = $refresher;
+    }
+
+    public function refresh(MutableResourceInterface $resource)
+    {
+        foreach ($this->refreshers as $refresher) {
+            $refresher->refresh($resource);
+        }
+    }
+}

--- a/src/Symfony/Component/Config/Resource/Refresher/RefresherInterface.php
+++ b/src/Symfony/Component/Config/Resource/Refresher/RefresherInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Resource\Refresher;
+
+use Symfony\Component\Config\Resource\MutableResourceInterface;
+
+/**
+ * @author Luc Vieillescazes <luc@vieillescazes.net>
+ */
+interface RefresherInterface
+{
+    public function refresh(MutableResourceInterface $resource);
+}

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -61,20 +61,12 @@ class ConfigCacheTest extends \PHPUnit_Framework_TestCase
 
     public function testCacheIsAlwaysFreshIfFileExistsWithDebugDisabled()
     {
+        unlink($this->metaFile);
         $this->makeCacheStale();
 
         $cache = new ConfigCache($this->cacheFile, false);
 
         $this->assertTrue($cache->isFresh());
-    }
-
-    public function testCacheIsNotFreshWithoutMetaFile()
-    {
-        unlink($this->metaFile);
-
-        $cache = new ConfigCache($this->cacheFile, true);
-
-        $this->assertFalse($cache->isFresh());
     }
 
     public function testCacheIsFreshIfResourceIsFresh()


### PR DESCRIPTION
This PR is another try to use non-local file resources in ConfigCache, like #7230

There are 2 main changes:
- A new interface "MutableResourceInterface" which extends "ResourceInterface" for compatibility and adds a new method "isMutable()".
  The metafile is now created if at least one resource is mutable, and not according to the debug flag like before.
- "isFresh()" method can take as first argument an instance of "RefresherInterface" which has only one method: "refresh(MutableResourceInterface $resource)"
  It serves for example to reinject the database connexion after unserializing ressources

Compatibility should be maintained.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7230 |
| License | MIT |
| Doc PR |  |

TODO:
- [ ] Comments
