### PR TITLE
Add DNT header check support

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1463,6 +1463,16 @@ class Request
     }
 
     /**
+     * Returns if the DNT header has been set on the request
+     *
+     * @return bool true if set and DNT is preferred
+     */
+    public function isDoNotTrack()
+    {
+        return $this->headers->get('dnt', false) == '1';
+    }
+
+    /**
      * Returns the preferred language.
      *
      * @param array $locales An array of ordered available locales

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1265,6 +1265,23 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($request->hasPreviousSession());
     }
 
+    public function testIsDoNotTrack()
+    {
+    	$request = new Request();
+    	$isDNT = $request->isDoNotTrack();
+    	$this->assertFalse($isDNT);
+
+    	$request = new Request();
+    	$request->headers->set('DNT', '1');
+    	$isDNT = $request->isDoNotTrack();
+    	$this->assertTrue($isDNT);
+
+    	$request = new Request();
+    	$request->headers->set('DNT', '0');
+    	$isDNT = $request->isDoNotTrack();
+    	$this->assertFalse($isDNT);
+    }
+
     public function testToString()
     {
         $request = new Request();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [] |

This add support for checking the HTTP `HTTP_DNT`-header as send by some browsers.
Added a test for this and manual tested with Firefox 29.0.1, Chrome 35.0.1916.153 m, IE 11.
I would like to add this because even if the DNT proposal gets changed overtime this method can be changed/extented accordingly without having to change applications based on the class.
@see http://en.wikipedia.org/wiki/Do_Not_Track and https://www.mozilla.org/en-US/dnt/
