### PR TITLE
Remove undefined variable $e

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -465,7 +465,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         if (isset($this->loading[$id])) {
-            throw new LogicException(sprintf('The service "%s" has a circular reference to itself.', $id), 0, $e);
+            throw new LogicException(sprintf('The service "%s" has a circular reference to itself.', $id));
         }
 
         if (!$this->hasDefinition($id) && isset($this->aliasDefinitions[$id])) {


### PR DESCRIPTION
This PR was submitted on the symfony/DependencyInjection read-only repository and moved automatically to the main Symfony repository (closes symfony/DependencyInjection#6).
