### PR TITLE
[FrameworkBundle] Improving bad bundle exception in _controller

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -46,6 +46,7 @@ class ControllerNameParser
      */
     public function parse($controller)
     {
+        $originalController = $controller;
         if (3 != count($parts = explode(':', $controller))) {
             throw new \InvalidArgumentException(sprintf('The "%s" controller is not a valid "a:b:c" controller string.', $controller));
         }
@@ -54,8 +55,24 @@ class ControllerNameParser
         $controller = str_replace('/', '\\', $controller);
         $bundles = array();
 
-        // this throws an exception if there is no such bundle
-        foreach ($this->kernel->getBundle($bundle, false) as $b) {
+        try {
+            // this throws an exception if there is no such bundle
+            $allBundles = $this->kernel->getBundle($bundle, false);
+        } catch (\InvalidArgumentException $e) {
+            $message = sprintf(
+                'The "%s" (from the _controller value "%s") does not exist or is not enabled in your kernel!',
+                $bundle,
+                $originalController
+            );
+
+            if ($alternative = $this->findAlternative($bundle)) {
+                $message .= sprintf(' Did you mean "%s:%s:%s"?', $alternative, $controller, $action);
+            }
+
+            throw new \InvalidArgumentException($message, 0, $e);
+        }
+
+        foreach ($allBundles as $b) {
             $try = $b->getNamespace().'\\Controller\\'.$controller.'Controller';
             if (class_exists($try)) {
                 return $try.'::'.$action.'Action';
@@ -99,5 +116,34 @@ class ControllerNameParser
         }
 
         throw new \InvalidArgumentException(sprintf('Unable to find a bundle that defines controller "%s".', $controller));
+    }
+
+    /**
+     * Attempts to find a bundle that is *similar* to the given bundle name
+     *
+     * @param string $nonExistentBundleName
+     * @return string
+     */
+    private function findAlternative($nonExistentBundleName)
+    {
+        $bundleNames = array_map(function ($b) {
+            return $b->getName();
+        }, $this->kernel->getBundles());
+
+        $alternative = null;
+        $shortest = null;
+        foreach ($bundleNames as $bundleName) {
+            // if there's a partial match, return it immediately
+            if (false !== strpos($bundleName, $nonExistentBundleName)) {
+                return $bundleName;
+            }
+
+            $lev = levenshtein($nonExistentBundleName, $bundleName);
+            if ($lev <= strlen($nonExistentBundleName) / 3 && ($alternative === null || $lev < $shortest)) {
+                $alternative = $bundleName;
+            }
+        }
+
+        return $alternative;
     }
 }


### PR DESCRIPTION
...ntroller in a routeHi guys!

This improves the exception message when you use a bad bundle name in the `_controller` syntax in a routing file. Here is the before and after of the message with this mistake (real bundle is `KnpUniversityBundle`):

``` yaml
some_route:
    pattern:  /
    defaults: { _controller: "Knp2UniversityBundle:Course:index" }
```

![screen shot 2014-06-23 at 9 27 55 pm](https://cloud.githubusercontent.com/assets/121003/3367065/448e8298-fb54-11e3-92ea-9bf04510cb6d.png)

![screen shot 2014-06-23 at 9 48 14 pm](https://cloud.githubusercontent.com/assets/121003/3367063/3c79cf36-fb54-11e3-87c4-29428248ee47.png)

Notice the before and after behavior is the same `InvalidArgumentException` (just a different message).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Catching the plain `InvalidArgumentException` from `Kernel::getBundles()` seems a bit "loose". Should we consider creating a new exception (e.g. `BundleDoesNotExistException`) that extends `InvalidArgumentException` and throw it from inside `Kernel::getBundles`? This would allow us to catch more precisely, and it seems like it would be BC.

Suggestions and thoughts warmly welcome!

Thanks!
