### PR TITLE
[Console] [Table] Added footers to console tables

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -36,6 +36,13 @@ class Table
     private $rows = array();
 
     /**
+     * Table footers.
+     *
+     * @var array
+     */
+    private $footers = array();
+
+    /**
      * Column widths cache.
      *
      * @var array
@@ -144,6 +151,13 @@ class Table
         return $this;
     }
 
+    public function setFooters(array $footers)
+    {
+        $this->footers = array_values($footers);
+
+        return $this;
+    }
+
     public function setRows(array $rows)
     {
         $this->rows = array();
@@ -218,6 +232,8 @@ class Table
      * | 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
      * | 960-425-059-0 | The Lord of the Rings | J. R. R. Tolkien |
      * +---------------+-----------------------+------------------+
+     * | Footer 1      | Footer 2              | Footer 3         |
+     *
      */
     public function render()
     {
@@ -236,6 +252,8 @@ class Table
         if (!empty($this->rows)) {
             $this->renderRowSeparator();
         }
+
+        $this->renderRow($this->footers, $this->style->getCellFooterFormat());
 
         $this->cleanup();
     }
@@ -332,6 +350,7 @@ class Table
         foreach ($this->rows as $row) {
             $columns[] = count($row);
         }
+        $columns[] = count($this->footers);
 
         return $this->numberOfColumns = max($columns);
     }
@@ -357,6 +376,7 @@ class Table
 
             $lengths[] = $this->getCellWidth($row, $column);
         }
+        $lengths[] = $this->getCellWidth($this->footers, $column);
 
         return $this->columnWidths[$column] = max($lengths) + strlen($this->style->getCellRowContentFormat()) - 2;
     }

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -75,6 +75,13 @@ class TableHelper extends Helper
         return $this;
     }
 
+    public function setFooters(array $footers)
+    {
+        $this->table->setFooters($footers);
+
+        return $this;
+    }
+
     public function setRows(array $rows)
     {
         $this->table->setRows($rows);
@@ -169,6 +176,20 @@ class TableHelper extends Helper
     public function setCellHeaderFormat($cellHeaderFormat)
     {
         $this->table->getStyle()->setCellHeaderFormat($cellHeaderFormat);
+
+        return $this;
+    }
+
+    /**
+     * Sets footer cell format.
+     *
+     * @param string $cellFooterFormat
+     *
+     * @return TableHelper
+     */
+    public function setCellFooterFormat($cellFooterFormat)
+    {
+        $this->table->getStyle()->setCellFooterFormat($cellFooterFormat);
 
         return $this;
     }

--- a/src/Symfony/Component/Console/Helper/TableStyle.php
+++ b/src/Symfony/Component/Console/Helper/TableStyle.php
@@ -24,6 +24,7 @@ class TableStyle
     private $verticalBorderChar = '|';
     private $crossingChar = '+';
     private $cellHeaderFormat = '<info>%s</info>';
+    private $cellFooterFormat = '<comment>%s</comment>';
     private $cellRowFormat = '%s';
     private $cellRowContentFormat = ' %s ';
     private $borderFormat = '%s';
@@ -144,6 +145,20 @@ class TableStyle
     }
 
     /**
+     * Sets footer cell format.
+     *
+     * @param string $cellFooterFormat
+     *
+     * @return TableStyle
+     */
+    public function setCellFooterFormat($cellFooterFormat)
+    {
+        $this->cellFooterFormat = $cellFooterFormat;
+
+        return $this;
+    }
+
+    /**
      * Gets header cell format.
      *
      * @return string
@@ -151,6 +166,16 @@ class TableStyle
     public function getCellHeaderFormat()
     {
         return $this->cellHeaderFormat;
+    }
+
+    /**
+     * Gets header cell format.
+     *
+     * @return string
+     */
+    public function getCellFooterFormat()
+    {
+        return $this->cellFooterFormat;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -32,12 +32,13 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRender($headers, $rows, $layout, $expected)
+    public function testRender($headers, $rows, $footers, $layout, $expected)
     {
         $table = new TableHelper();
         $table
             ->setHeaders($headers)
             ->setRows($rows)
+            ->setFooters($footers)
             ->setLayout($layout)
         ;
         $table->render($output = $this->getOutputStream());
@@ -48,12 +49,13 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRenderAddRows($headers, $rows, $layout, $expected)
+    public function testRenderAddRows($headers, $rows, $footers, $layout, $expected)
     {
         $table = new TableHelper();
         $table
             ->setHeaders($headers)
             ->addRows($rows)
+            ->setFooters($footers)
             ->setLayout($layout)
         ;
         $table->render($output = $this->getOutputStream());
@@ -64,11 +66,12 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRenderAddRowsOneByOne($headers, $rows, $layout, $expected)
+    public function testRenderAddRowsOneByOne($headers, $rows, $footers, $layout, $expected)
     {
         $table = new TableHelper();
         $table
             ->setHeaders($headers)
+            ->setFooters($footers)
             ->setLayout($layout)
         ;
         foreach ($rows as $row) {
@@ -89,9 +92,11 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
         );
 
         return array(
+            // 0
             array(
                 array('ISBN', 'Title', 'Author'),
                 $books,
+                array('Footer1', 'Footer2', 'Footer3'),
                 TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+--------------------------+------------------+
@@ -102,12 +107,15 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
 | 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
 | 80-902734-1-6 | And Then There Were None | Agatha Christie  |
 +---------------+--------------------------+------------------+
+| Footer1       | Footer2                  | Footer3          |
 
 TABLE
             ),
+            // 1
             array(
                 array('ISBN', 'Title', 'Author'),
                 $books,
+                array('Footer1-1', 'Footer1-2', 'Footer1-3'),
                 TableHelper::LAYOUT_COMPACT,
 <<<TABLE
  ISBN          Title                    Author           
@@ -115,12 +123,15 @@ TABLE
  9971-5-0210-0 A Tale of Two Cities     Charles Dickens  
  960-425-059-0 The Lord of the Rings    J. R. R. Tolkien 
  80-902734-1-6 And Then There Were None Agatha Christie  
+ Footer1-1     Footer1-2                Footer1-3        
 
 TABLE
             ),
+            // 2
             array(
                 array('ISBN', 'Title', 'Author'),
                 $books,
+                array('Footer1', 'Footer2', 'Footer3'),
                 TableHelper::LAYOUT_BORDERLESS,
 <<<TABLE
  =============== ========================== ================== 
@@ -131,9 +142,11 @@ TABLE
   960-425-059-0   The Lord of the Rings      J. R. R. Tolkien  
   80-902734-1-6   And Then There Were None   Agatha Christie   
  =============== ========================== ================== 
+  Footer1         Footer2                    Footer3           
 
 TABLE
             ),
+            // 3
             array(
                 array('ISBN', 'Title'),
                 array(
@@ -142,6 +155,7 @@ TABLE
                     array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
+                array('Footer1', 'Footer2'),
                 TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+--------------------------+------------------+
@@ -152,9 +166,11 @@ TABLE
 | 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
 | 80-902734-1-6 | And Then There Were None | Agatha Christie  |
 +---------------+--------------------------+------------------+
+| Footer1       | Footer2                  |                  |
 
 TABLE
             ),
+            // 4
             array(
                 array(),
                 array(
@@ -163,6 +179,7 @@ TABLE
                     array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
+                array(),
                 TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+--------------------------+------------------+
@@ -174,6 +191,7 @@ TABLE
 
 TABLE
             ),
+            // 5
             array(
                 array('ISBN', 'Title', 'Author'),
                 array(
@@ -182,6 +200,7 @@ TABLE
                     array("9971-5-0210-2", "Harry Potter\nand the Chamber of Secrets", "Rowling\nJoanne K."),
                     array("960-425-059-0", "The Lord of the Rings", "J. R. R.\nTolkien"),
                 ),
+                array(),
                 TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+----------------------------+-----------------+
@@ -199,29 +218,48 @@ TABLE
 
 TABLE
             ),
+            // 6
             array(
                 array('ISBN', 'Title'),
                 array(),
+                array('Footer1', 'Footer2'),
                 TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
-+------+-------+
-| ISBN | Title |
-+------+-------+
++---------+---------+
+| ISBN    | Title   |
++---------+---------+
+| Footer1 | Footer2 |
 
 TABLE
             ),
+            // 7
             array(
+                array(),
+                array(),
+                array('Footer1', 'Footer2'),
+                TableHelper::LAYOUT_DEFAULT,
+<<<TABLE
++---------+---------+
+| Footer1 | Footer2 |
+
+TABLE
+            ),
+            // 8
+            array(
+                array(),
                 array(),
                 array(),
                 TableHelper::LAYOUT_DEFAULT,
                 '',
             ),
+            // 9
             'Cell text with tags used for Output styling' => array(
                 array('ISBN', 'Title', 'Author'),
                 array(
                     array('<info>99921-58-10-7</info>', '<error>Divine Comedy</error>', '<fg=blue;bg=white>Dante Alighieri</fg=blue;bg=white>'),
                     array('9971-5-0210-0', 'A Tale of Two Cities', '<info>Charles Dickens</>'),
                 ),
+                array(),
                 TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+----------------------+-----------------+
@@ -233,12 +271,14 @@ TABLE
 
 TABLE
             ),
+            // 10
             'Cell text with tags not used for Output styling' => array(
                 array('ISBN', 'Title', 'Author'),
                 array(
                     array('<strong>99921-58-10-700</strong>', '<f>Divine Com</f>', 'Dante Alighieri'),
                     array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
                 ),
+                array(),
                 TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +----------------------------------+----------------------+-----------------+

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -34,12 +34,13 @@ class TableTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRender($headers, $rows, $style, $expected)
+    public function testRender($headers, $rows, $footers, $style, $expected)
     {
         $table = new Table($output = $this->getOutputStream());
         $table
             ->setHeaders($headers)
             ->setRows($rows)
+            ->setFooters($footers)
             ->setStyle($style)
         ;
         $table->render();
@@ -50,12 +51,13 @@ class TableTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRenderAddRows($headers, $rows, $style, $expected)
+    public function testRenderAddRows($headers, $rows, $footers, $style, $expected)
     {
         $table = new Table($output = $this->getOutputStream());
         $table
             ->setHeaders($headers)
             ->addRows($rows)
+            ->setFooters($footers)
             ->setStyle($style)
         ;
         $table->render();
@@ -66,11 +68,12 @@ class TableTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRenderAddRowsOneByOne($headers, $rows, $style, $expected)
+    public function testRenderAddRowsOneByOne($headers, $rows, $footers, $style, $expected)
     {
         $table = new Table($output = $this->getOutputStream());
         $table
             ->setHeaders($headers)
+            ->setFooters($footers)
             ->setStyle($style)
         ;
         foreach ($rows as $row) {
@@ -94,6 +97,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
             array(
                 array('ISBN', 'Title', 'Author'),
                 $books,
+                array('Footer1', 'Footer2', 'Footer3'),
                 'default',
 <<<TABLE
 +---------------+--------------------------+------------------+
@@ -104,12 +108,14 @@ class TableTest extends \PHPUnit_Framework_TestCase
 | 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
 | 80-902734-1-6 | And Then There Were None | Agatha Christie  |
 +---------------+--------------------------+------------------+
+| Footer1       | Footer2                  | Footer3          |
 
 TABLE
             ),
             array(
                 array('ISBN', 'Title', 'Author'),
                 $books,
+                array('Footer1', 'Footer2', 'Footer3'),
                 'compact',
 <<<TABLE
  ISBN          Title                    Author           
@@ -117,12 +123,14 @@ TABLE
  9971-5-0210-0 A Tale of Two Cities     Charles Dickens  
  960-425-059-0 The Lord of the Rings    J. R. R. Tolkien 
  80-902734-1-6 And Then There Were None Agatha Christie  
+ Footer1       Footer2                  Footer3          
 
 TABLE
             ),
             array(
                 array('ISBN', 'Title', 'Author'),
                 $books,
+                array(),
                 'borderless',
 <<<TABLE
  =============== ========================== ================== 
@@ -144,6 +152,7 @@ TABLE
                     array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
+                array(),
                 'default',
 <<<TABLE
 +---------------+--------------------------+------------------+
@@ -165,6 +174,7 @@ TABLE
                     array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
+                array(),
                 'default',
 <<<TABLE
 +---------------+--------------------------+------------------+
@@ -184,6 +194,7 @@ TABLE
                     array("9971-5-0210-2", "Harry Potter\nand the Chamber of Secrets", "Rowling\nJoanne K."),
                     array("960-425-059-0", "The Lord of the Rings", "J. R. R.\nTolkien"),
                 ),
+                array(),
                 'default',
 <<<TABLE
 +---------------+----------------------------+-----------------+
@@ -204,6 +215,7 @@ TABLE
             array(
                 array('ISBN', 'Title'),
                 array(),
+                array(),
                 'default',
 <<<TABLE
 +------+-------+
@@ -215,6 +227,7 @@ TABLE
             array(
                 array(),
                 array(),
+                array(),
                 'default',
                 '',
             ),
@@ -224,6 +237,7 @@ TABLE
                     array('<info>99921-58-10-7</info>', '<error>Divine Comedy</error>', '<fg=blue;bg=white>Dante Alighieri</fg=blue;bg=white>'),
                     array('9971-5-0210-0', 'A Tale of Two Cities', '<info>Charles Dickens</>'),
                 ),
+                array(),
                 'default',
 <<<TABLE
 +---------------+----------------------+-----------------+
@@ -241,6 +255,7 @@ TABLE
                     array('<strong>99921-58-10-700</strong>', '<f>Divine Com</f>', 'Dante Alighieri'),
                     array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
                 ),
+                array(),
                 'default',
 <<<TABLE
 +----------------------------------+----------------------+-----------------+
@@ -323,7 +338,9 @@ TABLE;
                 array('Bar2'),
                 new TableSeparator(),
                 array('Bar3'),
-            ));
+            ))
+            ->setFooters(array('Baz'))
+        ;
         $table->render();
 
         $expected =
@@ -337,6 +354,7 @@ TABLE;
 +------+
 | Bar3 |
 +------+
+| Baz  |
 
 TABLE;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none yet |

I needed some footers to tables, so I added it

```
+---------------+-----------------------+------------------+
| ISBN          | Title                 | Author           |
+---------------+-----------------------+------------------+
| 99921-58-10-7 | Divine Comedy         | Dante Alighieri  |
| 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
| 960-425-059-0 | The Lord of the Rings | J. R. R. Tolkien |
+---------------+-----------------------+------------------+
| Footer 1      | Footer 2              | Footer 3         |
```

I decided I didnt wanted the last row seperator after the footers, I think it looks better without it.

Footers have the default style of `<comment>%s</comment>` (yellow on black background)

Footers is also included in the tests

--- edit
[Coding standard](http://fabbot.io/report/symfony/symfony/10922/09dba6b7be1bc0e2126f6c03b2607ef16783bc41) fails on this PR - The reason is the test line endings needs trailing spaces, or else the test of course fails when creating table.

If I download the [cf patch](http://fabbot.io/patch/symfony/symfony/10922/09dba6b7be1bc0e2126f6c03b2607ef16783bc41/cs.diff) provided, the unit test fails
