### PR TITLE
[Tests] don't disable constructor calls to mockups of classes that extend intern...

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -76,8 +76,12 @@ class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('hasField')
             ->will($this->returnValue(true))
         ;
-        $refl = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionProperty')
+        $reflParser = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionParser')
             ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $refl = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionProperty')
+            ->setConstructorArgs(array($reflParser, 'property-name'))
             ->setMethods(array('getValue'))
             ->getMock()
         ;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -59,7 +59,7 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $file = $this
             ->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')
-            ->disableOriginalConstructor()
+            ->setConstructorArgs(array(__DIR__.'/../../../Fixtures/foo', 'foo'))
             ->getMock()
         ;
         $file

--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
@@ -48,7 +48,7 @@ class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTest
     protected function getMockFile()
     {
         return $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')
-            ->disableOriginalConstructor()
+            ->setConstructorArgs(array(__DIR__.'/../../Fixtures/foo', 'foo'))
             ->getMock();
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -180,8 +180,8 @@ class BinaryFileResponseTest extends ResponseTestCase
         $request->headers->set('X-Accel-Mapping', $mapping);
 
         $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
-                     ->disableOriginalConstructor()
-                     ->getMock();
+            ->setConstructorArgs(array(__DIR__.'/File/Fixtures/test'))
+            ->getMock();
         $file->expects($this->any())
              ->method('getRealPath')
              ->will($this->returnValue($realpath));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -34,7 +34,6 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $mongoClass = (version_compare(phpversion('mongo'), '1.3.0', '<')) ? 'Mongo' : 'MongoClient';
 
         $this->mongo = $this->getMockBuilder($mongoClass)
-            ->disableOriginalConstructor()
             ->getMock();
 
         $this->options = array(
@@ -76,9 +75,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testWrite()
     {
-        $collection = $this->getMockBuilder('MongoCollection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $collection = $this->createMongoCollectionMock();
 
         $this->mongo->expects($this->once())
             ->method('selectCollection')
@@ -105,9 +102,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testReplaceSessionData()
     {
-        $collection = $this->getMockBuilder('MongoCollection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $collection = $this->createMongoCollectionMock();
 
         $this->mongo->expects($this->once())
             ->method('selectCollection')
@@ -130,9 +125,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testDestroy()
     {
-        $collection = $this->getMockBuilder('MongoCollection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $collection = $this->createMongoCollectionMock();
 
         $this->mongo->expects($this->once())
             ->method('selectCollection')
@@ -148,9 +141,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testGc()
     {
-        $collection = $this->getMockBuilder('MongoCollection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $collection = $this->createMongoCollectionMock();
 
         $this->mongo->expects($this->once())
             ->method('selectCollection')
@@ -167,5 +158,20 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             }));
 
         $this->assertTrue($this->storage->gc(-1));
+    }
+
+    private function createMongoCollectionMock()
+    {
+
+        $mongoClient = $this->getMockBuilder('MongoClient')
+            ->getMock();
+        $mongoDb = $this->getMockBuilder('MongoDB')
+            ->setConstructorArgs(array($mongoClient, 'database-name'))
+            ->getMock();
+        $collection = $this->getMockBuilder('MongoCollection')
+            ->setConstructorArgs(array($mongoDb, 'collection-name'))
+            ->getMock();
+
+        return $collection;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -165,7 +165,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $file = $this
             ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
-            ->disableOriginalConstructor()
+            ->setConstructorArgs(array(__DIR__.'/Fixtures/foo'))
             ->getMock()
         ;
         $file
@@ -193,7 +193,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $file = $this
             ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
-            ->disableOriginalConstructor()
+            ->setConstructorArgs(array(__DIR__.'/Fixtures/foo'))
             ->getMock()
         ;
         $file
@@ -221,7 +221,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $file = $this
             ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
-            ->disableOriginalConstructor()
+            ->setConstructorArgs(array(__DIR__.'/Fixtures/foo'))
             ->getMock()
         ;
         $file
@@ -255,7 +255,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $file = $this
             ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
-            ->disableOriginalConstructor()
+            ->setConstructorArgs(array(__DIR__.'/Fixtures/foo'))
             ->getMock()
         ;
         $file


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Fixes the tests for the 2.3 branch as reported by @stof in #11176.
