### PR TITLE
[HttpKernel] Fix event dispatcher dependency

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/event-dispatcher": "~2.1",
+        "symfony/event-dispatcher": "~2.5",
         "symfony/http-foundation": "~2.4",
         "symfony/debug": "~2.5",
         "psr/log": "~1.0"


### PR DESCRIPTION
Update composer.json to account for #9792.

[Symfony\Component\HttpKernel\DependencyInjection\RegisterListenersPass](https://github.com/symfony/symfony/blob/2.5/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterListenersPass.php#L14) extends `Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass` which exists only in 2.5
