### PR TITLE
[Validator] Add an integer constraint and validator

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * added an Integer validator
+
 2.5.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/Integer.php
+++ b/src/Symfony/Component/Validator/Constraints/Integer.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Elnur Abdurrakhimov <elnur@elnur.pro>
+ */
+class Integer extends Constraint
+{
+    public $message = 'This value should be an integer.';
+}

--- a/src/Symfony/Component/Validator/Constraints/IntegerValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IntegerValidator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author Elnur Abdurrakhimov <elnur@elnur.pro>
+ */
+class IntegerValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        if (false === $value || true === $value || array() === $value || $value != filter_var($value, FILTER_VALIDATE_INT)) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/IntegerValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IntegerValidatorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Integer;
+use Symfony\Component\Validator\Constraints\IntegerValidator;
+
+/**
+ * @author Elnur Abdurrakhimov <elnur@elnur.pro>
+ */
+class IntegerValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    const MESSAGE = 'message';
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $context;
+
+    /**
+     * @var IntegerValidator
+     */
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContextInterface');
+        $this->validator = new IntegerValidator();
+        $this->validator->initialize($this->context);
+    }
+
+    /**
+     * @dataProvider validValues
+     */
+    public function testValidValues($value)
+    {
+        $this->context
+            ->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($value, new Integer());
+    }
+
+    /**
+     * @dataProvider invalidValues
+     */
+    public function testInvalidValues($value)
+    {
+        $this->context
+            ->expects($this->once())
+            ->method('addViolation')
+            ->with(self::MESSAGE);
+
+        $this->validator->validate($value, new Integer(array(
+            'message' => self::MESSAGE,
+        )));
+    }
+
+    public function testNullIsValid()
+    {
+        $this->context
+            ->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate(null, new Integer());
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->context
+            ->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate('', new Integer());
+    }
+
+    /**
+     * @return array
+     */
+    public function validValues()
+    {
+        return array(
+            array(0),
+            array('0'),
+            array('-0'),
+            array(-1),
+            array('-1'),
+            array(100500),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function invalidValues()
+    {
+        return array(
+            array(1.5),
+            array('0.1'),
+            array('blah'),
+            array(new \DateTime()),
+            array(false),
+            array(true),
+            array(array()),
+            array(array('a')),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none that I'm aware of |
| License | MIT |
| Doc PR | will be added when this PR gets approved |

Who would think it's so hard to write a validator for an integer that works with both `int` and `string` types like `1` and `'1'`. That's why I decided to add this validator to the core.
