### PR TITLE
Fixed contextually wrong translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -88,7 +88,7 @@
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
-                <target>Bu değer boşluk olamaz.</target>
+                <target>Bu değer boş bırakılmamalıdır.</target>
             </trans-unit>
             <trans-unit id="23">
                 <source>This value should not be null.</source>


### PR DESCRIPTION
This PR was submitted on the symfony/Validator read-only repository and moved automatically to the main Symfony repository (closes symfony/Validator#9).

"This value should not be blank." was translated as "Bu değer boşluk olamaz." However,  the word "boşluk" means "space" in Turkish, therefore reverse translation implies "This value should not be space." and obviously this is wrong. The corrected translation should be "Bu değer boş bırakılmamalıdır."
