### PR TITLE
[Validator] Added option for specifying the size format for the File validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -25,6 +25,7 @@ class File extends Constraint
 {
     public $maxSize = null;
     public $mimeTypes = array();
+    public $sizeFormat = FileValidator::SIZE_FORMAT_DECIMAL;
     public $notFoundMessage = 'The file could not be found.';
     public $notReadableMessage = 'The file is not readable.';
     public $maxSizeMessage = 'The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.';

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -107,13 +107,17 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($this->getFile($this->path), $constraint);
     }
 
-    public function testTooLargeKiloBytes()
+    /**
+     * @dataProvider sizeFormatProvider
+     */
+    public function testTooLargeKiloBytes($sizeFormat, $size)
     {
-        fwrite($this->file, str_repeat('0', 1400));
+        fwrite($this->file, str_repeat('0', 1.4 * $size));
 
         $constraint = new File(array(
             'maxSize'           => '1k',
             'maxSizeMessage'    => 'myMessage',
+            'sizeFormat'        => $sizeFormat,
         ));
 
         $this->context->expects($this->once())
@@ -128,13 +132,17 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($this->getFile($this->path), $constraint);
     }
 
-    public function testTooLargeMegaBytes()
+    /**
+     * @dataProvider sizeFormatProvider
+     */
+    public function testTooLargeMegaBytes($sizeFormat, $size)
     {
-        fwrite($this->file, str_repeat('0', 1400000));
+        fwrite($this->file, str_repeat('0', 1.4 * pow($size, 2)));
 
         $constraint = new File(array(
             'maxSize'           => '1M',
             'maxSizeMessage'    => 'myMessage',
+            'sizeFormat'        => $sizeFormat,
         ));
 
         $this->context->expects($this->once())
@@ -303,6 +311,14 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->validator->validate($file, $constraint);
 
+    }
+
+    public function sizeFormatProvider()
+    {
+        return array(
+            array('binary', 1024),
+            array('decimal', 1000),
+        );
     }
 
     public function uploadedFileErrorProvider()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | yes and no, as the current calculation is not consistent |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10648 |
| License | MIT |
| Doc PR | - |

This lets someone choose between binary (multiples of 1024) and decimal (multiple of 1000) formats for specifying the size.

Example:

``` php
use Symfony\Component\Validator\Constraints as Assert;

class Curriculum
{
    /**
     * @Assert\File(size=2000, sizeFormat="decimal")
    */
    public $file;
}
```

By default, the size format is in binary.
