### PR TITLE
[Component][Translation][Loader] Include file path in exception message 

### DIFF
--- a/src/Symfony/Component/Translation/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/YamlFileLoader.php
@@ -50,7 +50,7 @@ class YamlFileLoader extends ArrayLoader implements LoaderInterface
         try {
             $messages = $this->yamlParser->parse(file_get_contents($resource));
         } catch (ParseException $e) {
-            throw new InvalidResourceException('Error parsing YAML.', 0, $e);
+            throw new InvalidResourceException(sprintf('Error parsing YAML, invalid file "%s"', $resource), 0, $e);
         }
 
         // empty file


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | on |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When Translation component tryes to load an invalid YAML file, you get 

```
InvalidResourceException: Error parsing YAML.
```

Which is not very helpful, I spent 1 hour looking for the invalid file, I think is better to include the file path in the exception message.
