### PR TITLE
[Validator] Fixed StaticMethodLoaderTest on systems that don't have E_STRICT enabled by default

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -17,6 +17,18 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 
 class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
 {
+    private $errorLevel;
+
+    protected function setUp()
+    {
+        $this->errorLevel = error_reporting();
+    }
+
+    protected function tearDown()
+    {
+        error_reporting($this->errorLevel);
+    }
+
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
         $loader = new StaticMethodLoader('loadMetadata');
@@ -78,6 +90,8 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadClassMetadataIgnoresAbstractMethods()
     {
+        error_reporting(E_ALL | E_STRICT);
+
         $loader = new StaticMethodLoader('loadMetadata');
         $caught = false;
         try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
