### PR TITLE
Update MessageSelector.php to show which value was passed

### DIFF
--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -82,7 +82,7 @@ class MessageSelector
                 return $standardRules[0];
             }
 
-            throw new \InvalidArgumentException(sprintf('Unable to choose a translation for "%s" with locale "%s". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %%count%% apples").', $message, $locale));
+            throw new \InvalidArgumentException(sprintf('Unable to choose a translation for "%s" with locale "%s" for value "%d". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %%count%% apples").', $message, $locale, $number));
         }
 
         return $standardRules[$position];


### PR DESCRIPTION
When the translator can't find a correct match using transChoice() a string is logged today with the following text:

<em>Unable to choose a translation for "[string]" with locale "[locale]". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %%count%% apples").</em>

This change introduces the value that was passed to transChoice() so the developer will have more information as to what value did not match any of the translation options:

<em>Unable to choose a translation for "[string]" with locale "[locale]" for value "[value]". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %%count%% apples").</em>
