### PR TITLE
[Form] Deprecated read_only option

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -374,7 +374,6 @@
 {% block widget_attributes %}
 {% spaceless %}
     id="{{ id }}" name="{{ full_name }}"
-    {%- if read_only %} readonly="readonly"{% endif -%}
     {%- if disabled %} disabled="disabled"{% endif -%}
     {%- if required %} required="required"{% endif -%}
     {%- for attrname, attrvalue in attr -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -1,4 +1,4 @@
-id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($read_only): ?>readonly="readonly" <?php endif ?>
+id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>"
 <?php if ($disabled): ?>disabled="disabled" <?php endif ?>
 <?php if ($required): ?>required="required" <?php endif ?>
 <?php foreach ($attr as $k => $v): ?>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 2.5.0
 ------
 
- * deprecated options "max_length" and "pattern" in favor of putting these values in "attr" option
+ * deprecated options "max_length", "pattern" and "read_only" in favor of putting these values in "attr" option
  * added an option for multiple files upload
  * form errors now reference their cause (constraint violation, exception, ...)
  * form errors now remember which form they were originally added to

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -72,7 +72,7 @@ class FormType extends BaseType
         parent::buildView($view, $form, $options);
 
         $name = $form->getName();
-        $readOnly = $options['read_only'];
+        $readOnly = isset($options['attr']['readonly']) ? $options['attr']['readonly'] : false;
 
         if ($view->parent) {
             if ('' === $name) {
@@ -81,12 +81,12 @@ class FormType extends BaseType
 
             // Complex fields are read-only if they themselves or their parents are.
             if (!$readOnly) {
-                $readOnly = $view->parent->vars['read_only'];
+                $readOnly = isset($view->parent->vars['attr']['readonly']) ? $view->parent->vars['attr']['readonly'] : false;
             }
         }
 
         $view->vars = array_replace($view->vars, array(
-            'read_only'  => $readOnly,
+            'read_only'  => $readOnly, // Deprecated
             'errors'     => $form->getErrors(),
             'valid'      => $form->isSubmitted() ? $form->isValid() : true,
             'value'      => $form->getViewData(),
@@ -170,7 +170,7 @@ class FormType extends BaseType
             'data',
         ));
 
-        // BC clause for the "max_length" and "pattern" option
+        // BC clause for the "max_length", "pattern" and "read_only" options
         // Add these values to the "attr" option instead
         $defaultAttr = function (Options $options) {
             $attributes = array();
@@ -181,6 +181,10 @@ class FormType extends BaseType
 
             if (null !== $options['pattern']) {
                 $attributes['pattern'] = $options['pattern'];
+            }
+
+            if (false !== $options['read_only']) {
+                $attributes['readonly'] = $options['read_only'];
             }
 
             return $attributes;

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1294,7 +1294,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testReadOnly()
     {
         $form = $this->factory->createNamed('name', 'text', null, array(
-            'read_only' => true,
+            'attr' => array('readonly' => true),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1899,14 +1899,13 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $form = $this->factory->createNamed('text', 'text', 'value', array(
             'required' => true,
             'disabled' => true,
-            'read_only' => true,
-            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
+            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'readonly' => true, 'class' => 'foobar', 'data-foo' => 'bar'),
         ));
 
         $html = $this->renderWidget($form->createView());
 
         // compare plain HTML to check the whitespace
-        $this->assertSame('<input type="text" id="text" name="text" readonly="readonly" disabled="disabled" required="required" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value" />', $html);
+        $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" maxlength="10" pattern="\d+" readonly="readonly" class="foobar" data-foo="bar" value="value" />', $html);
     }
 
     public function testWidgetAttributeNameRepeatedIfTrue()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -102,22 +102,42 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
+        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('attr' => array('readonly' => true)))
+            ->add('child', 'form')
+            ->getForm()
+            ->createView();
+
+        $this->assertTrue($view['child']->vars['attr']['readonly']);
+    }
+
+    public function testNonReadOnlyFormWithReadOnlyParentBCIsReadOnly()
+    {
         $view = $this->factory->createNamedBuilder('parent', 'form', null, array('read_only' => true))
             ->add('child', 'form')
             ->getForm()
             ->createView();
 
-        $this->assertTrue($view['child']->vars['read_only']);
+        $this->assertTrue($view['child']->vars['attr']['readonly']);
     }
 
     public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
         $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form', array('read_only' => true))
+            ->add('child', 'form', array('attr' => array('readonly' => true)))
             ->getForm()
             ->createView();
 
-        $this->assertTrue($view['child']->vars['read_only']);
+        $this->assertTrue($view['child']->vars['attr']['readonly']);
+    }
+
+    public function testReadOnlyFormWithNonReadOnlyParentBCIsReadOnly()
+    {
+        $view = $this->factory->createNamedBuilder('parent', 'form')
+            ->add('child', 'form', array('readonly' => true))
+            ->getForm()
+            ->createView();
+
+        $this->assertTrue($view['child']->vars['attr']['readonly']);
     }
 
     public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
@@ -127,7 +147,7 @@ class FormTypeTest extends BaseTypeTest
                 ->getForm()
                 ->createView();
 
-        $this->assertFalse($view['child']->vars['read_only']);
+        $this->assertFalse($view['child']->vars['attr']['readonly']);
     }
 
     public function testPassMaxLengthToView()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | read_only in form options |
| Tests pass? | no |
| Fixed tickets | #10658 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3824 |
- [ ] figure out why tests aren't passing
