### PR TITLE
[HttpFoundation] Allow File instance to be passed to BinaryFileResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -81,7 +81,9 @@ class BinaryFileResponse extends Response
      */
     public function setFile($file, $contentDisposition = null, $autoEtag = false, $autoLastModified = true)
     {
-        $file = new File((string) $file);
+        if (!$file instanceof File) {
+            $file = new File((string) $file);
+        }
 
         if (!$file->isReadable()) {
             throw new FileException('File must be readable.');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10608 |
| License | MIT |
| Doc PR |  |

See https://github.com/symfony/symfony/issues/10608 for discussion and reasoning.

The docblocks get rather long with this change. The File class does extend SplFileObject so technically it could be left out of the docblock if that is more desirable.
