### PR TITLE
[HttpFoundation] save session data as binary & add lazy-connect & create table & lifetime per session

### DIFF
--- a/UPGRADE-2.5.md
+++ b/UPGRADE-2.5.md
@@ -1,6 +1,26 @@
 ﻿UPGRADE FROM 2.4 to 2.5
 =======================
 
+HttpFoundation
+--------------
+
+ * The PdoSessionHandler to store sessions in a database changed significantly.
+   - It now implements session locking to prevent loss of data by concurrent access to the same session.
+     - It does so using a transaction between opening and closing a session. For this reason, it's not recommended to
+       use the same database connection that you also use for your application logic. Otherwise you have to make sure
+       to access your database after the session is closed and committed. Instead of passing an existing connection
+       to the handler, you can now also pass a DSN string which will be used to lazy-connect when a session is started.
+     - Since accessing a session now blocks when the same session is still open, it is best practice to save the session
+       as soon as you don't need to write to it anymore. For example, read-only AJAX request to a session can save the
+       session immediately after opening it to increase concurrency.
+   - The expected schema of the table changed.
+     - Session data is binary text that can contain null bytes and thus should also be saved as-is in a binary column like BLOB.
+       For this reason, the handler does not base64_encode the data anymore.
+     - A new column to store the lifetime of a session is required. This allows to have different lifetimes per session
+       configured via session.gc_maxlifetime ini setting.
+     - You would need to migrate the table manually if you want to keep session information of your users.
+     - You could use PdoSessionHandler::createTable to initialize a correctly defined table depending on the used database vendor.
+
 Routing
 -------
 

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,13 @@ CHANGELOG
 2.5.0
 -----
 
+ * PdoSessionHandler changes
+   - implemented session locking to prevent loss of data by concurrent access to the same session
+   - save session data in a binary column without base64_encode
+   - added lifetime column to the session table which allows to have different lifetimes for each session
+   - implemented lazy connections that are only opened when a session is used by either passing a dsn string explicitly
+     or falling back to session.save_path ini setting
+   - added a createTable method that initializes a correctly defined table depending on the database vendor
  * added `JsonResponse::setEncodingOptions()` & `JsonResponse::getEncodingOptions()` for easier manipulation
    of the options used while encoding data to JSON format.
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -109,6 +109,9 @@ class PdoSessionHandler implements \SessionHandlerInterface
      * pass a DSN string that will be used to lazy-connect to the database
      * when the session is actually used. Furthermore it's possible to pass null
      * which will then use the session.save_path ini setting as PDO DSN parameter.
+     * Since locking uses a transaction between opening and closing a session,
+     * it's not recommended to use the same database connection that you also use
+     * for your application logic.
      *
      * List of available options:
      *  * db_table: The name of the table [default: sessions]

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -37,9 +37,14 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 class PdoSessionHandler implements \SessionHandlerInterface
 {
     /**
-     * @var \PDO PDO instance
+     * @var \PDO|null PDO instance or null when not connected yet
      */
     private $pdo;
+
+    /**
+     * @var string|null|false DNS string or null for session.save_path or false when lazy connection disabled
+     */
+    private $dns = false;
 
     /**
      * @var string Database driver
@@ -67,6 +72,21 @@ class PdoSessionHandler implements \SessionHandlerInterface
     private $timeCol;
 
     /**
+     * @var string Username when lazy-connect
+     */
+    private $username;
+
+    /**
+     * @var string Password when lazy-connect
+     */
+    private $password;
+
+    /**
+     * @var array Connection options when lazy-connect
+     */
+    private $connectionOptions = array();
+
+    /**
      * @var bool Whether a transaction is active
      */
     private $inTransaction = false;
@@ -79,37 +99,54 @@ class PdoSessionHandler implements \SessionHandlerInterface
     /**
      * Constructor.
      *
+     * You can either pass an existing database connection as PDO instance or
+     * pass a DNS string that will be used to lazy-connect to the database
+     * when the session is actually used. Furthermore it's possible to pass null
+     * which will then use the session.save_path ini setting as PDO DNS parameter.
+     *
      * List of available options:
      *  * db_table: The name of the table [default: sessions]
      *  * db_id_col: The column where to store the session id [default: sess_id]
      *  * db_data_col: The column where to store the session data [default: sess_data]
      *  * db_time_col: The column where to store the timestamp [default: sess_time]
+     *  * db_username: The username when lazy-connect [default: '']
+     *  * db_password: The password when lazy-connect [default: '']
+     *  * db_connection_options: An array of driver-specific connection options [default: array()]
      *
-     * @param \PDO  $pdo     A \PDO instance
-     * @param array $options An associative array of DB options
+     * @param \PDO|string|null $pdoOrDns A \PDO instance or DNS string or null
+     * @param array            $options  An associative array of DB options
      *
      * @throws \InvalidArgumentException When PDO error mode is not PDO::ERRMODE_EXCEPTION
      */
-    public function __construct(\PDO $pdo, array $options = array())
+    public function __construct($pdoOrDns, array $options = array())
     {
-        if (\PDO::ERRMODE_EXCEPTION !== $pdo->getAttribute(\PDO::ATTR_ERRMODE)) {
-            throw new \InvalidArgumentException(sprintf('"%s" requires PDO error mode attribute be set to throw Exceptions (i.e. $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION))', __CLASS__));
+        if ($pdoOrDns instanceof \PDO) {
+            if (\PDO::ERRMODE_EXCEPTION !== $pdoOrDns->getAttribute(\PDO::ATTR_ERRMODE)) {
+                throw new \InvalidArgumentException(sprintf('"%s" requires PDO error mode attribute be set to throw Exceptions (i.e. $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION))', __CLASS__));
+            }
+
+            $this->pdo = $pdoOrDns;
+        } else {
+            $this->dns = $pdoOrDns;
         }
 
-        $this->pdo = $pdo;
-        $this->driver = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
-
         $options = array_replace(array(
-            'db_table'    => 'sessions',
-            'db_id_col'   => 'sess_id',
-            'db_data_col' => 'sess_data',
-            'db_time_col' => 'sess_time',
+            'db_table'              => 'sessions',
+            'db_id_col'             => 'sess_id',
+            'db_data_col'           => 'sess_data',
+            'db_time_col'           => 'sess_time',
+            'db_username'           => '',
+            'db_password'           => '',
+            'db_connection_options' => array()
         ), $options);
 
         $this->table = $options['db_table'];
         $this->idCol = $options['db_id_col'];
         $this->dataCol = $options['db_data_col'];
         $this->timeCol = $options['db_time_col'];
+        $this->username = $options['db_username'];
+        $this->password = $options['db_password'];
+        $this->connectionOptions = $options['db_connection_options'];
     }
 
     /**
@@ -118,6 +155,11 @@ class PdoSessionHandler implements \SessionHandlerInterface
     public function open($savePath, $sessionName)
     {
         $this->gcCalled = false;
+        if (null === $this->pdo) {
+            $this->pdo = new \PDO($this->dns ?: $savePath, $this->username, $this->password, $this->connectionOptions);
+            $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        }
+        $this->driver = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
 
         return true;
     }
@@ -255,6 +297,10 @@ class PdoSessionHandler implements \SessionHandlerInterface
             $stmt = $this->pdo->prepare($sql);
             $stmt->bindValue(':time', time() - $maxlifetime, \PDO::PARAM_INT);
             $stmt->execute();
+        }
+
+        if (false !== $this->dns) {
+            $this->pdo = null;
         }
 
         return true;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -42,9 +42,9 @@ class PdoSessionHandler implements \SessionHandlerInterface
     private $pdo;
 
     /**
-     * @var string|null|false DNS string or null for session.save_path or false when lazy connection disabled
+     * @var string|null|false DSN string or null for session.save_path or false when lazy connection disabled
      */
-    private $dns = false;
+    private $dsn = false;
 
     /**
      * @var string Database driver
@@ -65,6 +65,11 @@ class PdoSessionHandler implements \SessionHandlerInterface
      * @var string Column for session data
      */
     private $dataCol;
+
+    /**
+     * @var string Column for lifetime
+     */
+    private $lifetimeCol;
 
     /**
      * @var string Column for timestamp
@@ -100,40 +105,43 @@ class PdoSessionHandler implements \SessionHandlerInterface
      * Constructor.
      *
      * You can either pass an existing database connection as PDO instance or
-     * pass a DNS string that will be used to lazy-connect to the database
+     * pass a DSN string that will be used to lazy-connect to the database
      * when the session is actually used. Furthermore it's possible to pass null
-     * which will then use the session.save_path ini setting as PDO DNS parameter.
+     * which will then use the session.save_path ini setting as PDO DSN parameter.
      *
      * List of available options:
      *  * db_table: The name of the table [default: sessions]
      *  * db_id_col: The column where to store the session id [default: sess_id]
      *  * db_data_col: The column where to store the session data [default: sess_data]
+     *  * db_lifetime_col: The column where to store the lifetime [default: sess_lifetime]
      *  * db_time_col: The column where to store the timestamp [default: sess_time]
      *  * db_username: The username when lazy-connect [default: '']
      *  * db_password: The password when lazy-connect [default: '']
      *  * db_connection_options: An array of driver-specific connection options [default: array()]
      *
-     * @param \PDO|string|null $pdoOrDns A \PDO instance or DNS string or null
+     * @param \PDO|string|null $pdoOrDsn A \PDO instance or DSN string or null
      * @param array            $options  An associative array of DB options
      *
      * @throws \InvalidArgumentException When PDO error mode is not PDO::ERRMODE_EXCEPTION
      */
-    public function __construct($pdoOrDns, array $options = array())
+    public function __construct($pdoOrDsn, array $options = array())
     {
-        if ($pdoOrDns instanceof \PDO) {
-            if (\PDO::ERRMODE_EXCEPTION !== $pdoOrDns->getAttribute(\PDO::ATTR_ERRMODE)) {
+        if ($pdoOrDsn instanceof \PDO) {
+            if (\PDO::ERRMODE_EXCEPTION !== $pdoOrDsn->getAttribute(\PDO::ATTR_ERRMODE)) {
                 throw new \InvalidArgumentException(sprintf('"%s" requires PDO error mode attribute be set to throw Exceptions (i.e. $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION))', __CLASS__));
             }
 
-            $this->pdo = $pdoOrDns;
+            $this->pdo = $pdoOrDsn;
+            $this->driver = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
         } else {
-            $this->dns = $pdoOrDns;
+            $this->dsn = $pdoOrDsn;
         }
 
         $options = array_replace(array(
             'db_table'              => 'sessions',
             'db_id_col'             => 'sess_id',
             'db_data_col'           => 'sess_data',
+            'db_lifetime_col'       => 'sess_lifetime',
             'db_time_col'           => 'sess_time',
             'db_username'           => '',
             'db_password'           => '',
@@ -143,6 +151,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
         $this->table = $options['db_table'];
         $this->idCol = $options['db_id_col'];
         $this->dataCol = $options['db_data_col'];
+        $this->lifetimeCol = $options['db_lifetime_col'];
         $this->timeCol = $options['db_time_col'];
         $this->username = $options['db_username'];
         $this->password = $options['db_password'];
@@ -156,10 +165,10 @@ class PdoSessionHandler implements \SessionHandlerInterface
     {
         $this->gcCalled = false;
         if (null === $this->pdo) {
-            $this->pdo = new \PDO($this->dns ?: $savePath, $this->username, $this->password, $this->connectionOptions);
+            $this->pdo = new \PDO($this->dsn ?: $savePath, $this->username, $this->password, $this->connectionOptions);
             $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            $this->driver = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
         }
-        $this->driver = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
 
         return true;
     }
@@ -176,13 +185,12 @@ class PdoSessionHandler implements \SessionHandlerInterface
 
             // We need to make sure we do not return session data that is already considered garbage according
             // to the session.gc_maxlifetime setting because gc() is called after read() and only sometimes.
-            $maxlifetime = (int) ini_get('session.gc_maxlifetime');
 
-            $sql = "SELECT $this->dataCol FROM $this->table WHERE $this->idCol = :id AND $this->timeCol > :time";
+            $sql = "SELECT $this->dataCol FROM $this->table WHERE $this->idCol = :id AND $this->lifetimeCol + $this->timeCol >= :time";
 
             $stmt = $this->pdo->prepare($sql);
             $stmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
-            $stmt->bindValue(':time', time() - $maxlifetime, \PDO::PARAM_INT);
+            $stmt->bindValue(':time', time(), \PDO::PARAM_INT);
             $stmt->execute();
 
             // We use fetchAll instead of fetchColumn to make sure the DB cursor gets closed
@@ -239,6 +247,8 @@ class PdoSessionHandler implements \SessionHandlerInterface
         // do an insert or update even if we created a row in read() for locking.
         // We use a MERGE SQL query when supported by the database.
 
+        $maxlifetime = (int) ini_get('session.gc_maxlifetime');
+
         try {
             $mergeSql = $this->getMergeSql();
 
@@ -246,6 +256,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
                 $mergeStmt = $this->pdo->prepare($mergeSql);
                 $mergeStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
                 $mergeStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
+                $mergeStmt->bindParam(':lifetime', $maxlifetime, \PDO::PARAM_INT);
                 $mergeStmt->bindValue(':time', time(), \PDO::PARAM_INT);
                 $mergeStmt->execute();
 
@@ -253,10 +264,11 @@ class PdoSessionHandler implements \SessionHandlerInterface
             }
 
             $updateStmt = $this->pdo->prepare(
-                "UPDATE $this->table SET $this->dataCol = :data, $this->timeCol = :time WHERE $this->idCol = :id"
+                "UPDATE $this->table SET $this->dataCol = :data, $this->lifetimeCol = :lifetime, $this->timeCol = :time WHERE $this->idCol = :id"
             );
             $updateStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
             $updateStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
+            $updateStmt->bindParam(':lifetime', $maxlifetime, \PDO::PARAM_INT);
             $updateStmt->bindValue(':time', time(), \PDO::PARAM_INT);
             $updateStmt->execute();
 
@@ -265,10 +277,11 @@ class PdoSessionHandler implements \SessionHandlerInterface
             // unique anyway.
             if (!$updateStmt->rowCount()) {
                 $insertStmt = $this->pdo->prepare(
-                    "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time)"
+                    "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, :lifetime, :time)"
                 );
                 $insertStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
                 $insertStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
+                $insertStmt->bindParam(':lifetime', $maxlifetime, \PDO::PARAM_INT);
                 $insertStmt->bindValue(':time', time(), \PDO::PARAM_INT);
                 $insertStmt->execute();
             }
@@ -289,17 +302,15 @@ class PdoSessionHandler implements \SessionHandlerInterface
         $this->commit();
 
         if ($this->gcCalled) {
-            $maxlifetime = (int) ini_get('session.gc_maxlifetime');
-
             // delete the session records that have expired
-            $sql = "DELETE FROM $this->table WHERE $this->timeCol <= :time";
+            $sql = "DELETE FROM $this->table WHERE $this->lifetimeCol + $this->timeCol < :time";
 
             $stmt = $this->pdo->prepare($sql);
-            $stmt->bindValue(':time', time() - $maxlifetime, \PDO::PARAM_INT);
+            $stmt->bindValue(':time', time(), \PDO::PARAM_INT);
             $stmt->execute();
         }
 
-        if (false !== $this->dns) {
+        if (false !== $this->dsn) {
             $this->pdo = null;
         }
 
@@ -316,20 +327,14 @@ class PdoSessionHandler implements \SessionHandlerInterface
      */
     private function beginTransaction()
     {
-        if ($this->inTransaction) {
-            $this->rollback();
-
-            throw new \BadMethodCallException(
-                'Session handler methods have been invoked in wrong sequence. ' .
-                'Expected sequence: open() -> read() -> destroy() / write() -> close()');
+        if (!$this->inTransaction) {
+            if ('sqlite' === $this->driver) {
+                $this->pdo->exec('BEGIN IMMEDIATE TRANSACTION');
+            } else {
+                $this->pdo->beginTransaction();
+            }
+            $this->inTransaction = true;
         }
-
-        if ('sqlite' === $this->driver) {
-            $this->pdo->exec('BEGIN IMMEDIATE TRANSACTION');
-        } else {
-            $this->pdo->beginTransaction();
-        }
-        $this->inTransaction = true;
     }
 
     /**
@@ -387,19 +392,19 @@ class PdoSessionHandler implements \SessionHandlerInterface
         switch ($this->driver) {
             case 'mysql':
                 // will also lock the row when actually nothing got updated (id = id)
-                $sql = "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) " .
+                $sql = "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, :lifetime, :time) " .
                     "ON DUPLICATE KEY UPDATE $this->idCol = $this->idCol";
                 break;
             case 'oci':
                 // DUAL is Oracle specific dummy table
                 $sql = "MERGE INTO $this->table USING DUAL ON ($this->idCol = :id) " .
-                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) " .
+                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, :lifetime, :time) " .
                     "WHEN MATCHED THEN UPDATE SET $this->idCol = $this->idCol";
                 break;
             case 'sqlsrv':
                 // MS SQL Server requires MERGE be terminated by semicolon
                 $sql = "MERGE INTO $this->table USING (SELECT 'x' AS dummy) AS src ON ($this->idCol = :id) " .
-                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) " .
+                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, :lifetime, :time) " .
                     "WHEN MATCHED THEN UPDATE SET $this->idCol = $this->idCol;";
                 break;
             case 'pgsql':
@@ -420,6 +425,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
         $stmt = $this->pdo->prepare($sql);
         $stmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
         $stmt->bindValue(':data', '', \PDO::PARAM_STR);
+        $stmt->bindValue(':lifetime', 0, \PDO::PARAM_INT);
         $stmt->bindValue(':time', time(), \PDO::PARAM_INT);
         $stmt->execute();
     }
@@ -433,20 +439,20 @@ class PdoSessionHandler implements \SessionHandlerInterface
     {
         switch ($this->driver) {
             case 'mysql':
-                return "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) " .
-                    "ON DUPLICATE KEY UPDATE $this->dataCol = VALUES($this->dataCol), $this->timeCol = VALUES($this->timeCol)";
+                return "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, :lifetime, :time) " .
+                    "ON DUPLICATE KEY UPDATE $this->dataCol = VALUES($this->dataCol), $this->lifetimeCol = VALUES($this->lifetimeCol), $this->timeCol = VALUES($this->timeCol)";
             case 'oci':
                 // DUAL is Oracle specific dummy table
                 return "MERGE INTO $this->table USING DUAL ON ($this->idCol = :id) " .
-                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) " .
-                    "WHEN MATCHED THEN UPDATE SET $this->dataCol = :data, $this->timeCol = :time";
+                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, :lifetime, :time) " .
+                    "WHEN MATCHED THEN UPDATE SET $this->dataCol = :data, $this->lifetimeCol = :lifetime, $this->timeCol = :time";
             case 'sqlsrv':
                 // MS SQL Server requires MERGE be terminated by semicolon
                 return "MERGE INTO $this->table USING (SELECT 'x' AS dummy) AS src ON ($this->idCol = :id) " .
-                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) " .
-                    "WHEN MATCHED THEN UPDATE SET $this->dataCol = :data, $this->timeCol = :time;";
+                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, :lifetime, :time) " .
+                    "WHEN MATCHED THEN UPDATE SET $this->dataCol = :data, $this->lifetimeCol = :lifetime, $this->timeCol = :time;";
             case 'sqlite':
-                return "INSERT OR REPLACE INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time)";
+                return "INSERT OR REPLACE INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, :lifetime, :time)";
         }
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -24,6 +24,10 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  * for another to finish. So saving session in SQLite should only be considered for
  * development or prototypes.
  *
+ * Session data is a binary string that can contain non-printable characters like the null byte.
+ * For this reason it must be saved in a binary column in the database like BLOB in MySQL.
+ * Saving it in a character column could corrupt the data.
+ *
  * @see http://php.net/sessionhandlerinterface
  *
  * @author Fabien Potencier <fabien@symfony.com>
@@ -142,11 +146,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
             // We use fetchAll instead of fetchColumn to make sure the DB cursor gets closed
             $sessionRows = $stmt->fetchAll(\PDO::FETCH_NUM);
 
-            if ($sessionRows) {
-                return base64_decode($sessionRows[0][0]);
-            }
-
-            return '';
+            return $sessionRows ? $sessionRows[0][0] : '';
         } catch (\PDOException $e) {
             $this->rollback();
 
@@ -192,9 +192,6 @@ class PdoSessionHandler implements \SessionHandlerInterface
      */
     public function write($sessionId, $data)
     {
-        // Session data can contain non binary safe characters so we need to encode it.
-        $encoded = base64_encode($data);
-
         // The session ID can be different from the one previously received in read()
         // when the session ID changed due to session_regenerate_id(). So we have to
         // do an insert or update even if we created a row in read() for locking.
@@ -206,7 +203,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
             if (null !== $mergeSql) {
                 $mergeStmt = $this->pdo->prepare($mergeSql);
                 $mergeStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
-                $mergeStmt->bindParam(':data', $encoded, \PDO::PARAM_STR);
+                $mergeStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
                 $mergeStmt->bindValue(':time', time(), \PDO::PARAM_INT);
                 $mergeStmt->execute();
 
@@ -217,7 +214,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
                 "UPDATE $this->table SET $this->dataCol = :data, $this->timeCol = :time WHERE $this->idCol = :id"
             );
             $updateStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
-            $updateStmt->bindParam(':data', $encoded, \PDO::PARAM_STR);
+            $updateStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
             $updateStmt->bindValue(':time', time(), \PDO::PARAM_INT);
             $updateStmt->execute();
 
@@ -229,7 +226,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
                     "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time)"
                 );
                 $insertStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
-                $insertStmt->bindParam(':data', $encoded, \PDO::PARAM_STR);
+                $insertStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
                 $insertStmt->bindValue(':time', time(), \PDO::PARAM_INT);
                 $insertStmt->execute();
             }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -106,19 +106,21 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         @unlink($dbFile);
     }
 
-    public function testReadWriteRead()
+    public function testReadWriteReadWithNullByte()
     {
+        $sessionData = 'da' . "\0" . 'ta';
+
         $storage = new PdoSessionHandler($this->pdo);
         $storage->open('', 'sid');
-        $data = $storage->read('id');
-        $storage->write('id', 'data');
+        $readData = $storage->read('id');
+        $storage->write('id', $sessionData);
         $storage->close();
-        $this->assertSame('', $data, 'New session returns empty string data');
+        $this->assertSame('', $readData, 'New session returns empty string data');
 
         $storage->open('', 'sid');
-        $data = $storage->read('id');
+        $readData = $storage->read('id');
         $storage->close();
-        $this->assertSame('data', $data, 'Written value can be read back correctly');
+        $this->assertSame($sessionData, $readData, 'Written value can be read back correctly');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -25,7 +25,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->pdo = new \PDO('sqlite::memory:');
         $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data BLOB, sess_time INTEGER)';
+        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(128) PRIMARY KEY, sess_data BLOB, sess_lifetime MEDIUMINT, sess_time INTEGER)';
         $this->pdo->exec($sql);
     }
 
@@ -59,7 +59,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         }
 
         $pdo = new \PDO('sqlite:' . $dbFile);
-        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data BLOB, sess_time INTEGER)';
+        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(128) PRIMARY KEY, sess_data BLOB, sess_lifetime MEDIUMINT, sess_time INTEGER)';
         $pdo->exec($sql);
         $pdo = null;
 
@@ -86,7 +86,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         }
 
         $pdo = new \PDO('sqlite:' . $dbFile);
-        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data BLOB, sess_time INTEGER)';
+        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(128) PRIMARY KEY, sess_data BLOB, sess_lifetime MEDIUMINT, sess_time INTEGER)';
         $pdo->exec($sql);
         $pdo = null;
 
@@ -138,18 +138,24 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $storage->open('', 'sid');
         $data = $storage->read('new_id');
         $storage->close();
+
         $this->assertSame('data_of_new_session_id', $data, 'Data of regenerated session id is available');        
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
-    public function testWrongUsage()
+    public function testWrongUsageStillWorks()
     {
+        // wrong method sequence that should no happen, but still works
         $storage = new PdoSessionHandler($this->pdo);
+        $storage->write('id', 'data');
+        $storage->write('other_id', 'other_data');
+        $storage->destroy('inexistent');
         $storage->open('', 'sid');
-        $storage->read('id');
-        $storage->read('id');
+        $data = $storage->read('id');
+        $otherData = $storage->read('other_id');
+        $storage->close();
+
+        $this->assertSame('data', $data);
+        $this->assertSame('other_data', $otherData);
     }
 
     public function testSessionDestroy()
@@ -176,29 +182,35 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testSessionGC()
     {
-        $previousLifeTime = ini_set('session.gc_maxlifetime', 0);
+        $previousLifeTime = ini_set('session.gc_maxlifetime', 1000);
         $storage = new PdoSessionHandler($this->pdo);
 
         $storage->open('', 'sid');
         $storage->read('id');
         $storage->write('id', 'data');
         $storage->close();
-        $this->assertEquals(1, $this->pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn());
 
         $storage->open('', 'sid');
-        $data = $storage->read('id');
-        $storage->gc(0);
+        $storage->read('gc_id');
+        ini_set('session.gc_maxlifetime', -1); // test that you can set lifetime of a session after it has been read
+        $storage->write('gc_id', 'data');
+        $storage->close();
+        $this->assertEquals(2, $this->pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn(), 'No session pruned because gc not called');
+
+        $storage->open('', 'sid');
+        $data = $storage->read('gc_id');
+        $storage->gc(-1);
         $storage->close();
 
         ini_set('session.gc_maxlifetime', $previousLifeTime);
 
         $this->assertSame('', $data, 'Session already considered garbage, so not returning data even if it is not pruned yet');
-        $this->assertEquals(0, $this->pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn());
+        $this->assertEquals(1, $this->pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn(), 'Expired session is pruned');
     }
 
     public function testGetConnection()
     {
-        $storage = new PdoSessionHandler($this->pdo, array('db_table' => 'sessions'), array());
+        $storage = new PdoSessionHandler($this->pdo);
 
         $method = new \ReflectionMethod($storage, 'getConnection');
         $method->setAccessible(true);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -23,9 +23,9 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('This test requires SQLite support in your environment');
         }
 
-        $this->pdo = new \PDO("sqlite::memory:");
+        $this->pdo = new \PDO('sqlite::memory:');
         $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $sql = "CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data TEXT, sess_time INTEGER)";
+        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data BLOB, sess_time INTEGER)';
         $this->pdo->exec($sql);
     }
 
@@ -51,17 +51,74 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $storage->close();
     }
 
+    public function testWithLazyDnsConnection()
+    {
+        $dbFile = tempnam(sys_get_temp_dir(), 'sf2_sqlite_sessions');
+        if (file_exists($dbFile)) {
+            @unlink($dbFile);
+        }
+
+        $pdo = new \PDO('sqlite:' . $dbFile);
+        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data BLOB, sess_time INTEGER)';
+        $pdo->exec($sql);
+        $pdo = null;
+
+        $storage = new PdoSessionHandler('sqlite:' . $dbFile);
+        $storage->open('', 'sid');
+        $data = $storage->read('id');
+        $storage->write('id', 'data');
+        $storage->close();
+        $this->assertSame('', $data, 'New session returns empty string data');
+
+        $storage->open('', 'sid');
+        $data = $storage->read('id');
+        $storage->close();
+        $this->assertSame('data', $data, 'Written value can be read back correctly');
+
+        @unlink($dbFile);
+    }
+
+    public function testWithLazySavePathConnection()
+    {
+        $dbFile = tempnam(sys_get_temp_dir(), 'sf2_sqlite_sessions');
+        if (file_exists($dbFile)) {
+            @unlink($dbFile);
+        }
+
+        $pdo = new \PDO('sqlite:' . $dbFile);
+        $sql = 'CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data BLOB, sess_time INTEGER)';
+        $pdo->exec($sql);
+        $pdo = null;
+
+        // Open is called with what ini_set('session.save_path', 'sqlite:' . $dbFile) would mean
+        $storage = new PdoSessionHandler(null);
+        $storage->open('sqlite:' . $dbFile, 'sid');
+        $data = $storage->read('id');
+        $storage->write('id', 'data');
+        $storage->close();
+        $this->assertSame('', $data, 'New session returns empty string data');
+
+        $storage->open('sqlite:' . $dbFile, 'sid');
+        $data = $storage->read('id');
+        $storage->close();
+        $this->assertSame('data', $data, 'Written value can be read back correctly');
+
+        @unlink($dbFile);
+    }
+
     public function testReadWriteRead()
     {
         $storage = new PdoSessionHandler($this->pdo);
         $storage->open('', 'sid');
-        $this->assertSame('', $storage->read('id'), 'New session returns empty string data');
+        $data = $storage->read('id');
         $storage->write('id', 'data');
         $storage->close();
+        $this->assertSame('', $data, 'New session returns empty string data');
 
         $storage->open('', 'sid');
-        $this->assertSame('data', $storage->read('id'), 'Written value can be read back correctly');
+        $data = $storage->read('id');
         $storage->close();
+        $this->assertSame('data', $data, 'Written value can be read back correctly');
     }
 
     /**
@@ -77,8 +134,9 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $storage->close();
 
         $storage->open('', 'sid');
-        $this->assertSame('data_of_new_session_id', $storage->read('new_id'), 'Data of regenerated session id is available');
+        $data = $storage->read('new_id');
         $storage->close();
+        $this->assertSame('data_of_new_session_id', $data, 'Data of regenerated session id is available');        
     }
 
     /**
@@ -109,8 +167,9 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn());
 
         $storage->open('', 'sid');
-        $this->assertSame('', $storage->read('id'), 'Destroyed session returns empty string');
+        $data = $storage->read('id');
         $storage->close();
+        $this->assertSame('', $data, 'Destroyed session returns empty string');
     }
 
     public function testSessionGC()
@@ -125,12 +184,14 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $this->pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn());
 
         $storage->open('', 'sid');
-        $this->assertSame('', $storage->read('id'), 'Session already considered garbage, so not returning data even if it is not pruned yet');
+        $data = $storage->read('id');
         $storage->gc(0);
         $storage->close();
-        $this->assertEquals(0, $this->pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn());
 
         ini_set('session.gc_maxlifetime', $previousLifeTime);
+
+        $this->assertSame('', $data, 'Session already considered garbage, so not returning data even if it is not pruned yet');
+        $this->assertEquals(0, $this->pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn());
     }
 
     public function testGetConnection()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5483, #2067, #2382 |
| License | MIT |
1. [x] Encoding session data was definitely the wrong solution. Session data is binary text (esp. when using other session.serialize_handler) that must stay as-is and thus must also be safed in a binary column. Base64 encoding session data just decreses performance and increases storage costs and is semantically wrong because it does not have a character encoding.
   That saving null bytes in Posgres won't work on a character column is also documented
   
   > First, binary strings specifically allow storing octets of value zero and other "non-printable" octets (usually, octets outside the range 32 to 126). Character strings disallow zero octets, and also disallow any other octet values and sequences of octet values that are invalid according to the database's selected character set encoding. 
   > http://www.postgresql.org/docs/9.1/static/datatype-binary.html#DATATYPE-BINARY-TABLE
2. [x] Implement lazy connections that are only opened when session is used by either passing a dsn string explicitly or falling back to session.save_path ini setting.
3. [x] add a create table method that creates the correct table depending on database vendor. This makes the class self-documenting and standalone useable.
4. [x] add lifetime column to session table which allows to have different lifetimes for each session
5. [x] added upgrade and changelog notes
