### PR TITLE
[Console] OutputFormatter Unset Bold has wrong id

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -41,7 +41,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         'white'     => array('set' => 47, 'unset' => 49)
     );
     private static $availableOptions = array(
-        'bold'          => array('set' => 1, 'unset' => 21),
+        'bold'          => array('set' => 1, 'unset' => 22),
         'underscore'    => array('set' => 4, 'unset' => 24),
         'blink'         => array('set' => 5, 'unset' => 25),
         'reverse'       => array('set' => 7, 'unset' => 27),
@@ -202,7 +202,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     public function apply($text)
     {
         $setCodes = array();
-        $unsetCode = array();
+        $unsetCodes = array();
 
         if (null !== $this->foreground) {
             $setCodes[] = $this->foreground['set'];

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
@@ -18,7 +18,7 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
     public function testConstructor()
     {
         $style = new OutputFormatterStyle('green', 'black', array('bold', 'underscore'));
-        $this->assertEquals("\033[32;40;1;4mfoo\033[39;49;21;24m", $style->apply('foo'));
+        $this->assertEquals("\033[32;40;1;4mfoo\033[39;49;22;24m", $style->apply('foo'));
 
         $style = new OutputFormatterStyle('red', null, array('blink'));
         $this->assertEquals("\033[31;5mfoo\033[39;25m", $style->apply('foo'));

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
@@ -63,16 +63,16 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("\033[7;8mfoo\033[27;28m", $style->apply('foo'));
 
         $style->setOption('bold');
-        $this->assertEquals("\033[7;8;1mfoo\033[27;28;21m", $style->apply('foo'));
+        $this->assertEquals("\033[7;8;1mfoo\033[27;28;22m", $style->apply('foo'));
 
         $style->unsetOption('reverse');
-        $this->assertEquals("\033[8;1mfoo\033[28;21m", $style->apply('foo'));
+        $this->assertEquals("\033[8;1mfoo\033[28;22m", $style->apply('foo'));
 
         $style->setOption('bold');
-        $this->assertEquals("\033[8;1mfoo\033[28;21m", $style->apply('foo'));
+        $this->assertEquals("\033[8;1mfoo\033[28;22m", $style->apply('foo'));
 
         $style->setOptions(array('bold'));
-        $this->assertEquals("\033[1mfoo\033[21m", $style->apply('foo'));
+        $this->assertEquals("\033[1mfoo\033[22m", $style->apply('foo'));
 
         try {
             $style->setOption('foo');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

The Unsetter for Bold in *nix Console is the 22 not the 21. Problem is that the 21 is invalid and so no style will be unsetted. Don't look very nice. Also fixed small Typo with Vars in apply()
