### PR TITLE
[DomCrawler] Fixed the coding standards to use strict comparisons

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -119,10 +119,10 @@ class ChoiceFormField extends FormField
      */
     public function setValue($value)
     {
-        if ('checkbox' == $this->type && false === $value) {
+        if ('checkbox' === $this->type && false === $value) {
             // uncheck
             $this->value = null;
-        } elseif ('checkbox' == $this->type && true === $value) {
+        } elseif ('checkbox' === $this->type && true === $value) {
             // check
             $this->value = $this->options[0]['value'];
         } else {
@@ -163,7 +163,7 @@ class ChoiceFormField extends FormField
      */
     public function addChoice(\DOMNode $node)
     {
-        if (!$this->multiple && 'radio' != $this->type) {
+        if (!$this->multiple && 'radio' !== $this->type) {
             throw new \LogicException(sprintf('Unable to add a choice for "%s" as it is not multiple or is not a radio button.', $this->name));
         }
 
@@ -202,11 +202,11 @@ class ChoiceFormField extends FormField
      */
     protected function initialize()
     {
-        if ('input' != $this->node->nodeName && 'select' != $this->node->nodeName) {
+        if ('input' !== $this->node->nodeName && 'select' !== $this->node->nodeName) {
             throw new \LogicException(sprintf('A ChoiceFormField can only be created from an input or select tag (%s given).', $this->node->nodeName));
         }
 
-        if ('input' == $this->node->nodeName && 'checkbox' != strtolower($this->node->getAttribute('type')) && 'radio' != strtolower($this->node->getAttribute('type'))) {
+        if ('input' === $this->node->nodeName && 'checkbox' !== strtolower($this->node->getAttribute('type')) && 'radio' !== strtolower($this->node->getAttribute('type'))) {
             throw new \LogicException(sprintf('A ChoiceFormField can only be created from an input tag with a type of checkbox or radio (given type is %s).', $this->node->getAttribute('type')));
         }
 
@@ -271,7 +271,7 @@ class ChoiceFormField extends FormField
     }
 
     /**
-     * Checks whether given vale is in the existing options
+     * Checks whether given value is in the existing options
      *
      * @param string $optionValue
      * @param array  $options

--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -99,11 +99,11 @@ class FileFormField extends FormField
      */
     protected function initialize()
     {
-        if ('input' != $this->node->nodeName) {
+        if ('input' !== $this->node->nodeName) {
             throw new \LogicException(sprintf('A FileFormField can only be created from an input tag (%s given).', $this->node->nodeName));
         }
 
-        if ('file' != strtolower($this->node->getAttribute('type'))) {
+        if ('file' !== strtolower($this->node->getAttribute('type'))) {
             throw new \LogicException(sprintf('A FileFormField can only be created from an input tag with a type of file (given type is %s).', $this->node->getAttribute('type')));
         }
 

--- a/src/Symfony/Component/DomCrawler/Field/InputFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/InputFormField.php
@@ -30,15 +30,15 @@ class InputFormField extends FormField
      */
     protected function initialize()
     {
-        if ('input' != $this->node->nodeName && 'button' != $this->node->nodeName) {
+        if ('input' !== $this->node->nodeName && 'button' !== $this->node->nodeName) {
             throw new \LogicException(sprintf('An InputFormField can only be created from an input or button tag (%s given).', $this->node->nodeName));
         }
 
-        if ('checkbox' == strtolower($this->node->getAttribute('type'))) {
+        if ('checkbox' === strtolower($this->node->getAttribute('type'))) {
             throw new \LogicException('Checkboxes should be instances of ChoiceFormField.');
         }
 
-        if ('file' == strtolower($this->node->getAttribute('type'))) {
+        if ('file' === strtolower($this->node->getAttribute('type'))) {
             throw new \LogicException('File inputs should be instances of FileFormField.');
         }
 

--- a/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
@@ -27,7 +27,7 @@ class TextareaFormField extends FormField
      */
     protected function initialize()
     {
-        if ('textarea' != $this->node->nodeName) {
+        if ('textarea' !== $this->node->nodeName) {
             throw new \LogicException(sprintf('A TextareaFormField can only be created from a textarea tag (%s given).', $this->node->nodeName));
         }
 

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -28,7 +28,7 @@ class Form extends Link implements \ArrayAccess
     private $button;
 
     /**
-     * @var Field\FormField[]
+     * @var FormFieldRegistry
      */
     private $fields;
 
@@ -352,7 +352,7 @@ class Form extends Link implements \ArrayAccess
     protected function setNode(\DOMNode $node)
     {
         $this->button = $node;
-        if ('button' == $node->nodeName || ('input' == $node->nodeName && in_array(strtolower($node->getAttribute('type')), array('submit', 'button', 'image')))) {
+        if ('button' === $node->nodeName || ('input' === $node->nodeName && in_array(strtolower($node->getAttribute('type')), array('submit', 'button', 'image')))) {
             if ($node->hasAttribute('form')) {
                 // if the node has the HTML5-compliant 'form' attribute, use it
                 $formId = $node->getAttribute('form');
@@ -369,8 +369,8 @@ class Form extends Link implements \ArrayAccess
                 if (null === $node = $node->parentNode) {
                     throw new \LogicException('The selected node does not have a form ancestor.');
                 }
-            } while ('form' != $node->nodeName);
-        } elseif ('form' != $node->nodeName) {
+            } while ('form' !== $node->nodeName);
+        } elseif ('form' !== $node->nodeName) {
             throw new \LogicException(sprintf('Unable to submit on a "%s" tag.', $node->nodeName));
         }
 

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -137,7 +137,7 @@ class FormFieldRegistry
     /**
      * Returns the list of field with their value.
      *
-     * @return array The list of fields as array((string) Fully qualified name => (mixed) value)
+     * @return FormField[] The list of fields as array((string) Fully qualified name => (mixed) value)
      */
     public function all()
     {
@@ -196,7 +196,7 @@ class FormFieldRegistry
      *
      * @param string $name The name of the field
      *
-     * @return array The list of segments
+     * @return string[] The list of segments
      *
      * @throws \InvalidArgumentException when the name is malformed
      */

--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -188,7 +188,7 @@ class Link
      */
     protected function setNode(\DOMNode $node)
     {
-        if ('a' != $node->nodeName && 'area' != $node->nodeName) {
+        if ('a' !== $node->nodeName && 'area' !== $node->nodeName) {
             throw new \LogicException(sprintf('Unable to click on a "%s" tag.', $node->nodeName));
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -793,7 +793,6 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $dom = new \DOMDocument();
         $dom->loadHTML('<html>'.$form.'</html>');
 
-        $nodes = $dom->getElementsByTagName('input');
         $xPath = new \DOMXPath($dom);
         $nodes = $xPath->query('//input | //button');
 
@@ -856,5 +855,4 @@ class FormTest extends \PHPUnit_Framework_TestCase
       $form = new Form($nodes->item(0), 'http://example.com');
       $this->assertEquals($form->getPhpValues(), array('example' => ''));
     }
-
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Many places in DomCrawler are using loose comparison instead of strict comparison. I saw them while checking the whole component for DOMNode vs DOMElement usage whe working on #10927. However, I submitted this change to 2.3 instead, to ease merging between branches (applying the change only in master would likely create conflicts regularly when merging changes in DomCrawler between branches later)
