### PR TITLE
[2.3] Fix phpunit test suite on travis #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
     - sudo locale-gen fr_FR.UTF-8 && sudo update-locale
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
+    - wget https://phar.phpunit.de/phpunit.phar && rm `which phpunit` && sudo cp phpunit.phar /usr/local/bin/phpunit && sudo chmod +x /usr/local/bin/phpunit
 
 script:
     - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || exit 1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10821 |
| License | MIT |

This is a second approach to solve #10821.
Something is weird: `Symfony\Component\Form\Tests\Extension\Core\EventListener\TrimListenerTest` passes when using PHPUnit as phar and fails when using a composer global install
