### PR TITLE
[HttpKernel] Fixed cache behavior when TTL has expired and a default "global" TTL is defined

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -428,12 +428,6 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
         $response = $this->forward($subRequest, $catch);
 
-        if ($this->isPrivateRequest($request) && !$response->headers->hasCacheControlDirective('public')) {
-            $response->setPrivate(true);
-        } elseif ($this->options['default_ttl'] > 0 && null === $response->getTtl() && !$response->headers->getCacheControlDirective('must-revalidate')) {
-            $response->setTtl($this->options['default_ttl']);
-        }
-
         if ($response->isCacheable()) {
             $this->store($request, $response);
         }
@@ -486,6 +480,12 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         }
 
         $this->processResponseBody($request, $response);
+
+        if ($this->isPrivateRequest($request) && !$response->headers->hasCacheControlDirective('public')) {
+            $response->setPrivate(true);
+        } elseif ($this->options['default_ttl'] > 0 && null === $response->getTtl() && !$response->headers->getCacheControlDirective('must-revalidate')) {
+            $response->setTtl($this->options['default_ttl']);
+        }
 
         return $response;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #8232, #10822, #9919 |
| License | MIT |

From #9919:

"When the cache is stale the `validate` method `forward` the request to the backend. A new response will be created with or without TTL configuration. If the TTL was not set then the default one should be set like in the `fetch` method."

This PR fixes this issue, the tests provided in #9919 pass, and I've tweaked them to avoid the costly sleep calls.
