### PR TITLE
Use PSR-4 everywhere instead of PSR-0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
         "egulias/email-validator": "~1.2"
     },
     "autoload": {
-        "psr-0": { "Symfony\\": "src/" },
+        "psr-4": { "Symfony\\": "src/Symfony/" },
         "classmap": [
             "src/Symfony/Component/HttpFoundation/Resources/stubs",
             "src/Symfony/Component/Intl/Resources/stubs"

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -39,9 +39,8 @@
         "doctrine/orm": ""
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Doctrine\\": "" }
+        "psr-4": { "Symfony\\Bridge\\Doctrine\\": "" }
     },
-    "target-dir": "Symfony/Bridge/Doctrine",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -30,9 +30,8 @@
         "symfony/event-dispatcher": "Needed when using log messages in console commands"
      },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Monolog\\": "" }
+        "psr-4": { "Symfony\\Bridge\\Monolog\\": "" }
     },
-    "target-dir": "Symfony/Bridge/Monolog",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -26,9 +26,8 @@
         "symfony/stopwatch": "~2.2"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Propel1\\": "" }
+        "psr-4": { "Symfony\\Bridge\\Propel1\\": "" }
     },
-    "target-dir": "Symfony/Bridge/Propel1",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -24,11 +24,8 @@
         "symfony/config": "2.3"
     },
     "autoload": {
-        "psr-0": {
-            "Symfony\\Bridge\\ProxyManager\\": ""
-        }
+        "psr-4": { "Symfony\\Bridge\\ProxyManager\\": "" }
     },
-    "target-dir": "Symfony/Bridge/ProxyManager",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -23,9 +23,8 @@
         "symfony/http-kernel": ""
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Swiftmailer\\": "" }
+        "psr-4": { "Symfony\\Bridge\\Swiftmailer\\": "" }
     },
-    "target-dir": "Symfony/Bridge/Swiftmailer",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -48,9 +48,8 @@
         "symfony/expression-language": "For using the ExpressionExtension"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Twig\\": "" }
+        "psr-4": { "Symfony\\Bridge\\Twig\\": "" }
     },
-    "target-dir": "Symfony/Bridge/Twig",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -30,9 +30,8 @@
         "symfony/dependency-injection": "For using as a service from the container"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\DebugBundle\\": "" }
+        "psr-4": { "Symfony\\Bundle\\DebugBundle\\": "" }
     },
-    "target-dir": "Symfony/Bundle/DebugBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -52,9 +52,8 @@
         "doctrine/cache": "For using alternative cache drivers"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\FrameworkBundle\\": "" }
+        "psr-4": { "Symfony\\Bundle\\FrameworkBundle\\": "" }
     },
-    "target-dir": "Symfony/Bundle/FrameworkBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -33,9 +33,8 @@
         "doctrine/doctrine-bundle": "~1.2"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\SecurityBundle\\": "" }
+        "psr-4": { "Symfony\\Bundle\\SecurityBundle\\": "" }
     },
-    "target-dir": "Symfony/Bundle/SecurityBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -31,9 +31,8 @@
         "symfony/framework-bundle": "~2.1"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\TwigBundle\\": "" }
+        "psr-4": { "Symfony\\Bundle\\TwigBundle\\": "" }
     },
-    "target-dir": "Symfony/Bundle/TwigBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -28,9 +28,8 @@
         "symfony/stopwatch": "~2.2"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\WebProfilerBundle\\": "" }
+        "psr-4": { "Symfony\\Bundle\\WebProfilerBundle\\": "" }
     },
-    "target-dir": "Symfony/Bundle/WebProfilerBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -27,9 +27,8 @@
         "symfony/process": ""
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\BrowserKit\\": "" }
+        "psr-4": { "Symfony\\Component\\BrowserKit\\": "" }
     },
-    "target-dir": "Symfony/Component/BrowserKit",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -23,9 +23,8 @@
         "symfony/finder": "~2.0"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\ClassLoader\\": "" }
+        "psr-4": { "Symfony\\Component\\ClassLoader\\": "" }
     },
-    "target-dir": "Symfony/Component/ClassLoader",
     "extra": {
         "branch-alias": {
             "dev-master": "2.7-dev"

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -20,9 +20,8 @@
         "symfony/filesystem": "~2.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Config\\": "" }
+        "psr-4": { "Symfony\\Component\\Config\\": "" }
     },
-    "target-dir": "Symfony/Component/Config",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -29,9 +29,8 @@
         "psr/log": "For using the console logger"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Console\\": "" }
+        "psr-4": { "Symfony\\Component\\Console\\": "" }
     },
-    "target-dir": "Symfony/Component/Console",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/CssSelector/composer.json
+++ b/src/Symfony/Component/CssSelector/composer.json
@@ -23,9 +23,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\CssSelector\\": "" }
+        "psr-4": { "Symfony\\Component\\CssSelector\\": "" }
     },
-    "target-dir": "Symfony/Component/CssSelector",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -117,9 +117,16 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
                     }
                 }
             }
+            if ($function[0] instanceof ComposerClassLoader) {
+                foreach ($function[0]->getPrefixesPsr4() as $prefix => $paths) {
+                    foreach ($paths as $path) {
+                        $classes = array_merge($classes, $this->findClassInPath($path, $class, $prefix));
+                    }
+                }
+            }
         }
 
-        return $classes;
+        return array_unique($classes);
     }
 
     /**

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -13,9 +13,30 @@ namespace Symfony\Component\Debug\Tests\FatalErrorHandler;
 
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\Debug\FatalErrorHandler\ClassNotFoundFatalErrorHandler;
+use Symfony\Component\Debug\DebugClassLoader;
+use Composer\Autoload\ClassLoader as ComposerClassLoader;
 
 class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        foreach (spl_autoload_functions() as $function) {
+            if (!is_array($function)) {
+                continue;
+            }
+
+            // get class loaders wrapped by DebugClassLoader
+            if ($function[0] instanceof DebugClassLoader) {
+                $function = $function[0]->getClassLoader();
+            }
+
+            if ($function[0] instanceof ComposerClassLoader) {
+                $function[0]->add('Symfony\Component\Debug\Tests\Fixtures', dirname(dirname(dirname(dirname(dirname(__DIR__))))));
+                break;
+            }
+        }
+    }
+
     /**
      * @dataProvider provideClassNotFoundData
      */

--- a/src/Symfony/Component/Debug/composer.json
+++ b/src/Symfony/Component/Debug/composer.json
@@ -28,9 +28,8 @@
         "symfony/http-kernel": ""
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Debug\\": "" }
+        "psr-4": { "Symfony\\Component\\Debug\\": "" }
     },
-    "target-dir": "Symfony/Component/Debug",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -29,9 +29,8 @@
         "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\DependencyInjection\\": "" }
+        "psr-4": { "Symfony\\Component\\DependencyInjection\\": "" }
     },
-    "target-dir": "Symfony/Component/DependencyInjection",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -25,9 +25,8 @@
         "symfony/css-selector": ""
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\DomCrawler\\": "" }
+        "psr-4": { "Symfony\\Component\\DomCrawler\\": "" }
     },
-    "target-dir": "Symfony/Component/DomCrawler",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -30,9 +30,8 @@
         "symfony/http-kernel": ""
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\EventDispatcher\\": "" }
+        "psr-4": { "Symfony\\Component\\EventDispatcher\\": "" }
     },
-    "target-dir": "Symfony/Component/EventDispatcher",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\ExpressionLanguage\\": "" }
+        "psr-4": { "Symfony\\Component\\ExpressionLanguage\\": "" }
     },
-    "target-dir": "Symfony/Component/ExpressionLanguage",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Filesystem\\": "" }
+        "psr-4": { "Symfony\\Component\\Filesystem\\": "" }
     },
-    "target-dir": "Symfony/Component/Filesystem",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Finder\\": "" }
+        "psr-4": { "Symfony\\Component\\Finder\\": "" }
     },
-    "target-dir": "Symfony/Component/Finder",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -36,9 +36,8 @@
         "symfony/framework-bundle": "For templating with PHP."
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Form\\": "" }
+        "psr-4": { "Symfony\\Component\\Form\\": "" }
     },
-    "target-dir": "Symfony/Component/Form",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -22,10 +22,9 @@
         "symfony/expression-language": "~2.4"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\HttpFoundation\\": "" },
+        "psr-4": { "Symfony\\Component\\HttpFoundation\\": "" },
         "classmap": [ "Symfony/Component/HttpFoundation/Resources/stubs" ]
     },
-    "target-dir": "Symfony/Component/HttpFoundation",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -47,9 +47,8 @@
         "symfony/var-dumper": ""
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\HttpKernel\\": "" }
+        "psr-4": { "Symfony\\Component\\HttpKernel\\": "" }
     },
-    "target-dir": "Symfony/Component/HttpKernel",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Intl/composer.json
+++ b/src/Symfony/Component/Intl/composer.json
@@ -33,11 +33,10 @@
         "ext-intl": "to use the component with locales other than \"en\""
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Intl\\": "" },
+        "psr-4": { "Symfony\\Component\\Intl\\": "" },
         "classmap": [ "Symfony/Component/Intl/Resources/stubs" ],
         "files": [ "Symfony/Component/Intl/Resources/stubs/functions.php" ]
     },
-    "target-dir": "Symfony/Component/Intl",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -20,9 +20,8 @@
         "symfony/intl": ">=2.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Locale\\": "" }
+        "psr-4": { "Symfony\\Component\\Locale\\": "" }
     },
-    "target-dir": "Symfony/Component/Locale",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/OptionsResolver/composer.json
+++ b/src/Symfony/Component/OptionsResolver/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\OptionsResolver\\": "" }
+        "psr-4": { "Symfony\\Component\\OptionsResolver\\": "" }
     },
-    "target-dir": "Symfony/Component/OptionsResolver",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Process\\": "" }
+        "psr-4": { "Symfony\\Component\\Process\\": "" }
     },
-    "target-dir": "Symfony/Component/Process",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\PropertyAccess\\": "" }
+        "psr-4": { "Symfony\\Component\\PropertyAccess\\": "" }
     },
-    "target-dir": "Symfony/Component/PropertyAccess",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -33,9 +33,8 @@
         "doctrine/annotations": "For using the annotation loader"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Routing\\": "" }
+        "psr-4": { "Symfony\\Component\\Routing\\": "" }
     },
-    "target-dir": "Symfony/Component/Routing",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Security/Acl/composer.json
+++ b/src/Symfony/Component/Security/Acl/composer.json
@@ -30,9 +30,8 @@
         "doctrine/dbal": "For using the built-in ACL implementation"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Security\\Acl\\": "" }
+        "psr-4": { "Symfony\\Component\\Security\\Acl\\": "" }
     },
-    "target-dir": "Symfony/Component/Security/Acl",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -34,9 +34,8 @@
         "ircmaxell/password-compat": "For using the BCrypt password encoder in PHP <5.5"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Security\\Core\\": "" }
+        "psr-4": { "Symfony\\Component\\Security\\Core\\": "" }
     },
-    "target-dir": "Symfony/Component/Security/Core",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -26,9 +26,8 @@
         "symfony/http-foundation": "For using the class SessionTokenStorage."
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Security\\Csrf\\": "" }
+        "psr-4": { "Symfony\\Component\\Security\\Csrf\\": "" }
     },
-    "target-dir": "Symfony/Component/Security/Csrf",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -32,9 +32,8 @@
         "symfony/routing": "For using the HttpUtils class to create sub-requests, redirect the user, and match URLs"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Security\\Http\\": "" }
+        "psr-4": { "Symfony\\Component\\Security\\Http\\": "" }
     },
-    "target-dir": "Symfony/Component/Security/Http",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -46,9 +46,8 @@
         "ircmaxell/password-compat": "For using the BCrypt password encoder in PHP <5.5"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Security\\": "" }
+        "psr-4": { "Symfony\\Component\\Security\\": "" }
     },
-    "target-dir": "Symfony/Component/Security",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Serializer\\": "" }
+        "psr-4": { "Symfony\\Component\\Serializer\\": "" }
     },
-    "target-dir": "Symfony/Component/Serializer",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Stopwatch\\": "" }
+        "psr-4": { "Symfony\\Component\\Stopwatch\\": "" }
     },
-    "target-dir": "Symfony/Component/Stopwatch",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Templating/composer.json
+++ b/src/Symfony/Component/Templating/composer.json
@@ -25,9 +25,8 @@
         "psr/log": "For using debug logging in loaders"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Templating\\": "" }
+        "psr-4": { "Symfony\\Component\\Templating\\": "" }
     },
-    "target-dir": "Symfony/Component/Templating",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -30,9 +30,8 @@
         "psr/log": "To use logging capability in translator"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Translation\\": "" }
+        "psr-4": { "Symfony\\Component\\Translation\\": "" }
     },
-    "target-dir": "Symfony/Component/Translation",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -43,9 +43,8 @@
         "symfony/expression-language": "For using the 2.4 Expression validator"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Validator\\": "" }
+        "psr-4": { "Symfony\\Component\\Validator\\": "" }
     },
-    "target-dir": "Symfony/Component/Validator",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -19,9 +19,8 @@
     },
     "autoload": {
         "files": [ "Resources/functions/dump.php" ],
-        "psr-0": { "Symfony\\Component\\VarDumper\\": "" }
+        "psr-4": { "Symfony\\Component\\VarDumper\\": "" }
     },
-    "target-dir": "Symfony/Component/VarDumper",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -19,9 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Yaml\\": "" }
+        "psr-4": { "Symfony\\Component\\Yaml\\": "" }
     },
-    "target-dir": "Symfony/Component/Yaml",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11189 |
| License | MIT |

Includes and replaces #11190 + psr-4 support for ClassNotFoundFatalErrorHandler (not sure if this is considered as a new feature, it's kinda trivial)
