### PR TITLE
Added failing test for ParameterBag#getInt

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -183,6 +183,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(123, $bag->getInt('digits'), '->getInt() gets a value of parameter as integer');
         $this->assertEquals(0, $bag->getInt('unknown'), '->getInt() returns zero if a parameter is not defined');
+        $this->assertSame(null, $bag->getInt('unknown', null), '->getInt() returns the default value if a parameter is not defined');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

`ParameterBag::getInt` will cast the default value to an integer which is problematic when you want `null` to be returned when the key is not present. https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/ParameterBag.php#L253
