### PR TITLE
[Debug] generic ErrorHandler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -61,6 +61,9 @@ class FrameworkExtension extends Extension
         if ($container->getParameter('kernel.debug')) {
             $loader->load('debug.xml');
 
+            $definition = $container->findDefinition('debug.debug_handlers_listener');
+            $definition->replaceArgument(0, array(new Reference('http_kernel', ContainerInterface::NULL_ON_INVALID_REFERENCE), 'terminateWithException'));
+
             $definition = $container->findDefinition('http_kernel');
             $definition->replaceArgument(2, new Reference('debug.controller_resolver'));
 
@@ -69,6 +72,9 @@ class FrameworkExtension extends Extension
             $definition->setPublic(false);
             $container->setDefinition('debug.event_dispatcher.parent', $definition);
             $container->setAlias('event_dispatcher', 'debug.event_dispatcher');
+        } else {
+            $definition = $container->findDefinition('debug.debug_handlers_listener');
+            $definition->replaceArgument(2, E_COMPILE_ERROR | E_PARSE | E_ERROR | E_CORE_ERROR);
         }
 
         $configuration = $this->getConfiguration($configs, $container);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -9,7 +9,6 @@
         <parameter key="debug.stopwatch.class">Symfony\Component\Stopwatch\Stopwatch</parameter>
         <parameter key="debug.container.dump">%kernel.cache_dir%/%kernel.container_class%.xml</parameter>
         <parameter key="debug.controller_resolver.class">Symfony\Component\HttpKernel\Controller\TraceableControllerResolver</parameter>
-        <parameter key="debug.debug_handlers_listener.class">Symfony\Component\HttpKernel\EventListener\DebugHandlersListener</parameter>
     </parameters>
 
     <services>
@@ -25,28 +24,6 @@
         <service id="debug.controller_resolver" class="%debug.controller_resolver.class%">
             <argument type="service" id="controller_resolver" />
             <argument type="service" id="debug.stopwatch" />
-        </service>
-
-        <service id="debug.deprecation_logger_listener" class="%debug.errors_logger_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <tag name="monolog.logger" channel="deprecation" />
-            <argument>deprecation</argument>
-            <argument type="service" id="logger" on-invalid="null" />
-        </service>
-
-        <service id="debug.scream_logger_listener" class="%debug.errors_logger_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <tag name="monolog.logger" channel="scream" />
-            <argument>scream</argument>
-            <argument type="service" id="logger" on-invalid="null" />
-        </service>
-
-        <service id="debug.debug_handlers_listener" class="%debug.debug_handlers_listener.class%">
-            <tag name="kernel.event_subscriber" />
-            <argument type="collection">
-                <argument type="service" id="http_kernel" on-invalid="null" />
-                <argument>terminateWithException</argument>
-            </argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -5,15 +5,17 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="debug.errors_logger_listener.class">Symfony\Component\HttpKernel\EventListener\ErrorsLoggerListener</parameter>
+        <parameter key="debug.debug_handlers_listener.class">Symfony\Component\HttpKernel\EventListener\DebugHandlersListener</parameter>
     </parameters>
 
     <services>
-        <service id="debug.emergency_logger_listener" class="%debug.errors_logger_listener.class%">
+        <service id="debug.debug_handlers_listener" class="%debug.debug_handlers_listener.class%">
             <tag name="kernel.event_subscriber" />
-            <tag name="monolog.logger" channel="emergency" />
-            <argument>emergency</argument>
+            <tag name="monolog.logger" channel="php" />
+            <argument /><!-- Exception handler -->
             <argument type="service" id="logger" on-invalid="null" />
+            <argument /><!-- Log levels map for enabled error levels -->
+            <argument>%kernel.debug%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -21,7 +21,7 @@
         "symfony/config" : "~2.4",
         "symfony/event-dispatcher": "~2.5",
         "symfony/http-foundation": "~2.4",
-        "symfony/http-kernel": "~2.5",
+        "symfony/http-kernel": "~2.6",
         "symfony/filesystem": "~2.3",
         "symfony/routing": "~2.2",
         "symfony/security-core": "~2.4",

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -105,7 +105,7 @@
 
 
 {% macro display_message(log_index, log) %}
-    {% if constant('Symfony\\Component\\HttpKernel\\Debug\\ErrorHandler::TYPE_DEPRECATION') == log.context.type|default(0) %}
+    {% if log.context.level is defined and log.context.type is defined and (constant('E_DEPRECATED') == log.context.type or constant('E_USER_DEPRECATED') == log.context.type) %}
         DEPRECATION -  {{ log.message }}
         {% set id = 'sf-call-stack-' ~ log_index %}
         <a href="#" onclick="Sfjs.toggle('{{ id }}', document.getElementById('{{ id }}-on'), document.getElementById('{{ id }}-off')); return false;">

--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 2.6.0
 -----
 
+* generalized ErrorHandler and ExceptionHandler,
+  with some new methods and others deprecated
 * enhanced error messages for uncaught exceptions
 
 2.5.0

--- a/src/Symfony/Component/Debug/Debug.php
+++ b/src/Symfony/Component/Debug/Debug.php
@@ -39,14 +39,22 @@ class Debug
 
         static::$enabled = true;
 
-        error_reporting(-1);
+        if (null !== $errorReportingLevel) {
+            error_reporting($errorReportingLevel);
+        } else {
+            error_reporting(-1);
+        }
 
-        ErrorHandler::register($errorReportingLevel, $displayErrors);
         if ('cli' !== php_sapi_name()) {
+            ini_set('display_errors', 0);
             ExceptionHandler::register();
-        // CLI - display errors only if they're not already logged to STDERR
         } elseif ($displayErrors && (!ini_get('log_errors') || ini_get('error_log'))) {
+            // CLI - display errors only if they're not already logged to STDERR
             ini_set('display_errors', 1);
+        }
+        $handler = ErrorHandler::register();
+        if (!$displayErrors) {
+            $handler->throwAt(0, true);
         }
 
         DebugClassLoader::enable();

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -78,7 +78,7 @@ class DebugClassLoader
     public static function enable()
     {
         // Ensures we don't hit https://bugs.php.net/42098
-        class_exists(__NAMESPACE__.'\ErrorHandler', true);
+        class_exists('Symfony\Component\Debug\ErrorHandler');
 
         if (!is_array($functions = spl_autoload_functions())) {
             return;

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -22,188 +22,492 @@ use Symfony\Component\Debug\FatalErrorHandler\ClassNotFoundFatalErrorHandler;
 use Symfony\Component\Debug\FatalErrorHandler\FatalErrorHandlerInterface;
 
 /**
- * ErrorHandler.
+ * A generic ErrorHandler for the PHP engine.
  *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Konstantin Myakshin <koc-dp@yandex.ru>
+ * Provides five bit fields that control how errors are handled:
+ * - thrownErrors: errors thrown as \ErrorException
+ * - loggedErrors: logged errors, when not @-silenced
+ * - scopedErrors: errors thrown or logged with their local context
+ * - tracedErrors: errors logged with their stack trace, only once for repeated errors
+ * - screamedErrors: never @-silenced errors
+ *
+ * Each error level can be logged by a dedicated PSR-3 logger object.
+ * Screaming only applies to logging.
+ * Throwing takes precedence over logging.
+ * Uncaught exceptions are logged as E_ERROR.
+ * E_DEPRECATED and E_USER_DEPRECATED levels never throw.
+ * E_RECOVERABLE_ERROR and E_USER_ERROR levels always throw.
+ * Non catchable errors that can be detected at shutdown time are logged when the scream bit field allows so.
+ * As errors have a performance cost, repeated errors are all logged, so that the developer
+ * can see them and weight them as more important to fix than others of the same level.
+ *
  * @author Nicolas Grekas <p@tchwork.com>
  */
 class ErrorHandler
 {
+    /**
+     * @deprecated since 2.6, to be removed in 3.0.
+     */
     const TYPE_DEPRECATION = -100;
 
     private $levels = array(
-        E_WARNING           => 'Warning',
-        E_NOTICE            => 'Notice',
-        E_USER_ERROR        => 'User Error',
-        E_USER_WARNING      => 'User Warning',
-        E_USER_NOTICE       => 'User Notice',
-        E_STRICT            => 'Runtime Notice',
-        E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
         E_DEPRECATED        => 'Deprecated',
         E_USER_DEPRECATED   => 'User Deprecated',
-        E_ERROR             => 'Error',
-        E_CORE_ERROR        => 'Core Error',
+        E_NOTICE            => 'Notice',
+        E_USER_NOTICE       => 'User Notice',
+        E_STRICT            => 'Runtime Notice',
+        E_WARNING           => 'Warning',
+        E_USER_WARNING      => 'User Warning',
+        E_COMPILE_WARNING   => 'Compile Warning',
+        E_CORE_WARNING      => 'Core Warning',
+        E_USER_ERROR        => 'User Error',
+        E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
         E_COMPILE_ERROR     => 'Compile Error',
         E_PARSE             => 'Parse Error',
+        E_ERROR             => 'Error',
+        E_CORE_ERROR        => 'Core Error',
     );
 
-    private $level;
+    private $loggers = array(
+        E_DEPRECATED        => array(null, LogLevel::INFO),
+        E_USER_DEPRECATED   => array(null, LogLevel::INFO),
+        E_NOTICE            => array(null, LogLevel::NOTICE),
+        E_USER_NOTICE       => array(null, LogLevel::NOTICE),
+        E_STRICT            => array(null, LogLevel::NOTICE),
+        E_WARNING           => array(null, LogLevel::WARNING),
+        E_USER_WARNING      => array(null, LogLevel::WARNING),
+        E_COMPILE_WARNING   => array(null, LogLevel::WARNING),
+        E_CORE_WARNING      => array(null, LogLevel::WARNING),
+        E_USER_ERROR        => array(null, LogLevel::ERROR),
+        E_RECOVERABLE_ERROR => array(null, LogLevel::ERROR),
+        E_COMPILE_ERROR     => array(null, LogLevel::EMERGENCY),
+        E_PARSE             => array(null, LogLevel::EMERGENCY),
+        E_ERROR             => array(null, LogLevel::EMERGENCY),
+        E_CORE_ERROR        => array(null, LogLevel::EMERGENCY),
+    );
 
-    private $reservedMemory;
+    private $thrownErrors = 0x1FFF; // E_ALL - E_DEPRECATED - E_USER_DEPRECATED
+    private $scopedErrors = 0x1FFF; // E_ALL - E_DEPRECATED - E_USER_DEPRECATED
+    private $tracedErrors = 0x77FB; // E_ALL - E_STRICT - E_PARSE
+    private $screamedErrors = 0x55; // E_ERROR + E_CORE_ERROR + E_COMPILE_ERROR + E_PARSE
+    private $loggedErrors = 0;
 
-    private $displayErrors;
+    private $loggedTraces = array();
+    private $isRecursive = 0;
+    private $exceptionHandler;
+
+    private static $reservedMemory;
+    private static $stackedErrors = array();
+    private static $stackedErrorLevels = array();
 
     /**
-     * @var LoggerInterface[] Loggers for channels
+     * Same init value as thrownErrors
+     *
+     * @deprecated since 2.6, to be removed in 3.0.
      */
-    private static $loggers = array();
-
-    private static $stackedErrors = array();
-
-    private static $stackedErrorLevels = array();
+    private $displayErrors = 0x1FFF;
 
     /**
      * Registers the error handler.
      *
-     * @param int  $level         The level at which the conversion to Exception is done (null to use the error_reporting() value and 0 to disable)
-     * @param bool $displayErrors Display errors (for dev environment) or just log them (production usage)
+     * @param int  $levels Levels to register to for throwing, 0 for none
+     * @param bool $throw  @deprecated argument, same as setting $levels to 0
      *
      * @return ErrorHandler The registered error handler
      */
-    public static function register($level = null, $displayErrors = true)
+    public static function register($levels = -1, $throw = true)
     {
-        $handler = new static();
-        $handler->setLevel($level);
-        $handler->setDisplayErrors($displayErrors);
+        if (null === self::$reservedMemory) {
+            self::$reservedMemory = str_repeat('x', 10240);
+            register_shutdown_function(__CLASS__.'::handleFatalError');
+        }
 
-        ini_set('display_errors', 0);
-        set_error_handler(array($handler, 'handle'));
-        register_shutdown_function(array($handler, 'handleFatal'));
-        $handler->reservedMemory = str_repeat('x', 10240);
+        $handler = new static();
+        $levels &= $handler->thrownErrors;
+        set_error_handler(array($handler, 'handleError'), $levels);
+        $handler->throwAt($throw ? $levels : 0, true);
+        $handler->setExceptionHandler(set_exception_handler(array($handler, 'handleException')));
 
         return $handler;
     }
 
     /**
-     * Sets the level at which the conversion to Exception is done.
+     * Sets a logger to non assigned errors levels.
      *
-     * @param int|null     $level The level (null to use the error_reporting() value and 0 to disable)
+     * @param LoggerInterface $logger  A PSR-3 logger to put as default for the given levels
+     * @param array|int       $levels  An array map of E_* to LogLevel::* or an integer bit field of E_* constants
+     * @param bool            $replace Whether to replace or not any existing logger
      */
-    public function setLevel($level)
+    public function setDefaultLogger(LoggerInterface $logger, $levels = null, $replace = false)
     {
-        $this->level = null === $level ? error_reporting() : $level;
+        $loggers = array();
+
+        if (is_array($levels)) {
+            foreach ($levels as $type => $logLevel) {
+                if (empty($this->loggers[$type][0]) || $replace) {
+                    $loggers[$type] = array($logger, $logLevel);
+                }
+            }
+        } else {
+            if (null === $levels) {
+                $levels = E_ALL | E_STRICT;
+            }
+            foreach ($this->loggers as $type => $log) {
+                if (($type & $levels) && (empty($log[0]) || $replace)) {
+                    $log[0] = $logger;
+                    $loggers[$type] = $log;
+                }
+            }
+        }
+
+        $this->setLoggers($loggers);
     }
 
     /**
-     * Sets the display_errors flag value.
+     * Sets a logger for each error level.
      *
-     * @param int     $displayErrors The display_errors flag value
+     * @param array $loggers Error levels to [LoggerInterface|null, LogLevel::*] map
+     *
+     * @return array The previous map
+     *
+     * @throws \InvalidArgumentException
      */
-    public function setDisplayErrors($displayErrors)
+    public function setLoggers(array $loggers)
     {
-        $this->displayErrors = $displayErrors;
+        $prevLogged = $this->loggedErrors;
+        $prev = $this->loggers;
+
+        foreach ($loggers as $type => $log) {
+            if (!isset($prev[$type])) {
+                throw new \InvalidArgumentException('Unknown error type: '.$type);
+            }
+            if (!is_array($log)) {
+                $log = array($log);
+            } elseif (!array_key_exists(0, $log)) {
+                throw new \InvalidArgumentException('No logger provided');
+            }
+            if (null === $log[0]) {
+                $this->loggedErrors &= ~$type;
+            } elseif ($log[0] instanceof LoggerInterface) {
+                $this->loggedErrors |= $type;
+            } else {
+                throw new \InvalidArgumentException('Invalid logger provided');
+            }
+            $this->loggers[$type] = $log + $prev[$type];
+        }
+        $this->reRegister($prevLogged | $this->thrownErrors);
+
+        return $prev;
     }
 
     /**
-     * Sets a logger for the given channel.
+     * Sets a user exception handler.
      *
-     * @param LoggerInterface $logger  A logger interface
-     * @param string          $channel The channel associated with the logger (deprecation, emergency or scream)
+     * @param callable $handler A handler that will be called on Exception
+     *
+     * @return callable|null The previous exception handler
+     *
+     * @throws \InvalidArgumentException
      */
-    public static function setLogger(LoggerInterface $logger, $channel = 'deprecation')
+    public function setExceptionHandler($handler)
     {
-        self::$loggers[$channel] = $logger;
+        if (null !== $handler && !is_callable($handler)) {
+            throw new \LogicException('The exception handler must be a valid PHP callable.');
+        }
+        $prev = $this->exceptionHandler;
+        $this->exceptionHandler = $handler;
+
+        return $prev;
     }
 
     /**
-     * @throws \ErrorException When error_reporting returns error
+     * Sets the error levels that are to be thrown.
+     *
+     * @param int  $levels  A bit field of E_* constants for thrown errors
+     * @param bool $replace Replace or amend the previous value
+     *
+     * @return int The previous value
      */
-    public function handle($level, $message, $file = 'unknown', $line = 0, $context = array())
+    public function throwAt($levels, $replace = false)
     {
-        if ($level & (E_USER_DEPRECATED | E_DEPRECATED)) {
-            if (isset(self::$loggers['deprecation'])) {
-                if (self::$stackedErrorLevels) {
-                    self::$stackedErrors[] = func_get_args();
+        $prev = $this->thrownErrors;
+        $this->thrownErrors = ($levels | E_RECOVERABLE_ERROR | E_USER_ERROR) & ~E_USER_DEPRECATED & ~E_DEPRECATED;
+        if (!$replace) {
+            $this->thrownErrors |= $prev;
+        }
+        $this->reRegister($prev | $this->loggedErrors);
+
+        // $this->displayErrors is @deprecated since 2.6
+        $this->displayErrors = $this->thrownErrors;
+
+        return $prev;
+    }
+
+    /**
+     * Sets the error levels that are logged or thrown with their local scope.
+     *
+     * @param int  $levels  A bit field of E_* constants for scoped errors
+     * @param bool $replace Replace or amend the previous value
+     *
+     * @return int The previous value
+     */
+    public function scopeAt($levels, $replace = false)
+    {
+        $prev = $this->scopedErrors;
+        $this->scopedErrors = (int) $levels;
+        if (!$replace) {
+            $this->scopedErrors |= $prev;
+        }
+
+        return $prev;
+    }
+
+    /**
+     * Sets the error levels that are logged with their stack trace.
+     *
+     * @param int  $levels  A bit field of E_* constants for traced errors
+     * @param bool $replace Replace or amend the previous value
+     *
+     * @return int The previous value
+     */
+    public function traceAt($levels, $replace = false)
+    {
+        $prev = $this->tracedErrors;
+        $this->tracedErrors = (int) $levels;
+        if (!$replace) {
+            $this->tracedErrors |= $prev;
+        }
+
+        return $prev;
+    }
+
+    /**
+     * Sets the error levels where the @-operator is ignored.
+     *
+     * @param int  $levels  A bit field of E_* constants for screamed errors
+     * @param bool $replace Replace or amend the previous value
+     *
+     * @return int The previous value
+     */
+    public function screamAt($levels, $replace = false)
+    {
+        $prev = $this->screamedErrors;
+        $this->screamedErrors = (int) $levels;
+        if (!$replace) {
+            $this->screamedErrors |= $prev;
+        }
+
+        return $prev;
+    }
+
+    /**
+     * Re-registers as a PHP error handler if levels changed.
+     */
+    private function reRegister($prev)
+    {
+        if ($prev !== $this->thrownErrors | $this->loggedErrors) {
+            $handler = set_error_handler('var_dump', 0);
+            $handler = is_array($handler) ? $handler[0] : null;
+            restore_error_handler();
+            if ($handler === $this) {
+                restore_error_handler();
+                set_error_handler(array($this, 'handleError'), $this->thrownErrors | $this->loggedErrors);
+            }
+        }
+    }
+
+    /**
+     * Handles errors by filtering then logging them according to the configured bit fields.
+     *
+     * @param int    $type One of the E_* constants
+     * @param string $file
+     * @param int    $line
+     * @param array  $context
+     *
+     * @return bool Returns false when no handling happens so that the PHP engine can handle the error itself.
+     *
+     * @throws \ErrorException When $this->thrownErrors requests so
+     *
+     * @internal
+     */
+    public function handleError($type, $message, $file, $line, array $context)
+    {
+        $level = error_reporting() | E_RECOVERABLE_ERROR | E_USER_ERROR;
+        $log = $this->loggedErrors & $type;
+        $throw = $this->thrownErrors & $type & $level;
+        $type &= $level | $this->screamedErrors;
+
+        if ($type && ($log || $throw)) {
+            if (PHP_VERSION_ID < 50400 && isset($context['GLOBALS']) && ($this->scopedErrors & $type)) {
+                $e = $context;                  // Whatever the signature of the method,
+                unset($e['GLOBALS'], $context); // $context is always a reference in 5.3
+                $context = $e;
+            }
+
+            if ($throw) {
+                if (($this->scopedErrors & $type) && class_exists('Symfony\Component\Debug\Exception\ContextErrorException')) {
+                    // Checking for class existence is a work around for https://bugs.php.net/42098
+                    $throw = new ContextErrorException($this->levels[$type].': '.$message, 0, $type, $file, $line, $context);
                 } else {
-                    if (version_compare(PHP_VERSION, '5.4', '<')) {
-                        $stack = array_map(
-                            function ($row) {
-                                unset($row['args']);
+                    $throw = new \ErrorException($this->levels[$type].': '.$message, 0, $type, $file, $line);
+                }
 
-                                return $row;
-                            },
-                            array_slice(debug_backtrace(false), 0, 10)
-                        );
-                    } else {
-                        $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+                if (PHP_VERSION_ID <= 50407 && (PHP_VERSION_ID >= 50400 || PHP_VERSION_ID <= 50317)) {
+                    // Exceptions thrown from error handlers are sometimes not caught by the exception
+                    // handler and shutdown handlers are bypassed before 5.4.8/5.3.18.
+                    // We temporarily re-enable display_errors to prevent any blank page related to this bug.
+
+                    $throw->errorHandlerCanary = new ErrorHandlerCanary();
+                }
+
+                throw $throw;
+            }
+
+            // For duplicated errors, log the trace only once
+            $e = md5("{$type}/{$line}/{$file}\x00{$message}", true);
+            $trace = true;
+
+            if (!($this->tracedErrors & $type) || isset($this->loggedTraces[$e])) {
+                $trace = false;
+            } else {
+                $this->loggedTraces[$e] = 1;
+            }
+
+            $e = compact('type', 'file', 'line', 'level');
+
+            if ($type & $level) {
+                if ($this->scopedErrors & $type) {
+                    $e['context'] = $context;
+                    if ($trace) {
+                        $e['stack'] = debug_backtrace(true); // Provide object
                     }
-
-                    self::$loggers['deprecation']->warning($message, array('type' => self::TYPE_DEPRECATION, 'stack' => $stack));
+                } elseif ($trace) {
+                    $e['stack'] = debug_backtrace(PHP_VERSION_ID >= 50306 ? DEBUG_BACKTRACE_IGNORE_ARGS : false);
                 }
-
-                return true;
-            }
-        } elseif ($this->displayErrors && error_reporting() & $level && $this->level & $level) {
-            if (PHP_VERSION_ID < 50400 && isset($context['GLOBALS']) && is_array($context)) {
-                $c = $context;                  // Whatever the signature of the method,
-                unset($c['GLOBALS'], $context); // $context is always a reference in 5.3
-                $context = $c;
             }
 
-            $exception = sprintf('%s: %s', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message);
-            if ($context && class_exists('Symfony\Component\Debug\Exception\ContextErrorException')) {
-                // Checking for class existence is a work around for https://bugs.php.net/42098
-                $exception = new ContextErrorException($exception, 0, $level, $file, $line, $context);
+            if ($this->isRecursive) {
+                $log = 0;
+            } elseif (self::$stackedErrorLevels) {
+                self::$stackedErrors[] = array($this->loggers[$type], $message, $e);
             } else {
-                $exception = new \ErrorException($exception, 0, $level, $file, $line);
-            }
+                try {
+                    $this->isRecursive = true;
+                    $this->loggers[$type][0]->log($this->loggers[$type][1], $message, $e);
+                    $this->isRecursive = false;
+                } catch (\Exception $e) {
+                    $this->isRecursive = false;
 
-            if (PHP_VERSION_ID <= 50407 && (PHP_VERSION_ID >= 50400 || PHP_VERSION_ID <= 50317)) {
-                // Exceptions thrown from error handlers are sometimes not caught by the exception
-                // handler and shutdown handlers are bypassed before 5.4.8/5.3.18.
-                // We temporarily re-enable display_errors to prevent any blank page related to this bug.
-
-                $exception->errorHandlerCanary = new ErrorHandlerCanary();
-            }
-
-            throw $exception;
-        }
-
-        if (isset(self::$loggers['scream']) && !(error_reporting() & $level)) {
-            if (self::$stackedErrorLevels) {
-                self::$stackedErrors[] = func_get_args();
-            } else {
-                switch ($level) {
-                    case E_USER_ERROR:
-                    case E_RECOVERABLE_ERROR:
-                        $logLevel = LogLevel::ERROR;
-                        break;
-
-                    case E_WARNING:
-                    case E_USER_WARNING:
-                        $logLevel = LogLevel::WARNING;
-                        break;
-
-                    default:
-                        $logLevel = LogLevel::NOTICE;
-                        break;
+                    throw $e;
                 }
-
-                self::$loggers['scream']->log($logLevel, $message, array(
-                    'type' => $level,
-                    'file' => $file,
-                    'line' => $line,
-                    'scream' => error_reporting(),
-                ));
             }
         }
 
-        return false;
+        return $type && $log;
     }
 
     /**
-     * Configure the error handler for delayed handling.
+     * Handles an exception by logging then forwarding it to an other handler.
+     *
+     * @param \Exception $exception An exception to handle
+     * @param array      $error     An array as returned by error_get_last()
+     *
+     * @internal
+     */
+    public function handleException(\Exception $exception, array $error = null)
+    {
+        $level = error_reporting();
+        if ($this->loggedErrors & E_ERROR & ($level | $this->screamedErrors)) {
+            $e = array(
+                'type' => E_ERROR,
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+                'level' => $level,
+                'stack' => $exception->getTrace(),
+            );
+            if ($exception instanceof FatalErrorException) {
+                $message = 'Fatal '.$exception->getMessage();
+            } elseif ($exception instanceof \ErrorException) {
+                $message = 'Uncaught '.$exception->getMessage();
+                if ($exception instanceof ContextErrorException) {
+                    $e['context'] = $exception->getContext();
+                }
+            } else {
+                $message = 'Uncaught Exception: '.$exception->getMessage();
+            }
+            if ($this->loggedErrors & $e['type']) {
+                $this->loggers[$e['type']][0]->log($this->loggers[$e['type']][1], $message, $e);
+            }
+        }
+        if ($exception instanceof FatalErrorException && !$exception instanceof OutOfMemoryException && $error) {
+            foreach ($this->getFatalErrorHandlers() as $handler) {
+                if ($e = $handler->handleError($error, $exception)) {
+                    $exception = $e;
+                    break;
+                }
+            }
+        }
+        if (empty($this->exceptionHandler)) {
+            throw $exception; // Give back $exception to the native handler
+        }
+        try {
+            call_user_func($this->exceptionHandler, $exception);
+        } catch (\Exception $handlerException) {
+            $this->exceptionHandler = null;
+            $this->handleException($handlerException);
+        }
+    }
+
+    /**
+     * Shutdown registered function for handling PHP fatal errors.
+     *
+     * @param array $error An array as returned by error_get_last()
+     *
+     * @internal
+     */
+    public static function handleFatalError(array $error = null)
+    {
+        self::$reservedMemory = '';
+        gc_collect_cycles();
+        $handler = set_error_handler('var_dump', 0);
+        $handler = is_array($handler) ? $handler[0] : null;
+        restore_error_handler();
+        if ($handler instanceof self) {
+            if (null === $error) {
+                $error = error_get_last();
+            }
+
+            try {
+                while (self::$stackedErrorLevels) {
+                    static::unstackErrors();
+                }
+            } catch (\Exception $exception) {
+                // Handled below
+            }
+
+            if ($error && ($error['type'] & (E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR))) {
+                // Let's not throw anymore but keep logging
+                $handler->throwAt(0, true);
+
+                if (0 === strpos($error['message'], 'Allowed memory') || 0 === strpos($error['message'], 'Out of memory')) {
+                    $exception = new OutOfMemoryException($handler->levels[$error['type']].': '.$error['message'], 0, $error['type'], $error['file'], $error['line'], 2, false);
+                } else {
+                    $exception = new FatalErrorException($handler->levels[$error['type']].': '.$error['message'], 0, $error['type'], $error['file'], $error['line'], 2, true);
+                }
+            } elseif (!isset($exception)) {
+                return;
+            }
+
+            try {
+                $handler->handleException($exception, $error);
+            } catch (FatalErrorException $e) {
+                // Ignore this re-throw
+            }
+        }
+    }
+
+    /**
+     * Configures the error handler for delayed handling.
      * Ensures also that non-catchable fatal errors are never silenced.
      *
      * As shown by http://bugs.php.net/42098 and http://bugs.php.net/60724
@@ -219,7 +523,7 @@ class ErrorHandler
     }
 
     /**
-     * Unstacks stacked errors and forwards to the regular handler
+     * Unstacks stacked errors and forwards to the logger
      */
     public static function unstackErrors()
     {
@@ -237,61 +541,9 @@ class ErrorHandler
             $errors = self::$stackedErrors;
             self::$stackedErrors = array();
 
-            $errorHandler = set_error_handler('var_dump');
-            restore_error_handler();
-
-            if ($errorHandler) {
-                foreach ($errors as $e) {
-                    call_user_func_array($errorHandler, $e);
-                }
+            foreach ($errors as $e) {
+                $e[0][0]->log($e[0][1], $e[1], $e[2]);
             }
-        }
-    }
-
-    public function handleFatal()
-    {
-        $this->reservedMemory = '';
-        gc_collect_cycles();
-        $error = error_get_last();
-
-        // get current exception handler
-        $exceptionHandler = set_exception_handler('var_dump');
-        restore_exception_handler();
-
-        try {
-            while (self::$stackedErrorLevels) {
-                static::unstackErrors();
-            }
-        } catch (\Exception $exception) {
-            if ($exceptionHandler) {
-                call_user_func($exceptionHandler, $exception);
-
-                return;
-            }
-
-            if ($this->displayErrors) {
-                ini_set('display_errors', 1);
-            }
-
-            throw $exception;
-        }
-
-        if (!$error || !$this->level || !($error['type'] & (E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_PARSE))) {
-            return;
-        }
-
-        if (isset(self::$loggers['emergency'])) {
-            $fatal = array(
-                'type' => $error['type'],
-                'file' => $error['file'],
-                'line' => $error['line'],
-            );
-
-            self::$loggers['emergency']->emergency($error['message'], $fatal);
-        }
-
-        if ($this->displayErrors && $exceptionHandler) {
-            $this->handleFatalError($exceptionHandler, $error);
         }
     }
 
@@ -311,32 +563,81 @@ class ErrorHandler
         );
     }
 
-    private function handleFatalError($exceptionHandler, array $error)
+    /**
+     * Sets the level at which the conversion to Exception is done.
+     *
+     * @param int|null     $level The level (null to use the error_reporting() value and 0 to disable)
+     *
+     * @deprecated since 2.6, to be removed in 3.0. Use throwAt() instead.
+     */
+    public function setLevel($level)
     {
-        // Let PHP handle any further error
-        set_error_handler('var_dump', 0);
-        ini_set('display_errors', 1);
+        $level = null === $level ? error_reporting() : $level;
+        $this->throwAt($level, true);
+    }
 
-        $exception = sprintf('%s: %s', $this->levels[$error['type']], $error['message']);
-        if (0 === strpos($error['message'], 'Allowed memory') || 0 === strpos($error['message'], 'Out of memory')) {
-            $exception = new OutOfMemoryException($exception, 0, $error['type'], $error['file'], $error['line'], 3, false);
+    /**
+     * Sets the display_errors flag value.
+     *
+     * @param int     $displayErrors The display_errors flag value
+     *
+     * @deprecated since 2.6, to be removed in 3.0. Use throwAt() instead.
+     */
+    public function setDisplayErrors($displayErrors)
+    {
+        if ($displayErrors) {
+            $this->throwAt($this->displayErrors, true);
         } else {
-            $exception = new FatalErrorException($exception, 0, $error['type'], $error['file'], $error['line'], 3, true);
-
-            foreach ($this->getFatalErrorHandlers() as $handler) {
-                if ($e = $handler->handleError($error, $exception)) {
-                    $exception = $e;
-                    break;
-                }
-            }
+            $displayErrors = $this->displayErrors;
+            $this->throwAt(0, true);
+            $this->displayErrors = $displayErrors;
         }
+    }
 
-        try {
-            call_user_func($exceptionHandler, $exception);
-        } catch (\Exception $e) {
-            // The handler failed. Let PHP handle that now.
-            throw $exception;
+    /**
+     * Sets a logger for the given channel.
+     *
+     * @param LoggerInterface $logger  A logger interface
+     * @param string          $channel The channel associated with the logger (deprecation, emergency or scream)
+     *
+     * @deprecated since 2.6, to be removed in 3.0. Use setLoggers() or setDefaultLogger() instead.
+     */
+    public static function setLogger(LoggerInterface $logger, $channel = 'deprecation')
+    {
+        $handler = set_error_handler('var_dump', 0);
+        $handler = is_array($handler) ? $handler[0] : null;
+        restore_error_handler();
+        if (!$handler instanceof self) {
+            return;
         }
+        if ('deprecation' === $channel) {
+            $handler->setDefaultLogger($logger, E_DEPRECATED | E_USER_DEPRECATED, true);
+            $handler->screamAt(E_DEPRECATED | E_USER_DEPRECATED);
+        } elseif ('scream' === $channel) {
+            $handler->setDefaultLogger($logger, E_ALL | E_STRICT, false);
+            $handler->screamAt(E_ALL | E_STRICT);
+        } elseif ('emergency' === $channel) {
+            $handler->setDefaultLogger($logger, E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR, true);
+            $handler->screamAt(E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR);
+        }
+    }
+
+    /**
+     * @deprecated since 2.6, to be removed in 3.0. Use handleError() instead.
+     */
+    public function handle($level, $message, $file = 'unknown', $line = 0, $context = array())
+    {
+        return $this->handleError($level, $message, $file, $line, (array) $context);
+    }
+
+    /**
+     * Handles PHP fatal errors.
+     *
+     * @deprecated since 2.6, to be removed in 3.0. Use handleFatalError() instead.
+     */
+    public function handleFatal()
+    {
+        static::handleFatalError();
     }
 }
 

--- a/src/Symfony/Component/Debug/README.md
+++ b/src/Symfony/Component/Debug/README.md
@@ -15,14 +15,13 @@ You can also use the tools individually:
     use Symfony\Component\Debug\ErrorHandler;
     use Symfony\Component\Debug\ExceptionHandler;
 
-    error_reporting(-1);
-
-    ErrorHandler::register($errorReportingLevel);
     if ('cli' !== php_sapi_name()) {
+        ini_set('display_errors', 0);
         ExceptionHandler::register();
     } elseif (!ini_get('log_errors') || ini_get('error_log')) {
         ini_set('display_errors', 1);
     }
+    ErrorHandler::register($errorReportingLevel);
 
 Note that the `Debug::enable()` call also registers the debug class loader
 from the Symfony ClassLoader component when available.

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -106,11 +106,11 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals(E_STRICT, $exception->getSeverity());
             $this->assertStringStartsWith(__FILE__, $exception->getFile());
             $this->assertRegexp('/^Runtime Notice: Declaration/', $exception->getMessage());
-        } catch (\Exception $e) {
+        } catch (\Exception $exception) {
             restore_error_handler();
             restore_exception_handler();
 
-            throw $e;
+            throw $exception;
         }
     }
 

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Debug\Tests;
 
+use Psr\Log\LogLevel;
 use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\Debug\Exception\ContextErrorException;
 
@@ -18,6 +19,7 @@ use Symfony\Component\Debug\Exception\ContextErrorException;
  * ErrorHandlerTest
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
  */
 class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,6 +56,8 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         } catch (ContextErrorException $exception) {
             // if an exception is thrown, the test passed
             restore_error_handler();
+            restore_exception_handler();
+
             $this->assertEquals(E_NOTICE, $exception->getSeverity());
             $this->assertEquals(__FILE__, $exception->getFile());
             $this->assertRegexp('/^Notice: Undefined variable: (foo|bar)/', $exception->getMessage());
@@ -62,7 +66,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $trace = $exception->getTrace();
             $this->assertEquals(__FILE__, $trace[0]['file']);
             $this->assertEquals('Symfony\Component\Debug\ErrorHandler', $trace[0]['class']);
-            $this->assertEquals('handle', $trace[0]['function']);
+            $this->assertEquals('handleError', $trace[0]['function']);
             $this->assertEquals('->', $trace[0]['type']);
 
             $this->assertEquals(__FILE__, $trace[1]['file']);
@@ -76,11 +80,10 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals('->', $trace[2]['type']);
         } catch (\Exception $e) {
             restore_error_handler();
+            restore_exception_handler();
 
             throw $e;
         }
-
-        restore_error_handler();
     }
 
     // dummy function to test trace in error handler.
@@ -94,78 +97,250 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testConstruct()
     {
         try {
-            $handler = ErrorHandler::register(3);
-
-            $level = new \ReflectionProperty($handler, 'level');
-            $level->setAccessible(true);
-
-            $this->assertEquals(3, $level->getValue($handler));
+            $this->assertEquals(3 | E_RECOVERABLE_ERROR | E_USER_ERROR, ErrorHandler::register(3)->throwAt(0));
 
             restore_error_handler();
+            restore_exception_handler();
         } catch (\Exception $e) {
             restore_error_handler();
+            restore_exception_handler();
 
             throw $e;
         }
     }
 
-    public function testHandle()
+    public function testDefaultLogger()
+    {
+        try {
+            $handler = ErrorHandler::register();
+
+            $logger = $this->getMock('Psr\Log\LoggerInterface');
+
+            $handler->setDefaultLogger($logger, E_NOTICE);
+            $handler->setDefaultLogger($logger, array(E_USER_NOTICE => LogLevel::CRITICAL));
+
+            $loggers = array(
+                E_DEPRECATED        => array(null, LogLevel::INFO),
+                E_USER_DEPRECATED   => array(null, LogLevel::INFO),
+                E_NOTICE            => array($logger, LogLevel::NOTICE),
+                E_USER_NOTICE       => array($logger, LogLevel::CRITICAL),
+                E_STRICT            => array(null, LogLevel::NOTICE),
+                E_WARNING           => array(null, LogLevel::WARNING),
+                E_USER_WARNING      => array(null, LogLevel::WARNING),
+                E_COMPILE_WARNING   => array(null, LogLevel::WARNING),
+                E_CORE_WARNING      => array(null, LogLevel::WARNING),
+                E_USER_ERROR        => array(null, LogLevel::ERROR),
+                E_RECOVERABLE_ERROR => array(null, LogLevel::ERROR),
+                E_COMPILE_ERROR     => array(null, LogLevel::EMERGENCY),
+                E_PARSE             => array(null, LogLevel::EMERGENCY),
+                E_ERROR             => array(null, LogLevel::EMERGENCY),
+                E_CORE_ERROR        => array(null, LogLevel::EMERGENCY),
+            );
+            $this->assertSame($loggers, $handler->setLoggers(array()));
+
+            restore_error_handler();
+            restore_exception_handler();
+        } catch (\Exception $e) {
+            restore_error_handler();
+            restore_exception_handler();
+
+            throw $e;
+        }
+    }
+
+    public function testHandleError()
     {
         try {
             $handler = ErrorHandler::register(0);
-            $this->assertFalse($handler->handle(0, 'foo', 'foo.php', 12, array()));
+            $this->assertFalse($handler->handleError(0, 'foo', 'foo.php', 12, array()));
 
             restore_error_handler();
+            restore_exception_handler();
 
             $handler = ErrorHandler::register(3);
-            $this->assertFalse($handler->handle(4, 'foo', 'foo.php', 12, array()));
+            $this->assertFalse($handler->handleError(4, 'foo', 'foo.php', 12, array()));
 
             restore_error_handler();
+            restore_exception_handler();
 
             $handler = ErrorHandler::register(3);
             try {
-                $handler->handle(4, 'foo', 'foo.php', 12, array());
+                $handler->handleError(4, 'foo', 'foo.php', 12, array());
             } catch (\ErrorException $e) {
-                $this->assertSame('Parse Error: foo in foo.php line 12', $e->getMessage());
+                $this->assertSame('Parse Error: foo', $e->getMessage());
                 $this->assertSame(4, $e->getSeverity());
                 $this->assertSame('foo.php', $e->getFile());
                 $this->assertSame(12, $e->getLine());
             }
 
             restore_error_handler();
+            restore_exception_handler();
 
             $handler = ErrorHandler::register(E_USER_DEPRECATED);
-            $this->assertFalse($handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array()));
+            $this->assertFalse($handler->handleError(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array()));
 
             restore_error_handler();
+            restore_exception_handler();
 
             $handler = ErrorHandler::register(E_DEPRECATED);
-            $this->assertFalse($handler->handle(E_DEPRECATED, 'foo', 'foo.php', 12, array()));
+            $this->assertFalse($handler->handleError(E_DEPRECATED, 'foo', 'foo.php', 12, array()));
 
             restore_error_handler();
+            restore_exception_handler();
 
             $logger = $this->getMock('Psr\Log\LoggerInterface');
 
             $that = $this;
-            $warnArgCheck = function ($message, $context) use ($that) {
+            $warnArgCheck = function ($logLevel, $message, $context) use ($that) {
+                $that->assertEquals('info', $logLevel);
                 $that->assertEquals('foo', $message);
                 $that->assertArrayHasKey('type', $context);
-                $that->assertEquals($context['type'], ErrorHandler::TYPE_DEPRECATION);
+                $that->assertEquals($context['type'], E_USER_DEPRECATED);
                 $that->assertArrayHasKey('stack', $context);
                 $that->assertInternalType('array', $context['stack']);
             };
 
             $logger
                 ->expects($this->once())
-                ->method('warning')
+                ->method('log')
                 ->will($this->returnCallback($warnArgCheck))
             ;
 
             $handler = ErrorHandler::register(E_USER_DEPRECATED);
-            $handler->setLogger($logger);
-            $this->assertTrue($handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array()));
+            $handler->setDefaultLogger($logger, E_USER_DEPRECATED);
+            $this->assertTrue($handler->handleError(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array()));
 
             restore_error_handler();
+            restore_exception_handler();
+
+            $logger = $this->getMock('Psr\Log\LoggerInterface');
+
+            $that = $this;
+            $logArgCheck = function ($level, $message, $context) use ($that) {
+                $that->assertEquals('Undefined variable: undefVar', $message);
+                $that->assertArrayHasKey('type', $context);
+                $that->assertEquals($context['type'], E_NOTICE);
+            };
+
+            $logger
+                ->expects($this->once())
+                ->method('log')
+                ->will($this->returnCallback($logArgCheck))
+            ;
+
+            $handler = ErrorHandler::register(E_NOTICE);
+            $handler->setDefaultLogger($logger, E_NOTICE);
+            $handler->screamAt(E_NOTICE);
+            unset($undefVar);
+            @$undefVar++;
+
+            restore_error_handler();
+            restore_exception_handler();
+        } catch (\Exception $e) {
+            restore_error_handler();
+            restore_exception_handler();
+
+            throw $e;
+        }
+    }
+
+    public function testHandleException()
+    {
+        try {
+            $handler = ErrorHandler::register();
+
+            $exception = new \Exception('foo');
+
+            $logger = $this->getMock('Psr\Log\LoggerInterface');
+
+            $that = $this;
+            $logArgCheck = function ($level, $message, $context) use ($that) {
+                $that->assertEquals('Uncaught Exception: foo', $message);
+                $that->assertArrayHasKey('type', $context);
+                $that->assertEquals($context['type'], E_ERROR);
+            };
+
+            $logger
+                ->expects($this->exactly(2))
+                ->method('log')
+                ->will($this->returnCallback($logArgCheck))
+            ;
+
+            $handler->setDefaultLogger($logger, E_ERROR);
+
+            try {
+                $handler->handleException($exception);
+                $this->fail('Exception expected');
+            } catch (\Exception $e) {
+                $this->assertSame($exception, $e);
+            }
+
+            $that = $this;
+            $handler->setExceptionHandler(function ($e) use ($exception, $that) {
+                $that->assertSame($exception, $e);
+            });
+
+            $handler->handleException($exception);
+
+            restore_error_handler();
+            restore_exception_handler();
+        } catch (\Exception $e) {
+            restore_error_handler();
+            restore_exception_handler();
+
+            throw $e;
+        }
+    }
+
+    public function testHandleFatalError()
+    {
+        try {
+            $handler = ErrorHandler::register();
+
+            $error = array(
+                'type' => E_PARSE,
+                'message' => 'foo',
+                'file' => 'bar',
+                'line' => 123,
+            );
+
+            $logger = $this->getMock('Psr\Log\LoggerInterface');
+
+            $that = $this;
+            $logArgCheck = function ($level, $message, $context) use ($that) {
+                $that->assertEquals('Fatal Parse Error: foo', $message);
+                $that->assertArrayHasKey('type', $context);
+                $that->assertEquals($context['type'], E_ERROR);
+            };
+
+            $logger
+                ->expects($this->once())
+                ->method('log')
+                ->will($this->returnCallback($logArgCheck))
+            ;
+
+            $handler->setDefaultLogger($logger, E_ERROR);
+
+            $handler->handleFatalError($error);
+
+            restore_error_handler();
+            restore_exception_handler();
+        } catch (\Exception $e) {
+            restore_error_handler();
+            restore_exception_handler();
+
+            throw $e;
+        }
+    }
+
+    public function testDeprecated()
+    {
+        try {
+            $handler = ErrorHandler::register(0);
+            $this->assertFalse($handler->handle(0, 'foo', 'foo.php', 12, array()));
+
+            restore_error_handler();
+            restore_exception_handler();
 
             $logger = $this->getMock('Psr\Log\LoggerInterface');
 
@@ -188,8 +363,10 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             @$undefVar++;
 
             restore_error_handler();
+            restore_exception_handler();
         } catch (\Exception $e) {
             restore_error_handler();
+            restore_exception_handler();
 
             throw $e;
         }

--- a/src/Symfony/Component/Debug/composer.json
+++ b/src/Symfony/Component/Debug/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "symfony/http-kernel": "~2.1",

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * deprecated `Symfony\Component\HttpKernel\EventListener\ErrorsLoggerListener`, use `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener` instead
+
 2.5.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -11,33 +11,72 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-use Symfony\Component\Debug\ExceptionHandler;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Debug\ErrorHandler;
+use Symfony\Component\Debug\AbstractExceptionHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Configures the ExceptionHandler.
+ * Configures errors and exceptions handlers.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
 class DebugHandlersListener implements EventSubscriberInterface
 {
     private $exceptionHandler;
+    private $logger;
+    private $levels;
+    private $debug;
 
-    public function __construct($exceptionHandler)
+    /**
+     * @param callable             $exceptionHandler A handler that will be called on Exception
+     * @param LoggerInterface|null $logger           A PSR-3 logger
+     * @param array|int            $levels           An array map of E_* to LogLevel::* or an integer bit field of E_* constants
+     * @param bool                 $debug            Enables/disables debug mode
+     */
+    public function __construct($exceptionHandler, LoggerInterface $logger = null, $levels = null, $debug = true)
     {
         if (is_callable($exceptionHandler)) {
             $this->exceptionHandler = $exceptionHandler;
         }
+        $this->logger = $logger;
+        $this->levels = $levels;
+        $this->debug = $debug;
     }
 
     public function configure()
     {
+        if ($this->logger) {
+            $handler = set_error_handler('var_dump', 0);
+            $handler = is_array($handler) ? $handler[0] : null;
+            restore_error_handler();
+            if ($handler instanceof ErrorHandler) {
+                if ($this->debug) {
+                    $handler->throwAt(-1);
+                }
+                $handler->setDefaultLogger($this->logger, $this->levels);
+                if (is_array($this->levels)) {
+                    $scream = 0;
+                    foreach ($this->levels as $type => $log) {
+                        $scream |= $type;
+                    }
+                    $this->levels = $scream;
+                }
+                $handler->screamAt($this->levels);
+            }
+            $this->logger = $this->levels = null;
+        }
         if ($this->exceptionHandler) {
             $handler = set_exception_handler('var_dump');
             $handler = is_array($handler) ? $handler[0] : null;
             restore_exception_handler();
-            if ($handler instanceof ExceptionHandler) {
+            if ($handler instanceof ErrorHandler) {
+                $h = $handler->setExceptionHandler('var_dump') ?: $this->exceptionHandler;
+                $handler->setExceptionHandler($h);
+                $handler = is_array($h) ? $h[0] : null;
+            }
+            if ($handler instanceof AbstractExceptionHandler) {
                 $handler->setHandler($this->exceptionHandler);
             }
             $this->exceptionHandler = null;

--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorsLoggerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorsLoggerListener.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * @author Colin Frei <colin@colinfrei.com>
  * @author Konstantin Myakshin <koc-dp@yandex.ru>
+ *
+ * @deprecated since 2.6, to be removed in 3.0. Use DebugHandlersListener instead.
  */
 class ErrorsLoggerListener implements EventSubscriberInterface
 {

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests\DataCollector;
 
 use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
-use Symfony\Component\HttpKernel\Debug\ErrorHandler;
 
 class LoggerDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
@@ -66,14 +65,20 @@ class LoggerDataCollectorTest extends \PHPUnit_Framework_TestCase
             array(
                 1,
                 array(
-                    array('message' => 'foo', 'context' => array('type' => ErrorHandler::TYPE_DEPRECATION), 'priority' => 100, 'priorityName' => 'DEBUG'),
-                    array('message' => 'foo2', 'context' => array('type' => ErrorHandler::TYPE_DEPRECATION), 'priority' => 100, 'priorityName' => 'DEBUG'),
-                    array('message' => 'foo3', 'context' => array('type' => E_USER_WARNING, 'scream' => 0), 'priority' => 100, 'priorityName' => 'DEBUG'),
+                    array('message' => 'foo', 'context' => array('type' => E_DEPRECATED, 'level' => E_ALL), 'priority' => 100, 'priorityName' => 'DEBUG'),
+                    array('message' => 'foo2', 'context' => array('type' => E_USER_DEPRECATED, 'level' => E_ALL), 'priority' => 100, 'priorityName' => 'DEBUG'),
                 ),
                 null,
                 2,
+                0,
+                array(100 => array('count' => 2, 'name' => 'DEBUG')),
+            ),
+            array(
                 1,
-                array(100 => array('count' => 3, 'name' => 'DEBUG')),
+                array(array('message' => 'foo3', 'context' => array('type' => E_USER_WARNING, 'level' => 0), 'priority' => 100, 'priorityName' => 'DEBUG')),
+                array(array('message' => 'foo3', 'context' => array('type' => E_USER_WARNING, 'level' => 0, 'scream' => true), 'priority' => 100, 'priorityName' => 'DEBUG')),
+                0,
+                1,
             ),
         );
     }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.5",
         "symfony/http-foundation": "~2.4",
-        "symfony/debug": "~2.5",
+        "symfony/debug": "~2.6",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | minor, see updated tests |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

The proposed goal of this PR is to build a class that can serve as a foundation for a standard error handler, shared with other projects and not only used by the FrameworkBundle.

This is a merge of my previous work on the subject (https://github.com/nicolas-grekas/Patchwork/blob/master/core/logger/class/Patchwork/PHP/InDepthErrorHandler.php) and recent improvements of error handling in Symfony's Debug\ErrorHandler.

ErrorHandler is introduced, which provides five bit fields that control how errors are handled:
- thrownErrors: errors thrown as ContextErrorException
- loggedErrors: logged errors, when not @-silenced
- scopedErrors: errors thrown or logged with their local context
- tracedErrors: errors logged with their trace, only once for repeated errors
- screamedErrors: never @-silenced errors

Each error level can be logged by a dedicated PSR-3 logger object.
Screaming only applies to logging.
Throwing takes precedence over logging.
Uncaught exceptions are logged as E_ERROR.
E_DEPRECATED and E_USER_DEPRECATED levels never throw.
E_RECOVERABLE_ERROR and E_USER_ERROR levels always throw.
Non catchable errors that can be detected at shutdown time are logged when the scream bit field allows so.
As errors have a performance cost, repeated errors are all logged, so that the developer
can see them and weight them as more important to fix than others of the same level.
- [x] build a more generic ErrorHandler
- [x] update service/listeners definitions to take advantage of the new interface of ErrorHandler
- [x] add phpdocs
- [x] add tests
