### PR TITLE
error.html.twig should contain a email value

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
@@ -9,7 +9,7 @@
         <h2>The server returned a "{{ status_code }} {{ status_text }}".</h2>
 
         <div>
-            Something is broken. Please e-mail us at [email] and let us know
+            Something is broken. Please e-mail us at {{ email }} and let us know
             what you were doing when this error occurred. We will fix it as soon
             as possible. Sorry for any inconvenience caused.
         </div>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
@@ -9,9 +9,8 @@
         <h2>The server returned a "{{ status_code }} {{ status_text }}".</h2>
 
         <div>
-            Something is broken. Please e-mail us at {{ email }} and let us know
-            what you were doing when this error occurred. We will fix it as soon
-            as possible. Sorry for any inconvenience caused.
+            Something is broken. Please let us know what you were doing when this error occurred.
+            We will fix it as soon as possible. Sorry for any inconvenience caused.
         </div>
     </body>
 </html>


### PR DESCRIPTION
When getting an exception on env PROD it would be nice to have an email to report to.

Current code has [email] instead of a value.

I'm not sure how to fix this as the email value should come from exception.html.twig

``` html
<div id="logs">
    {% include 'TwigBundle:Exception:logs.html.twig' with { 'logs': logger.logs } only %}
</div>
```

Some hints are welcome.
