### PR TITLE
[FrameworkBundle] Allow to get MasterRequest in template

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -84,6 +84,18 @@ class GlobalVariables
     }
 
     /**
+     * Returns the master request.
+     *
+     * @return Request|null The HTTP request object
+     */
+    public function getMasterRequest()
+    {
+        if ($this->container->has('request_stack')) {
+            return $this->container->get('request_stack')->getMasterRequest();
+        }
+    }
+
+    /**
      * Returns the current session.
      *
      * @return Session|null The session


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7138 |
| License | MIT |
| Doc PR | n/a |

I want to get the MasterRequest in template because to get the correct REQUEST_PATH in sub-request templating (e.g. pagination).

example code:

``` twig
{{ dump(app.masterRequest.pathInfo) }}
```
