### PR TITLE
[FrameworkBundle] added WebTestHelper

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestHelper.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * WebTestHelper is an alternative to WebTestCase when you cannot inherit from
+ * WebTestCase.
+ *
+ * @author Guillaume Royer <guilro@redado.org>
+ */
+class WebTestHelper extends WebTestCase
+{
+    protected static $class;
+
+    /**
+     * @var KernelInterface
+     */
+    protected static $kernel;
+
+    /**
+     * Creates a Client.
+     *
+     * @param array $options An array of options to pass to the createKernel class
+     * @param array $server  An array of server parameters
+     *
+     * @return Client A Client instance
+     */
+    public static function createClient(array $options = array(), array $server = array())
+    {
+        return parent::createClient($options, $server);
+    }
+
+    /**
+     * Finds the directory where the phpunit.xml(.dist) is stored.
+     *
+     * If you run tests with the PHPUnit CLI tool, everything will work as expected.
+     * If not, override this method in your test classes.
+     *
+     * @return string The directory where phpunit.xml(.dist) is stored
+     *
+     * @throws \RuntimeException
+     */
+    public static function getPhpUnitXmlDir()
+    {
+        try {
+            return parent::getPhpUnitXmlDir();
+        } catch (\RuntimeException $exception) {
+            $message = str_replace('WebTestCase', 'WebTestHelper', $exception->getMessage());
+            throw new \RuntimeException($message);
+        }
+    }
+
+    /**
+     * Attempts to guess the kernel location.
+     *
+     * When the Kernel is located, the file is required.
+     *
+     * @return string The Kernel class name
+     *
+     * @throws \RuntimeException
+     */
+    public static function getKernelClass()
+    {
+        try {
+            return parent::getKernelClass();
+        } catch (\RuntimeException $exception) {
+            $message = str_replace('WebTestCase', 'WebTestHelper', $exception->getMessage());
+            throw new \RuntimeException($message);
+        }
+    }
+
+    /**
+     * Creates a Kernel.
+     *
+     * Available options:
+     *
+     *  * environment
+     *  * debug
+     *
+     * @param array $options An array of options
+     *
+     * @return KernelInterface A KernelInterface instance
+     */
+    public static function createKernel(array $options = array())
+    {
+        return parent::createKernel($options);
+    }
+
+    /**
+     * Shuts the kernel down. Should be used in tearDown with PHPUnit
+     */
+    public static function shutdownKernel()
+    {
+        if (null !== static::$kernel) {
+            static::$kernel->shutdown();
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestHelper as BaseWebTestHelper;
+
+class WebTestHelper extends BaseWebTestHelper
+{
+    public static function getKernelClass()
+    {
+        return WebTestCase::getKernelClass();
+    }
+
+    public static function createKernel(array $options = array())
+    {
+        return WebTestCase::createKernel($options);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestHelperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+/**
+ * @group functional
+ */
+class WebTestHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWebTestHelper()
+    {
+        $client = WebTestHelper::createClient(array('test_case' => 'Session'));
+
+        $crawler = $client->request('GET', '/session');
+        $this->assertContains('You are new here and gave no name.', $crawler->text());
+    }
+
+    public function tearDown()
+    {
+        WebTestHelper::shutdownKernel();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10753 |
| License | MIT |
- [ ] submit changes to the documentation

Added a way to perform functional test even when it is not possible to extends WebTestCase. `WebTestHelper::shutdownKernel()` must here be called by the user, so WebTestCase still remains easier to use when it is possible. WebTestHelper should be provided as an alternative.
