### PR TITLE
Fix mocks to support >=5.5.14 and >=5.4.30

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\HttpFoundation;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
 use Symfony\Component\Form\Tests\AbstractRequestHandlerTest;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -47,8 +48,6 @@ class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTest
 
     protected function getMockFile()
     {
-        return $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')
-            ->setConstructorArgs(array(__DIR__.'/../../Fixtures/foo', 'foo'))
-            ->getMock();
+        return new UploadedFile(__DIR__.'/../../Fixtures/foo', 'foo');
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Resources/stubs/FakeFile.php
+++ b/src/Symfony/Component/HttpFoundation/Resources/stubs/FakeFile.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Resources\stubs;
+
+use Symfony\Component\HttpFoundation\File\File as OrigFile;
+
+class FakeFile extends OrigFile
+{
+    private $realpath;
+
+    public function __construct($realpath, $path)
+    {
+        $this->realpath = $realpath;
+        parent::__construct($path, false);
+    }
+
+    public function isReadable()
+    {
+        return true;
+    }
+
+    public function getRealpath()
+    {
+        return $this->realpath;
+    }
+
+    public function getSize()
+    {
+        return 42;
+    }
+
+    public function getMTime()
+    {
+        return time();
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpFoundation\Tests;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\Resources\stubs\FakeFile;
 
 class BinaryFileResponseTest extends ResponseTestCase
 {
@@ -179,18 +180,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         $request->headers->set('X-Sendfile-Type', 'X-Accel-Redirect');
         $request->headers->set('X-Accel-Mapping', $mapping);
 
-        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
-            ->setConstructorArgs(array(__DIR__.'/File/Fixtures/test'))
-            ->getMock();
-        $file->expects($this->any())
-             ->method('getRealPath')
-             ->will($this->returnValue($realpath));
-        $file->expects($this->any())
-             ->method('isReadable')
-             ->will($this->returnValue(true));
-        $file->expects($this->any())
-             ->method('getMTime')
-             ->will($this->returnValue(time()));
+        $file = new FakeFile($realpath, __DIR__.'/File/Fixtures/test');
 
         BinaryFileResponse::trustXSendFileTypeHeader();
         $response = new BinaryFileResponse($file);


### PR DESCRIPTION
PHP 5.5.14 and PHP 5.4.30 disallow unseriliazing hand made strings for internal classes that forbids that (using zend_class_unserialize_deny)

There was a bug before, PHP did not filter those strings, which could lead to security problems.
Starting from 5.5.14 and 5.4.30 , PHP now reports an error when trying to unserialize such strings.
https://github.com/php/php-src/commit/2c88ae5c4ea8b641c407549d40c6ea61e834840d
PHPUnit relies on this (wrong) behavior to create mock objects. This is a problem for SPlFileInfo.

This PR fixes that.
