### PR TITLE
[Validator] Ability to validate only uploaded files for Assert/File

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -38,4 +38,5 @@ class File extends Constraint
     public $uploadCantWriteErrorMessage = 'Cannot write temporary file to disk.';
     public $uploadExtensionErrorMessage = 'A PHP extension caused the upload to fail.';
     public $uploadErrorMessage          = 'The file could not be uploaded.';
+    public $validateOnlyUploadedFiles = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -38,5 +38,5 @@ class File extends Constraint
     public $uploadCantWriteErrorMessage = 'Cannot write temporary file to disk.';
     public $uploadExtensionErrorMessage = 'A PHP extension caused the upload to fail.';
     public $uploadErrorMessage          = 'The file could not be uploaded.';
-    public $validateOnlyUploadedFiles = false;
+    public $validateOnlyNewUploadedFiles = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -34,7 +34,7 @@ class FileValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\File');
         }
 
-        if ($constraint->validateOnlyUploadedFiles && !$value instanceof UploadedFile) {
+        if ($constraint->validateOnlyNewUploadedFiles && !$value instanceof UploadedFile) {
             return true;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -34,7 +34,7 @@ class FileValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\File');
         }
 
-        if($constraint->validateOnlyUploadedFiles && !$value instanceof UploadedFile) {
+        if ($constraint->validateOnlyUploadedFiles && !$value instanceof UploadedFile) {
             return true;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -34,6 +34,10 @@ class FileValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\File');
         }
 
+        if($constraint->validateOnlyUploadedFiles && !$value instanceof UploadedFile) {
+            return true;
+        }
+
         if (null === $value || '' === $value) {
             return;
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | no |

We use gaufrette filesystem mapped via SFTP and located very weird perfomance issue. We have such a code in our doctrine entities 

```
     * @Assert\File(
     *     maxSize="100M",
     *     mimeTypes={"image/png", "image/jpeg", "image/jpg", "image/bmp", "image/gif"},
     * )
     * @Vich\UploadableField(mapping="shop", fileNameProperty="logotype")
     * /
     public $file;
```

In background it check file each time we load entity. If we load 100 entities - validator do lot of the useless requests to remote server and page load speed decrease a lot (from 0.2 to 1.5 seconds just because of this validator behavior)

I have created small patch for this issue, what do you think about it?
