### PR TITLE
Fixed undefined ImageValidator::$suffices property when uploading an image during functional tests

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -29,7 +29,7 @@ class FileValidator extends ConstraintValidator
 
     const MB_BYTES = 1000000;
 
-    protected static $suffices = array(
+    private static $suffices = array(
         1 => 'bytes',
         self::KB_BYTES => 'kB',
         self::MB_BYTES => 'MB',
@@ -160,7 +160,7 @@ class FileValidator extends ConstraintValidator
                 $this->context->addViolation($constraint->maxSizeMessage, array(
                     '{{ size }}'    => $sizeAsString,
                     '{{ limit }}'   => $limitAsString,
-                    '{{ suffix }}'  => static::$suffices[$coef],
+                    '{{ suffix }}'  => self::$suffices[$coef],
                     '{{ file }}'    => $path,
                 ));
 

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -29,7 +29,7 @@ class FileValidator extends ConstraintValidator
 
     const MB_BYTES = 1000000;
 
-    private static $suffices = array(
+    protected static $suffices = array(
         1 => 'bytes',
         self::KB_BYTES => 'kB',
         self::MB_BYTES => 'MB',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11110 |
| License | MIT |
| Doc PR |  |

This will make the FileValidator::$suffices attribute protected so ImageValidator or any inherited class can access it. It fixes #11110 in the most simple way possible.
