### PR TITLE
[WIP] [TwigBundle] [Exception] Make return value similar to error.json.twig

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,10 +1,10 @@
 CHANGELOG
 =========
 
-2.4.0
+2.6.0
 -----
 
- * fixed error.json.twig and exception.json.twig have same structure making clients independent of runtime environment.
+ * [BC BREAK] changed exception.json.twig to match same structure as error.json.twig making clients independent of runtime environment.
 
 2.3.0
 -----

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.4.0
+-----
+
+ * fixed error.json.twig and exception.json.twig have same structure making clients independent of runtime environment.
+
 2.3.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.json.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.json.twig
@@ -1,1 +1,1 @@
-{{ exception.toarray|json_encode|raw }}
+{{ { 'error': { 'code': status_code, 'message': status_text, 'exception': exception.toarray } }|json_encode|raw }}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | I guess this is a bug |
| New feature? | The exception structure changes for the default |
| BC breaks? | The exception structure changes for the default |
| Deprecations? | [yes |
| Tests pass? | [yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The result for `error.json.twig` and `exception.json.twig` differ making the client forced to check for it's result.

We think the structure should be the same to make the ie a javascript client try to respond similar for --env=dev|prod
