### PR TITLE
[HttpKernel] added an analyze of environment parameters for built-in server

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php
@@ -25,6 +25,7 @@ if (is_file($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$_SERVER['SCRIPT_NAME'
     return false;
 }
 
+$_SERVER = array_merge($_SERVER, $_ENV);
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app_dev.php';
 
 require 'app_dev.php';

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_prod.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_prod.php
@@ -25,6 +25,7 @@ if (is_file($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$_SERVER['SCRIPT_NAME'
     return false;
 }
 
+$_SERVER = array_merge($_SERVER, $_ENV);
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app.php';
 
 require 'app.php';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #10208 |
| License | MIT |
| Doc PR | - |

With the built-in server, it is not possible to use the external parameters: environment variables are only in `$_ENV`.
