### PR TITLE
adding library cliGenerator to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
         "propel/propel1": "1.6.*",
         "ircmaxell/password-compat": "1.0.*",
         "ocramius/proxy-manager": ">=0.3.1,<0.6-dev",
-        "egulias/email-validator": "1.1.0"
+        "egulias/email-validator": "1.1.0",
+        "enxebre/cli-generator": "1.0.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\": "src/" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |

Hi,
I am sending here the link to the library https://github.com/enxebre/CliGenerator as suggested in https://github.com/symfony/symfony/pull/10952 in case you want to use it in some way.

It has some improvements and has been renamed from CommandGenerator to CliGenerator. Just let me know in case you are going to use it as it is not in packagist at the moment.
