### PR TITLE
[DomCrawler]  Fix memory leak with filter method 

### DIFF
--- a/src/Symfony/Component/CssSelector/CssSelector.php
+++ b/src/Symfony/Component/CssSelector/CssSelector.php
@@ -61,8 +61,10 @@ class CssSelector
             ->registerParserShortcut(new ClassParser())
             ->registerParserShortcut(new HashParser())
         ;
+        $resp = $translator->cssToXPath($cssExpr, $prefix);
+        $translator->destroy();
 
-        return $translator->cssToXPath($cssExpr, $prefix);
+        return $resp;
     }
 
     /**

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -85,6 +85,21 @@ class Translator implements TranslatorInterface
     }
 
     /**
+     * Resets local properties to there initial values
+     */
+    public function destroy()
+    {
+        $this->mainParser = null;
+        $this->shortcutParsers = array();
+        $this->extensions = array();
+        $this->nodeTranslators = array();
+        $this->combinationTranslators = array();
+        $this->functionTranslators = array();
+        $this->pseudoClassTranslators = array();
+        $this->attributeMatchingTranslators = array();
+    }
+
+    /**
      * @param string $element
      *
      * @return string

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -396,6 +396,28 @@ EOF
     }
 
     /**
+     * Asserts that filter do not memory leak
+     */
+    public function testFilterXPathMemoryUsage()
+    {
+        $html = '<tr><td>abc</td><td>dce</td><td>abc</td><td>dce</td><td>abc</td><td>dce</td><td>abc</td><td>dce</td><tr>';
+
+        // Run the script one time before starting the measure to bootstrap the memory
+        $crawler = new Crawler($html);
+        $columns = $crawler->filter('tr > td');
+
+        $before = memory_get_usage(true);
+        for ($i = 0; $i < 10; $i++) {
+            $crawler = new Crawler($html);
+            $crawler->filter('tr > td');
+        }
+
+        $after = memory_get_usage(true);
+
+        $this->assertEquals(0, $after - $before);
+    }
+
+    /**
      * @covers Symfony\Component\DomCrawler\Crawler::filterXPath
      */
     public function testFilterXPath()

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -406,12 +406,14 @@ EOF
         $crawler = new Crawler($html);
         $columns = $crawler->filter('tr > td');
 
+        gc_collect_cycles();
         $before = memory_get_usage(true);
         for ($i = 0; $i < 10; $i++) {
             $crawler = new Crawler($html);
             $crawler->filter('tr > td');
         }
 
+        $this->assertEquals(0, gc_collect_cycles());
         $after = memory_get_usage(true);
 
         $this->assertEquals(0, $after - $before);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10879 |
| License | MIT |
| Doc PR | no |

Add a public method `destroy` on Translator to reset properties and free memory
