### PR TITLE
Allow xdebug.file_link_format from php ini to work when xdebug extension is not loaded

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -37,7 +37,7 @@ class CodeExtension extends \Twig_Extension
     {
         if (empty($fileLinkFormat)) {
             $fileLinkFormat = ini_get('xdebug.file_link_format');
-            
+
             if (empty($fileLinkFormat)) {
                 $fileLinkFormat = get_cfg_var('xdebug.file_link_format');
             }

--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -35,7 +35,15 @@ class CodeExtension extends \Twig_Extension
      */
     public function __construct($fileLinkFormat, $rootDir, $charset)
     {
-        $this->fileLinkFormat = empty($fileLinkFormat) ? ini_get('xdebug.file_link_format') : $fileLinkFormat;
+        if (empty($fileLinkFormat)) {
+            $fileLinkFormat = ini_get('xdebug.file_link_format');
+            
+            if (empty($fileLinkFormat)) {
+                $fileLinkFormat = get_cfg_var('xdebug.file_link_format');
+            }
+        }
+
+        $this->fileLinkFormat = $fileLinkFormat;
         $this->rootDir = str_replace('\\', '/', dirname($rootDir)).'/';
         $this->charset = $charset;
     }

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -349,7 +349,7 @@ EOF;
         $path = htmlspecialchars($path, ENT_QUOTES | ENT_SUBSTITUTE, $this->charset);
         $file = preg_match('#[^/\\\\]*$#', $path, $file) ? $file[0] : $path;
 
-        if ($linkFormat = ini_get('xdebug.file_link_format')) {
+        if (($linkFormat = ini_get('xdebug.file_link_format')) || ($linkFormat = get_cfg_var('xdebug.file_link_format'))) {
             $link = str_replace(array('%f', '%l'), array($path, $line), $linkFormat);
 
             return sprintf(' <a href="%s" title="Go to source">in %s line %d</a>', $link, $file, $line);


### PR DESCRIPTION
`ini_get('xdebug.file_link_format')` only returns the configuration value if the xdebug extension is actually loaded (ex: `zend_extension=xdebug.so`). As xdebug slows down even the smallest application tenfold, it's preferable to comment out the zend_extension line in the .ini unless performing debugging or profiling activities. PHP will not return the value of xdebug.file_link_format with `ini_get()` unless the extension is loaded; however, `get_cfg_var()` _does_ work.

So we can provide handy debugging links to the IDE so long as xdebug.file_link_format is set, regardless as to whether xdebug itself is loaded. Left the check with `ini_get()` first in case it was overwritten above the .ini level (ie: web server config or `ini_set()`).

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
