### PR TITLE
Fixed test cases failing when the Intl extension is not installed

### DIFF
--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation\Tests;
 
+use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Translation\MessageSelector;
 
@@ -59,6 +60,9 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetLocaleReturnsDefaultLocaleIfNotSet()
     {
+        // in order to test with "pt_BR"
+        IntlTestHelper::requireFullIntl($this);
+
         $translator = new IdentityTranslator(new MessageSelector());
 
         \Locale::setDefault('en');

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -107,7 +107,11 @@ class CountryValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidateUsingCountrySpecificLocale()
     {
+        // in order to test with "en_GB"
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('en_GB');
+
         $existingCountry = 'GB';
         $this->context->expects($this->never())
             ->method('addViolation');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I tested the 2.3 branch against PHP 5.5.12 with the following ICU versions:
- none
- 4.0
- 4.2
- 4.4
- 4.6
- 4.8
- 49
- 50
- 51
- 52
- 53

This PR contains the related fixes.
