### PR TITLE
[Security] bug #10242 Missing checkPreAuth from RememberMeAuthenticationProvider

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
@@ -50,7 +50,7 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
         }
 
         $user = $token->getUser();
-        $this->userChecker->checkPostAuth($user);
+        $this->userChecker->checkPreAuth($user);
 
         $authenticatedToken = new RememberMeToken($user, $this->providerKey, $this->key);
         $authenticatedToken->setAttributes($token->getAttributes());

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider;
-use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Role\Role;
 
 class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
@@ -45,15 +45,14 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccountExpiredException
+     * @expectedException \Symfony\Component\Security\Core\Exception\DisabledException
      */
-    public function testAuthenticateWhenPostChecksFails()
+    public function testAuthenticateWhenPreChecksFails()
     {
         $userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
         $userChecker->expects($this->once())
-                    ->method('checkPostAuth')
-                    ->will($this->throwException($this->getMock('Symfony\Component\Security\Core\Exception\AccountExpiredException', null, array(), '')))
-        ;
+            ->method('checkPreAuth')
+            ->will($this->throwException(new DisabledException()));
 
         $provider = $this->getProvider($userChecker);
 
@@ -65,8 +64,7 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $user->expects($this->exactly(2))
              ->method('getRoles')
-             ->will($this->returnValue(array('ROLE_FOO')))
-        ;
+             ->will($this->returnValue(array('ROLE_FOO')));
 
         $provider = $this->getProvider();
 
@@ -86,16 +84,14 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
             $user
                 ->expects($this->any())
                 ->method('getRoles')
-                ->will($this->returnValue(array()))
-            ;
+                ->will($this->returnValue(array()));
         }
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', array('getProviderKey'), array($user, 'foo', $key));
         $token
             ->expects($this->once())
             ->method('getProviderKey')
-            ->will($this->returnValue('foo'))
-        ;
+            ->will($this->returnValue('foo'));
 
         return $token;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10242 |
| License | MIT |

[Security] fixed missing call to UserChecker::checkPreAuth

edit : after the discution with @hellomedia , i replaced postcheck with precheck 
https://github.com/glutamatt/symfony/commit/e0730e07ed7806fd828c4ebe81d0ba3d89c79de4#commitcomment-6580764
