### PR TITLE
2.3 - Add mp3 extension in MimeTypeExtensionGuesser

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -23,7 +23,8 @@
     "require-dev": {
         "symfony/stopwatch": "~2.2",
         "symfony/dependency-injection": "~2.0",
-        "symfony/config": "~2.2"
+        "symfony/config": "~2.2",
+        "symfony/framework-bundle": "~2.1"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\TwigBundle\\": "" }


### PR DESCRIPTION
Right now the file symfony/symfony/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php does not contain any mp3 detection. I have to change the "audio/mpeg" => "mpga" to "audio/mpeg" => "mp3"

Can someone fix it? 
