### PR TITLE
Changed the default value of checkbox and radio to match the HTML spec

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 2.5.0
 -----
 
+* [BC BREAK] The default value for checkbox and radio inputs without a value attribute have changed
+  from '1' to 'on' to match the HTML specification.
 * [BC BREAK] The typehints on the `Link`, `Form` and `FormField` classes have been changed from
   `\DOMNode` to `DOMElement`. Using any other type of `DOMNode` was triggering fatal errors in previous
   versions. Code extending these classes will need to update the typehints when overwriting these methods.

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -267,7 +267,7 @@ class ChoiceFormField extends FormField
     {
         $option = array();
 
-        $defaultValue = (isset($node->nodeValue) && !empty($node->nodeValue)) ? $node->nodeValue : '1';
+        $defaultValue = (isset($node->nodeValue) && !empty($node->nodeValue)) ? $node->nodeValue : 'on';
         $option['value'] = $node->hasAttribute('value') ? $node->getAttribute('value') : $defaultValue;
         $option['disabled'] = ($node->hasAttribute('disabled') && $node->getAttribute('disabled') == 'disabled');
 

--- a/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
@@ -201,7 +201,7 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $field = new ChoiceFormField($node);
 
         $this->assertTrue($field->hasValue(), '->hasValue() returns true when the checkbox is checked');
-        $this->assertEquals('1', $field->getValue(), '->getValue() returns 1 if the checkbox is checked and has no value attribute');
+        $this->assertEquals('on', $field->getValue(), '->getValue() returns 1 if the checkbox is checked and has no value attribute');
 
         $node = $this->createNode('input', '', array('type' => 'checkbox', 'name' => 'name', 'checked' => 'checked', 'value' => 'foo'));
         $field = new ChoiceFormField($node);
@@ -240,7 +240,7 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $node = $this->createNode('input', '', array('type' => 'checkbox', 'name' => 'name'));
         $field = new ChoiceFormField($node);
         $field->tick();
-        $this->assertEquals(1, $field->getValue(), '->tick() ticks checkboxes');
+        $this->assertEquals('on', $field->getValue(), '->tick() ticks checkboxes');
     }
 
     public function testUntick()
@@ -266,7 +266,7 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $node = $this->createNode('input', '', array('type' => 'checkbox', 'name' => 'name', 'checked' => 'checked'));
         $field = new ChoiceFormField($node);
         $field->select(true);
-        $this->assertEquals(1, $field->getValue(), '->select() changes the value of the field');
+        $this->assertEquals('on', $field->getValue(), '->select() changes the value of the field');
         $field->select(false);
         $this->assertNull($field->getValue(), '->select() changes the value of the field');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | n/a |

When the checkbox or radio input does not have a value attribute, the [HTML spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/states-of-the-type-attribute.html#checkbox-state-%28type=checkbox%29) defines that the value [should be `on`](http://www.whatwg.org/specs/web-apps/current-work/multipage/common-input-element-attributes.html#dom-input-value-default-on), not `1`.

This change is a small BC break as a testsuite with an assertion on the `1` value would fail after the change. However, this means that such testsuite would assert a different behavior than the real usage of the application.
Note that people using the DomCrawler component on pages using the Symfony Form component are not affected by the change as the Form component always set an explicit value on checkboxes and radio buttons
