### PR TITLE
[Console] added ability for the Default Command to receive options

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -185,7 +186,7 @@ class Application
 
         if (!$name) {
             $name = $this->defaultCommand;
-            $input = new ArrayInput(array('command' => $this->defaultCommand));
+            $input = new StringInput($name.' '.(string) $input);
         }
 
         // the command name MUST be the first element of the input

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -118,9 +118,10 @@ class ArrayInput extends Input
     public function __toString()
     {
         $params = array();
+
         foreach ($this->parameters as $param => $val) {
             if ($param && '-' === $param[0]) {
-                $params[] = $param . ('' != $val ? '='.$this->escapeToken($val) : '');
+                $params[] = $param . (('' == $val || true === $val || false === $val) ? '':'='.$this->escapeToken($val));
             } else {
                 $params[] = $this->escapeToken($val);
             }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -947,6 +947,21 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('interact called'.PHP_EOL.'called'.PHP_EOL, $tester->getDisplay(), 'Application runs the default set command if different from \'list\' command');
     }
+
+    public function testOptionsPassedToCustomDefaultCommand()
+    {
+        $command = new \FooCommand();
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+        $application->setDefaultCommand($command->getName());
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('--ansi' => true));
+
+        $this->assertTrue($tester->getOutput()->isDecorated(), '->run() forces color output if --ansi is passed');
+    }
 }
 
 class CustomApplication extends Application


### PR DESCRIPTION
The previous implementation, while using ArrayInput, was lacking the abilty to
pass the options to the Default Command. Updated the code to use StringInput
instead, and pass the options (string) from the original command to the default one.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
- [x] submit changes to the documentation ( https://github.com/symfony/symfony-docs/pull/3973 )
