### PR TITLE
[HttpKernel] added value of DateTime object to ValueExporter

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -28,6 +28,10 @@ class ValueExporter
     public function exportValue($value, $depth = 1, $deep = false)
     {
         if (is_object($value)) {
+            if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
+                return sprintf('Object(%s) - %s', get_class($value), $value->format(\DateTime::ISO8601));
+            }
+
             return sprintf('Object(%s)', get_class($value));
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/Util/ValueExporterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/Util/ValueExporterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Util\DataCollector;
+
+use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
+
+class ValueExporterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ValueExporter
+     */
+    private $valueExporter;
+
+    protected function setUp()
+    {
+        $this->valueExporter = new ValueExporter();
+    }
+
+    public function testDateTime()
+    {
+        $dateTime = new \DateTime('2014-06-10 07:35:40', new \DateTimeZone('UTC'));
+        $this->assertSame('Object(DateTime) - 2014-06-10T07:35:40+0000', $this->valueExporter->exportValue($dateTime));
+    }
+
+    public function testDateTimeImmutable()
+    {
+        if (!class_exists('DateTimeImmutable', false)) {
+            $this->markTestSkipped('Test skipped, class DateTimeImmutable does not exist.');
+        }
+
+        $dateTime = new \DateTimeImmutable('2014-06-10 07:35:40', new \DateTimeZone('UTC'));
+        $this->assertSame('Object(DateTimeImmutable) - 2014-06-10T07:35:40+0000', $this->valueExporter->exportValue($dateTime));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This will output the actual value of a DateTime object in the form panel of the web debug toolbar.
- [x] gather feedback for my change (thank you stof, its my first contribution to oss)
- [x] finish the code
