### PR TITLE
[TwigBundle] [Tests] Add framework-bundle

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -25,7 +25,8 @@
         "symfony/dependency-injection": "~2.0",
         "symfony/config": "~2.2",
         "symfony/routing": "~2.1",
-        "symfony/templating": "~2.1"
+        "symfony/templating": "~2.1",
+        "symfony/framework-bundle": "~2.1"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\TwigBundle\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | [yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR |  |

I'm unable to run the test from within TwigBundle

``` bash
src/Symfony/Bundle/TwigBundle
composer install
phpunit
```

gives

```
PHP Fatal error:  Class 'Symfony\Bundle\FrameworkBundle\Templating\TemplateReference' not found
```

Adding the FrameworkBundle fixes this but is that what is needed?

I believe `require` and `require-dev` should use `dev-master`
- [x] require(-dev) is not up to par with symfony master. 
