### PR TITLE
[HttpFoundation] Fixed isSecure() check to be compliant with the docs

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1123,7 +1123,9 @@ class Request
             return in_array(strtolower(current(explode(',', $proto))), array('https', 'on', 'ssl', '1'));
         }
 
-        return 'on' == strtolower($this->server->get('HTTPS')) || 1 == $this->server->get('HTTPS');
+        $https = $this->server->get('HTTPS');
+
+        return !empty($https) && 'off' !== $https;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1125,7 +1125,7 @@ class Request
 
         $https = $this->server->get('HTTPS');
 
-        return !empty($https) && 'off' !== $https;
+        return !empty($https) && 'off' !== strtolower($https);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

According to the [php docs](http://www.php.net/manual/en/reserved.variables.server.php) the `HTTPS` field will be non-empty when the query was issued via HTTPS.

It isn't restricted to only "on" and 1.
Exception: "off" is sent by IIS

BC breaks: no, because old behavior was not conform with the docs.
