### PR TITLE
[HttpKernel] Dependency management

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "~2.2",
+        "symfony/dependency-injection": "~2.3",
         "symfony/debug": "~2.3",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
This PR fixes an issue I'm having when trying to test a bundle without installing the whole framework. I just created a bundle and need to test whether it autoloads fine or not.

I need this piece of code to work : 

`use Symfony\Component\HttpKernel\Bundle\Bundle;`

Naturally, I install `symfony/http-kernel`, and then get the following error message : 

>  Class 'Symfony\Component\DependencyInjection\ContainerAware' not found in /home/users/gparis/dev/phpcasbundle/vendor/symfony/http-kernel/Symfony/Component/HttpKernel/Bundle/Bundle.php

It seems there is a dependency between `http-kernel` and `dependency-injection`. This PR establishes this dependency. I'm not sure about the version constraint part though.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [comma separated list of tickets fixed by the PR] |
| License | MIT |
