### PR TITLE
[Filesystem] Throw Exception on copying from an unreadable file or to an unwritable file

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -51,10 +51,10 @@ class Filesystem
 
         if ($doCopy) {
             // https://bugs.php.net/bug.php?id=64634
-            if (($source = @fopen($originFile, 'r')) === false) {
+            if (false === $source = @fopen($originFile, 'r')) {
                 throw new IOException(sprintf('Failed to copy "%s" to "%s" because source file could not be opened for reading.', $originFile, $targetFile), 0, null, $originFile);
             }
-            if (($target = @fopen($targetFile, 'w')) === false) {
+            if (false === $target = @fopen($targetFile, 'w')) {
                 throw new IOException(sprintf('Failed to copy "%s" to "%s" because target file could not be opened for writing.', $originFile, $targetFile), 0, null, $originFile);
             }
             stream_copy_to_stream($source, $target);

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -51,8 +51,12 @@ class Filesystem
 
         if ($doCopy) {
             // https://bugs.php.net/bug.php?id=64634
-            $source = fopen($originFile, 'r');
-            $target = fopen($targetFile, 'w');
+            if (($source = @fopen($originFile, 'r')) === false) {
+                throw new IOException(sprintf('Failed to copy "%s" to "%s" because source file could not be opened for reading.', $originFile, $targetFile), 0, null, $originFile);
+            }
+            if (($target = @fopen($targetFile, 'w')) === false) {
+                throw new IOException(sprintf('Failed to copy "%s" to "%s" because target file could not be opened for writing.', $originFile, $targetFile), 0, null, $originFile);
+            }
             stream_copy_to_stream($source, $target);
             fclose($source);
             fclose($target);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -60,7 +60,7 @@ class FilesystemTest extends FilesystemTestCase
     {
         // skip test on Windows; PHP can't easily set file as unreadable on Windows
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            return;
+            $this->markTestSkipped('This test cannot run on Windows.');;
         }
 
         $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';
@@ -134,7 +134,7 @@ class FilesystemTest extends FilesystemTestCase
     {
         // skip test on Windows; PHP can't easily set file as unwritable on Windows
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            return;
+            $this->markTestSkipped('This test cannot run on Windows.');;
         }
 
         $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -58,6 +58,11 @@ class FilesystemTest extends FilesystemTestCase
      */
     public function testCopyUnreadableFileFails()
     {
+        // skip test on Windows; PHP can't easily set file as unreadable on Windows
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            return;
+        }
+
         $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';
         $targetFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_target_file';
 
@@ -127,6 +132,11 @@ class FilesystemTest extends FilesystemTestCase
      */
     public function testCopyWithOverrideWithReadOnlyTargetFails()
     {
+        // skip test on Windows; PHP can't easily set file as unwritable on Windows
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            return;
+        }
+
         $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';
         $targetFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_target_file';
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | No |
| New feature? | No |
| BC breaks? | No |
| Deprecations? | No |
| Tests pass? | Yes |
| Fixed tickets |  |
| License | MIT |

In certain circumstances (overwrite set to true, target file not writable), Filesystem->copy() would return success even though the file was not successfully copied. Unit tests included.
