### PR TITLE
[Debug] enhanced error messages for uncaught exceptions

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -36,7 +36,7 @@ class CodeExtension extends \Twig_Extension
     public function __construct($fileLinkFormat, $rootDir, $charset)
     {
         $this->fileLinkFormat = empty($fileLinkFormat) ? ini_get('xdebug.file_link_format') : $fileLinkFormat;
-        $this->rootDir = str_replace('\\', '/', $rootDir).'/';
+        $this->rootDir = str_replace('\\', '/', dirname($rootDir)).'/';
         $this->charset = $charset;
     }
 
@@ -164,12 +164,14 @@ class CodeExtension extends \Twig_Extension
      */
     public function formatFile($file, $line, $text = null)
     {
+        $file = trim($file);
+
         if (null === $text) {
-            $file = trim($file);
-            $text = $file;
+            $text = str_replace('\\', '/', $file);
             if (0 === strpos($text, $this->rootDir)) {
-                $text = str_replace($this->rootDir, '', str_replace('\\', '/', $text));
-                $text = sprintf('<abbr title="%s">kernel.root_dir</abbr>/%s', $this->rootDir, $text);
+                $text = substr($text, strlen($this->rootDir));
+                $text = explode('/', $text, 2);
+                $text = sprintf('<abbr title="%s%2$s">%s</abbr>%s', $this->rootDir, $text[0], isset($text[1]) ? '/'.$text[1] : '');
             }
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/admin.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/admin.html.twig
@@ -13,8 +13,8 @@
                 &#187;&#160;<a href="{{ path('_profiler_export', { 'token': token }) }}">Export</a>
             </div>
         {% endif %}
-        &#187;&#160;<label for="file">Import</label><br>
-        <input type="file" name="file" id="file"><br>
+        &#187;&#160;<label for="file">Import</label><br />
+        <input type="file" name="file" id="file"><br />
         <button type="submit" class="sf-button">
             <span class="border-l">
                 <span class="border-r">

--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+* enhanced error messages for uncaught exceptions
+
 2.5.0
 -----
 

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -151,7 +151,7 @@ class ErrorHandler
                 $context = $c;
             }
 
-            $exception = sprintf('%s: %s in %s line %d', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message, $file, $line);
+            $exception = sprintf('%s: %s', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message);
             if ($context && class_exists('Symfony\Component\Debug\Exception\ContextErrorException')) {
                 // Checking for class existence is a work around for https://bugs.php.net/42098
                 $exception = new ContextErrorException($exception, 0, $level, $file, $line, $context);
@@ -317,12 +317,11 @@ class ErrorHandler
         set_error_handler('var_dump', 0);
         ini_set('display_errors', 1);
 
-        $level = isset($this->levels[$error['type']]) ? $this->levels[$error['type']] : $error['type'];
-        $message = sprintf('%s: %s in %s line %d', $level, $error['message'], $error['file'], $error['line']);
+        $exception = sprintf('%s: %s', $this->levels[$error['type']], $error['message']);
         if (0 === strpos($error['message'], 'Allowed memory') || 0 === strpos($error['message'], 'Out of memory')) {
-            $exception = new OutOfMemoryException($message, 0, $error['type'], $error['file'], $error['line'], 3, false);
+            $exception = new OutOfMemoryException($exception, 0, $error['type'], $error['file'], $error['line'], 3, false);
         } else {
-            $exception = new FatalErrorException($message, 0, $error['type'], $error['file'], $error['line'], 3, true);
+            $exception = new FatalErrorException($exception, 0, $error['type'], $error['file'], $error['line'], 3, true);
 
             foreach ($this->getFatalErrorHandlers() as $handler) {
                 if ($e = $handler->handleError($error, $exception)) {

--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -51,29 +51,23 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
             if (false !== $namespaceSeparatorIndex = strrpos($fullyQualifiedClassName, '\\')) {
                 $className = substr($fullyQualifiedClassName, $namespaceSeparatorIndex + 1);
                 $namespacePrefix = substr($fullyQualifiedClassName, 0, $namespaceSeparatorIndex);
-                $message = sprintf(
-                    'Attempted to load %s "%s" from namespace "%s" in %s line %d. Do you need to "use" it from another namespace?',
-                    $typeName,
-                    $className,
-                    $namespacePrefix,
-                    $error['file'],
-                    $error['line']
-                );
+                $message = sprintf('Attempted to load %s "%s" from namespace "%s".', $typeName, $className, $namespacePrefix);
+                $tail = ' for another namespace?';
             } else {
                 $className = $fullyQualifiedClassName;
-                $message = sprintf(
-                    'Attempted to load %s "%s" from the global namespace in %s line %d. Did you forget a use statement for this %s?',
-                    $typeName,
-                    $className,
-                    $error['file'],
-                    $error['line'],
-                    $typeName
-                );
+                $message = sprintf('Attempted to load %s "%s" from the global namespace.', $typeName, $className);
+                $tail = '?';
             }
 
-            if ($classes = $this->getClassCandidates($className)) {
-                $message .= sprintf(' Perhaps you need to add a use statement for one of the following: %s.', implode(', ', $classes));
+            if ($candidates = $this->getClassCandidates($className)) {
+                $tail = array_pop($candidates).'"?';
+                if ($candidates) {
+                    $tail = ' for e.g. "'.implode('", "', $candidates).'" or "'.$tail;
+                } else {
+                    $tail = ' for "'.$tail;
+                }
             }
+            $message .= ' Did you forget a "use" statement'.$tail;
 
             return new ClassNotFoundException($message, $exception);
         }

--- a/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedFunctionFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedFunctionFatalErrorHandler.php
@@ -47,21 +47,10 @@ class UndefinedFunctionFatalErrorHandler implements FatalErrorHandlerInterface
         if (false !== $namespaceSeparatorIndex = strrpos($fullyQualifiedFunctionName, '\\')) {
             $functionName = substr($fullyQualifiedFunctionName, $namespaceSeparatorIndex + 1);
             $namespacePrefix = substr($fullyQualifiedFunctionName, 0, $namespaceSeparatorIndex);
-            $message = sprintf(
-                'Attempted to call function "%s" from namespace "%s" in %s line %d.',
-                $functionName,
-                $namespacePrefix,
-                $error['file'],
-                $error['line']
-            );
+            $message = sprintf('Attempted to call function "%s" from namespace "%s".', $functionName, $namespacePrefix);
         } else {
             $functionName = $fullyQualifiedFunctionName;
-            $message = sprintf(
-                'Attempted to call function "%s" from the global namespace in %s line %d.',
-                $functionName,
-                $error['file'],
-                $error['line']
-            );
+            $message = sprintf('Attempted to call function "%s" from the global namespace.', $functionName);
         }
 
         $candidates = array();
@@ -81,9 +70,13 @@ class UndefinedFunctionFatalErrorHandler implements FatalErrorHandlerInterface
 
         if ($candidates) {
             sort($candidates);
-            $message .= ' Did you mean to call: '.implode(', ', array_map(function ($val) {
-                return '"'.$val.'"';
-            }, $candidates)).'?';
+            $last = array_pop($candidates).'"?';
+            if ($candidates) {
+                $candidates = 'e.g. "'.implode('", "', $candidates).'" or "'.$last;
+            } else {
+                $candidates = '"'.$last;
+            }
+            $message .= ' Did you mean to call '.$candidates;
         }
 
         return new UndefinedFunctionException($message, $exception);

--- a/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
@@ -34,7 +34,7 @@ class UndefinedMethodFatalErrorHandler implements FatalErrorHandlerInterface
         $className = $matches[1];
         $methodName = $matches[2];
 
-        $message = sprintf('Attempted to call method "%s" on class "%s" in %s line %d.', $methodName, $className, $error['file'], $error['line']);
+        $message = sprintf('Attempted to call method "%s" on class "%s".', $methodName, $className);
 
         $candidates = array();
         foreach (get_class_methods($className) as $definedMethodName) {
@@ -46,7 +46,13 @@ class UndefinedMethodFatalErrorHandler implements FatalErrorHandlerInterface
 
         if ($candidates) {
             sort($candidates);
-            $message .= sprintf(' Did you mean to call: "%s"?', implode('", "', $candidates));
+            $last = array_pop($candidates).'"?';
+            if ($candidates) {
+                $candidates = 'e.g. "'.implode('", "', $candidates).'" or "'.$last;
+            } else {
+                $candidates = '"'.$last;
+            }
+            $message .= ' Did you mean to call '.$candidates;
         }
 
         return new UndefinedMethodException($message, $exception);

--- a/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
@@ -160,8 +160,8 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array(
             array(
-                'message'=> 'test',
-                'class'=>'Exception',
+                'message' => 'test',
+                'class' => 'Exception',
                 'trace'=>array(array(
                     'namespace'   => '', 'short_class' => '', 'class' => '','type' => '','function' => '', 'file' => 'foo.php', 'line' => 123,
                     'args'        => array()

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -41,7 +41,7 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class \'WhizBangFactory\' not found',
                 ),
-                'Attempted to load class "WhizBangFactory" from the global namespace in foo.php line 12. Did you forget a use statement for this class?',
+                'Attempted to load class "WhizBangFactory" from the global namespace. Did you forget a "use" statement?',
             ),
             array(
                 array(
@@ -50,7 +50,7 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class \'Foo\\Bar\\WhizBangFactory\' not found',
                 ),
-                'Attempted to load class "WhizBangFactory" from namespace "Foo\\Bar" in foo.php line 12. Do you need to "use" it from another namespace?',
+                'Attempted to load class "WhizBangFactory" from namespace "Foo\\Bar". Did you forget a "use" statement for another namespace?',
             ),
             array(
                 array(
@@ -59,7 +59,7 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class \'UndefinedFunctionException\' not found',
                 ),
-                'Attempted to load class "UndefinedFunctionException" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
+                'Attempted to load class "UndefinedFunctionException" from the global namespace. Did you forget a "use" statement for "Symfony\Component\Debug\Exception\UndefinedFunctionException"?',
             ),
             array(
                 array(
@@ -68,7 +68,7 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class \'PEARClass\' not found',
                 ),
-                'Attempted to load class "PEARClass" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following: Symfony_Component_Debug_Tests_Fixtures_PEARClass.',
+                'Attempted to load class "PEARClass" from the global namespace. Did you forget a "use" statement for "Symfony_Component_Debug_Tests_Fixtures_PEARClass"?',
             ),
             array(
                 array(
@@ -77,7 +77,7 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class \'Foo\\Bar\\UndefinedFunctionException\' not found',
                 ),
-                'Attempted to load class "UndefinedFunctionException" from namespace "Foo\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add a use statement for one of the following: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
+                'Attempted to load class "UndefinedFunctionException" from namespace "Foo\Bar". Did you forget a "use" statement for "Symfony\Component\Debug\Exception\UndefinedFunctionException"?',
             ),
         );
     }

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedFunctionFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedFunctionFatalErrorHandlerTest.php
@@ -42,7 +42,7 @@ class UndefinedFunctionFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Call to undefined function test_namespaced_function()',
                 ),
-                'Attempted to call function "test_namespaced_function" from the global namespace in foo.php line 12. Did you mean to call: "\\symfony\\component\\debug\\tests\\fatalerrorhandler\\test_namespaced_function"?',
+                'Attempted to call function "test_namespaced_function" from the global namespace. Did you mean to call "\\symfony\\component\\debug\\tests\\fatalerrorhandler\\test_namespaced_function"?',
             ),
             array(
                 array(
@@ -51,7 +51,7 @@ class UndefinedFunctionFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Call to undefined function Foo\\Bar\\Baz\\test_namespaced_function()',
                 ),
-                'Attempted to call function "test_namespaced_function" from namespace "Foo\\Bar\\Baz" in foo.php line 12. Did you mean to call: "\\symfony\\component\\debug\\tests\\fatalerrorhandler\\test_namespaced_function"?',
+                'Attempted to call function "test_namespaced_function" from namespace "Foo\\Bar\\Baz". Did you mean to call "\\symfony\\component\\debug\\tests\\fatalerrorhandler\\test_namespaced_function"?',
             ),
             array(
                 array(
@@ -60,7 +60,7 @@ class UndefinedFunctionFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Call to undefined function foo()',
                 ),
-                'Attempted to call function "foo" from the global namespace in foo.php line 12.',
+                'Attempted to call function "foo" from the global namespace.',
             ),
             array(
                 array(
@@ -69,7 +69,7 @@ class UndefinedFunctionFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Call to undefined function Foo\\Bar\\Baz\\foo()',
                 ),
-                'Attempted to call function "foo" from namespace "Foo\Bar\Baz" in foo.php line 12.',
+                'Attempted to call function "foo" from namespace "Foo\Bar\Baz".',
             ),
         );
     }

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedMethodFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedMethodFatalErrorHandlerTest.php
@@ -41,7 +41,7 @@ class UndefinedMethodFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Call to undefined method SplObjectStorage::what()',
                 ),
-                'Attempted to call method "what" on class "SplObjectStorage" in foo.php line 12.',
+                'Attempted to call method "what" on class "SplObjectStorage".',
             ),
             array(
                 array(
@@ -50,7 +50,7 @@ class UndefinedMethodFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Call to undefined method SplObjectStorage::walid()',
                 ),
-                'Attempted to call method "walid" on class "SplObjectStorage" in foo.php line 12. Did you mean to call: "valid"?',
+                'Attempted to call method "walid" on class "SplObjectStorage". Did you mean to call "valid"?',
             ),
             array(
                 array(
@@ -59,7 +59,7 @@ class UndefinedMethodFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Call to undefined method SplObjectStorage::offsetFet()',
                 ),
-                'Attempted to call method "offsetFet" on class "SplObjectStorage" in foo.php line 12. Did you mean to call: "offsetGet", "offsetSet", "offsetUnset"?',
+                'Attempted to call method "offsetFet" on class "SplObjectStorage". Did you mean to call e.g. "offsetGet", "offsetSet" or "offsetUnset"?',
             ),
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Before:

![capture du 2014-06-02 10 56 42](https://cloud.githubusercontent.com/assets/243674/3145281/3f8c4d24-ea34-11e3-948c-78898fb79a75.png)

After:

![capture du 2014-06-02 10 55 57](https://cloud.githubusercontent.com/assets/243674/3145283/44167a86-ea34-11e3-9786-f77f2f001638.png)

A double-click on the file name switches between short/full path name.
