### PR TITLE
[WebProfilerBundle ] Fixed an edge case on WDT loading

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -239,7 +239,7 @@ class ProfilerController
         $this->profiler->disable();
 
         if (!$profile = $this->profiler->loadProfile($token)) {
-            return new Response('', 204, array('Content-Type' => 'text/html'));
+            return new Response('', 404, array('Content-Type' => 'text/html'));
         }
 
         // the toolbar position (top, bottom, normal, or null -- use the configuration)

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -239,7 +239,7 @@ class ProfilerController
         $this->profiler->disable();
 
         if (!$profile = $this->profiler->loadProfile($token)) {
-            return new Response('', 200, array('Content-Type' => 'text/html'));
+            return new Response('', 204, array('Content-Type' => 'text/html'));
         }
 
         // the toolbar position (top, bottom, normal, or null -- use the configuration)

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -17,7 +17,7 @@
                         return null;
                     }
 
-                    if (xhr.status == 204 && options.maxTries > 1) {
+                    if (xhr.status == 404 && options.maxTries > 1) {
                         setTimeout(function(){
                             options.maxTries--;
                             request(url, onSuccess, onError, payload, options);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -6,27 +6,29 @@
 
             profilerStorageKey = 'sf2/profiler/',
 
-            retriesCount = 0,
-
             request = function(url, onSuccess, onError, payload, options) {
                 var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
                 options = options || {};
+                options.maxTries = options.maxTries || 0;
                 xhr.open(options.method || 'GET', url, true);
                 xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                 xhr.onreadystatechange = function(state) {
-                    if (4 === xhr.readyState && 200 === xhr.status) {
-                        retriesCount = 0;
-                        (onSuccess || noop)(xhr);
-                    } else if (4 === xhr.readyState && xhr.status != 200) {i
-                        if (xhr.status == 204 && retriesCount < 5) {
-                            retriesCount++;
-                            setTimeout(function(){
-                                request(url, onSuccess, onError, payload, options);
-                            }, 500);
-                            return null;
-                        }
+                    if (4 !== xhr.readyState) {
+                        return null;
+                    }
 
-                        retriesCount = 0;
+                    if (xhr.status == 204 && options.maxTries > 1) {
+                        setTimeout(function(){
+                            options.maxTries--;
+                            request(url, onSuccess, onError, payload, options);
+                        }, 500);
+
+                        return null;
+                    }
+
+                    if (200 === xhr.status) {
+                        (onSuccess || noop)(xhr);
+                    } else {
                         (onError || noop)(xhr);
                     }
                 };
@@ -87,6 +89,7 @@
                             (onSuccess || noop)(xhr, el);
                         },
                         function(xhr) { (onError || noop)(xhr, el); },
+                        '',
                         options
                     );
                 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -6,6 +6,8 @@
 
             profilerStorageKey = 'sf2/profiler/',
 
+            retriesCount = 0,
+
             request = function(url, onSuccess, onError, payload, options) {
                 var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
                 options = options || {};
@@ -13,8 +15,18 @@
                 xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                 xhr.onreadystatechange = function(state) {
                     if (4 === xhr.readyState && 200 === xhr.status) {
+                        retriesCount = 0;
                         (onSuccess || noop)(xhr);
-                    } else if (4 === xhr.readyState && xhr.status != 200) {
+                    } else if (4 === xhr.readyState && xhr.status != 200) {i
+                        if (xhr.status == 204 && retriesCount < 5) {
+                            retriesCount++;
+                            setTimeout(function(){
+                                request(url, onSuccess, onError, payload, options);
+                            }, 500);
+                            return null;
+                        }
+
+                        retriesCount = 0;
                         (onError || noop)(xhr);
                     }
                 };

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -34,7 +34,8 @@
                 if (xhr.status !== 0) {
                     confirm('An error occurred while loading the web debug toolbar (' + xhr.status + ': ' + xhr.statusText + ').\n\nDo you want to open the profiler?') && (window.location = '{{ path("_profiler", { "token": token }) }}');
                 }
-            }
+            },
+            {'maxTries': 5}
         );
     })();
 /*]]>*/</script>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6824 ? |
| License | MIT |
| Doc PR | none |

In some case you can notice the WDT just disappears.
By tracking it down, I noticed that the XHR call returns an empty response with 200 as status code, but if you go directly on the _wdt/my_token URL it works correctly.
What's happening is that when you have a slow listener on `kernel.terminate` (for example the SwiftMailer one with a slow connection), you response (and therefore the WDT javascript) is sent and processed by the browser, the XHR call is done, but the Profiler storage didn't happened yet so no profiling data is available and the `ProfilerController` just sends an empty response with 200 as status code.

Here we change to instead send a specific status code, and treat it in javascript by retrying several times before failing. 

The question are:
- Is 204 the most appropriate response code?
- Are 500 ms and 5 max retries good values?
