### PR TITLE
[Form] Composer dependencies

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -25,7 +25,7 @@ class FormDataExtractorTest_SimpleValueExporter extends ValueExporter
     /**
      * {@inheritdoc}
      */
-    public function exportValue($value)
+    public function exportValue($value, $depth = 1, $deep = false)
     {
         return var_export($value, true);
     }

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -25,7 +25,9 @@
     "require-dev": {
         "symfony/validator": "~2.2",
         "symfony/http-foundation": "~2.2",
-        "symfony/security-csrf": "~2.4"
+        "symfony/http-kernel": "~2.4",
+        "symfony/security-csrf": "~2.4",
+        "doctrine/collections": "~1.0"
     },
     "suggest": {
         "symfony/validator": "For form validation.",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Right now, launching tests from the Form component's directory doesn't work, due to missing dev dependencies. This should be merged back into master afterwards.

Also fixed a problem related to a bad method signature in `Symfony\Component\Form\Tests\Extension\DataCollector\FormDataExtractorTest_SimpleValueExporter`
