### PR TITLE
[DomCrawler] Empty select with attribute name="foo[]" bug fix

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -146,9 +146,11 @@ class Form extends Link implements \ArrayAccess
         $values = array();
         foreach ($this->getValues() as $name => $value) {
             $qs = http_build_query(array($name => $value), '', '&');
-            parse_str($qs, $expandedValue);
-            $varName = substr($name, 0, strlen(key($expandedValue)));
-            $values = array_replace_recursive($values, array($varName => current($expandedValue)));
+            if(!empty($qs)) {
+                parse_str($qs, $expandedValue);
+                $varName = substr($name, 0, strlen(key($expandedValue)));
+                $values = array_replace_recursive($values, array($varName => current($expandedValue)));
+            }
         }
 
         return $values;
@@ -169,9 +171,11 @@ class Form extends Link implements \ArrayAccess
         $values = array();
         foreach ($this->getFiles() as $name => $value) {
             $qs = http_build_query(array($name => $value), '', '&');
-            parse_str($qs, $expandedValue);
-            $varName = substr($name, 0, strlen(key($expandedValue)));
-            $values = array_replace_recursive($values, array($varName => current($expandedValue)));
+            if(!empty($qs)) {
+                parse_str($qs, $expandedValue);
+                $varName = substr($name, 0, strlen(key($expandedValue)));
+                $values = array_replace_recursive($values, array($varName => current($expandedValue)));
+            }
         }
 
         return $values;


### PR DESCRIPTION
If you have a select with attribute name="foo[]", and you submit your form, http_build_query returns empty string as a result. In this case you get a form extra field validation error, because your field "foo" converts to
'' => bool(false)
