### PR TITLE
[Process] Deprecate Process::setStdin in favor of Process::setInput

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -966,4 +966,8 @@ UPGRADE FROM 2.x to 3.0
 
    ```
    Yaml::parse(file_get_contents($fileName));
-   ```
+
+### Process
+
+ * Process::setStdin() and Process::getStdin() have been removed. Use
+   Process::setInput() and Process::getInput() that works the same way.

--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * added support for PTY mode
  * added the convenience method "mustRun"
+ * deprecation: Process::setStdin() is deprecated in favor of Process::setInput()
+ * deprecation: Process::getStdin() is deprecated in favor of Process::getInput()
 
 2.4.0
 -----

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -45,7 +45,7 @@ class Process
     private $commandline;
     private $cwd;
     private $env;
-    private $stdin;
+    private $input;
     private $starttime;
     private $lastOutputTime;
     private $timeout;
@@ -128,7 +128,7 @@ class Process
      * @param string             $commandline The command line to run
      * @param string|null        $cwd         The working directory or null to use the working dir of the current PHP process
      * @param array|null         $env         The environment variables or null to inherit
-     * @param string|null        $stdin       The STDIN content
+     * @param string|null        $input       The input
      * @param int|float|null     $timeout     The timeout in seconds or null to disable
      * @param array              $options     An array of options for proc_open
      *
@@ -136,7 +136,7 @@ class Process
      *
      * @api
      */
-    public function __construct($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    public function __construct($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array())
     {
         if (!function_exists('proc_open')) {
             throw new RuntimeException('The Process class relies on proc_open, which is not available on your PHP installation.');
@@ -156,7 +156,7 @@ class Process
             $this->setEnv($env);
         }
 
-        $this->stdin = $stdin;
+        $this->input = $input;
         $this->setTimeout($timeout);
         $this->useFileHandles = defined('PHP_WINDOWS_VERSION_BUILD');
         $this->pty = false;
@@ -224,7 +224,7 @@ class Process
     }
 
     /**
-     * Starts the process and returns after sending the STDIN.
+     * Starts the process and returns after writing the input to STDIN.
      *
      * This method blocks until all STDIN data is sent to the process then it
      * returns while the process runs in the background.
@@ -288,7 +288,7 @@ class Process
             return;
         }
 
-        $this->processPipes->write(false, $this->stdin);
+        $this->processPipes->write(false, $this->input);
         $this->updateStatus(false);
         $this->checkTimeout();
     }
@@ -1038,10 +1038,23 @@ class Process
      * Gets the contents of STDIN.
      *
      * @return string|null The current contents
+     *
+     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+     *             This method is deprecated in favor of getInput.
      */
     public function getStdin()
     {
-        return $this->stdin;
+        return $this->getInput();
+    }
+
+    /**
+     * Gets the Process input.
+     *
+     * @return null|string The Process input
+     */
+    public function getInput()
+    {
+        return $this->input;
     }
 
     /**
@@ -1052,14 +1065,33 @@ class Process
      * @return self The current Process instance
      *
      * @throws LogicException In case the process is running
+     *
+     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+     *             This method is deprecated in favor of setInput.
      */
     public function setStdin($stdin)
     {
+        return $this->setInput($stdin);
+    }
+
+    /**
+     * Sets the input.
+     *
+     * This content will be passed to the underlying process standard input.
+     *
+     * @param string|null $input The content
+     *
+     * @return self The current Process instance
+     *
+     * @throws LogicException In case the process is running
+     */
+    public function setInput($input)
+    {
         if ($this->isRunning()) {
-            throw new LogicException('STDIN can not be set while the process is running.');
+            throw new LogicException('Input can not be set while the process is running.');
         }
 
-        $this->stdin = $stdin;
+        $this->input = $input;
 
         return $this;
     }

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -24,7 +24,7 @@ class ProcessBuilder
     private $arguments;
     private $cwd;
     private $env = array();
-    private $stdin;
+    private $input;
     private $timeout = 60;
     private $options = array();
     private $inheritEnv = true;
@@ -156,13 +156,13 @@ class ProcessBuilder
     /**
      * Sets the input of the process.
      *
-     * @param string $stdin The input as a string
+     * @param string $input The input as a string
      *
      * @return ProcessBuilder
      */
-    public function setInput($stdin)
+    public function setInput($input)
     {
-        $this->stdin = $stdin;
+        $this->input = $input;
 
         return $this;
     }
@@ -261,7 +261,7 @@ class ProcessBuilder
             $env = $this->env;
         }
 
-        $process = new Process($script, $this->cwd, $env, $this->stdin, $this->timeout, $options);
+        $process = new Process($script, $this->cwd, $env, $this->input, $this->timeout, $options);
 
         if ($this->outputDisabled) {
             $process->disableOutput();

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -151,23 +151,23 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $expectedLength = (1024 * $size) + 1;
 
         $p = $this->getProcess(sprintf('php -r %s', escapeshellarg($code)));
-        $p->setStdin($expected);
+        $p->setInput($expected);
         $p->run();
 
         $this->assertEquals($expectedLength, strlen($p->getOutput()));
         $this->assertEquals($expectedLength, strlen($p->getErrorOutput()));
     }
 
-    public function testSetStdinWhileRunningThrowsAnException()
+    public function testSetInputWhileRunningThrowsAnException()
     {
         $process = $this->getProcess('php -r "usleep(500000);"');
         $process->start();
         try {
-            $process->setStdin('foobar');
+            $process->setInput('foobar');
             $process->stop();
             $this->fail('A LogicException should have been raised.');
         } catch (LogicException $e) {
-            $this->assertEquals('STDIN can not be set while the process is running.', $e->getMessage());
+            $this->assertEquals('Input can not be set while the process is running.', $e->getMessage());
         }
         $process->stop();
     }
@@ -993,6 +993,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
             array('WorkingDirectory'),
             array('Env'),
             array('Stdin'),
+            array('Input'),
             array('Options')
         );
 
@@ -1000,14 +1001,14 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string  $commandline
-     * @param null    $cwd
-     * @param array   $env
-     * @param null    $stdin
-     * @param int     $timeout
-     * @param array   $options
+     * @param string         $commandline
+     * @param null|string    $cwd
+     * @param null|array     $env
+     * @param null|string    $input
+     * @param int            $timeout
+     * @param array          $options
      *
      * @return Process
      */
-    abstract protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array());
+    abstract protected function getProcess($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array());
 }

--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -150,9 +150,9 @@ class SimpleProcessTest extends AbstractProcessTest
     /**
      * {@inheritdoc}
      */
-    protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    protected function getProcess($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array())
     {
-        return new Process($commandline, $cwd, $env, $stdin, $timeout, $options);
+        return new Process($commandline, $cwd, $env, $input, $timeout, $options);
     }
 
     private function skipIfPHPSigchild()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

From the `Process` point of view, what we pass is an _input_, as well as we retrieve _output_ and _error output_.
As we use `getOutput` and `getErrorOutput` we should use `setInput` and let the underlying `ProcessPipes` deal with the actual `STDIN`.

By the way, `ProcessBuilder` already has `setInput` method and no `setStdin` method
