### PR TITLE
[HttpFoundation] Make MIME type / extension guessers extendable

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser.php
@@ -30,7 +30,7 @@ class ExtensionGuesser implements ExtensionGuesserInterface
      *
      * @var ExtensionGuesser
      */
-    private static $instance = null;
+    protected static $instance = null;
 
     /**
      * All registered ExtensionGuesserInterface instances
@@ -46,17 +46,17 @@ class ExtensionGuesser implements ExtensionGuesserInterface
      */
     public static function getInstance()
     {
-        if (null === self::$instance) {
-            self::$instance = new self();
+        if (null === static::$instance) {
+            static::$instance = new static();
         }
 
-        return self::$instance;
+        return static::$instance;
     }
 
     /**
      * Registers all natively provided extension guessers
      */
-    private function __construct()
+    protected function __construct()
     {
         $this->register(new MimeTypeExtensionGuesser());
     }

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
@@ -44,7 +44,7 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
      *
      * @var MimeTypeGuesser
      */
-    private static $instance = null;
+    protected static $instance = null;
 
     /**
      * All registered MimeTypeGuesserInterface instances
@@ -60,17 +60,17 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
      */
     public static function getInstance()
     {
-        if (null === self::$instance) {
-            self::$instance = new self();
+        if (null === static::$instance) {
+            static::$instance = new static();
         }
 
-        return self::$instance;
+        return static::$instance;
     }
 
     /**
      * Registers all natively provided mime type guessers
      */
-    private function __construct()
+    protected function __construct()
     {
         if (FileBinaryMimeTypeGuesser::isSupported()) {
             $this->register(new FileBinaryMimeTypeGuesser());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | None |

I was working on https://drupal.org/node/1921558 trying to switch our mimetype retrieval system to the Symfony one which is a lot nicer, and i had to override certain things..eg the hardcoded registration of checkers on the constructor.
But self:: and private made me copy/paste more stuff than needed.

Could we switch to static:: and protected instead? Or i am doing something fundamentally wrong extending those classes?

Thanks
