### PR TITLE
Added missing `break` statement

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -256,6 +256,7 @@ abstract class AbstractFindAdapter extends AbstractAdapter
                 case '!=':
                     $command->add('-size -'.$size->getTarget().'c');
                     $command->add('-size +'.$size->getTarget().'c');
+                    break;
                 case '<':
                 default:
                     $command->add('-size -'.$size->getTarget().'c');


### PR DESCRIPTION
Added a missing `break` statement in `AbstractFindAdapter` - a fall-through doesn't seem to be intended here.
