### PR TITLE
[DependencyInjection] [Routing] [Config] Recursive directory loading

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -12,6 +12,7 @@
         <parameter key="routing.loader.xml.class">Symfony\Component\Routing\Loader\XmlFileLoader</parameter>
         <parameter key="routing.loader.yml.class">Symfony\Component\Routing\Loader\YamlFileLoader</parameter>
         <parameter key="routing.loader.php.class">Symfony\Component\Routing\Loader\PhpFileLoader</parameter>
+        <parameter key="routing.loader.directory.class">Symfony\Component\Routing\Loader\DirectoryLoader</parameter>
         <parameter key="router.options.generator_class">Symfony\Component\Routing\Generator\UrlGenerator</parameter>
         <parameter key="router.options.generator_base_class">Symfony\Component\Routing\Generator\UrlGenerator</parameter>
         <parameter key="router.options.generator_dumper_class">Symfony\Component\Routing\Generator\Dumper\PhpGeneratorDumper</parameter>
@@ -41,6 +42,11 @@
         </service>
 
         <service id="routing.loader.php" class="%routing.loader.php.class%" public="false">
+            <tag name="routing.loader" />
+            <argument type="service" id="file_locator" />
+        </service>
+
+        <service id="routing.loader.directory" class="%routing.loader.directory.class%" public="false">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
         </service>

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -55,6 +55,14 @@ abstract class FileLoader extends Loader
     }
 
     /**
+     * @return string
+     */
+    public function getCurrentDir()
+    {
+        return $this->currentDir;
+    }
+
+    /**
      * Returns the file locator used by this loader.
      *
      * @return FileLocatorInterface

--- a/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * DirectoryLoader is a recursive loader to go through directories
+ *
+ * @author Sebastien Lavoie <seb@wemakecustom.com>
+ */
+class DirectoryLoader extends FileLoader
+{
+    /**
+     * @param mixed  $file The resource
+     * @param string $type The resource type
+     */
+    public function load($file, $type = null)
+    {
+        $file = rtrim($file, '/');
+        $path = $this->locator->locate($file);
+
+        foreach (scandir($path) as $dir) {
+            if ($dir[0] !== '.') {
+                if (is_dir("$path/$dir")) {
+                    $dir .= '/'; // append / to allow recursion
+                }
+
+                $this->setCurrentDir($path);
+
+                $this->import($dir, null, false, $path);
+            }
+        }
+    }
+
+    /**
+     * Returns true if this class supports the given resource.
+     *
+     * @param mixed  $resource A resource
+     * @param string $type     The resource type
+     *
+     * @return bool true if this class supports the given resource, false otherwise
+     */
+    public function supports($resource, $type = null)
+    {
+        return 'directory' === $type || (!$type && preg_match('/\/$/', $resource) === 1); // ends with a slash
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
+use Symfony\Component\Config\Resource\DirectoryResource;
+
 /**
  * DirectoryLoader is a recursive loader to go through directories
  *
@@ -26,6 +28,7 @@ class DirectoryLoader extends FileLoader
     {
         $file = rtrim($file, '/');
         $path = $this->locator->locate($file);
+        $this->container->addResource(new DirectoryResource($path));
 
         foreach (scandir($path) as $dir) {
             if ($dir[0] !== '.') {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/directory/recurse/simple.ini
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/directory/recurse/simple.ini
@@ -1,0 +1,2 @@
+[parameters]
+  ini = ini

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/directory/recurse/simple.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/directory/recurse/simple.yml
@@ -1,0 +1,2 @@
+parameters:
+    yaml: yaml

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/directory/simple.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/directory/simple.php
@@ -1,0 +1,3 @@
+<?php
+
+$container->setParameter('php', 'php');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Loader;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\Config\FileLocator;
+
+class DirectoryLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $fixturesPath;
+
+    protected $container;
+    protected $loader;
+
+    public static function setUpBeforeClass()
+    {
+        self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
+    }
+
+    protected function setUp()
+    {
+        $locator         = new FileLocator(self::$fixturesPath);
+        $this->container = new ContainerBuilder();
+        $this->loader    = new DirectoryLoader($this->container, $locator);
+        $resolver        = new LoaderResolver(array(
+            new PhpFileLoader($this->container, $locator),
+            new IniFileLoader($this->container, $locator),
+            new YamlFileLoader($this->container, $locator),
+            $this->loader,
+        ));
+        $this->loader->setResolver($resolver);
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\Loader\DirectoryLoader::__construct
+     * @covers Symfony\Component\DependencyInjection\Loader\DirectoryLoader::load
+     */
+    public function testDirectoryCanBeLoadedRecursively()
+    {
+        $this->loader->load('directory/');
+        $this->assertEquals(array('ini' => 'ini', 'yaml' => 'yaml', 'php' => 'php'), $this->container->getParameterBag()->all(), '->load() takes a single file name as its first argument');
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\Loader\DirectoryLoader::__construct
+     * @covers Symfony\Component\DependencyInjection\Loader\DirectoryLoader::load
+     *
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The file "foo" does not exist (in:
+     */
+    public function testExceptionIsRaisedWhenDirectoryDoesNotExist()
+    {
+        $this->loader->load('foo/');
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\Loader\DirectoryLoader::supports
+     */
+    public function testSupports()
+    {
+        $loader = new DirectoryLoader(new ContainerBuilder(), new FileLocator());
+
+        $this->assertTrue($loader->supports('foo/'), '->supports() returns true if the resource is loadable');
+        $this->assertTrue($loader->supports('foo/', 'directory'), '->supports() returns true if the resource is loadable');
+        $this->assertTrue($loader->supports('foo', 'directory'), '->supports() returns true if the resource is loadable');
+        $this->assertFalse($loader->supports('foo'), '->supports() returns true if the resource is loadable');
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -741,6 +742,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             new YamlFileLoader($container, $locator),
             new IniFileLoader($container, $locator),
             new PhpFileLoader($container, $locator),
+            new DirectoryLoader($container, $locator),
             new ClosureLoader($container),
         ));
 

--- a/src/Symfony/Component/Routing/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/DirectoryLoader.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader;
+
+use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Config\Resource\DirectoryResource;
+
+class DirectoryLoader extends FileLoader
+{
+    private $currentDir;
+
+    /**
+     * @param mixed  $file The resource
+     * @param string $type The resource type
+     */
+    public function load($file, $type = null)
+    {
+        $path = $this->locator->locate($file);
+
+        $collection = new RouteCollection();
+        $collection->addResource(new DirectoryResource($path));
+
+        foreach (scandir($path) as $dir) {
+            if ($dir[0] !== '.') {
+                $this->setCurrentDir($path);
+
+                $subType = is_dir("$path/$dir") ? 'directory' : null;
+                $subCollection = $this->import("$path/$dir", $subType, false, $path);
+                $collection->addCollection($subCollection);
+            }
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Store here as well because FileLoader::currentDir is private
+     */
+    public function setCurrentDir($currentDir)
+    {
+        $this->currentDir = $currentDir;
+
+        parent::setCurrentDir($currentDir);
+    }
+
+    /**
+     * Returns true if this class supports the given resource.
+     *
+     * @param mixed  $resource A resource
+     * @param string $type     The resource type
+     *
+     * @return bool true if this class supports the given resource, false otherwise
+     */
+    public function supports($resource, $type = null)
+    {
+        try {
+            $path = $this->locator->locate($resource, $this->currentDir);
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return is_string($resource) && 'directory' === $type;
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/directory/recurse/routes1.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/directory/recurse/routes1.yml
@@ -1,0 +1,2 @@
+route1:
+    path: /route/1

--- a/src/Symfony/Component/Routing/Tests/Fixtures/directory/recurse/routes2.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/directory/recurse/routes2.yml
@@ -1,0 +1,2 @@
+route2:
+    path: /route/2

--- a/src/Symfony/Component/Routing/Tests/Fixtures/directory/routes3.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/directory/routes3.yml
@@ -1,0 +1,2 @@
+route3:
+    path: /route/3

--- a/src/Symfony/Component/Routing/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/DirectoryLoaderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Loader;
+
+use Symfony\Component\Routing\Loader\DirectoryLoader;
+use Symfony\Component\Routing\Loader\YamlFileLoader;
+use Symfony\Component\Routing\Loader\AnnotationFileLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\Config\FileLocator;
+
+class DirectoryLoaderTest extends AbstractAnnotationLoaderTest
+{
+    protected $loader;
+    protected $reader;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $locator      = new FileLocator();
+        $this->reader = $this->getReader();
+        $this->loader = new DirectoryLoader($locator);
+        $resolver     = new LoaderResolver(array(
+            new YamlFileLoader($locator),
+            new AnnotationFileLoader($locator, $this->getClassLoader($this->reader)),
+            $this->loader,
+        ));
+        $this->loader->setResolver($resolver);
+    }
+
+    public function testLoadDirectory()
+    {
+        $collection = $this->loader->load(__DIR__.'/../Fixtures/directory', 'directory');
+        $routes = $collection->all();
+
+        $this->assertCount(3, $routes, 'Three routes are loaded');
+        $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
+
+        for ($i = 1; $i <= 3; $i++) {
+            $this->assertSame('/route/'.$i, $routes["route".$i]->getPath());
+        }
+    }
+
+    public function testSupports()
+    {
+        $fixturesDir = __DIR__.'/../Fixtures';
+
+        $this->assertFalse($this->loader->supports($fixturesDir), '->supports() returns true if the resource is loadable');
+        $this->assertFalse($this->loader->supports('foo.foo'), '->supports() returns true if the resource is loadable');
+
+        $this->assertTrue($this->loader->supports($fixturesDir, 'directory'), '->supports() checks the resource type if specified');
+        $this->assertFalse($this->loader->supports($fixturesDir, 'foo'), '->supports() checks the resource type if specified');
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11045 |
| License | MIT |
| Doc PR | TODO |

See those about creating a cookbook for better file organization:
Issue: symfony/symfony-docs#3680
PR: symfony/symfony-docs#3885

This PR allows to specify a directory to load and it will recursively load all files from it, using the `LoaderResolver`.
### Example

``` yml
# app/config/config.yml
imports:
    - { resource: 'dev/' }
```

```
└── app
   ├── config
   │  ├── common
   │  │  └── framework.yml
   │  │  └── assetic.yml
   │  └── config.yml
```

It also works for routing configuration:

``` yml
_common:
    resource: "common/"
    type: directory
```
### Advantages
1. Allows easy separation of configuration files per bundle.
2. This could eventually allow a bundle installation tool that would automatically install needed configuration files.
3. Could superseed the `AnnotationDirectoryLoader`, so it does not duplicate the logic.
4. Is entirely optional and introduces no BC break.
5. Files are loaded lexically with scandir, allowing someone to control the load order through a number prefix.
6. Even if the initial configuration load may be a little bit longer, it does not impact the compiled configuration (production).
### Conflicts

For now, the Routing DirectoryLoader requires the type `directory` to be specified so it does not conflict with `AnnotationDirectoryLoader`. However, this could be refactored.

~~The type declaration requires a [patch in AsseticBundle](https://github.com/symfony/AsseticBundle/commit/f76291c4655f6b7b29f4d20650c020d3be516ad5) for it to be used on `framework.router.resource`. The patch is already merged in master, but not in a release yet.~~ Released in [2.5.0](https://github.com/symfony/AsseticBundle/releases/tag/v2.5.0). Changing the main router would be like this: 

``` yml
framework:
    router:
        resource: "%kernel.root_dir%/config/routing/common/"
        type: directory
```
