### PR TITLE
[Security] Role class magic method to make comparisons easier

### DIFF
--- a/src/Symfony/Component/Security/Core/Role/Role.php
+++ b/src/Symfony/Component/Security/Core/Role/Role.php
@@ -38,7 +38,7 @@ class Role implements RoleInterface
     {
         return $this->role;
     }
-    
+
     public function __toString()
     {
         return $this->role;

--- a/src/Symfony/Component/Security/Core/Role/Role.php
+++ b/src/Symfony/Component/Security/Core/Role/Role.php
@@ -39,7 +39,7 @@ class Role implements RoleInterface
         return $this->role;
     }
     
-    public method __toString()
+    public function __toString()
     {
         return $this->role;
     }

--- a/src/Symfony/Component/Security/Core/Role/Role.php
+++ b/src/Symfony/Component/Security/Core/Role/Role.php
@@ -38,4 +38,9 @@ class Role implements RoleInterface
     {
         return $this->role;
     }
+    
+    public method __toString()
+    {
+        return $this->role;
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Now 

```
in_array('ROLE_ADMIN', $user->getRoles())
```

 will work.

I know this can be done with $user->hasRole() method, but consider following:

```
!!array_intersect(array('ROLE_1', 'ROLE_2'), $user->getRoles())
```

to check if user has at least one of roles.
