### PR TITLE
[2.5][PropertyAccess] Fixed getValue() when accessing non-existing indices of ArrayAccess implementations

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -231,7 +231,22 @@ class PropertyAccessor implements PropertyAccessorInterface
             // Create missing nested arrays on demand
             if ($isIndex && $isArrayAccess && !isset($objectOrArray[$property])) {
                 if (!$ignoreInvalidIndices) {
-                    throw new NoSuchIndexException(sprintf('Cannot read property "%s". Available properties are "%s"', $property, print_r(array_keys($objectOrArray), true)));
+                    if (!is_array($objectOrArray)) {
+                        if (!$objectOrArray instanceof \Traversable) {
+                            throw new NoSuchIndexException(sprintf(
+                                'Cannot read property "%s".',
+                                $property
+                            ));
+                        }
+
+                        $objectOrArray = iterator_to_array($objectOrArray);
+                    }
+
+                    throw new NoSuchIndexException(sprintf(
+                        'Cannot read property "%s". Available properties are "%s"',
+                        $property,
+                        print_r(array_keys($objectOrArray), true)
+                    ));
                 }
 
                 $objectOrArray[$property] = $i + 1 < $propertyPath->getLength() ? array() : null;

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/NonTraversableArrayObject.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/NonTraversableArrayObject.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+/**
+ * This class is a hand written simplified version of PHP native `ArrayObject`
+ * class, to show that it behaves differently than the PHP native implementation.
+ */
+class NonTraversableArrayObject implements \ArrayAccess, \Countable, \Serializable
+{
+    private $array;
+
+    public function __construct(array $array = null)
+    {
+        $this->array = $array ?: array();
+    }
+
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->array);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->array[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (null === $offset) {
+            $this->array[] = $value;
+        } else {
+            $this->array[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->array[$offset]);
+    }
+
+    public function count()
+    {
+        return count($this->array);
+    }
+
+    public function serialize()
+    {
+        return serialize($this->array);
+    }
+
+    public function unserialize($serialized)
+    {
+        $this->array = (array) unserialize((string) $serialized);
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TraversableArrayObject.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TraversableArrayObject.php
@@ -15,7 +15,7 @@ namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
  * This class is a hand written simplified version of PHP native `ArrayObject`
  * class, to show that it behaves differently than the PHP native implementation.
  */
-class CustomArrayObject implements \ArrayAccess, \IteratorAggregate, \Countable, \Serializable
+class TraversableArrayObject implements \ArrayAccess, \IteratorAggregate, \Countable, \Serializable
 {
     private $array;
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+abstract class PropertyAccessorArrayAccessTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PropertyAccessor
+     */
+    protected $propertyAccessor;
+
+    protected function setUp()
+    {
+        $this->propertyAccessor = new PropertyAccessor();
+    }
+
+    abstract protected function getContainer(array $array);
+
+    public function getValidPropertyPaths()
+    {
+        return array(
+            array($this->getContainer(array('firstName' => 'Bernhard')), '[firstName]', 'Bernhard'),
+            array($this->getContainer(array('person' => $this->getContainer(array('firstName' => 'Bernhard')))), '[person][firstName]', 'Bernhard'),
+        );
+    }
+
+    /**
+     * @dataProvider getValidPropertyPaths
+     */
+    public function testGetValue($collection, $path, $value)
+    {
+        $this->assertSame($value, $this->propertyAccessor->getValue($collection, $path));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
+     */
+    public function testGetValueFailsIfNoSuchIndex()
+    {
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->getPropertyAccessor();
+
+        $object = $this->getContainer(array('firstName' => 'Bernhard'));
+
+        $this->propertyAccessor->getValue($object, '[lastName]');
+    }
+
+    /**
+     * @dataProvider getValidPropertyPaths
+     */
+    public function testSetValue($collection, $path)
+    {
+        $this->propertyAccessor->setValue($collection, $path, 'Updated');
+
+        $this->assertSame('Updated', $this->propertyAccessor->getValue($collection, $path));
+    }
+
+    /**
+     * @dataProvider getValidPropertyPaths
+     */
+    public function testIsReadable($collection, $path)
+    {
+        $this->assertTrue($this->propertyAccessor->isReadable($collection, $path));
+    }
+
+    /**
+     * @dataProvider getValidPropertyPaths
+     */
+    public function testIsWritable($collection, $path)
+    {
+        $this->assertTrue($this->propertyAccessor->isWritable($collection, $path, 'Updated'));
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayObjectTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayObjectTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\PropertyAccess\Tests;
 
 class PropertyAccessorArrayObjectTest extends PropertyAccessorCollectionTest
 {
-    protected function getCollection(array $array)
+    protected function getContainer(array $array)
     {
         return new \ArrayObject($array);
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorNonTraversableArrayObjectTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorNonTraversableArrayObjectTest.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\PropertyAccess\Tests;
 
-class PropertyAccessorArrayTest extends PropertyAccessorCollectionTest
+use Symfony\Component\PropertyAccess\Tests\Fixtures\NonTraversableArrayObject;
+
+class PropertyAccessorNonTraversableArrayObjectTest extends PropertyAccessorArrayAccessTest
 {
     protected function getContainer(array $array)
     {
-        return $array;
+        return new NonTraversableArrayObject($array);
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTraversableArrayObjectTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTraversableArrayObjectTest.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\Component\PropertyAccess\Tests;
 
-use Symfony\Component\PropertyAccess\Tests\Fixtures\CustomArrayObject;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TraversableArrayObject;
 
-class PropertyAccessorCustomArrayObjectTest extends PropertyAccessorCollectionTest
+class PropertyAccessorTraversableArrayObjectTest extends PropertyAccessorCollectionTest
 {
-    protected function getCollection(array $array)
+    protected function getContainer(array $array)
     {
-        return new CustomArrayObject($array);
+        return new TraversableArrayObject($array);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Previously, when the following code was executed:

``` php
$object = new ImplOfArrayAccess();

$propertyAccessor->setValue($object, '[index]', 'Value');
```

and that index did not exist, a fatal error would be generated because `array_keys()` was executed on `$object`. This error is fixed now.
