### PR TITLE
[Debug] ErrorHandler: remove $GLOBALS from context in PHP5.3 fix #10292

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -126,6 +126,10 @@ class ErrorHandler
                 require __DIR__.'/Exception/ContextErrorException.php';
             }
 
+            if (PHP_VERSION_ID < 50400 && isset($context['GLOBALS'])) {
+                unset($context['GLOBALS']);
+            }
+
             $exception = new ContextErrorException(sprintf('%s: %s in %s line %d', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message, $file, $line), 0, $level, $file, $line, $context);
 
             // Exceptions thrown from error handlers are sometimes not caught by the exception


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10292 |
| License | MIT |
| Doc PR | none |
