### PR TITLE
[Templating] #9071 array param for EngineInterface::render()

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/TwigEngineTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/TwigEngineTest.php
@@ -51,6 +51,7 @@ class TwigEngineTest extends \PHPUnit_Framework_TestCase
     {
         $engine = $this->getTwig();
 
+        $this->assertSame('foo', $engine->render(array('foo', 'index')));
         $this->assertSame('foo', $engine->render('index'));
         $this->assertSame('foo', $engine->render(new TemplateReference('index')));
     }

--- a/src/Symfony/Bridge/Twig/TwigEngine.php
+++ b/src/Symfony/Bridge/Twig/TwigEngine.php
@@ -109,8 +109,9 @@ class TwigEngine implements EngineInterface, StreamingEngineInterface
     /**
      * Loads the given template.
      *
-     * @param string|TemplateReferenceInterface|\Twig_Template $name A template name or an instance of
-     *                                                               TemplateReferenceInterface or \Twig_Template
+     * @param string|TemplateReferenceInterface|\Twig_Template|array $name A template name or an instance of
+     *                                                                     TemplateReferenceInterface or \Twig_Template or
+     *                                                                     an array of thoses.
      *
      * @return \Twig_TemplateInterface A \Twig_TemplateInterface instance
      *
@@ -123,7 +124,9 @@ class TwigEngine implements EngineInterface, StreamingEngineInterface
         }
 
         try {
-            return $this->environment->loadTemplate((string) $name);
+            return $this->environment->resolveTemplate(
+                is_array($name) ? $name : (string) $name
+            );
         } catch (\Twig_Error_Loader $e) {
             throw new \InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -83,8 +83,8 @@ class Controller extends ContainerAware
     /**
      * Returns a rendered view.
      *
-     * @param string $view       The view name
-     * @param array  $parameters An array of parameters to pass to the view
+     * @param string|array $view       The view name or an array of view names.
+     * @param array        $parameters An array of parameters to pass to the view
      *
      * @return string The rendered view
      */
@@ -96,9 +96,9 @@ class Controller extends ContainerAware
     /**
      * Renders a view.
      *
-     * @param string   $view       The view name
-     * @param array    $parameters An array of parameters to pass to the view
-     * @param Response $response   A response instance
+     * @param string|array   $view       The view name or an array of view names.
+     * @param array          $parameters An array of parameters to pass to the view
+     * @param Response       $response   A response instance
      *
      * @return Response A Response instance
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/EngineInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/EngineInterface.php
@@ -24,7 +24,7 @@ interface EngineInterface extends BaseEngineInterface
     /**
      * Renders a view and returns a Response.
      *
-     * @param string   $view       The view name
+     * @param string|array   $view       The view name or an array of view names.
      * @param array    $parameters An array of parameters to pass to the view
      * @param Response $response   A Response instance
      *

--- a/src/Symfony/Component/Templating/EngineInterface.php
+++ b/src/Symfony/Component/Templating/EngineInterface.php
@@ -35,8 +35,8 @@ interface EngineInterface
     /**
      * Renders a template.
      *
-     * @param string|TemplateReferenceInterface $name       A template name or a TemplateReferenceInterface instance
-     * @param array                             $parameters An array of parameters to pass to the template
+     * @param string|TemplateReferenceInterface|array $name       A template name or a TemplateReferenceInterface instance or an array of view names.
+     * @param array                                   $parameters An array of parameters to pass to the template
      *
      * @return string The evaluated template as a string
      *
@@ -62,7 +62,7 @@ interface EngineInterface
     /**
      * Returns true if this class is able to render the given template.
      *
-     * @param string|TemplateReferenceInterface $name A template name or a TemplateReferenceInterface instance
+     * @param string|TemplateReferenceInterface|array $name A template name or a TemplateReferenceInterface instance or an array of thoses.
      *
      * @return bool    true if this class supports the given template, false otherwise
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | ? |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9071 |
| License | MIT |
| Doc PR |  |
- [ ] submit changes to the documentation

We allow an array to be given as param to Symfony/Component/Templating/EngineInterface::render() and Symfony/Bundle/FrameworkBundle/Templating/EngineInterface::renderView(). We modify Symfony\Bridge\Twig\TwigEngine so it accepts an array as param to TwigEngine::render(). We add a test for that. Controller:render() and ::renderView() now accept array as parameter.

This change asks implementer of `EngineInterface::render()` to accept arrays as parameters, but it will never break existing code, as it is just a change in the docblock, so I do not know if it is a BC break.
