### PR TITLE
[Process] Deprecate using values that are not string for Process::setStdin and ProcessBuilder::setInput

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -971,3 +971,4 @@ UPGRADE FROM 2.x to 3.0
 
  * Process::setStdin() and Process::getStdin() have been removed. Use
    Process::setInput() and Process::getInput() that works the same way.
+ * Process::setInput() and ProcessBuilder::setInput() do not accept non-scalar types.

--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added the convenience method "mustRun"
  * deprecation: Process::setStdin() is deprecated in favor of Process::setInput()
  * deprecation: Process::getStdin() is deprecated in favor of Process::getInput()
+ * deprecation: Process::setInput() and ProcessBuilder::setInput() do not accept non-scalar types
 
 2.4.0
 -----

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1060,6 +1060,8 @@ class Process
     /**
      * Sets the contents of STDIN.
      *
+     * Deprecation: As of Symfony 2.5, this method only accepts scalar values.
+     *
      * @param string|null $stdin The new contents
      *
      * @return self The current Process instance

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -156,6 +156,8 @@ class ProcessBuilder
     /**
      * Sets the input of the process.
      *
+     * Deprecation: As of Symfony 2.5, this method only accepts string values.
+     *
      * @param string|null $input The input as a string
      *
      * @return ProcessBuilder

--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -75,7 +75,7 @@ class ProcessUtils
     }
 
     /**
-     * Validates and normalized a Process input
+     * Validates and normalizes a Process input
      *
      * @param string $caller The name of method call that validates the input
      * @param mixed  $input  The input to validate
@@ -87,7 +87,11 @@ class ProcessUtils
     public static function validateInput($caller, $input)
     {
         if (null !== $input) {
-            if (is_scalar($input) || (is_object($input) && method_exists($input, '__toString'))) {
+            if (is_scalar($input)) {
+                return (string) $input;
+            }
+            // deprecated as of Symfony 2.5, to be removed in 3.0
+            if (is_object($input) && method_exists($input, '__toString')) {
                 return (string) $input;
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

This deprecates passing a `Process` input any value that is not a strict string. This needs #10929 to be merged.
I don't know if the use of `trigger_error` is correct or should be removed.
