### PR TITLE
Make rootPath part of regex greedy

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -53,6 +53,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $bundleMap;
     protected $container;
     protected $rootDir;
+    protected $realRootDir;
     protected $environment;
     protected $debug;
     protected $booted = false;
@@ -729,24 +730,17 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             return $content;
         }
 
-        // find the "real" root dir (by finding the composer.json file)
-        $rootDir = $this->getRootDir();
-        $previous = $rootDir;
-        while (!file_exists($rootDir.'/composer.json')) {
-            if ($previous === $rootDir = realpath($rootDir.'/..')) {
-                // unable to detect the project root, give up
-                return $content;
-            }
-
-            $previous = $rootDir;
+        $rootDir = $this->getRealRootDir();
+        if (!$rootDir) {
+            return $content;
         }
 
         $rootDir = rtrim($rootDir, '/');
         $cacheDir = $this->getCacheDir();
         $filesystem = new Filesystem();
 
-        return preg_replace_callback("{'([^']*)(".preg_quote($rootDir)."[^']*)'}", function ($match) use ($filesystem, $cacheDir) {
-            $prefix = isset($match[1]) && $match[1] ? "'$match[1]'.__DIR__" : "__DIR__";
+        return preg_replace_callback("{'([^']*?)(".preg_quote($rootDir)."[^']*)'}", function ($match) use ($filesystem, $cacheDir) {
+            $prefix = !empty($match[1]) ? "'$match[1]'.__DIR__" : "__DIR__";
 
             if ('.' === $relativePath = rtrim($filesystem->makePathRelative($match[2], $cacheDir), '/')) {
                 return $prefix;
@@ -754,6 +748,33 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
             return $prefix.".'/".$relativePath."'";
         }, $content);
+    }
+
+    /**
+     * Find the "real" root dir (by finding the composer.json file)
+     *
+     * @return null|string
+     */
+    private function getRealRootDir()
+    {
+        if (null !== $this->realRootDir) {
+            return $this->realRootDir;
+        }
+
+        $rootDir = $this->getRootDir();
+        $previous = $rootDir;
+        while (!file_exists($rootDir.'/composer.json')) {
+            if ($previous === $rootDir = realpath($rootDir.'/..')) {
+                // unable to detect the project root, give up
+                return $this->realRootDir = false;
+            }
+
+            $previous = $rootDir;
+        }
+
+        $this->realRootDir = $rootDir;
+
+        return $this->realRootDir;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -39,4 +39,9 @@ class KernelForTest extends Kernel
     {
         return $this->booted;
     }
+
+    public function setRealRootDir($dir)
+    {
+        $this->realRootDir = $dir;
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -750,6 +750,22 @@ EOF;
         $this->assertEquals($newContent, $content);
     }
 
+    public function testRemoveAbsolutePathsFromContainerWithSpecialCase()
+    {
+        $kernel = new KernelForTest('dev', true);
+        $kernel->setRootDir('/app/app');
+        $kernel->setRealRootDir('/app');
+        $symfonyRootDir = __DIR__.'/Fixtures/DumpedContainers/app';
+
+        $content = file_get_contents($symfonyRootDir.'/cache/dev/withAbsolutePaths.php');
+        $content = str_replace('ROOT_DIR', '/app', $content);
+
+        $m = new \ReflectionMethod($kernel, 'removeAbsolutePathsFromContainer');
+        $m->setAccessible(true);
+        $content = $m->invoke($kernel, $content);
+        $this->assertEquals(file_get_contents($symfonyRootDir.'/cache/dev/withoutAbsolutePaths.php'), $content);
+    }
+
     /**
      * Returns a mock for the BundleInterface
      *


### PR DESCRIPTION
- Fixes #10977
- Also replaced `isset() && true` with simple `!empty()` which is equivalent.
