### PR TITLE
[Form] Automatically add step attribute to HTML5 time widgets to display seconds if needed

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -140,6 +140,10 @@ class TimeType extends AbstractType
 
         if ('single_text' === $options['widget']) {
             $view->vars['type'] = 'time';
+
+            if ($options['with_seconds'] && !isset($view->vars['attr']['step'])) {
+                $view->vars['attr']['step'] = 1;
+            }
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -141,6 +141,10 @@ class TimeType extends AbstractType
         if ('single_text' === $options['widget']) {
             $view->vars['type'] = 'time';
 
+            // we need to force the browser to display the seconds by
+            // adding the HTML attribute step if not already defined.
+            // Otherwise the browser will not display and so not send the seconds
+            // therefore the value will always be considered as invalid.
             if ($options['with_seconds'] && !isset($view->vars['attr']['step'])) {
                 $view->vars['attr']['step'] = 1;
             }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -492,6 +492,33 @@ class TimeTypeTest extends TypeTestCase
         $this->assertEquals('time', $view->vars['type']);
     }
 
+    public function testSingleTextWidgetWithSecondsShouldHaveRightStepAttribute()
+    {
+        $form = $this->factory->create('time', null, array(
+            'widget' => 'single_text',
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertArrayHasKey('step', $view->vars['attr']);
+        $this->assertEquals(1, $view->vars['attr']['step']);
+    }
+
+    public function testSingleTextWidgetWithSecondsShouldNotOverrideStepAttribute()
+    {
+        $form = $this->factory->create('time', null, array(
+            'widget' => 'single_text',
+            'with_seconds' => true,
+            'attr' => array(
+                'step' => 30
+            )
+        ));
+
+        $view = $form->createView();
+        $this->assertArrayHasKey('step', $view->vars['attr']);
+        $this->assertEquals(30, $view->vars['attr']['step']);
+    }
+
     public function testPassDefaultEmptyValueToViewIfNotRequired()
     {
         $form = $this->factory->create('time', null, array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9976, #10203 |
| License | MIT |
| Doc PR | none |

Same issue as #9976 and #10203: when you add a `time` field to a form with options `single_text` (so HTML5) and `with_seconds`, the generated input does not contain the `step` attribute, therefore the browser does not show them, leading to an error at the submit because of an invalid format.

Compared to #9976/#10203:
- Unit testable
- Available directly in the component
- Available in other templating format than twig
- Still able to customise the step attribute by hand
