### PR TITLE
[WebProfilerBundle] Fixed profiler seach/homepage with empty token

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -232,7 +232,7 @@ class ProfilerController
             $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
         }
 
-        if (null === $token) {
+        if ('empty' === $token || null === $token) {
             return new Response('', 200, array('Content-Type' => 'text/html'));
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController;
+use Symfony\Component\HttpFoundation\Request;
+
+class ProfilerControllerTest extends TestCase
+{
+    /**
+     * @dataProvider getEmptyTokenCases
+     */
+    public function testEmptyToken($token)
+    {
+        $urlGenerator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $twig = $this->getMock('Twig_Environment');
+        $profiler = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Profiler\Profiler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $controller = new ProfilerController($urlGenerator, $profiler, $twig, array());
+
+        $response = $controller->toolbarAction(Request::create('/_wdt/empty'), $token);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function getEmptyTokenCases()
+    {
+        return array(
+            array(null),
+            // "empty" is also a valid empty token case, see https://github.com/symfony/symfony/issues/10806
+            array('empty'),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10806 |
| License | MIT |
| Doc PR | none |
