### PR TITLE
[DomCrawler] Changed typehints form DomNode to DomElement

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+2.5.0
+-----
+
+* [BC BREAK] The typehints on the `Link`, `Form` and `FormField` classes have been changed from
+  `\DOMNode` to `DOMElement`. Using any other type of `DOMNode` was triggering fatal errors in previous
+  versions. Code extending these classes will need to update the typehints when overwriting these methods.
+
 2.4.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\DomCrawler;
 use Symfony\Component\CssSelector\CssSelector;
 
 /**
- * Crawler eases navigation of a list of \DOMNode objects.
+ * Crawler eases navigation of a list of \DOMElement objects.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -161,11 +161,11 @@ class ChoiceFormField extends FormField
      *
      * This method should only be used internally.
      *
-     * @param \DOMNode $node A \DOMNode
+     * @param \DOMElement $node
      *
      * @throws \LogicException When choice provided is not multiple nor radio
      */
-    public function addChoice(\DOMNode $node)
+    public function addChoice(\DOMElement $node)
     {
         if (!$this->multiple && 'radio' != $this->type) {
             throw new \LogicException(sprintf('Unable to add a choice for "%s" as it is not multiple or is not a radio button.', $this->name));
@@ -259,11 +259,11 @@ class ChoiceFormField extends FormField
     /**
      * Returns option value with associated disabled flag
      *
-     * @param \DOMNode $node
+     * @param \DOMElement $node
      *
      * @return array
      */
-    private function buildOptionValue($node)
+    private function buildOptionValue(\DOMElement $node)
     {
         $option = array();
 

--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\DomCrawler\Field;
 abstract class FormField
 {
     /**
-     * @var \DOMNode
+     * @var \DOMElement
      */
     protected $node;
     /**
@@ -46,9 +46,9 @@ abstract class FormField
     /**
      * Constructor.
      *
-     * @param \DOMNode $node The node associated with this field
+     * @param \DOMElement $node The node associated with this field
      */
-    public function __construct(\DOMNode $node)
+    public function __construct(\DOMElement $node)
     {
         $this->node = $node;
         $this->name = $node->getAttribute('name');

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -23,7 +23,7 @@ use Symfony\Component\DomCrawler\Field\FormField;
 class Form extends Link implements \ArrayAccess
 {
     /**
-     * @var \DOMNode
+     * @var \DOMElement
      */
     private $button;
 
@@ -35,15 +35,15 @@ class Form extends Link implements \ArrayAccess
     /**
      * Constructor.
      *
-     * @param \DOMNode $node       A \DOMNode instance
-     * @param string   $currentUri The URI of the page where the form is embedded
-     * @param string   $method     The method to use for the link (if null, it defaults to the method defined by the form)
+     * @param \DOMElement $node       A \DOMElement instance
+     * @param string      $currentUri The URI of the page where the form is embedded
+     * @param string      $method     The method to use for the link (if null, it defaults to the method defined by the form)
      *
      * @throws \LogicException if the node is not a button inside a form tag
      *
      * @api
      */
-    public function __construct(\DOMNode $node, $currentUri, $method = null)
+    public function __construct(\DOMElement $node, $currentUri, $method = null)
     {
         parent::__construct($node, $currentUri, $method);
 
@@ -53,7 +53,7 @@ class Form extends Link implements \ArrayAccess
     /**
      * Gets the form node associated with this form.
      *
-     * @return \DOMNode A \DOMNode instance
+     * @return \DOMElement A \DOMElement instance
      */
     public function getFormNode()
     {
@@ -359,13 +359,13 @@ class Form extends Link implements \ArrayAccess
     /**
      * Sets the node for the form.
      *
-     * Expects a 'submit' button \DOMNode and finds the corresponding form element.
+     * Expects a 'submit' button \DOMElement and finds the corresponding form element, or the form element itself.
      *
-     * @param \DOMNode $node A \DOMNode instance
+     * @param \DOMElement $node A \DOMElement instance
      *
      * @throws \LogicException If given node is not a button or input or does not have a form ancestor
      */
-    protected function setNode(\DOMNode $node)
+    protected function setNode(\DOMElement $node)
     {
         $this->button = $node;
         if ('button' == $node->nodeName || ('input' == $node->nodeName && in_array(strtolower($node->getAttribute('type')), array('submit', 'button', 'image')))) {
@@ -454,7 +454,7 @@ class Form extends Link implements \ArrayAccess
         }
     }
 
-    private function addField(\DOMNode $node)
+    private function addField(\DOMElement $node)
     {
         if (!$node->hasAttribute('name') || !$node->getAttribute('name')) {
             return;

--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\DomCrawler;
 class Link
 {
     /**
-     * @var \DOMNode A \DOMNode instance
+     * @var \DOMElement
      */
     protected $node;
     /**
@@ -36,15 +36,15 @@ class Link
     /**
      * Constructor.
      *
-     * @param \DOMNode $node       A \DOMNode instance
-     * @param string   $currentUri The URI of the page where the link is embedded (or the base href)
-     * @param string   $method     The method to use for the link (get by default)
+     * @param \DOMElement $node       A \DOMElement instance
+     * @param string      $currentUri The URI of the page where the link is embedded (or the base href)
+     * @param string      $method     The method to use for the link (get by default)
      *
      * @throws \InvalidArgumentException if the node is not a link
      *
      * @api
      */
-    public function __construct(\DOMNode $node, $currentUri, $method = 'GET')
+    public function __construct(\DOMElement $node, $currentUri, $method = 'GET')
     {
         if (!in_array(strtolower(substr($currentUri, 0, 4)), array('http', 'file'))) {
             throw new \InvalidArgumentException(sprintf('Current URI must be an absolute URL ("%s").', $currentUri));
@@ -58,7 +58,7 @@ class Link
     /**
      * Gets the node associated with this link.
      *
-     * @return \DOMNode A \DOMNode instance
+     * @return \DOMElement A \DOMElement instance
      */
     public function getNode()
     {
@@ -180,13 +180,13 @@ class Link
     }
 
     /**
-     * Sets current \DOMNode instance.
+     * Sets current \DOMElement instance.
      *
-     * @param \DOMNode $node A \DOMNode instance
+     * @param \DOMElement $node A \DOMElement instance
      *
      * @throws \LogicException If given node is not an anchor
      */
-    protected function setNode(\DOMNode $node)
+    protected function setNode(\DOMElement $node)
     {
         if ('a' != $node->nodeName && 'area' != $node->nodeName) {
             throw new \LogicException(sprintf('Unable to click on a "%s" tag.', $node->nodeName));

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -47,7 +47,7 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
 
         $crawler = new Crawler();
         $crawler->add($this->createNodeList()->item(0));
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from an \DOMNode');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a \DOMElement');
 
         $crawler = new Crawler();
         $crawler->add('<html><body>Foo</body></html>');
@@ -280,7 +280,7 @@ EOF
         $crawler = new Crawler();
         $crawler->addNode($this->createNodeList()->item(0));
 
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNode() adds nodes from an \DOMNode');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNode() adds nodes from a \DOMElement');
     }
 
     public function testClear()

--- a/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
@@ -191,7 +191,7 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $this->assertNull($field->getValue(), '->getValue() returns null if the checkbox is not checked');
         $this->assertFalse($field->isMultiple(), '->hasValue() returns false for checkboxes');
         try {
-            $field->addChoice(new \DOMNode());
+            $field->addChoice(new \DOMElement('input'));
             $this->fail('->addChoice() throws a \LogicException for checkboxes');
         } catch (\LogicException $e) {
             $this->assertTrue(true, '->initialize() throws a \LogicException for checkboxes');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | only for people hacking the internal classes (which requires replacing the crawler too) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10924 |
| License | MIT |
| Doc PR | n/a |
