### PR TITLE
[DomCrawler] Fixed charset detection in html5 meta charset tag

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -109,7 +109,7 @@ class Crawler extends \SplObjectStorage
         }
 
         if (null === $charset &&
-            preg_match('/\<meta[^\>]+charset *= *["\']?([a-zA-Z\-0-9]+)/i', $content, $matches)) {
+            preg_match('/\<meta[^\>]+charset *= *["\']?([a-zA-Z\-0-9_]+)/i', $content, $matches)) {
             $charset = $matches[1];
         }
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -108,8 +108,10 @@ class Crawler extends \SplObjectStorage
             }
         }
 
+        // http://www.w3.org/TR/encoding/#encodings
+        // http://www.w3.org/TR/REC-xml/#NT-EncName
         if (null === $charset &&
-            preg_match('/\<meta[^\>]+charset *= *["\']?([a-zA-Z\-0-9_]+)/i', $content, $matches)) {
+            preg_match('/\<meta[^\>]+charset *= *["\']?([a-zA-Z\-0-9_:\.]+)/i', $content, $matches)) {
             $charset = $matches[1];
         }
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -111,7 +111,7 @@ class Crawler extends \SplObjectStorage
         // http://www.w3.org/TR/encoding/#encodings
         // http://www.w3.org/TR/REC-xml/#NT-EncName
         if (null === $charset &&
-            preg_match('/\<meta[^\>]+charset *= *["\']?([a-zA-Z\-0-9_:\.]+)/i', $content, $matches)) {
+            preg_match('/\<meta[^\>]+charset *= *["\']?([a-zA-Z\-0-9_:.]+)/i', $content, $matches)) {
             $charset = $matches[1];
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -236,6 +236,13 @@ EOF
         $crawler = new Crawler();
         $crawler->addContent(mb_convert_encoding('<html><head><meta charset="Shift_JIS"></head><body>日本語</body></html>', 'SJIS', 'UTF-8'));
         $this->assertEquals('日本語', $crawler->filterXPath('//body')->text(), '->addContent() can recognize "Shift_JIS" in html5 meta charset tag');
+
+        $charsets = array('ansi_x3.4-1968', 'iso_8859-7:1987');
+        foreach ($charsets as $charset) {
+            $crawler = $this->getMockBuilder('\Symfony\Component\DomCrawler\Crawler')->setMethods(array('addHtmlContent'))->getMock();
+            $crawler->expects($this->once())->method('addHtmlContent')->with($this->anything(), $this->equalTo($charset));
+            $crawler->addContent(sprintf('<html><head><meta charset="%s"><body></body></html>', $charset));
+        }
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -232,6 +232,10 @@ EOF
         $crawler = new Crawler();
         $crawler->addContent('<html><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><span>中文</span></html>');
         $this->assertEquals('中文', $crawler->filterXPath('//span')->text(), '->addContent() guess wrong charset');
+
+        $crawler = new Crawler();
+        $crawler->addContent(mb_convert_encoding('<html><head><meta charset="Shift_JIS"></head><body>日本語</body></html>', 'SJIS', 'UTF-8'));
+        $this->assertEquals('日本語', $crawler->filterXPath('//body')->text(), '->addContent() can recognize "Shift_JIS" in html5 meta charset tag');
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -236,13 +236,6 @@ EOF
         $crawler = new Crawler();
         $crawler->addContent(mb_convert_encoding('<html><head><meta charset="Shift_JIS"></head><body>日本語</body></html>', 'SJIS', 'UTF-8'));
         $this->assertEquals('日本語', $crawler->filterXPath('//body')->text(), '->addContent() can recognize "Shift_JIS" in html5 meta charset tag');
-
-        $charsets = array('ansi_x3.4-1968', 'iso_8859-7:1987');
-        foreach ($charsets as $charset) {
-            $crawler = $this->getMockBuilder('\Symfony\Component\DomCrawler\Crawler')->setMethods(array('addHtmlContent'))->getMock();
-            $crawler->expects($this->once())->method('addHtmlContent')->with($this->anything(), $this->equalTo($charset));
-            $crawler->addContent(sprintf('<html><head><meta charset="%s"><body></body></html>', $charset));
-        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |

It may be minor to folks with ascii-charactered language, but is critical for us Japanese.
Many Japanese websites with SJIS encoding have "Shift_JIS" as their encoding declaration.
