### PR TITLE
[DX] remplace the isXmlHttpRequest method by isAjaxRequest

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -107,7 +107,7 @@ class ProfilerController
             'page'      => $page,
             'request'   => $request,
             'templates' => $this->getTemplateManager()->getTemplates($profile),
-            'is_ajax'   => $request->isXmlHttpRequest(),
+            'is_ajax'   => $request->isAjaxRequest(),
         )), 200, array('Content-Type' => 'text/html'));
     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -70,7 +70,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
         }
 
         // do not capture redirects or modify XML HTTP Requests
-        if ($request->isXmlHttpRequest()) {
+        if ($request->isAjaxRequest()) {
             return;
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -210,11 +210,11 @@ class WebDebugToolbarListenerTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->getMock(
             'Symfony\Component\HttpFoundation\Request',
-            array('getSession', 'isXmlHttpRequest', 'getRequestFormat'),
+            array('getSession', 'isAjaxRequest', 'getRequestFormat'),
             array(), '', false
         );
         $request->expects($this->any())
-            ->method('isXmlHttpRequest')
+            ->method('isAjaxRequest')
             ->will($this->returnValue($isXmlHttpRequest));
         $request->expects($this->any())
             ->method('getRequestFormat')

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1599,8 +1599,25 @@ class Request
      * @return bool    true if the request is an XMLHttpRequest, false otherwise
      *
      * @api
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     public function isXmlHttpRequest()
+    {
+        return $this->isAjaxRequest();
+    }
+
+    /**
+     * Returns true if the request is a XMLHttpRequest.
+     *
+     * It works if your JavaScript library set an X-Requested-With HTTP header.
+     * It is known to work with common JavaScript frameworks:
+     * @link http://en.wikipedia.org/wiki/List_of_Ajax_frameworks#JavaScript
+     *
+     * @return bool    true if the request is an XMLHttpRequest, false otherwise
+     *
+     * @api
+     */
+    public function isAjaxRequest()
     {
         return 'XMLHttpRequest' == $this->headers->get('X-Requested-With');
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1118,13 +1118,13 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testIsXmlHttpRequest()
     {
         $request = new Request();
-        $this->assertFalse($request->isXmlHttpRequest());
+        $this->assertFalse($request->isAjaxRequest());
 
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
-        $this->assertTrue($request->isXmlHttpRequest());
+        $this->assertTrue($request->isAjaxRequest());
 
         $request->headers->remove('X-Requested-With');
-        $this->assertFalse($request->isXmlHttpRequest());
+        $this->assertFalse($request->isAjaxRequest());
     }
 
     public function testIntlLocale()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #11145 |
| License | MIT |
