### PR TITLE
Made use of "kB" vs. "KiB" consistent

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -92,15 +92,15 @@ abstract class Helper implements HelperInterface
     public static function formatMemory($memory)
     {
         if ($memory >= 1024 * 1024 * 1024) {
-            return sprintf('%.1f GB', $memory / 1024 / 1024 / 1024);
+            return sprintf('%.1f GiB', $memory / 1024 / 1024 / 1024);
         }
 
         if ($memory >= 1024 * 1024) {
-            return sprintf('%.1f MB', $memory / 1024 / 1024);
+            return sprintf('%.1f MiB', $memory / 1024 / 1024);
         }
 
         if ($memory >= 1024) {
-            return sprintf('%d kB', $memory / 1024);
+            return sprintf('%d KiB', $memory / 1024);
         }
 
         return sprintf('%d B', $memory);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -367,17 +367,17 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
             $this->generateOutput(
                 " \033[44;37m Starting the demo... fingers crossed  \033[0m\n".
                 "  0/15 ".$progress.str_repeat($empty, 26)."   0%\n".
-                " 🏁  1 sec                          \033[44;37m 0 B \033[0m"
+                " \xf0\x9f\x8f\x81  1 sec                          \033[44;37m 0 B \033[0m"
             ).
             $this->generateOutput(
                 " \033[44;37m Looks good to me...                   \033[0m\n".
                 "  4/15 ".str_repeat($done, 7).$progress.str_repeat($empty, 19)."  26%\n".
-                " 🏁  1 sec                        \033[41;37m 97 kB \033[0m"
+                " \xf0\x9f\x8f\x81  1 sec                       \033[41;37m 97 KiB \033[0m"
             ).
             $this->generateOutput(
                 " \033[44;37m Thanks, bye                           \033[0m\n".
                 " 15/15 ".str_repeat($done, 28)." 100%\n".
-                " 🏁  1 sec                       \033[41;37m 195 kB \033[0m"
+                " \xf0\x9f\x8f\x81  1 sec                      \033[41;37m 195 KiB \033[0m"
             ),
             stream_get_contents($output->getStream())
         );

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -291,7 +291,7 @@ class UploadedFile extends File
     public function getErrorMessage()
     {
         static $errors = array(
-            UPLOAD_ERR_INI_SIZE   => 'The file "%s" exceeds your upload_max_filesize ini directive (limit is %d kb).',
+            UPLOAD_ERR_INI_SIZE   => 'The file "%s" exceeds your upload_max_filesize ini directive (limit is %d KiB).',
             UPLOAD_ERR_FORM_SIZE  => 'The file "%s" exceeds the upload limit defined in your form.',
             UPLOAD_ERR_PARTIAL    => 'The file "%s" was only partially uploaded.',
             UPLOAD_ERR_NO_FILE    => 'No file was uploaded.',

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -25,6 +25,16 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class FileValidator extends ConstraintValidator
 {
+    const KB_BYTES = 1000;
+
+    const MB_BYTES = 1000000;
+
+    private static $suffices = array(
+        1 => 'bytes',
+        self::KB_BYTES => 'kB',
+        self::MB_BYTES => 'MB',
+    );
+
     /**
      * {@inheritdoc}
      */
@@ -43,21 +53,21 @@ class FileValidator extends ConstraintValidator
                 case UPLOAD_ERR_INI_SIZE:
                     if ($constraint->maxSize) {
                         if (ctype_digit((string) $constraint->maxSize)) {
-                            $maxSize = (int) $constraint->maxSize;
+                            $limitInBytes = (int) $constraint->maxSize;
                         } elseif (preg_match('/^\d++k$/', $constraint->maxSize)) {
-                            $maxSize = $constraint->maxSize * 1000;
+                            $limitInBytes = $constraint->maxSize * self::KB_BYTES;
                         } elseif (preg_match('/^\d++M$/', $constraint->maxSize)) {
-                            $maxSize = $constraint->maxSize * 1000 * 1000;
+                            $limitInBytes = $constraint->maxSize * self::MB_BYTES;
                         } else {
                             throw new ConstraintDefinitionException(sprintf('"%s" is not a valid maximum size', $constraint->maxSize));
                         }
-                        $maxSize = min(UploadedFile::getMaxFilesize(), $maxSize);
+                        $limitInBytes = min(UploadedFile::getMaxFilesize(), $limitInBytes);
                     } else {
-                        $maxSize = UploadedFile::getMaxFilesize();
+                        $limitInBytes = UploadedFile::getMaxFilesize();
                     }
 
                     $this->context->addViolation($constraint->uploadIniSizeErrorMessage, array(
-                        '{{ limit }}' => $maxSize,
+                        '{{ limit }}' => $limitInBytes,
                         '{{ suffix }}' => 'bytes',
                     ));
 
@@ -112,27 +122,45 @@ class FileValidator extends ConstraintValidator
         }
 
         if ($constraint->maxSize) {
-            if (ctype_digit((string) $constraint->maxSize)) {
-                $size = filesize($path);
-                $limit = (int) $constraint->maxSize;
-                $suffix = 'bytes';
-            } elseif (preg_match('/^\d++k$/', $constraint->maxSize)) {
-                $size = round(filesize($path) / 1000, 2);
-                $limit = (int) $constraint->maxSize;
-                $suffix = 'KB';
+            $sizeInBytes = filesize($path);
+            $limitInBytes = (int) $constraint->maxSize;
+
+            if (preg_match('/^\d++k$/', $constraint->maxSize)) {
+                $limitInBytes *= self::KB_BYTES;
             } elseif (preg_match('/^\d++M$/', $constraint->maxSize)) {
-                $size = round(filesize($path) / (1000 * 1000), 2);
-                $limit = (int) $constraint->maxSize;
-                $suffix = 'MB';
-            } else {
+                $limitInBytes *= self::MB_BYTES;
+            } elseif (!ctype_digit((string) $constraint->maxSize)) {
                 throw new ConstraintDefinitionException(sprintf('"%s" is not a valid maximum size', $constraint->maxSize));
             }
 
-            if ($size > $limit) {
+            if ($sizeInBytes > $limitInBytes) {
+                // Convert the limit to the smallest possible number
+                // (i.e. try "MB", then "kB", then "bytes")
+                $coef = self::MB_BYTES;
+                $limitAsString = (string) ($limitInBytes / $coef);
+
+                // Restrict the limit to 2 decimals (without rounding! we
+                // need the precise value)
+                while (self::moreDecimalsThan($limitAsString, 2)) {
+                    $coef /= 1000;
+                    $limitAsString = (string) ($limitInBytes / $coef);
+                }
+
+                // Convert size to the same measure, but round to 2 decimals
+                $sizeAsString = (string) round($sizeInBytes / $coef, 2);
+
+                // If the size and limit produce the same string output
+                // (due to rounding), reduce the coefficient
+                while ($sizeAsString === $limitAsString) {
+                    $coef /= 1000;
+                    $limitAsString = (string) ($limitInBytes / $coef);
+                    $sizeAsString = (string) round($sizeInBytes / $coef, 2);
+                }
+
                 $this->context->addViolation($constraint->maxSizeMessage, array(
-                    '{{ size }}'    => $size,
-                    '{{ limit }}'   => $limit,
-                    '{{ suffix }}'  => $suffix,
+                    '{{ size }}'    => $sizeAsString,
+                    '{{ limit }}'   => $limitAsString,
+                    '{{ suffix }}'  => static::$suffices[$coef],
                     '{{ file }}'    => $path,
                 ));
 
@@ -171,5 +199,10 @@ class FileValidator extends ConstraintValidator
                 ));
             }
         }
+    }
+
+    private static function moreDecimalsThan($double, $numberOfDecimals)
+    {
+        return strlen((string) $double) > strlen(round($double, $numberOfDecimals));
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -45,9 +45,9 @@ class FileValidator extends ConstraintValidator
                         if (ctype_digit((string) $constraint->maxSize)) {
                             $maxSize = (int) $constraint->maxSize;
                         } elseif (preg_match('/^\d++k$/', $constraint->maxSize)) {
-                            $maxSize = $constraint->maxSize * 1024;
+                            $maxSize = $constraint->maxSize * 1000;
                         } elseif (preg_match('/^\d++M$/', $constraint->maxSize)) {
-                            $maxSize = $constraint->maxSize * 1048576;
+                            $maxSize = $constraint->maxSize * 1000 * 1000;
                         } else {
                             throw new ConstraintDefinitionException(sprintf('"%s" is not a valid maximum size', $constraint->maxSize));
                         }
@@ -119,9 +119,9 @@ class FileValidator extends ConstraintValidator
             } elseif (preg_match('/^\d++k$/', $constraint->maxSize)) {
                 $size = round(filesize($path) / 1000, 2);
                 $limit = (int) $constraint->maxSize;
-                $suffix = 'kB';
+                $suffix = 'KB';
             } elseif (preg_match('/^\d++M$/', $constraint->maxSize)) {
-                $size = round(filesize($path) / 1000000, 2);
+                $size = round(filesize($path) / (1000 * 1000), 2);
                 $limit = (int) $constraint->maxSize;
                 $suffix = 'MB';
             } else {

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -116,8 +116,8 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage', array(
                 '{{ limit }}'   => '1',
-                '{{ size }}'    => '1.4',
-                '{{ suffix }}'  => 'kB',
+                '{{ size }}'    => '1.37',
+                '{{ suffix }}'  => 'KiB',
                 '{{ file }}'    => $this->path,
             ));
 
@@ -137,11 +137,35 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage', array(
                 '{{ limit }}'   => '1',
-                '{{ size }}'    => '1.4',
-                '{{ suffix }}'  => 'MB',
+                '{{ size }}'    => '1.34',
+                '{{ suffix }}'  => 'MiB',
                 '{{ file }}'    => $this->path,
             ));
 
+        $this->validator->validate($this->getFile($this->path), $constraint);
+    }
+
+    public function testMaxSizeKiloBytes()
+    {
+        fwrite($this->file, str_repeat('0', 1010));
+
+        $constraint = new File(array(
+            'maxSize' => '1k',
+        ));
+
+        $this->context->expects($this->never())->method('addViolation');
+        $this->validator->validate($this->getFile($this->path), $constraint);
+    }
+
+    public function testMaxSizeMegaBytes()
+    {
+        fwrite($this->file, str_repeat('0', (1024 * 1022)));
+
+        $constraint = new File(array(
+            'maxSize' => '1M',
+        ));
+
+        $this->context->expects($this->never())->method('addViolation');
         $this->validator->validate($this->getFile($this->path), $constraint);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Continuation of #10661.

This PR makes the usage of "kB" and "KiB" consistent across the project. The notations equal the internationally recognized ones:

| Short form | Long form | Value in Bytes |
| --- | --- | --- |
| B | bytes | 1 |
| kB | kilobytes | 1000 |
| KiB | kibibytes | 1024 |
| MB | megabytes | 1000000 |
| MiB | mebibytes | 1048576 |
| GB | gigabytes | 1000000000 |
| GiB | gibibytes | 1073741824 |

The reason for differentiating between the two is that several users got confused with the current mix (see #10648, #10917, #10661).

FileValidator, UploadedFile and the ProgressBar helper were changed accordingly.

Follow-up feature request: #10962
