### PR TITLE
[MemcacheSessionHandler] [MemcachedSessionHandler] added option to explicitly set memcace prefix to nothing.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -55,7 +55,7 @@ class MemcacheSessionHandler implements \SessionHandlerInterface
 
         $this->memcache = $memcache;
         $this->ttl = isset($options['expiretime']) ? (int) $options['expiretime'] : 86400;
-        $this->prefix = isset($options['prefix']) ? $options['prefix'] : 'sf2s';
+        $this->prefix = array_key_exists('prefix', $options) ? $options['prefix'] : 'sf2s';
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -61,7 +61,7 @@ class MemcachedSessionHandler implements \SessionHandlerInterface
         }
 
         $this->ttl = isset($options['expiretime']) ? (int) $options['expiretime'] : 86400;
-        $this->prefix = isset($options['prefix']) ? $options['prefix'] : 'sf2s';
+        $this->prefix = array_key_exists('prefix', $options) ? $options['prefix'] : 'sf2s';
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Previous code insisted your memcache session have a prefix. I understand it is good practice to have one, but when working with an old simplesaml project none was set and I could not add one without having update several other products. Our Symfony 2.4 code was unable to get that saml session from memcache because it kept insisting on giving the session id a prefix of 'sf2s'. 

This code will now give the 'sf2s' prefix when no prefix is set, but you can explicitly set the prefix to null or empty string to have no prefix at all.
