### PR TITLE
[Security] add an AbstractVoter implementation

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Abstract Voter implementation that reduces boilerplate code required to create a custom Voter
+ *
+ * @author Roman Marintšenko <inoryy@gmail.com>
+ */
+abstract class AbstractVoter implements VoterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsAttribute($attribute)
+    {
+        return in_array($attribute, $this->getSupportedAttributes());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        foreach ($this->getSupportedClasses() as $supportedClass) {
+            if ($supportedClass === $class || is_subclass_of($class, $supportedClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Iteratively check all given attributes by calling voteOnAttribute
+     * This method terminates as soon as it is able to return either ACCESS_GRANTED or ACCESS_DENIED vote
+     * Otherwise it will return ACCESS_ABSTAIN
+     *
+     * @param TokenInterface $token      A TokenInterface instance
+     * @param object         $object     The object to secure
+     * @param array          $attributes An array of attributes associated with the method being invoked
+     *
+     * @return int     either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+     */
+    public function vote(TokenInterface $token, $object, array $attributes)
+    {
+        if (!$this->supportsClass(get_class($object))) {
+            return VoterInterface::ACCESS_ABSTAIN;
+        }
+
+        $user = $token->getUser();
+
+        foreach ($attributes as $attribute) {
+            if ($this->supportsAttribute($attribute)) {
+                $vote = $this->voteOnAttribute($attribute, $object, $user);
+                if (VoterInterface::ACCESS_ABSTAIN !== $vote) {
+                    return $vote;
+                }
+            }
+        }
+
+        return VoterInterface::ACCESS_ABSTAIN;
+    }
+
+    /**
+     * Return an array of supported classes. This will be called by supportsClass
+     *
+     * @return array    an array of supported classes, i.e. ['\Acme\DemoBundle\Model\Product']
+     */
+    abstract protected function getSupportedClasses();
+
+    /**
+     * Return an array of supported attributes. This will be called by supportsAttribute
+     *
+     * @return array    an array of supported attributes, i.e. ['CREATE', 'READ']
+     */
+    abstract protected function getSupportedAttributes();
+
+    /**
+     * Perform a single vote operation on a given attribute, object and (optionally) user
+     * It is safe to assume that $attribute and $object's class pass supportsAttribute/supportsClass
+     *
+     * @param string        $attribute
+     * @param object        $object
+     * @param UserInterface $user
+     *
+     * @return int     either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+     */
+    abstract protected function voteOnAttribute($attribute, $object, UserInterface $user = null);
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Security\Core\Authorization\Voter;
 
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -93,11 +102,10 @@ abstract class AbstractVoter implements VoterInterface
      * $user can be one of the following:
      *   a UserInterface object (fully authenticated user)
      *   a string               (anonymously authenticated user)
-     *   null                   (non-authenticated user)
      *
-     * @param string                    $attribute
-     * @param object                    $object
-     * @param UserInterface|string|null $user
+     * @param string               $attribute
+     * @param object               $object
+     * @param UserInterface|string $user
      *
      * @return bool
      */

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Voter/AbstractVoterTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Voter/AbstractVoterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Tests\Core\Authentication\Voter;
+
+use Symfony\Component\Security\Core\Authorization\Voter\AbstractVoter;
+
+/**
+ * @author Roman Marintšenko <inoryy@gmail.com>
+ */
+class AbstractVoterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AbstractVoter
+     */
+    private $voter;
+
+    private $token;
+
+    public function setUp()
+    {
+        $this->voter = new VoterFixture();
+
+        $tokenMock = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $tokenMock
+            ->expects($this->any())
+            ->method('getUser')
+            ->will($this->returnValue('user'));
+
+        $this->token = $tokenMock;
+    }
+
+    /**
+     * @dataProvider getData
+     */
+    public function testVote($expectedVote, $object, $attributes, $message)
+    {
+        $this->assertEquals($expectedVote, $this->voter->vote($this->token, $object, $attributes), $message);
+    }
+
+    public function getData()
+    {
+        return array(
+            array(AbstractVoter::ACCESS_ABSTAIN, null, array(), 'ACCESS_ABSTAIN for null objects'),
+            array(AbstractVoter::ACCESS_ABSTAIN, new UnsupportedObjectFixture(), array(), 'ACCESS_ABSTAIN for objects with unsupported class'),
+            array(AbstractVoter::ACCESS_ABSTAIN, new ObjectFixture(), array(), 'ACCESS_ABSTAIN for no attributes'),
+            array(AbstractVoter::ACCESS_ABSTAIN, new ObjectFixture(), array('foobar'), 'ACCESS_ABSTAIN for unsupported attributes'),
+            array(AbstractVoter::ACCESS_GRANTED, new ObjectFixture(), array('foo'), 'ACCESS_GRANTED if attribute grants access'),
+            array(AbstractVoter::ACCESS_GRANTED, new ObjectFixture(), array('bar', 'foo'), 'ACCESS_GRANTED if *at least one* attribute grants access'),
+            array(AbstractVoter::ACCESS_GRANTED, new ObjectFixture(), array('foobar', 'foo'), 'ACCESS_GRANTED if *at least one* attribute grants access'),
+            array(AbstractVoter::ACCESS_DENIED, new ObjectFixture(), array('bar', 'baz'), 'ACCESS_DENIED for if no attribute grants access'),
+        );
+    }
+}
+
+class VoterFixture extends AbstractVoter
+{
+    protected function getSupportedClasses()
+    {
+        return array(
+            'Symfony\Component\Security\Tests\Core\Authentication\Voter\ObjectFixture',
+        );
+    }
+
+    protected function getSupportedAttributes()
+    {
+        return array( 'foo', 'bar', 'baz');
+    }
+
+    protected function isGranted($attribute, $object, $user = null)
+    {
+        return $attribute === 'foo';
+    }
+}
+
+class ObjectFixture
+{
+}
+
+class UnsupportedObjectFixture
+{
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/4257 |

The idea is to reduce boilerplate required to create custom Voter, doing most of the work for the developer and guiding him on the path by providing simple requirements via abstract methods that will be called by the AbstractVoter.

P.S. This is meant to be a [DX Initiative](https://github.com/symfony/symfony/issues?labels=DX&state=open) improvement.
