### PR TITLE
[Filesystem] Fix test suite on OSX

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -981,6 +981,8 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         if ($datas = posix_getgrgid($infos['gid'])) {
             return $datas['name'];
         }
+
+        $this->markTestSkipped('Unable to retrieve file group name');
     }
 
     private function markAsSkippedIfSymlinkIsMissing()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

Reviewing PR's, I realized the filesystem test suite fails on my setup (OSX, PHP 5.5.13 with posix ext). `posix_getgrgid` returns false, so some tests are failing.
This solves this issue.

Be aware that the patched method has been moved in FilesystemTestCase in recent branches
