### PR TITLE
[HttpKernel] Revert BC break introduced by #8957

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -132,7 +132,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
 
         $server['REMOTE_ADDR'] = '127.0.0.1';
 
-        $subRequest = Request::create($uri, 'get', array(), $cookies, array(), $server);
+        $subRequest = $request::create($uri, 'get', array(), $cookies, array(), $server);
         if ($request->headers->has('Surrogate-Capability')) {
             $subRequest->headers->set('Surrogate-Capability', $request->headers->get('Surrogate-Capability'));
         }

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -267,7 +267,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
                 // As per the RFC, invalidate Location and Content-Location URLs if present
                 foreach (array('Location', 'Content-Location') as $header) {
                     if ($uri = $response->headers->get($header)) {
-                        $subRequest = Request::create($uri, 'get', array(), array(), array(), $request->server->all());
+                        $subRequest = $request::create($uri, 'get', array(), array(), array(), $request->server->all());
 
                         $this->store->invalidate($subRequest);
                     }

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -72,7 +72,7 @@ class HttpUtils
      */
     public function createRequest(Request $request, $path)
     {
-        $newRequest = Request::create($this->generateUri($request, $path), 'get', array(), $request->cookies->all(), array(), $request->server->all());
+        $newRequest = $request::create($this->generateUri($request, $path), 'get', array(), $request->cookies->all(), array(), $request->server->all());
         if ($request->hasSession()) {
             $newRequest->setSession($request->getSession());
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

464439d195fc895079176498cb28d182dc8aef14 (https://github.com/symfony/symfony/pull/8957) creates a BC break. At least the SonataPage CMS used with the "host and path" strategy (http://sonata-project.org/bundles/page/master/doc/reference/multisite.html#host-and-path-strategy) is not working anymore because of this patch.

SonataPage extends the `Request` class without using the new factory system (there is probably a cleaner way to implement the "host and path" strategy in the CMS too).

When a subrequest is handled by `InlineFragment`, a request of type `Symfony\Component\HttpFoundation\Request` is instantiated instead of the expected `Sonata\PageBundle\Request\SiteRequest`. Then, SonataPage fail on the subrequest.

I've just reverted the part of this commit changing the previous behavior, the factory system is still working.

ping @fabpot @rande @Sinjonathan
