### PR TITLE
[HttpFoundation] enhance PdoSessionHandler

### DIFF
--- a/UPGRADE-2.6.md
+++ b/UPGRADE-2.6.md
@@ -105,8 +105,8 @@ Security
 HttpFoundation
 --------------
 
- * The PdoSessionHandler to store sessions in a database changed significantly.
-   - It now implements session locking to prevent loss of data by concurrent access to the same session.
+ * The `PdoSessionHandler` to store sessions in a database changed significantly.
+   - By default, it now implements session locking to prevent loss of data by concurrent access to the same session.
      - It does so using a transaction between opening and closing a session. For this reason, it's not
        recommended to use the same database connection that you also use for your application logic.
        Otherwise you have to make sure to access your database after the session is closed and committed.
@@ -115,11 +115,16 @@ HttpFoundation
      - Since accessing a session now blocks when the same session is still open, it is best practice to
        save the session as soon as you don't need to write to it anymore. For example, read-only AJAX
        request to a session can save the session immediately after opening it to increase concurrency.
+     - As alternative to transactional locking you can also use advisory locks which do not require a transaction.
+       Additionally, you can also revert back to no locking in case you have custom logic to deal with race conditions
+       like an optimistic concurrency control approach. The locking strategy can be chosen by passing the corresponding
+       constant as `lock_mode` option, e.g. `new PdoSessionHandler($pdoOrDsn, array('lock_mode' => PdoSessionHandler::LOCK_NONE))`.
+       For more information please read the class documentation.
    - The expected schema of the table changed.
      - Session data is binary text that can contain null bytes and thus should also be saved as-is in a
        binary column like BLOB. For this reason, the handler does not base64_encode the data anymore.
      - A new column to store the lifetime of a session is required. This allows to have different
        lifetimes per session configured via session.gc_maxlifetime ini setting.
      - You would need to migrate the table manually if you want to keep session information of your users.
-     - You could use PdoSessionHandler::createTable to initialize a correctly defined table depending on
+     - You could use `PdoSessionHandler::createTable` to initialize a correctly defined table depending on
        the used database vendor.

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,9 +5,9 @@ CHANGELOG
 -----
 
  * PdoSessionHandler changes
-   - implemented session locking to prevent loss of data by concurrent access to the same session
-   - save session data in a binary column without base64_encode
-   - added lifetime column to the session table which allows to have different lifetimes for each session
+   - implemented different session locking strategies to prevent loss of data by concurrent access to the same session
+   - [BC BREAK] save session data in a binary column without base64_encode
+   - [BC BREAK] added lifetime column to the session table which allows to have different lifetimes for each session
    - implemented lazy connections that are only opened when a session is used by either passing a dsn string
      explicitly or falling back to session.save_path ini setting
    - added a createTable method that initializes a correctly defined table depending on the database vendor

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,17 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * PdoSessionHandler changes
+   - implemented session locking to prevent loss of data by concurrent access to the same session
+   - save session data in a binary column without base64_encode
+   - added lifetime column to the session table which allows to have different lifetimes for each session
+   - implemented lazy connections that are only opened when a session is used by either passing a dsn string
+     explicitly or falling back to session.save_path ini setting
+   - added a createTable method that initializes a correctly defined table depending on the database vendor
+
 2.5.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -26,7 +26,8 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  *
  * Session data is a binary string that can contain non-printable characters like the null byte.
  * For this reason it must be saved in a binary column in the database like BLOB in MySQL.
- * Saving it in a character column could corrupt the data.
+ * Saving it in a character column could corrupt the data. You can use createTable()
+ * to initialize a correctly defined table.
  *
  * @see http://php.net/sessionhandlerinterface
  *
@@ -159,15 +160,57 @@ class PdoSessionHandler implements \SessionHandlerInterface
     }
 
     /**
+     * Creates the table to store sessions which can be called once for setup.
+     *
+     * Session ID is saved in a VARCHAR(128) column because that is enough even for
+     * a 512 bit configured session.hash_function like Whirlpool. Session data is
+     * saved in a BLOB. One could also use a shorter inlined varbinary column
+     * if one was sure the data fits into it.
+     *
+     * @throws \PDOException    When the table already exists
+     * @throws \DomainException When an unsupported PDO driver is used
+     */
+    public function createTable()
+    {
+        // connect if we are not yet
+        $this->getConnection();
+
+        switch ($this->driver) {
+            case 'mysql':
+                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol MEDIUMINT NOT NULL, $this->timeCol INTEGER NOT NULL) ENGINE = InnoDB";
+                break;
+            case 'sqlite':
+                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol MEDIUMINT NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                break;
+            case 'pgsql':
+                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BYTEA NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                break;
+            case 'oci':
+                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR2(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                break;
+            case 'sqlsrv':
+                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol VARBINARY(MAX) NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                break;
+            default:
+                throw new \DomainException(sprintf('"%s" does not currently support PDO driver "%s".', __CLASS__, $this->driver));
+        }
+
+        try {
+            $this->pdo->exec($sql);
+        } catch (\PDOException $e) {
+            $this->rollback();
+
+            throw $e;
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function open($savePath, $sessionName)
     {
-        $this->gcCalled = false;
         if (null === $this->pdo) {
-            $this->pdo = new \PDO($this->dsn ?: $savePath, $this->username, $this->password, $this->connectionOptions);
-            $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-            $this->driver = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+            $this->connect($this->dsn ?: $savePath);
         }
 
         return true;
@@ -315,6 +358,8 @@ class PdoSessionHandler implements \SessionHandlerInterface
         $this->commit();
 
         if ($this->gcCalled) {
+            $this->gcCalled = false;
+
             // delete the session records that have expired
             $sql = "DELETE FROM $this->table WHERE $this->lifetimeCol + $this->timeCol < :time";
 
@@ -328,6 +373,18 @@ class PdoSessionHandler implements \SessionHandlerInterface
         }
 
         return true;
+    }
+
+    /**
+     * Lazy-connects to the database.
+     *
+     * @param string $dsn DSN string
+     */
+    private function connect($dsn)
+    {
+        $this->pdo = new \PDO($dsn, $this->username, $this->password, $this->connectionOptions);
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->driver = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
     }
 
     /**
@@ -399,6 +456,8 @@ class PdoSessionHandler implements \SessionHandlerInterface
      * INSERT when not found can result in a deadlock for one connection.
      *
      * @param string $sessionId Session ID
+     *
+     * @throws \DomainException When an unsupported PDO driver is used
      */
     private function lockSession($sessionId)
     {
@@ -429,8 +488,10 @@ class PdoSessionHandler implements \SessionHandlerInterface
                 $stmt->execute();
 
                 return;
+            case 'sqlite':
+                return; // we already locked when starting transaction
             default:
-                return;
+                throw new \DomainException(sprintf('"%s" does not currently support PDO driver "%s".', __CLASS__, $this->driver));
         }
 
         // We create a DML lock for the session by inserting empty data or updating the row.
@@ -478,6 +539,10 @@ class PdoSessionHandler implements \SessionHandlerInterface
      */
     protected function getConnection()
     {
+        if (null === $this->pdo) {
+            $this->connect($this->dsn ?: ini_get('session.save_path'));
+        }
+
         return $this->pdo;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -109,6 +109,9 @@ class PdoSessionHandler implements \SessionHandlerInterface
      * pass a DSN string that will be used to lazy-connect to the database
      * when the session is actually used. Furthermore it's possible to pass null
      * which will then use the session.save_path ini setting as PDO DSN parameter.
+     * Since locking uses a transaction between opening and closing a session,
+     * it's not recommended to use the same database connection that you also use
+     * for your application logic.
      *
      * List of available options:
      *  * db_table: The name of the table [default: sessions]

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -180,10 +180,10 @@ class PdoSessionHandler implements \SessionHandlerInterface
 
         switch ($this->driver) {
             case 'mysql':
-                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol MEDIUMINT NOT NULL, $this->timeCol INTEGER NOT NULL) ENGINE = InnoDB";
+                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol MEDIUMINT NOT NULL, $this->timeCol INTEGER UNSIGNED NOT NULL) ENGINE = InnoDB";
                 break;
             case 'sqlite':
-                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol MEDIUMINT NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                $sql = "CREATE TABLE $this->table ($this->idCol TEXT NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
                 break;
             case 'pgsql':
                 $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BYTEA NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -36,7 +36,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $this->dbFile = tempnam(sys_get_temp_dir(), 'sf2_sqlite_sessions');
 
-        return 'sqlite:' . $this->dbFile;
+        return 'sqlite:'.$this->dbFile;
     }
 
     protected function getMemorySqlitePdo()
@@ -120,7 +120,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testReadWriteReadWithNullByte()
     {
-        $sessionData = 'da' . "\0" . 'ta';
+        $sessionData = 'da'."\0".'ta';
 
         $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
         $storage->open('', 'sid');

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -106,19 +106,21 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         @unlink($dbFile);
     }
 
-    public function testReadWriteRead()
+    public function testReadWriteReadWithNullByte()
     {
+        $sessionData = 'da' . "\0" . 'ta';
+
         $storage = new PdoSessionHandler($this->pdo);
         $storage->open('', 'sid');
-        $data = $storage->read('id');
-        $storage->write('id', 'data');
+        $readData = $storage->read('id');
+        $storage->write('id', $sessionData);
         $storage->close();
-        $this->assertSame('', $data, 'New session returns empty string data');
+        $this->assertSame('', $readData, 'New session returns empty string data');
 
         $storage->open('', 'sid');
-        $data = $storage->read('id');
+        $readData = $storage->read('id');
         $storage->close();
-        $this->assertSame('data', $data, 'Written value can be read back correctly');
+        $this->assertSame($sessionData, $readData, 'Written value can be read back correctly');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5483, #2067, #2382, #9029 |
| License | MIT |
1. [x] Continuation of locking implementation (#10908): Implement different locking strategies
   - `PdoSessionHandler::LOCK_TRANSACTIONAL` (default): Issues a real row lock but requires a transaction
   - `PdoSessionHandler::LOCK_ADVISORY`: app-level lock, safe as long as only the PdoSessionHandler accesses sessions, advantage is it does not require a transaction (not implemented for oracle or sqlsrv yet)
   - `PdoSessionHandler::LOCK_NONE`: basically what is was before, prone to race conditions, means the last session write wins
2. [x] Save session data as binary: Encoding session data was definitely the wrong solution. Session data is binary text (esp. when using other session.serialize_handler) that must stay as-is and thus must also be safed in a binary column. Base64 encoding session data just decreses performance and increases storage costs and is semantically wrong because it does not have a character encoding.
   That saving null bytes in Posgres won't work on a character column is also documented
   
   > First, binary strings specifically allow storing octets of value zero and other "non-printable" octets (usually, octets outside the range 32 to 126). Character strings disallow zero octets, and also disallow any other octet values and sequences of octet values that are invalid according to the database's selected character set encoding. 
   > http://www.postgresql.org/docs/9.1/static/datatype-binary.html#DATATYPE-BINARY-TABLE
3. [x] Implement lazy connections that are only opened when session is used by either passing a dsn string explicitly or falling back to session.save_path ini setting. Fixes #9029
4. [x] add a create table method that creates the correct table depending on database vendor. This makes the class self-documenting and standalone useable.
5. [x] add lifetime column to session table which allows to have different lifetimes for each session
6. [x] add isSessionExpired() method to be able to distinguish between a new session and one that expired due to inactivity, e.g. to display flash message to user
7. [x] added upgrade and changelog notes
