### PR TITLE
[Stopwatch] PR for #10454: Random failures in test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ before_script:
     - wget https://phar.phpunit.de/phpunit.phar && rm `which phpunit` && sudo cp phpunit.phar /usr/local/bin/phpunit && sudo chmod +x /usr/local/bin/phpunit
 
 script:
-    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || false
+    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark,timing {};' || false
     - echo "Running tests requiring tty"; phpunit --group tty

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -64,6 +64,9 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $event->getPeriods());
     }
 
+    /**
+     * @group benchmark
+     */
     public function testDuration()
     {
         $event = new StopwatchEvent(microtime(true) * 1000);
@@ -82,6 +85,9 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
     }
 
+    /**
+     * @group benchmark
+     */
     public function testDurationBeforeStop()
     {
         $event = new StopwatchEvent(microtime(true) * 1000);
@@ -120,6 +126,9 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($event->isStarted());
     }
 
+    /**
+     * @group benchmark
+     */
     public function testEnsureStopped()
     {
         // this also test overlap between two periods
@@ -132,6 +141,9 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(300, $event->getDuration(), null, self::DELTA);
     }
 
+    /**
+     * @group benchmark
+     */
     public function testStartTime()
     {
         $event = new StopwatchEvent(microtime(true) * 1000);
@@ -149,6 +161,9 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $event->getStartTime(), null, self::DELTA);
     }
 
+    /**
+     * @group benchmark
+     */
     public function testEndTime()
     {
         $event = new StopwatchEvent(microtime(true) * 1000);

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -65,7 +65,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group benchmark
+     * @group timing
      */
     public function testDuration()
     {
@@ -86,7 +86,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group benchmark
+     * @group timing
      */
     public function testDurationBeforeStop()
     {
@@ -127,7 +127,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group benchmark
+     * @group timing
      */
     public function testEnsureStopped()
     {
@@ -142,7 +142,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group benchmark
+     * @group timing
      */
     public function testStartTime()
     {
@@ -162,7 +162,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group benchmark
+     * @group timing
      */
     public function testEndTime()
     {

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -70,7 +70,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group benchmark
+     * @group timing
      */
     public function testStop()
     {
@@ -84,7 +84,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group benchmark
+     * @group timing
      */
     public function testLap()
     {

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -69,6 +69,9 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($stopwatch->isStarted('foo'));
     }
 
+    /**
+     * @group benchmark
+     */
     public function testStop()
     {
         $stopwatch = new Stopwatch();
@@ -80,6 +83,9 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
     }
 
+    /**
+     * @group benchmark
+     */
     public function testLap()
     {
         $stopwatch = new Stopwatch();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/10454 |
| License | MIT |
| Doc PR | - |

I've added a `@group benchmark` annotation to specific Stopwatch tests that rely on timing, so they can be treated differently if the user demands it. For symfony, it fixes the issue we have with Travis failing on these timing tests because this `benchmark` group is excluded from Travis' phpunit coverage.

Thus it improves testing time (saving on retry attempts done by Travis after each random failure), and prevents false-positives reported under a contributor's PR. 

In my opinion we should be able to trust Travis tests and any reported failures. Having to ignore certain test results because they can't be fixed suggests to me we should disable that test until we can trust it again.

Alternatively; I could make a new group like `timing` so it's more distinct from the other `benchmark` tests. Let me know.

**UPDATE**:
- replaced `benchmark` with `timing` to be more specific to the use-case.
- added `timing` as excluded-group in the travis configuration
