### PR TITLE
[Finder] Fix wrong implementation on sortable callback comparator

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -30,8 +30,8 @@ class SortableIterator implements \IteratorAggregate
     /**
      * Constructor.
      *
-     * @param \Traversable     $iterator The Iterator to filter
-     * @param int|callback     $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a PHP callback)
+     * @param \Traversable $iterator The Iterator to filter
+     * @param int|callback $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a PHP callback)
      *
      * @throws \InvalidArgumentException
      */
@@ -58,21 +58,23 @@ class SortableIterator implements \IteratorAggregate
             };
         } elseif (self::SORT_BY_ACCESSED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                if($a->getATime() === $b->getATime()){
+                if ($a->getATime() === $b->getATime()) {
                     return 0;
                 };
+
                 return ($a->getATime() > $b->getATime())  < 0 ? -1 : 1;
             };
         } elseif (self::SORT_BY_CHANGED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                if(($a->getCTime() === $b->getCTime())){
+                if (($a->getCTime() === $b->getCTime())) {
                     return 0;
                 }
+
                 return ($a->getCTime() > $b->getCTime()) < 0 ? -1 : 1;
             };
         } elseif (self::SORT_BY_MODIFIED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                if($a->getMTime() === $b->getMTime()){
+                if ($a->getMTime() === $b->getMTime()) {
                     return 0;
                 }
 

--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -41,7 +41,9 @@ class SortableIterator implements \IteratorAggregate
 
         if (self::SORT_BY_NAME === $sort) {
             $this->sort = function ($a, $b) {
-                return strcmp($a->getRealpath(), $b->getRealpath());
+
+                //strcmp returns < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
+                return strcmp($a->getRealpath(), $b->getRealpath()) < 0 ? -1 : 1;
             };
         } elseif (self::SORT_BY_TYPE === $sort) {
             $this->sort = function ($a, $b) {
@@ -51,19 +53,30 @@ class SortableIterator implements \IteratorAggregate
                     return 1;
                 }
 
-                return strcmp($a->getRealpath(), $b->getRealpath());
+                //strcmp returns < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
+                return strcmp($a->getRealpath(), $b->getRealpath()) < 0 ? -1 : 1;
             };
         } elseif (self::SORT_BY_ACCESSED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                return ($a->getATime() > $b->getATime());
+                if($a->getATime() === $b->getATime()){
+                    return 0;
+                };
+                return ($a->getATime() > $b->getATime())  < 0 ? -1 : 1;
             };
         } elseif (self::SORT_BY_CHANGED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                return ($a->getCTime() > $b->getCTime());
+                if(($a->getCTime() === $b->getCTime())){
+                    return 0;
+                }
+                return ($a->getCTime() > $b->getCTime()) < 0 ? -1 : 1;
             };
         } elseif (self::SORT_BY_MODIFIED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                return ($a->getMTime() > $b->getMTime());
+                if($a->getMTime() === $b->getMTime()){
+                    return 0;
+                }
+
+                return ($a->getMTime() > $b->getMTime())  < 0 ? -1 : 1;
             };
         } elseif (is_callable($sort)) {
             $this->sort = $sort;

--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -31,7 +31,7 @@ class SortableIterator implements \IteratorAggregate
      * Constructor.
      *
      * @param \Traversable $iterator The Iterator to filter
-     * @param int|callback $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a PHP callback)
+     * @param int|callable $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a PHP callback)
      *
      * @throws \InvalidArgumentException
      */
@@ -41,15 +41,7 @@ class SortableIterator implements \IteratorAggregate
 
         if (self::SORT_BY_NAME === $sort) {
             $this->sort = function ($a, $b) {
-
-                //strcmp returns < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
-                $result = strcmp($a->getRealpath(), $b->getRealpath());
-
-                if ($result == 0) {
-                    return 0;
-                }
-
-                return $result < 0 ? -1 : 1;
+                return strcmp($a->getRealpath(), $b->getRealpath());
             };
         } elseif (self::SORT_BY_TYPE === $sort) {
             $this->sort = function ($a, $b) {
@@ -59,43 +51,24 @@ class SortableIterator implements \IteratorAggregate
                     return 1;
                 }
 
-                //strcmp returns < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
-                $result = strcmp($a->getRealpath(), $b->getRealpath()) < 0 ? -1 : 1;
-
-                if ($result == 0) {
-                    return 0;
-                }
-
-                return $result < 0 ? -1 : 1;
+                return strcmp($a->getRealpath(), $b->getRealpath());
             };
         } elseif (self::SORT_BY_ACCESSED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                if ($a->getATime() === $b->getATime()) {
-                    return 0;
-                };
-
-                return ($a->getATime() > $b->getATime())  < 0 ? -1 : 1;
+                return ($a->getATime() - $b->getATime());
             };
         } elseif (self::SORT_BY_CHANGED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                if (($a->getCTime() === $b->getCTime())) {
-                    return 0;
-                }
-
-                return ($a->getCTime() > $b->getCTime()) < 0 ? -1 : 1;
+                return ($a->getCTime() - $b->getCTime());
             };
         } elseif (self::SORT_BY_MODIFIED_TIME === $sort) {
             $this->sort = function ($a, $b) {
-                if ($a->getMTime() === $b->getMTime()) {
-                    return 0;
-                }
-
-                return ($a->getMTime() > $b->getMTime())  < 0 ? -1 : 1;
+                return ($a->getMTime() - $b->getMTime());
             };
         } elseif (is_callable($sort)) {
             $this->sort = $sort;
         } else {
-            throw new \InvalidArgumentException('The SortableIterator takes a PHP callback or a valid built-in sort algorithm as an argument.');
+            throw new \InvalidArgumentException('The SortableIterator takes a PHP callable or a valid built-in sort algorithm as an argument.');
         }
     }
 

--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -43,7 +43,13 @@ class SortableIterator implements \IteratorAggregate
             $this->sort = function ($a, $b) {
 
                 //strcmp returns < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
-                return strcmp($a->getRealpath(), $b->getRealpath()) < 0 ? -1 : 1;
+                $result = strcmp($a->getRealpath(), $b->getRealpath());
+
+                if ($result == 0) {
+                    return 0;
+                }
+
+                return $result < 0 ? -1 : 1;
             };
         } elseif (self::SORT_BY_TYPE === $sort) {
             $this->sort = function ($a, $b) {
@@ -54,7 +60,13 @@ class SortableIterator implements \IteratorAggregate
                 }
 
                 //strcmp returns < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
-                return strcmp($a->getRealpath(), $b->getRealpath()) < 0 ? -1 : 1;
+                $result = strcmp($a->getRealpath(), $b->getRealpath()) < 0 ? -1 : 1;
+
+                if ($result == 0) {
+                    return 0;
+                }
+
+                return $result < 0 ? -1 : 1;
             };
         } elseif (self::SORT_BY_ACCESSED_TIME === $sort) {
             $this->sort = function ($a, $b) {

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -52,14 +52,15 @@ abstract class RealIteratorTestCase extends IteratorTestCase
         }
 
         file_put_contents(self::toAbsolute('test.php'), str_repeat(' ', 800));
-        file_put_contents(self::toAbsolute('test.py'), str_repeat(' ', 2000));
-
-        sleep(1);
 
         touch(self::toAbsolute('foo/bar.tmp'), strtotime('2005-10-15'));
         touch(self::toAbsolute('test.php'), strtotime('2005-10-15'));
 
         file_get_contents(self::toAbsolute('.git'));
+        file_put_contents(self::toAbsolute('test.py'), 'bar -> foo');
+
+        usleep(99999);
+
         file_put_contents(self::toAbsolute('foo/bar.tmp'), 'foo -> bar');
     }
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -51,20 +51,11 @@ abstract class RealIteratorTestCase extends IteratorTestCase
             }
         }
 
-        sleep(1);
-
         file_put_contents(self::toAbsolute('test.php'), str_repeat(' ', 800));
         file_put_contents(self::toAbsolute('test.py'), str_repeat(' ', 2000));
 
-        sleep(1);
-
         touch(self::toAbsolute('foo/bar.tmp'), strtotime('2005-10-15'));
         touch(self::toAbsolute('test.php'), strtotime('2005-10-15'));
-
-        sleep(1);
-
-        file_get_contents(self::toAbsolute('.git'));
-        file_get_contents(self::toAbsolute('.bar'));
     }
 
     public static function tearDownAfterClass()

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -51,17 +51,20 @@ abstract class RealIteratorTestCase extends IteratorTestCase
             }
         }
 
+        sleep(1);
+
         file_put_contents(self::toAbsolute('test.php'), str_repeat(' ', 800));
+        file_put_contents(self::toAbsolute('test.py'), str_repeat(' ', 2000));
+
+        sleep(1);
 
         touch(self::toAbsolute('foo/bar.tmp'), strtotime('2005-10-15'));
         touch(self::toAbsolute('test.php'), strtotime('2005-10-15'));
 
+        sleep(1);
+
         file_get_contents(self::toAbsolute('.git'));
-        file_put_contents(self::toAbsolute('test.py'), 'bar -> foo');
-
-        usleep(99999);
-
-        file_put_contents(self::toAbsolute('foo/bar.tmp'), 'foo -> bar');
+        file_get_contents(self::toAbsolute('.bar'));
     }
 
     public static function tearDownAfterClass()

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -54,8 +54,13 @@ abstract class RealIteratorTestCase extends IteratorTestCase
         file_put_contents(self::toAbsolute('test.php'), str_repeat(' ', 800));
         file_put_contents(self::toAbsolute('test.py'), str_repeat(' ', 2000));
 
+        sleep(1);
+
         touch(self::toAbsolute('foo/bar.tmp'), strtotime('2005-10-15'));
         touch(self::toAbsolute('test.php'), strtotime('2005-10-15'));
+
+        file_get_contents(self::toAbsolute('.git'));
+        file_put_contents(self::toAbsolute('foo/bar.tmp'), 'foo -> bar');
     }
 
     public static function tearDownAfterClass()

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -30,6 +30,26 @@ class SortableIteratorTest extends RealIteratorTestCase
      */
     public function testAccept($mode, $expected)
     {
+        if(!is_callable($mode)){
+            switch($mode){
+                case SortableIterator::SORT_BY_ACCESSED_TIME :
+                    file_get_contents(self::toAbsolute('.git'));
+                    sleep(1);
+                    file_get_contents(self::toAbsolute('.bar'));
+                    break;
+                case SortableIterator::SORT_BY_CHANGED_TIME :
+                    file_put_contents(self::toAbsolute('test.php'), 'foo');
+                    sleep(1);
+                    file_put_contents(self::toAbsolute('test.py'), 'foo');
+                    break;
+                case SortableIterator::SORT_BY_MODIFIED_TIME :
+                    file_put_contents(self::toAbsolute('test.php'), 'foo');
+                    sleep(1);
+                    file_put_contents(self::toAbsolute('test.py'), 'foo');
+                    break;
+            }
+        }
+
         $inner = new Iterator(self::$files);
 
         $iterator = new SortableIterator($inner, $mode);
@@ -97,30 +117,30 @@ class SortableIteratorTest extends RealIteratorTestCase
         );
 
         $sortByChangedTime = array(
-            '.git',
             'foo',
-            'foo bar',
-            '.bar',
-            '.foo/bar',
-            '.foo',
-            '.foo/.bar',
-            'toto',
-            'test.py',
             'foo/bar.tmp',
-            'test.php'
+            'toto',
+            '.git',
+            '.bar',
+            '.foo',
+            'foo bar',
+            '.foo/.bar',
+            '.foo/bar',
+            'test.php',
+            'test.py'
         );
 
         $sortByModifiedTime = array(
             'foo/bar.tmp',
-            'test.php',
             'foo',
             'toto',
             '.git',
             '.bar',
             '.foo',
+            'foo bar',
             '.foo/.bar',
             '.foo/bar',
-            'foo bar',
+            'test.php',
             'test.py'
         );
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -30,6 +30,26 @@ class SortableIteratorTest extends RealIteratorTestCase
      */
     public function testAccept($mode, $expected)
     {
+        if (!is_callable($mode)) {
+            switch ($mode) {
+                case SortableIterator::SORT_BY_ACCESSED_TIME :
+                    file_get_contents(self::toAbsolute('.git'));
+                    sleep(1);
+                    file_get_contents(self::toAbsolute('.bar'));
+                    break;
+                case SortableIterator::SORT_BY_CHANGED_TIME :
+                    file_put_contents(self::toAbsolute('test.php'), 'foo');
+                    sleep(1);
+                    file_put_contents(self::toAbsolute('test.py'), 'foo');
+                    break;
+                case SortableIterator::SORT_BY_MODIFIED_TIME :
+                    file_put_contents(self::toAbsolute('test.php'), 'foo');
+                    sleep(1);
+                    file_put_contents(self::toAbsolute('test.py'), 'foo');
+                    break;
+            }
+        }
+
         $inner = new Iterator(self::$files);
 
         $iterator = new SortableIterator($inner, $mode);
@@ -97,30 +117,30 @@ class SortableIteratorTest extends RealIteratorTestCase
         );
 
         $sortByChangedTime = array(
-            '.git',
             'foo',
-            'foo bar',
-            '.bar',
-            '.foo/bar',
-            '.foo',
-            '.foo/.bar',
-            'toto',
-            'test.py',
             'foo/bar.tmp',
-            'test.php'
+            'toto',
+            '.git',
+            '.bar',
+            '.foo',
+            'foo bar',
+            '.foo/.bar',
+            '.foo/bar',
+            'test.php',
+            'test.py'
         );
 
         $sortByModifiedTime = array(
             'foo/bar.tmp',
-            'test.php',
             'foo',
             'toto',
             '.git',
             '.bar',
             '.foo',
+            'foo bar',
             '.foo/.bar',
             '.foo/bar',
-            'foo bar',
+            'test.php',
             'test.py'
         );
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -82,9 +82,54 @@ class SortableIteratorTest extends RealIteratorTestCase
             'toto',
         );
 
+        $sortByAccessedTime = array(
+            'foo/bar.tmp',
+            'test.php',
+            'toto',
+            'foo bar',
+            'foo',
+            'test.py',
+            '.foo',
+            '.foo/.bar',
+            '.foo/bar',
+            '.bar',
+            '.git'
+        );
+
+        $sortByChangedTime = array(
+            'foo',
+            'toto',
+            'foo bar',
+            '.git',
+            'test.py',
+            '.foo',
+            '.bar',
+            '.foo/bar',
+            '.foo/.bar',
+            'foo/bar.tmp',
+            'test.php'
+        );
+
+        $sortByModifiedTime = array(
+            'test.php',
+            'foo',
+            'toto',
+            'foo bar',
+            '.git',
+            'test.py',
+            '.foo',
+            '.foo/.bar',
+            '.foo/bar',
+            '.bar',
+            'foo/bar.tmp'
+        );
+
         return array(
             array(SortableIterator::SORT_BY_NAME, $this->toAbsolute($sortByName)),
             array(SortableIterator::SORT_BY_TYPE, $this->toAbsolute($sortByType)),
+            array(SortableIterator::SORT_BY_ACCESSED_TIME, $this->toAbsolute($sortByAccessedTime)),
+            array(SortableIterator::SORT_BY_CHANGED_TIME, $this->toAbsolute($sortByChangedTime)),
+            array(SortableIterator::SORT_BY_MODIFIED_TIME, $this->toAbsolute($sortByModifiedTime)),
             array(function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealpath(), $b->getRealpath()); }, $this->toAbsolute($customComparison)),
         );
     }

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -97,31 +97,31 @@ class SortableIteratorTest extends RealIteratorTestCase
         );
 
         $sortByChangedTime = array(
-            'foo',
+            'foo/bar.tmp',
+            'test.php',
             'toto',
             'foo bar',
-            '.git',
+            'foo',
             'test.py',
             '.foo',
-            '.bar',
-            '.foo/bar',
             '.foo/.bar',
-            'foo/bar.tmp',
-            'test.php'
+            '.foo/bar',
+            '.bar',
+            '.git',
         );
 
         $sortByModifiedTime = array(
             'test.php',
-            'foo',
+            'foo/bar.tmp',
             'toto',
             'foo bar',
-            '.git',
+            'foo',
             'test.py',
             '.foo',
             '.foo/.bar',
             '.foo/bar',
             '.bar',
-            'foo/bar.tmp'
+            '.git'
         );
 
         return array(

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -92,36 +92,36 @@ class SortableIteratorTest extends RealIteratorTestCase
             '.foo',
             '.foo/.bar',
             '.foo/bar',
-            '.bar',
-            '.git'
+            '.git',
+            '.bar'
         );
 
         $sortByChangedTime = array(
-            'foo/bar.tmp',
-            'test.php',
-            'toto',
-            'foo bar',
+            '.git',
             'foo',
-            'test.py',
+            'foo bar',
+            '.bar',
+            '.foo/bar',
             '.foo',
             '.foo/.bar',
-            '.foo/bar',
-            '.bar',
-            '.git',
+            'toto',
+            'test.py',
+            'foo/bar.tmp',
+            'test.php'
         );
 
         $sortByModifiedTime = array(
-            'test.php',
             'foo/bar.tmp',
-            'toto',
-            'foo bar',
+            'test.php',
             'foo',
-            'test.py',
+            'toto',
+            '.git',
+            '.bar',
             '.foo',
             '.foo/.bar',
             '.foo/bar',
-            '.bar',
-            '.git'
+            'foo bar',
+            'test.py'
         );
 
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | no |

Working on this issue, i find SORT_BY_ACCESSED_TIME, SORT_BY_CHANGED_TIME, SORT_BY_MODIFIED_TIME was not tested.
- [x] Add test for SORT_BY_ACCESSED_TIME case
- [x] Add test for SORT_BY_CHANGED_TIME case
- [x] add test for SORT_BY_MODIFIED_TIME case
