### PR TITLE
UPGRADE-2.5.md: Yaml component change in 2.5

### DIFF
--- a/UPGRADE-2.5.md
+++ b/UPGRADE-2.5.md
@@ -226,3 +226,26 @@ Validator
        ->getValidator();
    ```
 
+
+Yaml Component
+--------------
+
+ * The way Yaml handles duplicate keys in an array was changed from `rewrite with the
+   last element` behavior to ignoring all the elements with the same key after the first one.
+
+   Example:
+
+   ```
+   parentElement:
+       firstChild: foo
+       secondChild: 123
+       firstChild: bar
+   ```
+
+   Before:
+
+   This would be parsed in an array like this: `["parentElement" => ["firstChild" => "bar", "secondChild" => 123]]`
+
+   After:
+
+   The first value is used: `["parentElement" => ["firstChild" => "foo", "secondChild" => 123]]`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

We had a very hard to find bug when I was trying to upgrading symfony from 2.4 to 2.5, I think it's worth mentioning in the UPGRADE file. I understand we shouldn't have had duplicated keys in yaml but that was it...
BTW maybe we should raise an error in cases like this?

PS I figured I shouldn't include the PR template with table here because it's just a UPGRADE-\* file change, I will add it if you say
