### PR TITLE
[HttpFoundation] Added a switch to delete file after the response is send

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -30,6 +30,7 @@ class BinaryFileResponse extends Response
     protected $file;
     protected $offset;
     protected $maxlen;
+    protected $deleteFileAfterSend = false;
 
     /**
      * Constructor.
@@ -258,6 +259,10 @@ class BinaryFileResponse extends Response
 
         fclose($out);
         fclose($file);
+
+        if ($this->deleteFileAfterSend) {
+            unlink($this->file->getPathname());
+        }
     }
 
     /**
@@ -289,4 +294,19 @@ class BinaryFileResponse extends Response
     {
         self::$trustXSendfileTypeHeader = true;
     }
+
+    /**
+     * If this is set to true, the file will be unlinked after the request is send
+     * Note: If the X-Sendfile header is used, the deleteFileAfterSend setting will not be used.
+     * @param bool $shouldDelete
+     *
+     * @return BinaryFileResponse
+     */
+    public function deleteFileAfterSend($shouldDelete)
+    {
+        $this->deleteFileAfterSend = $shouldDelete;
+
+        return $this;
+    }
+
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -203,6 +203,24 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertEquals($virtual, $response->headers->get('X-Accel-Redirect'));
     }
 
+    public function testDeleteFileAfterSend()
+    {
+        $request = Request::create('/');
+
+        $path = __DIR__.'/File/Fixtures/to_delete';
+        touch($path);
+        $realPath = realpath($path);
+        $this->assertFileExists($realPath);
+
+        $response = new BinaryFileResponse($realPath);
+        $response->deleteFileAfterSend(true);
+
+        $response->prepare($request);
+        $response->sendContent();
+
+        $this->assertFileNotExists($path);
+    }
+
     public function getSampleXAccelMappings()
     {
         return array(
@@ -214,5 +232,13 @@ class BinaryFileResponseTest extends ResponseTestCase
     protected function provideResponse()
     {
         return new BinaryFileResponse(__DIR__ . '/../README.md');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $path = __DIR__.'/../Fixtures/to_delete';
+        if (file_exists($path)) {
+            @unlink($path);
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | symfony/symfony-docs#3975 |

I have not done any Unit Tests for this code as I suspect there may already be a way to solve my problem of deleting a file after the request was sent. Is it possible to use `sendContent` and delete the file after that? My attempts were unsuccessful.

If this code is desirable, please assist me in how I would write an unit test for this. Thanks.

TODO:
- [x] Add unit tests
- [x] Update documentation
- [x] Mention that using `X-Sendfile` will overwrite deleteFileAfterSend
