### PR TITLE
[Security] Add check for supported attributes in AclVoter

### DIFF
--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -48,12 +48,16 @@ class AclVoter implements VoterInterface
 
     public function supportsAttribute($attribute)
     {
-        return $this->permissionMap->contains($attribute);
+        return is_string($attribute) && $this->permissionMap->contains($attribute);
     }
 
     public function vote(TokenInterface $token, $object, array $attributes)
     {
         foreach ($attributes as $attribute) {
+            if (!$this->supportsAttribute($attribute)) {
+                continue;
+            }
+
             if (null === $masks = $this->permissionMap->getMasks($attribute, $object)) {
                 continue;
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Couldn't get the tests to pass but the issues were unrelated to the change.

This fixes issues with Attribute containing ExpressionLanguage instance when using allow_if.
