### PR TITLE
Added Interactive command trait.

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -31,19 +31,19 @@ use Symfony\Component\Console\Helper\HelperSet;
  */
 class Command
 {
-    private $application;
-    private $name;
-    private $processTitle;
-    private $aliases = array();
-    private $definition;
-    private $help;
-    private $description;
-    private $ignoreValidationErrors = false;
-    private $applicationDefinitionMerged = false;
-    private $applicationDefinitionMergedWithArgs = false;
-    private $code;
-    private $synopsis;
-    private $helperSet;
+    protected $application;
+    protected $name;
+    protected $processTitle;
+    protected $aliases = array();
+    protected $definition;
+    protected $help;
+    protected $description;
+    protected $ignoreValidationErrors = false;
+    protected $applicationDefinitionMerged = false;
+    protected $applicationDefinitionMergedWithArgs = false;
+    protected $code;
+    protected $synopsis;
+    protected $helperSet;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Console/Command/Interactive.php
+++ b/src/Symfony/Component/Console/Command/Interactive.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Symfony\Component\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+trait Interactive {
+    /**
+     * Interactively runs the command.
+     *
+     * The code to execute is either defined directly with the
+     * setCode() method or by overriding the execute() method
+     * in a sub-class.
+     *
+     * Asks question when missing arguments.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     *
+     * @return int     The command exit code
+     *
+     * @throws \Exception
+     *
+     * @see setCode()
+     * @see execute()
+     *
+     * @api
+     */
+    public function run(InputInterface $input, OutputInterface $output)
+    {
+        if (null !== $this->processTitle) {
+            if (function_exists('cli_set_process_title')) {
+                cli_set_process_title($this->processTitle);
+            } elseif (function_exists('setproctitle')) {
+                setproctitle($this->processTitle);
+            } elseif (OutputInterface::VERBOSITY_VERY_VERBOSE === $output->getVerbosity()) {
+                $output->writeln('<comment>Install the proctitle PECL to be able to change the process title.</comment>');
+            }
+        }
+
+        // force the creation of the synopsis before the merge with the app definition
+        $this->getSynopsis();
+
+        // add the application arguments and options
+        $this->mergeApplicationDefinition();
+
+        // bind the input against the command specific arguments/options
+        try {
+            $input->bind($this->definition);
+        } catch (\Exception $e) {
+            if (!$this->ignoreValidationErrors) {
+                throw $e;
+            }
+        }
+
+        $this->initialize($input, $output);
+
+        if ($input->isInteractive()) {
+            $this->interact($input, $output);
+        }
+
+        try {
+            $input->validate();
+        } catch (\RuntimeException $ex) {
+            foreach (array_keys($this->definition->getArguments()) as $argument) {
+                if (! isset($input->getArguments()[$argument])) {
+                    $helper = $this->getHelperSet()->get('question');
+
+                    $question = new Question($this->definition->getArguments()[$argument]->getDescription());
+                    $input->setArgument($argument, $helper->ask($input, $output, $question));
+                }
+            }
+
+            $input->validate();
+        }
+
+        if ($this->code) {
+            $statusCode = call_user_func($this->code, $input, $output);
+        } else {
+            $statusCode = $this->execute($input, $output);
+        }
+
+        return is_numeric($statusCode) ? (int) $statusCode : 0;
+    }
+}


### PR DESCRIPTION
Hi,

This a Proof of Concept PR which makes commands interactive when arguments are missing.

Missing in PR & notes:
- Compatibility (traits not available in PHP 5.3)
- Tests
- All `Command` properties have been set to protected, but only some are needed in the trait.

Possible extra features:
- Take configuration flags to:
  - Ask for options
    - "Give a value for: 'iterations'" <- `Question` when not `InputOption::VALUE_NONE`
    - "Set option 'yell'?" <- `ConfirmationQuestion` for `InputOption::VALUE_NONE`
  - Ask to ask for options "would you like to specify any options?"

The programmer could enable this on his application to provide for extra features. Some options for implementations:
- Trait (current)
- Extends `Command`
- As extra feature to the `Command` class

Example on [`GreetCommand`](http://symfony.com/doc/master/components/console/introduction.html#creating-a-basic-command) put `InputArgument::REQUIRED` for argument `name`. Then run `php application.php demo:greet`, the application will now ask: `Who do you want to greet?`
