### PR TITLE
[RFC] Add new method to Progress Helper getCurrent()

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -270,7 +270,7 @@ class ProgressHelper extends Helper
     }
     
     /**
-     * @return int  The current progress
+     * @return int The current progress
      */ 
     public function getCurrent()
     {

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -268,6 +268,14 @@ class ProgressHelper extends Helper
             $this->display();
         }
     }
+    
+    /**
+     * @return int    $current The current progress
+     */ 
+    public function getCurrent()
+    {
+        return $this->current;
+    }
 
     /**
      * Outputs the current progress string.

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -270,7 +270,7 @@ class ProgressHelper extends Helper
     }
     
     /**
-     * @return int    $current The current progress
+     * @return int  The current progress
      */ 
     public function getCurrent()
     {


### PR DESCRIPTION
Please see my example below for my reasoning on how this method can be useful:

``` php
$progress = $this->getHelperSet()->get('progress');

$total = 55;
$progress->start($output, $total);
$stepSize = 10;
$lastStepSize = $total % $stepSize; // 5
$i = 0;
while ($i++ <= $total) {
    // ... do some work

    if (($i % $stepSize) == 0) {
        // advances the progress bar 10 units or on the final iteration 5 units
        $progress->advance($progress->getCurrent() > $total - $lastStepSize ? $lastStepSize : $stepSize);
    }
}

$progress->finish();
```

I do this work in a listener so it would be nice if the method was part of the helper's api.
