### PR TITLE
[Process] Fix conflicts between latest 2.3 fix and 2.5 deprecation

### DIFF
--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -173,17 +173,17 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideInvalidStdinValues
+     * @dataProvider provideInvalidInputValues
      * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Symfony\Component\Process\Process::setStdin only accepts strings.
+     * @expectedExceptionMessage Symfony\Component\Process\Process::setInput only accepts strings.
      */
-    public function testInvalidStdin($value)
+    public function testInvalidInput($value)
     {
         $process = $this->getProcess('php -v');
-        $process->setStdin($value);
+        $process->setInput($value);
     }
 
-    public function provideInvalidStdinValues()
+    public function provideInvalidInputValues()
     {
         return array(
             array(array()),
@@ -193,16 +193,16 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideStdinValues
+     * @dataProvider provideInputValues
      */
-    public function testValidStdin($expected, $value)
+    public function testValidInput($expected, $value)
     {
         $process = $this->getProcess('php -v');
-        $process->setStdin($value);
-        $this->assertSame($expected, $process->getStdin());
+        $process->setInput($value);
+        $this->assertSame($expected, $process->getInput());
     }
 
-    public function provideStdinValues()
+    public function provideInputValues()
     {
         return array(
             array(null, null),

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -230,9 +230,9 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
     /**
      * {@inheritdoc}
      */
-    protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    protected function getProcess($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array())
     {
-        $process = new ProcessInSigchildEnvironment($commandline, $cwd, $env, $stdin, $timeout, $options);
+        $process = new ProcessInSigchildEnvironment($commandline, $cwd, $env, $input, $timeout, $options);
         $process->setEnhanceSigchildCompatibility(false);
 
         return $process;

--- a/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
@@ -123,9 +123,9 @@ class SigchildEnabledProcessTest extends AbstractProcessTest
     /**
      * {@inheritdoc}
      */
-    protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    protected function getProcess($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array())
     {
-        $process = new ProcessInSigchildEnvironment($commandline, $cwd, $env, $stdin, $timeout, $options);
+        $process = new ProcessInSigchildEnvironment($commandline, $cwd, $env, $input, $timeout, $options);
         $process->setEnhanceSigchildCompatibility(true);
 
         return $process;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

As reported in https://github.com/symfony/symfony/pull/10932#issuecomment-43939786, it's been introduced when merging 2.3 in master
