### PR TITLE
[Debug] fix handling deprecated warnings and stacked errors turned into exceptions

### DIFF
--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -134,12 +134,12 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             restore_error_handler();
 
             $handler = ErrorHandler::register(E_USER_DEPRECATED);
-            $this->assertTrue($handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array()));
+            $this->assertFalse($handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array()));
 
             restore_error_handler();
 
             $handler = ErrorHandler::register(E_DEPRECATED);
-            $this->assertTrue($handler->handle(E_DEPRECATED, 'foo', 'foo.php', 12, array()));
+            $this->assertFalse($handler->handle(E_DEPRECATED, 'foo', 'foo.php', 12, array()));
 
             restore_error_handler();
 
@@ -162,7 +162,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
             $handler = ErrorHandler::register(E_USER_DEPRECATED);
             $handler->setLogger($logger);
-            $handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array());
+            $this->assertTrue($handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array()));
 
             restore_error_handler();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

When no deprecation logger was registered, deprecated warnings were pretended to be handled (`return true`) when in fact there were just ignored. This is the first part fixed by this patch.
The second is in handleFatal(), when a stacked error was turned into an exception, this exception wasn't properly handled. Fixed also.
