### PR TITLE
Ticket 10242 rememberme checkpreauth

### DIFF
--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -7,6 +7,15 @@ in 2.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.4.0...v2.4.1
 
+* 2.4.6 (2014-05-31)
+
+ * bug #11014 [Validator] Remove property and method targets from the optional and required constraints (jakzal)
+ * bug #10983 [DomCrawler] Fixed charset detection in html5 meta charset tag (77web)
+ * Merge branch '2.3' into 2.4
+ * bug #10979 Make rootPath part of regex greedy (artursvonda)
+ * bug #10995 [TwigBridge][Trans]set %count% only on transChoice from the current context. (aitboudad)
+ * bug #10987 [DomCrawler] Fixed a forgotten case of complex XPath queries (stof)
+
 * 2.4.5 (2014-05-22)
 
  * bug #10849 [WIP][Finder] Fix wrong implementation on sortable callback comparator (ProPheT777)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION         = '2.4.6';
-    const VERSION_ID      = '20406';
+    const VERSION         = '2.4.7-DEV';
+    const VERSION_ID      = '20407';
     const MAJOR_VERSION   = '2';
     const MINOR_VERSION   = '4';
-    const RELEASE_VERSION = '6';
-    const EXTRA_VERSION   = '';
+    const RELEASE_VERSION = '7';
+    const EXTRA_VERSION   = 'DEV';
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION         = '2.4.6-DEV';
+    const VERSION         = '2.4.6';
     const VERSION_ID      = '20406';
     const MAJOR_VERSION   = '2';
     const MINOR_VERSION   = '4';
     const RELEASE_VERSION = '6';
-    const EXTRA_VERSION   = 'DEV';
+    const EXTRA_VERSION   = '';
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
@@ -50,6 +50,7 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
         }
 
         $user = $token->getUser();
+        $this->userChecker->checkPreAuth($user);
         $this->userChecker->checkPostAuth($user);
 
         $authenticatedToken = new RememberMeToken($user, $this->providerKey, $this->key);

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider;
-use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Role\Role;
 
 class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
@@ -42,6 +42,22 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $token = $this->getSupportedToken(null, 'key2');
 
         $provider->authenticate($token);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\DisabledException
+     */
+    public function testAuthenticateWhenPreChecksFails()
+    {
+        $userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
+        $userChecker->expects($this->once())
+            ->method('checkPreAuth')
+            ->will($this->throwException(new DisabledException()))
+        ;
+
+        $provider = $this->getProvider($userChecker);
+
+        $provider->authenticate($this->getSupportedToken());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10242 |
| License | MIT |

[Security] fixed missing call to UserChecker::checkPreAuth
