### PR TITLE
[Validator] support for unlimited validator

### DIFF
--- a/src/Symfony/Component/Validator/.gitignore
+++ b/src/Symfony/Component/Validator/.gitignore
@@ -1,3 +1,3 @@
-vendor/
-composer.lock
-phpunit.xml
+/vendor/
+/composer.lock
+/phpunit.xml

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -146,10 +146,12 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $metadata);
     }
 
+    /**
+     * @group now
+     */
     public function testLoadGroupSequenceProviderAnnotation()
     {
         $loader = new AnnotationLoader(new AnnotationReader());
-
         $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity');
         $loader->loadClassMetadata($metadata);
 

--- a/src/Symfony/Component/Validator/autoload.php
+++ b/src/Symfony/Component/Validator/autoload.php
@@ -1,0 +1,16 @@
+<?php
+
+if (version_compare(PHP_VERSION, '5.4', '>=') && gc_enabled()) {
+    // Disabling Zend Garbage Collection to prevent segfaults with PHP5.4+
+    // https://bugs.php.net/bug.php?id=53976
+    gc_disable();
+}
+
+$loader = require_once __DIR__.'/vendor/autoload.php';
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+AnnotationRegistry::registerAutoloadNamespace('Symfony\Component\Validator', __DIR__);
+
+return $loader;

--- a/src/Symfony/Component/Validator/phpunit.xml.dist
+++ b/src/Symfony/Component/Validator/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="autoload.php"
 >
     <testsuites>
         <testsuite name="Symfony Validator Component Test Suite">


### PR DESCRIPTION
is there a way not via custom validator to validate a collection of items each one of the elements constrained by a specific validator but the collection size is unspecified

or is this not supported?
