### PR TITLE
PHP Fatal error when getContainer method of ContainerAwareCommand has be...

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
@@ -36,7 +36,7 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
         if (null === $this->container) {
             $application = $this->getApplication();
             if (null === $application) {
-                throw new \LogicException('The application instance must be set.');
+                throw new \LogicException('The container cannot be retrieved as the application instance is not yet set.');
             }
 
             $this->container = $application->getKernel()->getContainer();

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
@@ -29,11 +29,17 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
 
     /**
      * @return ContainerInterface
+     * @throws \LogicException
      */
     protected function getContainer()
     {
         if (null === $this->container) {
-            $this->container = $this->getApplication()->getKernel()->getContainer();
+            $application = $this->getApplication();
+            if (null === $application) {
+                throw new \LogicException('The application instance must be set.');
+            }
+
+            $this->container = $application->getKernel()->getContainer();
         }
 
         return $this->container;


### PR DESCRIPTION
PHP Fatal error when getContainer method of ContainerAwareCommand has been called within the configure method of a Command (application property is not been set yet at that time)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
