### PR TITLE
[Validator] Remove property and method targets from the optional and required constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Optional.php
+++ b/src/Symfony/Component/Validator/Constraints/Optional.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ * @Target({"ANNOTATION"})
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */

--- a/src/Symfony/Component/Validator/Constraints/Required.php
+++ b/src/Symfony/Component/Validator/Constraints/Required.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ * @Target({"ANNOTATION"})
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11013 |
| License | MIT |
| Doc PR |  |

At the moment both constraints can only be defined on other annotations. Both constraints are [only mentioned in the docs in the context of the Collection](http://symfony.com/doc/current/reference/constraints/Collection.html#required-and-optional-field-constraints).

Defining the required or optional annotation directly on a field or method 
throws a ClassNotFoundException, since the constraint validator factory tries to load the validator (which does not exist):

```
ClassNotFoundException: Attempted to load class "OptionalValidator"
from namespace "Symfony\Component\Validator\Constraints" 
in /var/www/server/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php line 71. 
Do you need to "use" it from another namespace?
```

By applying this patch the end user will get a more helpful error message:

```
[Semantical Error] Annotation @Assert\Optional is not allowed to be declared on property Acme\DemoBundle\Entity\Contact::$message. 
You may only use this annotation on these code elements: ANNOTATION.
```
