### PR TITLE
Added explicit implementation of `AbstractType::getName()`

### DIFF
--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -53,4 +53,19 @@ abstract class AbstractType implements FormTypeInterface
     {
         return 'form';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName ()
+    {
+        $className = get_class($this);
+
+        if (false !== ($lastPosition = mb_strrpos($className, "\\")))
+        {
+            return mb_substr($className, $lastPosition + 1);
+        }
+
+        return $className;
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
#### Proposal

Provide a default implementation of `AbstractType::getName()` which just uses the class name as form name.
#### Caveats

This patch does not prevent name clashes - but you can override the method in your own `AbstractType` implementation. 

Another implementation could be to just use the full class name (and replace `\` with `_` for example - but this would produce really long form names).
#### Problems

Not unit-tested. The current implementation is not directly testable in a unit test - I could move the logic of the class name retrieval in a separate utils class, but I wasn't sure in which class to move it to. `FormUtil` sounds like a generic utils helper, but this logic is not exactly form-related..

PS: meant to be a contribution to the [DX](http://symfony.com/blog/making-the-symfony-experience-exceptional) initiative.
