### PR TITLE
[HttpFoundation] Added ParameterBag::getBoolean

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -254,6 +254,20 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Returns the parameter value converted to boolean.
+     *
+     * @param string  $key     The parameter key
+     * @param mixed   $default The default value if the parameter key does not exist
+     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
+     *
+     * @return bool    The filtered value
+     */
+    public function getBoolean($key, $default = false, $deep = false)
+    {
+        return $this->filter($key, $default, $deep, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
      * Filter key.
      *
      * @param string  $key     Key.

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -251,4 +251,17 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(count($parameters), count($bag));
     }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\ParameterBag::getBoolean
+     */
+    public function testGetBoolean()
+    {
+        $parameters = array('string_true' => 'true', 'string_false' => 'false');
+        $bag = new ParameterBag($parameters);
+
+        $this->assertTrue($bag->getBoolean('string_true'), '->getBoolean() gets the string true as boolean true');
+        $this->assertFalse($bag->getBoolean('string_false'), '->getBoolean() gets the string false as boolean false');
+        $this->assertFalse($bag->getBoolean('unknown'), '->getBoolean() returns false if a parameter is not defined');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

At the moment to pull a boolean value from a request the user has to use `ParameterBag::filter` or use `filter_var` directly

``` php
// GET /products?hide_archived=true
$request->query->filter('hide_archived', false, false, FILTER_VALIDATE_BOOLEAN); 
// or
filter_var($request->query->get('hide_archived'), FILTER_VALIDATE_BOOLEAN);
```

This is a pure convenience addition, adding a nice way of pulling a boolean value from a query string or request body (especially if http form/url encoded).

Example usage:

``` php
// GET /products?hide_archived=true
$request->query->getBoolean('hide_archived'); // (boolean) true
$request->query->get('hide_archived'); // (string) "true"

// GET /products?hide_archived=1
$request->query->getBoolean('hide_archived'); // (boolean) true

// GET /products?hide_archived=false
$request->query->getBoolean('hide_archived'); // (boolean) false

// GET /products?hide_archived=banana
$request->query->getBoolean('hide_archived'); // (boolean) false
```
