### PR TITLE
[DomCrawler] Fixed a forgotten case of complex XPath queries

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -839,6 +839,8 @@ class Crawler extends \SplObjectStorage
                 $expression = $nonMatchingExpression;
             } elseif (0 === strpos($expression, '//')) {
                 $expression = 'descendant-or-self::' . substr($expression, 2);
+            } elseif (0 === strpos($expression, './/')) {
+                $expression = 'descendant-or-self::' . substr($expression, 3);
             } elseif (0 === strpos($expression, './')) {
                 $expression = 'self::' . substr($expression, 2);
             } elseif ('/' === $expression[0]) {

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -376,6 +376,8 @@ EOF
         $this->assertCount(0, $crawler->filterXPath('/body'));
         $this->assertCount(1, $crawler->filterXPath('/_root/body'));
         $this->assertCount(1, $crawler->filterXPath('./body'));
+        $this->assertCount(1, $crawler->filterXPath('.//body'));
+        $this->assertCount(5, $crawler->filterXPath('.//input'));
         $this->assertCount(4, $crawler->filterXPath('//form')->filterXPath('//button | //input'));
         $this->assertCount(1, $crawler->filterXPath('body'));
         $this->assertCount(6, $crawler->filterXPath('//button | //input'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10986 |
| License | MIT |
| Doc PR | n/a |

This fixes the case I forgot when rewritting the XPath to avoid making it produce invalid queries. I ran the new tests against the old implementation first, to ensure they cover the BC properly.

I could have detected it by running the Mink 1.5 testsuite with the new code (which is the case for people reporting the bug), but I only ran it for Mink 1.6 which does not produce such XPath anymore.
