### PR TITLE
[Serializer] Fix BC break since 2.5

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -305,7 +305,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
             return $node->nodeValue;
         }
 
-        if (1 === $node->childNodes->length && XML_TEXT_NODE === $node->firstChild->nodeType) {
+        if (1 === $node->childNodes->length && in_array($node->firstChild->nodeType, array(XML_TEXT_NODE, XML_CDATA_SECTION_NODE))) {
             return $node->firstChild->nodeValue;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -228,6 +228,18 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(get_object_vars($obj), $this->encoder->decode($source, 'xml'));
     }
 
+    public function testDecodeCdataWrapping()
+    {
+        $expected = array(
+            'firstname' => 'Paul <or Me>',
+        );
+
+        $xml = '<?xml version="1.0"?>'."\n".
+            '<response><firstname><![CDATA[Paul <or Me>]]></firstname></response>'."\n";
+
+        $this->assertEquals($expected, $this->encoder->decode($xml, 'xml'));
+    }
+
     public function testDecodeScalarWithAttribute()
     {
         $source = '<?xml version="1.0"?>'."\n".


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

We spotted a BC break after upgrading to 2.5. The break seems to originate from PR #10668 and I hereby submit a test that passes if I revert the XmlEncoder.php back to before the PR.

The result of the given decode call currently is (notice the "#cdata-section"):

``` php
array(1) {
  'firstname' =>
  array(1) {
    '#cdata-section' =>
    string(12) "Paul <or Me>"
  }
}
```

I am looking for help fixing the issue, because so far I wasn't able to come up with a fix. @csarrazi as an author of the PR, do you perhaps have any thoughts on this matter?
