### PR TITLE
Fixed the Travis build to avoid exiting too early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ before_script:
     - wget https://phar.phpunit.de/phpunit.phar && rm `which phpunit` && sudo cp phpunit.phar /usr/local/bin/phpunit && sudo chmod +x /usr/local/bin/phpunit
 
 script:
-    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || return 1
+    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || false
     - echo "Running tests requiring tty"; phpunit --group tty

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ before_script:
     - wget https://phar.phpunit.de/phpunit.phar && rm `which phpunit` && sudo cp phpunit.phar /usr/local/bin/phpunit && sudo chmod +x /usr/local/bin/phpunit
 
 script:
-    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || exit 1
+    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || return 1
     - echo "Running tests requiring tty"; phpunit --group tty


### PR DESCRIPTION
currently, failed tests on Travis are exiting the build too early, avoiding to run some tests and maybe even loosing some output. See https://github.com/travis-ci/travis-ci/issues/2346 for more details
