### PR TITLE
[Component][Serializer] Support hydrating an existing object in GetSetMethodNormalizer.

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -54,11 +54,24 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testDenormalize()
+    public function testDenormalizeClass()
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'),
             __NAMESPACE__.'\GetSetDummy',
+            'any'
+        );
+        $this->assertEquals('foo', $obj->getFoo());
+        $this->assertEquals('bar', $obj->getBar());
+        $this->assertTrue($obj->isBaz());
+    }
+
+    public function testDenormalizeObject()
+    {
+        $obj = new GetSetDummy();
+        $obj = $this->normalizer->denormalize(
+            array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'),
+            $obj,
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());


### PR DESCRIPTION
Hello, 

GetSetMethodNormalizer always instantiates the class, I modified the code so that it does not instantiate the class and allows to call the setters of an existing object. 

Tell me if this is interesting so that I update the PHPDoc too. 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
