### PR TITLE
Fix a test that was ambiguous

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -79,10 +79,16 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataIgnoresAbstractMethods()
     {
         $loader = new StaticMethodLoader('loadMetadata');
+        $caught = false;
         try {
-            include __DIR__ . '/AbstractMethodStaticLoader.php';
-            $this->fail('AbstractMethodStaticLoader should produce a strict standard error.');
+            include __DIR__.'/AbstractMethodStaticLoader.php';
         } catch (\Exception $e) {
+            // catching the PHP notice that is converted to an exception by PHPUnit
+            $caught = true;
+        }
+
+        if (!$caught) {
+            $this->fail('AbstractMethodStaticLoader should produce a strict standard error.');
         }
 
         $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractMethodStaticLoader');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | see #9634 for a discussion of this and #9383 for the report |
| License | MIT |
| Doc PR | n/a |

This PR fixes a test that was always passing as the exception catch was catching the PHP notice but also the exception sent by `fail`, so it was useless. That said, I'm not even convinced that this test is useful at all.
