### PR TITLE
[FrameworkBundle] Simplify "invokable" controllers as services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -63,6 +63,10 @@ class ControllerResolver extends BaseControllerResolver
                 list($service, $method) = explode(':', $controller, 2);
 
                 return array($this->container->get($service), $method);
+            } elseif ($this->container->has($controller) &&
+                      method_exists($service = $this->container->get($controller), '__invoke')
+            ) {
+                return $service;
             } else {
                 throw new \LogicException(sprintf('Unable to parse the controller name "%s".', $controller));
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest as BaseControllerResolverTest;
+
+class ControllerResolverTest extends BaseControllerResolverTest
+{
+    public function testGetControllerOnContainerAware()
+    {
+        $resolver = $this->createControllerResolver();
+        $request = Request::create('/');
+        $request->attributes->set('_controller', 'Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController::testAction');
+
+        $controller = $resolver->getController($request);
+
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\ContainerInterface', $controller[0]->getContainer());
+        $this->assertSame('testAction', $controller[1]);
+    }
+
+    public function testGetControllerWithBundleNotation()
+    {
+        $shortName = 'FooBundle:Default:test';
+        $parser = $this->createMockParser();
+        $parser->expects($this->once())
+            ->method('parse')
+            ->with($shortName)
+            ->will($this->returnValue('Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController::testAction'))
+        ;
+
+        $resolver = $this->createControllerResolver(null, $parser);
+        $request = Request::create('/');
+        $request->attributes->set('_controller', $shortName);
+
+        $controller = $resolver->getController($request);
+
+        $this->assertInstanceOf('Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController', $controller[0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\ContainerInterface', $controller[0]->getContainer());
+        $this->assertSame('testAction', $controller[1]);
+    }
+
+    public function testGetControllerService()
+    {
+        $container = $this->createMockContainer();
+        $container->expects($this->once())
+            ->method('get')
+            ->with('foo')
+            ->will($this->returnValue($this))
+        ;
+
+        $resolver = $this->createControllerResolver(null, null, $container);
+        $request = Request::create('/');
+        $request->attributes->set('_controller', 'foo:controllerMethod1');
+
+        $controller = $resolver->getController($request);
+
+        $this->assertInstanceOf(get_class($this), $controller[0]);
+        $this->assertSame('controllerMethod1', $controller[1]);
+    }
+
+    public function testGetControllerInvokableService()
+    {
+        $container = $this->createMockContainer();
+        $container->expects($this->once())
+            ->method('has')
+            ->with('foo')
+            ->will($this->returnValue(true))
+        ;
+        $container->expects($this->once())
+            ->method('get')
+            ->with('foo')
+            ->will($this->returnValue($this))
+        ;
+
+        $resolver = $this->createControllerResolver(null, null, $container);
+        $request = Request::create('/');
+        $request->attributes->set('_controller', 'foo');
+
+        $controller = $resolver->getController($request);
+
+        $this->assertInstanceOf(get_class($this), $controller);
+    }
+
+    /**
+     * @dataProvider getUndefinedControllers
+     */
+    public function testGetControllerOnNonUndefinedFunction($controller, $exceptionName = null, $exceptionMessage = null)
+    {
+        $this->setExpectedException($exceptionName, $exceptionMessage);
+
+        parent::testGetControllerOnNonUndefinedFunction($controller);
+    }
+
+    public function getUndefinedControllers()
+    {
+        return array(
+            array('foo', '\LogicException', 'Unable to parse the controller name "foo".'),
+            array('foo::bar', '\InvalidArgumentException', 'Class "foo" does not exist.'),
+            array('stdClass', '\LogicException', 'Unable to parse the controller name "stdClass".'),
+            array(
+                'Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest::bar',
+                '\InvalidArgumentException',
+                'Controller "Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest::bar" for URI "/" is not callable.'
+            )
+        );
+    }
+
+    protected function createControllerResolver(LoggerInterface $logger = null, ControllerNameParser $parser = null, ContainerInterface $container = null)
+    {
+        if (!$parser) {
+            $parser = $this->createMockParser();
+        }
+
+        if (!$container) {
+            $container = $this->createMockContainer();
+        }
+
+        return new ControllerResolver($container, $parser, $logger);
+    }
+
+    protected function createMockParser()
+    {
+        return $this->getMock('Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser', array(), array(), '', false);
+    }
+
+    protected function createMockContainer()
+    {
+        return $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+    }
+}
+
+class ContainerAwareController implements ContainerAwareInterface
+{
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    public function testAction()
+    {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Controller;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolver;
-use Symfony\Component\HttpKernel\Tests\Logger;
 use Symfony\Component\HttpFoundation\Request;
 
 class ControllerResolverTest extends \PHPUnit_Framework_TestCase
@@ -28,7 +28,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
     {
         $logger = $this->getMock('Psr\Log\LoggerInterface');
         $logger->expects($this->once())->method('warning')->with('Unable to look for the controller as the "_controller" parameter is missing');
-        $resolver = new ControllerResolver($logger);
+        $resolver = $this->createControllerResolver($logger);
 
         $request = Request::create('/');
         $this->assertFalse($resolver->getController($request), '->getController() returns false when the request has no _controller attribute');
@@ -36,7 +36,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testGetControllerWithLambda()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', $lambda = function () {});
@@ -46,7 +46,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testGetControllerWithObjectAndInvokeMethod()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', $this);
@@ -56,7 +56,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testGetControllerWithObjectAndMethod()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', array($this, 'controllerMethod1'));
@@ -66,7 +66,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testGetControllerWithClassAndMethod()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', array('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest', 'controllerMethod4'));
@@ -76,7 +76,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testGetControllerWithObjectAndMethodAsString()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', 'Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest::controllerMethod1');
@@ -86,7 +86,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testGetControllerWithClassAndInvokeMethod()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', 'Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest');
@@ -99,7 +99,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetControllerOnObjectWithoutInvokeMethod()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', new \stdClass());
@@ -108,7 +108,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testGetControllerWithFunction()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', 'Symfony\Component\HttpKernel\Tests\Controller\some_controller_function');
@@ -122,7 +122,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetControllerOnNonUndefinedFunction($controller)
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', $controller);
@@ -141,7 +141,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testGetArguments()
     {
-        $resolver = new ControllerResolver();
+        $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $controller = array(new self(), 'testGetArguments');
@@ -212,6 +212,11 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $request->attributes->set('_controller', 'foobar');
         $mock->getController($request);
+    }
+
+    protected function createControllerResolver(LoggerInterface $logger = null)
+    {
+        return new ControllerResolver($logger);
     }
 
     public function __invoke($foo, $bar = null)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | symfony/symfony-docs#3966 |

Simplifies the configuration when defining controllers as services that implement `__invoke`.

Old:

``` yaml
my_route:
    path: /path
    defaults: { _controller: my.controller.service:__invoke }
```

New:

``` yaml
my_route:
    path: /path
    defaults: { _controller: my.controller.service }
```
