### PR TITLE
[Security] Allow overloading ContextListener::refreshUser()

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -142,7 +142,7 @@ class ContextListener implements ListenerInterface
      *
      * @throws \RuntimeException
      */
-    private function refreshUser(TokenInterface $token)
+    protected function refreshUser(TokenInterface $token)
     {
         $user = $token->getUser();
         if (!$user instanceof UserInterface) {


### PR DESCRIPTION
Allow overloading refreshUser() for the use case of doing something special with user providers.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n.A. |
| License | MIT |
| Doc PR | n.A. |
