### PR TITLE
Small comment update according to PSR-2

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -358,6 +358,7 @@ class Request
                 if (!isset($server['CONTENT_TYPE'])) {
                     $server['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
                 }
+                // no break
             case 'PATCH':
                 $request = $parameters;
                 $query = array();


### PR DESCRIPTION
See [PSR-2](http://www.php-fig.org/psr/psr-2/) paragraph 5.2

> There MUST be a comment such as `// no break` when fall-through is intentional in a non-empty case body.

Related to #11181
