### PR TITLE
add possibility to dump all bundle configurations in ConfigDumpReference

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -26,15 +26,15 @@ class XmlReferenceDumper
 {
     private $reference;
 
-    public function dump(ConfigurationInterface $configuration, $namespace = null)
+    public function dump(ConfigurationInterface $configuration, $namespace = null, $rootTagName = 'config')
     {
-        return $this->dumpNode($configuration->getConfigTreeBuilder()->buildTree(), $namespace);
+        return $this->dumpNode($configuration->getConfigTreeBuilder()->buildTree(), $namespace, $rootTagName);
     }
 
-    public function dumpNode(NodeInterface $node, $namespace = null)
+    public function dumpNode(NodeInterface $node, $namespace = null, $rootTagName = 'config')
     {
         $this->reference = '';
-        $this->writeNode($node, 0, true, $namespace);
+        $this->writeNode($node, 0, true, $namespace, $rootTagName);
         $ref = $this->reference;
         $this->reference = null;
 
@@ -46,10 +46,11 @@ class XmlReferenceDumper
      * @param int           $depth
      * @param bool          $root      If the node is the root node
      * @param string        $namespace The namespace of the node
+     * @param string        $rootTagName The root tag name
      */
-    private function writeNode(NodeInterface $node, $depth = 0, $root = false, $namespace = null)
+    private function writeNode(NodeInterface $node, $depth = 0, $root = false, $namespace = null, $rootTagName = 'config')
     {
-        $rootName = ($root ? 'config' : $node->getName());
+        $rootName = ($root ? $rootTagName : $node->getName());
         $rootNamespace = ($namespace ?: ($root ? 'http://example.org/schema/dic/'.$node->getName() : null));
 
         // xml remapping
@@ -63,7 +64,9 @@ class XmlReferenceDumper
                 $rootName = $singular;
             }
         }
-        $rootName = str_replace('_', '-', $rootName);
+
+        // ?
+        //$rootName = str_replace('_', '-', $rootName);
 
         $rootAttributes = array();
         $rootAttributeComments = array();

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -65,8 +65,7 @@ class XmlReferenceDumper
             }
         }
 
-        // ?
-        //$rootName = str_replace('_', '-', $rootName);
+        $rootName = str_replace('_', '-', $rootName);
 
         $rootAttributes = array();
         $rootAttributeComments = array();


### PR DESCRIPTION
In PhpStorm Symfony2 plugin we now have the possible to autocomplete config / security keys. It uses the xml output of `config:dump-reference`. plugin includes a default dump on standard edition, but per project dump is possible `/idea/symfony2-config.xml`.

Currently there so no way to dump all configs. would be nice if everyone can create it on a single command:

``` php
php bin/console config:dump-reference * --format=xml
```

corresponding foreign file
https://github.com/Haehnchen/idea-php-symfony2-plugin/blob/master/src/resources/symfony2-config.xml

![phpstorm-symfony2-plugin](https://cloud.githubusercontent.com/assets/1011712/3076794/aa639a9a-e3fd-11e3-8b8e-26e8691fd2fc.png)
