### PR TITLE
[DependencyInjection] GraphvizDumper now displays unresolved parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Dumper;
 
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -164,8 +165,14 @@ class GraphvizDumper extends Dumper
         $container = $this->cloneContainer();
 
         foreach ($container->getDefinitions() as $id => $definition) {
-            $nodes[$id] = array('class' => str_replace('\\', '\\\\', $this->container->getParameterBag()->resolveValue($definition->getClass())), 'attributes' => array_merge($this->options['node.definition'], array('style' => ContainerInterface::SCOPE_PROTOTYPE !== $definition->getScope() ? 'filled' : 'dotted')));
+            $className = $definition->getClass();
 
+            try {
+                $className = $this->container->getParameterBag()->resolveValue($className);
+            } catch (ParameterNotFoundException $e) {
+            }
+
+            $nodes[$id] = array('class' => str_replace('\\', '\\\\', $className), 'attributes' => array_merge($this->options['node.definition'], array('style' => ContainerInterface::SCOPE_PROTOTYPE !== $definition->getScope() ? 'filled' : 'dotted')));
             $container->setDefinition($id, new Definition('stdClass'));
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
@@ -62,4 +62,12 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
         $dumper = new GraphvizDumper($container);
         $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services14.dot')), $dumper->dump(), '->dump() dumps services');
     }
+
+    public function testDumpWithUnresolvedParameter()
+    {
+        $container = include self::$fixturesPath.'/containers/container17.php';
+        $dumper = new GraphvizDumper($container);
+
+        $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services17.dot')), $dumper->dump(), '->dump() dumps services');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container17.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container17.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+$container = new ContainerBuilder();
+$container
+    ->register('foo', '%foo.class%')
+;
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services17.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services17.dot
@@ -1,0 +1,8 @@
+digraph sc {
+  ratio="compress"
+  node [fontsize="11" fontname="Arial" shape="record"];
+  edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
+
+  node_foo [label="foo\n%foo.class%\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Previously, the graphviz dumper would throw an exception if given a container with an unresolved parameter. This change allows it to render the parameter name instead of the class name if the class can not be resolved. This is also closer to the other DI dumpers which do not error out in these circumstances but simply carry the parameter name over.

For a practical use case, see: https://github.com/rosstuck/TuckConverterBundle/issues/1
