### PR TITLE
[HttpFoundation] [Request] prepareBaseUrl doesn't compare URL case-insensitivly

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1662,7 +1662,7 @@ class Request
     {
         $filename = basename($this->server->get('SCRIPT_FILENAME'));
 
-        if (basename($this->server->get('SCRIPT_NAME')) === $filename) {
+        if (0 === strcasecmp(basename($this->server->get('SCRIPT_NAME')), $filename)) {
             $baseUrl = $this->server->get('SCRIPT_NAME');
         } elseif (basename($this->server->get('PHP_SELF')) === $filename) {
             $baseUrl = $this->server->get('PHP_SELF');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

If the comparison between SCRIPT_FILENAME and SCRIPT_NAME isn't case-insensitive
then accessing /App.php/myroute or /aPP.php/myroute won't work, and we will always have to verify accessing
/app.php/myroute (with app at lower case, which may cause many problems).
