### PR TITLE
[OptionsResolver] Exception doesn't report the actual type used

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -247,7 +247,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
                 continue;
             }
 
-            $value       = $options[$option];
+            $value = $options[$option];
             $optionTypes = (array) $optionTypes;
 
             foreach ($optionTypes as $type) {

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -98,13 +98,13 @@ class Options implements \ArrayAccess, \Iterator, \Countable
     public static function resolve(array $options, $defaults)
     {
         if (is_array($defaults)) {
-            static::validateNames($options, $defaults, true);
+            self::validateNames($options, $defaults, true);
 
             return array_replace($defaults, $options);
         }
 
         if ($defaults instanceof self) {
-            static::validateNames($options, $defaults->options, true);
+            self::validateNames($options, $defaults->options, true);
 
             // Make sure this method can be called multiple times
             $combinedOptions = clone $defaults;
@@ -119,8 +119,8 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         }
 
         if ($defaults instanceof OptionsConfig) {
-            static::validateNames($options, $defaults->knownOptions, true);
-            static::validateRequired($options, $defaults->requiredOptions, true);
+            self::validateNames($options, $defaults->knownOptions, true);
+            self::validateRequired($options, $defaults->requiredOptions, true);
 
             // Make sure this method can be called multiple times
             $combinedOptions = clone $defaults->defaultOptions;
@@ -133,8 +133,8 @@ class Options implements \ArrayAccess, \Iterator, \Countable
             // Resolve options
             $resolvedOptions = $combinedOptions->all();
 
-            static::validateTypes($resolvedOptions, $defaults->allowedTypes);
-            static::validateValues($resolvedOptions, $defaults->allowedValues);
+            self::validateTypes($resolvedOptions, $defaults->allowedTypes);
+            self::validateValues($resolvedOptions, $defaults->allowedValues);
 
             return $resolvedOptions;
         }
@@ -263,8 +263,8 @@ class Options implements \ArrayAccess, \Iterator, \Countable
             throw new InvalidOptionsException(sprintf(
                 'The option "%s" with value "%s" is expected to be of type "%s"',
                 $option,
-                static::formatValue($value),
-                static::formatTypesOf($optionTypes)
+                self::formatValue($value),
+                self::formatTypesOf($optionTypes)
             ));
         }
     }
@@ -288,7 +288,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         foreach ($acceptedValues as $option => $optionValues) {
             if (array_key_exists($option, $options)) {
                 if (is_array($optionValues) && !in_array($options[$option], $optionValues, true)) {
-                    throw new InvalidOptionsException(sprintf('The option "%s" has the value "%s", but is expected to be one of "%s"', $option, $options[$option], static::formatValues($optionValues)));
+                    throw new InvalidOptionsException(sprintf('The option "%s" has the value "%s", but is expected to be one of "%s"', $option, $options[$option], self::formatValues($optionValues)));
                 }
 
                 if (is_callable($optionValues) && !call_user_func($optionValues, $options[$option])) {
@@ -325,7 +325,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
     private static function formatTypesOf(array $types)
     {
         foreach ($types as $key => $value) {
-            $types[$key] = static::formatTypeOf($value);
+            $types[$key] = self::formatTypeOf($value);
         }
 
         return implode(', ', $types);
@@ -348,9 +348,9 @@ class Options implements \ArrayAccess, \Iterator, \Countable
     private static function formatValue($value)
     {
         $isDateTime = $value instanceof \DateTime || $value instanceof \DateTimeInterface;
-        if (static::PRETTY_DATE && $isDateTime) {
+        if (self::PRETTY_DATE && $isDateTime) {
             if (class_exists('IntlDateFormatter')) {
-                $locale    = \Locale::getDefault();
+                $locale = \Locale::getDefault();
                 $formatter = new \IntlDateFormatter($locale, \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT);
                 // neither the native nor the stub IntlDateFormatter support
                 // DateTimeImmutable as of yet
@@ -368,7 +368,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         }
 
         if (is_object($value)) {
-            if (static::OBJECT_TO_STRING && method_exists($value, '__toString')) {
+            if (self::OBJECT_TO_STRING && method_exists($value, '__toString')) {
                 return $value->__toString();
             }
 
@@ -417,7 +417,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
     private static function formatValues(array $values)
     {
         foreach ($values as $key => $value) {
-            $values[$key] = static::formatValue($value);
+            $values[$key] = self::formatValue($value);
         }
 
         return implode(', ', $values);

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -263,8 +263,8 @@ class Options implements \ArrayAccess, \Iterator, \Countable
             throw new InvalidOptionsException(sprintf(
                 'The option "%s" with value "%s" is expected to be of type "%s"',
                 $option,
-                self::formatValue($value),
-                implode('", "', self::formatTypesOf($optionTypes))
+                static::formatValue($value),
+                static::formatTypesOf($optionTypes)
             ));
         }
     }
@@ -288,7 +288,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         foreach ($acceptedValues as $option => $optionValues) {
             if (array_key_exists($option, $options)) {
                 if (is_array($optionValues) && !in_array($options[$option], $optionValues, true)) {
-                    throw new InvalidOptionsException(sprintf('The option "%s" has the value "%s", but is expected to be one of "%s"', $option, $options[$option], implode('", "', self::formatValues($optionValues))));
+                    throw new InvalidOptionsException(sprintf('The option "%s" has the value "%s", but is expected to be one of "%s"', $option, $options[$option], static::formatValues($optionValues)));
                 }
 
                 if (is_callable($optionValues) && !call_user_func($optionValues, $options[$option])) {
@@ -311,17 +311,24 @@ class Options implements \ArrayAccess, \Iterator, \Countable
     }
 
     /**
-     * @param array $optionTypes
+     * Returns a string representation of a list of types.
      *
-     * @return array
+     * Each of the types is converted to a string using
+     * {@link formatTypeOf()}. The values are then concatenated with commas.
+     *
+     * @param array $types A list of types
+     *
+     * @return string The string representation of the type list
+     *
+     * @see formatTypeOf()
      */
-    private static function formatTypesOf(array $optionTypes)
+    private static function formatTypesOf(array $types)
     {
-        foreach ($optionTypes as $x => $type) {
-            $optionTypes[$x] = self::formatTypeOf($type);
+        foreach ($types as $key => $value) {
+            $types[$key] = static::formatTypeOf($value);
         }
 
-        return $optionTypes;
+        return implode(', ', $types);
     }
 
     /**
@@ -334,16 +341,14 @@ class Options implements \ArrayAccess, \Iterator, \Countable
      * is set to true, {@link \DateTime} objects will be formatted as
      * RFC-3339 dates ("Y-m-d H:i:s").
      *
-     * @param mixed $value  The value to format as string
-     * @param int   $format A bitwise combination of the format
-     *                      constants in this class
+     * @param mixed $value The value to format as string
      *
      * @return string The string representation of the passed value
      */
-    private static function formatValue($value, $format = 0)
+    private static function formatValue($value)
     {
         $isDateTime = $value instanceof \DateTime || $value instanceof \DateTimeInterface;
-        if (($format & self::PRETTY_DATE) && $isDateTime) {
+        if (static::PRETTY_DATE && $isDateTime) {
             if (class_exists('IntlDateFormatter')) {
                 $locale    = \Locale::getDefault();
                 $formatter = new \IntlDateFormatter($locale, \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT);
@@ -363,7 +368,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         }
 
         if (is_object($value)) {
-            if ($format & self::OBJECT_TO_STRING && method_exists($value, '__toString')) {
+            if (static::OBJECT_TO_STRING && method_exists($value, '__toString')) {
                 return $value->__toString();
             }
 
@@ -400,16 +405,22 @@ class Options implements \ArrayAccess, \Iterator, \Countable
     /**
      * Returns a string representation of a list of values.
      *
-     * @param array $values
-     * @param bool  $prettyDateTime
+     * Each of the values is converted to a string using
+     * {@link formatValue()}. The values are then concatenated with commas.
      *
-     * @return string
+     * @param array $values A list of values
+     *
+     * @return string The string representation of the value list
+     *
+     * @see formatValue()
      */
-    private static function formatValues(array $values, $prettyDateTime = false)
+    private static function formatValues(array $values)
     {
-        return array_map(function ($value) use ($prettyDateTime) {
-            return self::formatValue($value, $prettyDateTime);
-        }, $values);
+        foreach ($values as $key => $value) {
+            $values[$key] = static::formatValue($value);
+        }
+
+        return implode(', ', $values);
     }
 
     /**

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -520,8 +520,8 @@ class Options implements \ArrayAccess, \Iterator, \Countable
             throw new OptionDefinitionException('Options cannot be replaced anymore once options have been read.');
         }
 
-        $this->options     = array();
-        $this->lazy        = array();
+        $this->options = array();
+        $this->lazy = array();
         $this->normalizers = array();
 
         foreach ($options as $option => $value) {
@@ -562,7 +562,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
             $reflClosure = is_array($value)
                 ? new \ReflectionMethod($value[0], $value[1])
                 : new \ReflectionFunction($value);
-            $params      = $reflClosure->getParameters();
+            $params = $reflClosure->getParameters();
 
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && __CLASS__ === $class->name) {
                 // Initialize the option if no previous value exists
@@ -665,8 +665,8 @@ class Options implements \ArrayAccess, \Iterator, \Countable
             throw new OptionDefinitionException('Options cannot be cleared anymore once options have been read.');
         }
 
-        $this->options     = array();
-        $this->lazy        = array();
+        $this->options = array();
+        $this->lazy = array();
         $this->normalizers = array();
     }
 
@@ -884,7 +884,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         /** @var \Closure $normalizer */
         $normalizer = $this->normalizers[$option];
 
-        $this->lock[$option]    = true;
+        $this->lock[$option] = true;
         $this->options[$option] = $normalizer($this, array_key_exists($option, $this->options) ? $this->options[$option] : null);
         unset($this->lock[$option]);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/11020 |
| License | MIT |
| Doc PR | - |

Note to moderator: Stopwatch tests are failing randomly here; not related to this PR!
For more info, see https://github.com/symfony/symfony/issues/10454

**UPDATE**:
- moved creation of printable value and type to separate methods for cleanliness
- improved printable value by making a difference between an empty string and NULL.
- restricted wrapping in quotes to only string values; further differentiating with other types.
- when printable type is an object, it's classname get's returned instead of just 'object'

**UPDATE 2**:
- applied feedback

**UPDATE 3**:
- applied more feedback
- squashed commits
