### PR TITLE
[2.5][FrameworkBundle] Redirect server output to /dev/null in case no verbosity is needed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -90,20 +90,21 @@ EOF
 
         $output->writeln(sprintf("Server running on <info>http://%s</info>\n", $input->getArgument('address')));
 
-        $router = $input->getOption('router') ?: $this
-            ->getContainer()
-            ->get('kernel')
-            ->locateResource(sprintf('@FrameworkBundle/Resources/config/router_%s.php', $env))
-        ;
-
         $builder = $this->createPhpProcessBuilder($input, $output, $env);
         $builder->setWorkingDirectory($input->getOption('docroot'));
         $builder->setTimeout(null);
-        $builder->getProcess()->run(function ($type, $buffer) use ($output) {
-            if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
+        $process = $builder->getProcess();
+
+        if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
+            $callback = function ($type, $buffer) use ($output) {
                 $output->write($buffer);
-            }
-        });
+            };
+        } else {
+            $callback = null;
+            $process->disableOutput();
+        }
+
+        $process->run($callback);
     }
 
     private function createPhpProcessBuilder(InputInterface $input, OutputInterface $output, $env)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

This should reduce I/Os
