### PR TITLE
[HttpKernel] Fix "absolute path" when we look to the cache directory

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -746,9 +746,15 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $filesystem = new Filesystem();
 
         return preg_replace_callback("{'([^']*)(".preg_quote($rootDir)."[^']*)'}", function ($match) use ($filesystem, $cacheDir) {
-            $prefix = isset($match[1]) && $match[1] ? "'$match[1]'.__DIR__.'/" : "__DIR__.'/";
+            $prefix = isset($match[1]) && $match[1] ? "'$match[1]'.__DIR__" : "__DIR__";
 
-            return $prefix.rtrim($filesystem->makePathRelative($match[2], $cacheDir), '/')."'";
+            $relativePath = rtrim($filesystem->makePathRelative($match[2], $cacheDir), '/');
+
+            if ($relativePath === '.') {
+                return $prefix;
+            }
+
+            return $prefix . ".'/" . $relativePath . "'";
         }, $content);
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/DumpedContainers/app/cache/dev/withAbsolutePaths.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/DumpedContainers/app/cache/dev/withAbsolutePaths.php
@@ -1,6 +1,7 @@
 'ROOT_DIR/app/cache/dev/foo'
 'ROOT_DIR/app/cache/foo'
 'ROOT_DIR/foo/bar.php'
+'ROOT_DIR/app/cache/dev'
 
 '/some/where/else/foo'
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/DumpedContainers/app/cache/dev/withoutAbsolutePaths.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/DumpedContainers/app/cache/dev/withoutAbsolutePaths.php
@@ -1,6 +1,7 @@
 __DIR__.'/foo'
 __DIR__.'/../foo'
 __DIR__.'/../../../foo/bar.php'
+__DIR__
 
 '/some/where/else/foo'
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

We should get `__DIR__` instead of `__DIR__ . '/.'`

I've seen this issue when trying to play with the symfony standard new directory structure
