### PR TITLE
DependencyInjection] Fix parameter description in ConfigurationExtensionInterface

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Extension/ConfigurationExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ConfigurationExtensionInterface.php
@@ -24,7 +24,7 @@ interface ConfigurationExtensionInterface
     /**
      * Returns extension configuration
      *
-     * @param array            $config    $config    An array of configuration values
+     * @param array            $config    An array of configuration values
      * @param ContainerBuilder $container A ContainerBuilder instance
      *
      * @return ConfigurationInterface|null The configuration or null


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #10845 |
| License | MIT |

This fixes the description of parameter `array $config` in file [ConfigurationExtensionInterface.php](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/DependencyInjection/Extension/ConfigurationExtensionInterface.php) by removing the extra `$config`.
