### PR TITLE
[Finder] Fix ignoring of unreadable dirs in the RecursiveDirectoryIterator

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -68,7 +68,14 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
     public function getChildren()
     {
         try {
-            return parent::getChildren();
+            $children = parent::getChildren();
+
+            if ($children instanceof self) {
+                // parent method will call the constructor with default arguments, so unreadable dirs won't be ignored anymore
+                $children->ignoreUnreadableDirs = $this->ignoreUnreadableDirs;
+            }
+
+            return $children;
         } catch (\UnexpectedValueException $e) {
             if ($this->ignoreUnreadableDirs) {
                 // If directory is unreadable and finder is set to ignore it, a fake empty content is returned.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10747 |
| License | MIT |
| Doc PR | - |

`\RecursiveDirectoryIterator::getChildren()` creates an instance of the current (overloaded) class with default constructor arguments. Therefore the `ignoreUnreadableDirs` is not passed to the child directories as @marcj suggested in #10747.

My fix relies on PHP's ability to modify private properties in objects of the same class. My reasoning behind choosing this approach, instead of using a setter, is that it's an internal detail which doesn't need to be part of a public interface. 

Unfortunately, I can't really cover this case by tests.
