### PR TITLE
[Validator] Fix array notation in the PropertyPath::append()

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Util/PropertyPathTest.php
@@ -29,6 +29,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
             array('foo', '', 'foo', 'It returns the basePath if subPath is empty'),
             array('', 'bar', 'bar', 'It returns the subPath if basePath is empty'),
             array('foo', 'bar', 'foo.bar', 'It append the subPath to the basePath'),
+            array('foo', '[bar]', 'foo[bar]', 'It does not include the dot separator if subPath uses the array notation')
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Util/PropertyPathTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Util;
+
+use Symfony\Component\Validator\Util\PropertyPath;
+
+class PropertyPathTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideAppendPaths
+     */
+    public function testAppend($basePath, $subPath, $expectedPath, $message)
+    {
+        $this->assertSame($expectedPath, PropertyPath::append($basePath, $subPath), $message);
+    }
+
+    public function provideAppendPaths()
+    {
+        return array(
+            array('foo', '', 'foo', 'It returns the basePath if subPath is empty'),
+            array('', 'bar', 'bar', 'It returns the subPath if basePath is empty'),
+            array('foo', 'bar', 'foo.bar', 'It append the subPath to the basePath'),
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Util/PropertyPath.php
+++ b/src/Symfony/Component/Validator/Util/PropertyPath.php
@@ -38,7 +38,7 @@ class PropertyPath
     public static function append($basePath, $subPath)
     {
         if ('' !== (string) $subPath) {
-            if ('[' === $subPath{1}) {
+            if ('[' === $subPath{0}) {
                 return $basePath.$subPath;
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | related  #11072 #11046 (not fixed yet) |
| License | MIT |
| Doc PR | - |
