### PR TITLE
[Console] Added verbosity level shorthand methods to OutputInterface

### DIFF
--- a/src/Symfony/Component/Console/Output/NullOutput.php
+++ b/src/Symfony/Component/Console/Output/NullOutput.php
@@ -90,4 +90,36 @@ class NullOutput implements OutputInterface
     {
         // do nothing
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isQuiet()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isVerbose()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isVeryVerbose()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDebug()
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -98,21 +98,33 @@ abstract class Output implements OutputInterface
         return $this->verbosity;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isQuiet()
     {
         return self::VERBOSITY_QUIET === $this->verbosity;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isVerbose()
     {
         return self::VERBOSITY_VERBOSE <= $this->verbosity;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isVeryVerbose()
     {
         return self::VERBOSITY_VERY_VERBOSE <= $this->verbosity;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isDebug()
     {
         return self::VERBOSITY_DEBUG <= $this->verbosity;

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -114,7 +114,7 @@ interface OutputInterface
     /**
      * Do not output any messages.
      *
-     * @return boolean
+     * @return bool
      *
      * @api
      */
@@ -123,7 +123,7 @@ interface OutputInterface
     /**
      * Increased verbosity of messages.
      *
-     * @return boolean
+     * @return bool
      *
      * @api
      */
@@ -132,7 +132,7 @@ interface OutputInterface
     /**
      * Informative non essential messages.
      *
-     * @return boolean
+     * @return bool
      *
      * @api
      */
@@ -141,7 +141,7 @@ interface OutputInterface
     /**
      * Debug messages.
      *
-     * @return boolean
+     * @return bool
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -110,4 +110,40 @@ interface OutputInterface
      * @api
      */
     public function getFormatter();
+
+    /**
+     * Do not output any messages.
+     *
+     * @return boolean
+     *
+     * @api
+     */
+    public function isQuiet();
+
+    /**
+     * Increased verbosity of messages.
+     *
+     * @return boolean
+     *
+     * @api
+     */
+    public function isVerbose();
+
+    /**
+     * Informative non essential messages.
+     *
+     * @return boolean
+     *
+     * @api
+     */
+    public function isVeryVerbose();
+
+    /**
+     * Debug messages.
+     *
+     * @return boolean
+     *
+     * @api
+     */
+    public function isDebug();
 }


### PR DESCRIPTION
Hello,

I've added the verbosity level shorthand methods to the interface "Symfony\Component\Console\Output\OutputInterface" as they should always be implemented by classes implementing the interface. Also it makes unit test easier and avoids warnings like:

"The method isVerbose() does not seem to exist on object<Symfony\Compon...put\OutputInterface>." (Scrutinizer-Cis PHP Analyzer)

As this possibly could break backwards compatibility I like to merge into master. 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | no |
