### PR TITLE
Added i18n support to ConfirmationQuestion

### DIFF
--- a/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
+++ b/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
@@ -18,17 +18,22 @@ namespace Symfony\Component\Console\Question;
  */
 class ConfirmationQuestion extends Question
 {
+    private $trueAnswerRegex;
+
     /**
      * Constructor.
      *
-     * @param string $question The question to ask to the user
-     * @param bool   $default  The default answer to return, true or false
+     * @param string $question   The question to ask to the user
+     * @param bool   $default    The default answer to return, true or false
+     * @param string $trueAnswerRegex A regex to match the "yes" answer
      */
-    public function __construct($question, $default = true)
+    public function __construct($question, $default = true, $trueAnswerRegex = '/^y/i')
     {
         parent::__construct($question, (bool) $default);
 
         $this->setNormalizer($this->getDefaultNormalizer());
+
+        $this->trueAnswerRegex = $trueAnswerRegex;
     }
 
     /**
@@ -45,11 +50,12 @@ class ConfirmationQuestion extends Question
                 return $answer;
             }
 
+            $answerIsTrue = (bool) preg_match($this->trueAnswerRegex, $answer);
             if (false === $default) {
-                return $answer && 'y' === strtolower($answer[0]);
+                return $answer && $answerIsTrue;
             }
 
-            return !$answer || 'y' === strtolower($answer[0]);
+            return !$answer || $answerIsTrue;
         };
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -143,27 +143,39 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('8AM', $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
     }
 
-    public function testAskConfirmation()
+    /**
+     * @dataProvider getAskConfirmationData
+     */
+    public function testAskConfirmation($question, $expected, $default = true)
     {
         $dialog = new QuestionHelper();
 
-        $dialog->setInputStream($this->getInputStream("\n\n"));
-        $question = new ConfirmationQuestion('Do you like French fries?');
-        $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
-        $question = new ConfirmationQuestion('Do you like French fries?', false);
-        $this->assertFalse($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
+        $dialog->setInputStream($this->getInputStream($question."\n"));
+        $question = new ConfirmationQuestion('Do you like French fries?', $default);
+        $this->assertEquals($expected, $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question), 'confirmation question should '.($expected ? 'pass' : 'cancel'));
+    }
 
-        $dialog->setInputStream($this->getInputStream("y\nyes\n"));
-        $question = new ConfirmationQuestion('Do you like French fries?', false);
-        $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
-        $question = new ConfirmationQuestion('Do you like French fries?', false);
-        $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
+    public function getAskConfirmationData()
+    {
+        return array(
+            array('', true),
+            array('', false, false),
+            array('y', true),
+            array('yes', true),
+            array('n', false),
+            array('no', false),
+        );
+    }
 
-        $dialog->setInputStream($this->getInputStream("n\nno\n"));
-        $question = new ConfirmationQuestion('Do you like French fries?', true);
-        $this->assertFalse($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
-        $question = new ConfirmationQuestion('Do you like French fries?', true);
-        $this->assertFalse($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
+    public function testAskConfirmationWithCustomTrueAnswer()
+    {
+        $dialog = new QuestionHelper();
+
+        $dialog->setInputStream($this->getInputStream("j\ny\n"));
+        $question = new ConfirmationQuestion('Do you like French fries?', false, '/^(j|y)/i');
+        $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
+        $question = new ConfirmationQuestion('Do you like French fries?', false, '/^(j|y)/i');
+        $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
     }
 
     public function testAskAndValidate()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/4879 |

For instance, when creating a dutch cli app, you want this to be `j` (from "Ja") instead of the english `y`.
