### PR TITLE
[Validator][WIP] Support validation for German banking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
         "propel/propel1": "1.6.*",
         "ircmaxell/password-compat": "1.0.*",
         "ocramius/proxy-manager": ">=0.3.1,<0.6-dev",
+        "malkusch/bav": "~1.0",
         "egulias/email-validator": "1.1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -15,17 +15,19 @@ use Symfony\Component\Validator\Constraint;
 
 /**
  * Value must be a BIC (Bank Identifier Code).
- * 
+ *
  * Set the option $country to limit valid BICs to one country only.
- * 
+ *
  * Note: BIC validation is currently implemented only with the country filter
  * Bic::DE.
- * 
+ *
  * Validation of a German BIC uses the library BAV. BAV's default configuration
  * is not recommended for BIC validation. Use a configuration with one of the
- * following DataBackendContainer implementations: PDODataBackendContainer or 
+ * following DataBackendContainer implementations: PDODataBackendContainer or
  * DoctrineBackendContainer.
- * 
+ *
+ * This constraint depends on malkusch/bav.
+ *
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
@@ -33,6 +35,8 @@ use Symfony\Component\Validator\Constraint;
  *
  * @see \malkusch\bav\BAV::isValidBIC()
  * @see \malkusch\bav\ConfigurationRegistry::setConfiguration()
+ * @see Blz
+ * @see Konto
  * @api
  */
 class Bic extends Constraint
@@ -41,14 +45,14 @@ class Bic extends Constraint
      * @var string validate only German BIC
      */
     const DE = 'de';
-    
+
     /**
      * @var string Limits the validation only for one country.
      */
     public $country;
-    
+
     public $message = 'This value is not a valid BIC.';
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Value must be a BIC (Bank Identifier Code).
+ * 
+ * Set the option $country to limit valid BICs to one country only.
+ * 
+ * Note: BIC validation is currently implemented only with the country filter
+ * Bic::DE.
+ * 
+ * Validation of a German BIC uses the library BAV. BAV's default configuration
+ * is not recommended for BIC validation. Use a configuration with one of the
+ * following DataBackendContainer implementations: PDODataBackendContainer or 
+ * DoctrineBackendContainer.
+ * 
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Markus Malkusch <markus@malkusch.de>
+ *
+ * @see \malkusch\bav\BAV::isValidBIC()
+ * @see \malkusch\bav\ConfigurationRegistry::setConfiguration()
+ * @api
+ */
+class Bic extends Constraint
+{
+    /**
+     * @var string validate only German BIC
+     */
+    const DE = 'de';
+    
+    /**
+     * @var string Limits the validation only for one country.
+     */
+    public $country;
+    
+    public $message = 'This value is not a valid BIC.';
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'country';
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\ValidatorException;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use malkusch\bav\BAV;
+use malkusch\bav\BAVException;
+
+/**
+ * @author Markus Malkusch <markus@malkusch.de>
+ *
+ * @see BAV::isValidBIC()
+ * @api
+ */
+class BicValidator extends ConstraintValidator
+{
+    /**
+     * @var BAV
+     */
+    private $bav;
+    
+    /**
+     * {@inheritdoc}
+     * 
+     * @throws ValidatorException
+     */
+    public function initialize(ExecutionContextInterface $context)
+    {
+        try {
+            parent::initialize($context);
+            $this->bav = new BAV();
+        } catch (BAVException $e) {
+            throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+    
+    /**
+     * {@inheritdoc}
+     * 
+     * @throws ValidatorException
+     * @throws ConstraintDefinitionException
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof Bic) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Bic');
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        $value = (string) $value;
+
+        switch ($constraint->country) {
+            case Bic::DE:
+                try {
+                    if (!$this->bav->isValidBIC($value)) {
+                        $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
+                    }
+                } catch (BAVException $e) {
+                    throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
+                }
+                break;
+
+            default:
+                //TODO implement a generic BIC validation.
+                throw new ConstraintDefinitionException(
+                    "BIC validation for country '$constraint->country' is not implemented"
+                );
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -32,10 +32,10 @@ class BicValidator extends ConstraintValidator
      * @var BAV
      */
     private $bav;
-    
+
     /**
      * {@inheritdoc}
-     * 
+     *
      * @throws ValidatorException
      */
     public function initialize(ExecutionContextInterface $context)
@@ -47,10 +47,10 @@ class BicValidator extends ConstraintValidator
             throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
         }
     }
-    
+
     /**
      * {@inheritdoc}
-     * 
+     *
      * @throws ValidatorException
      * @throws ConstraintDefinitionException
      */

--- a/src/Symfony/Component/Validator/Constraints/Blz.php
+++ b/src/Symfony/Component/Validator/Constraints/Blz.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Value must be a German bank id (Bankleitzahl)
+ * 
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Markus Malkusch <markus@malkusch.de>
+ *
+ * @see \malkusch\bav\BAV::isValidBank()
+ * @api
+ */
+class Blz extends Constraint
+{
+    public $message = 'This value is not a valid German bank id (BLZ).';
+}

--- a/src/Symfony/Component/Validator/Constraints/Blz.php
+++ b/src/Symfony/Component/Validator/Constraints/Blz.php
@@ -15,13 +15,17 @@ use Symfony\Component\Validator\Constraint;
 
 /**
  * Value must be a German bank id (Bankleitzahl)
- * 
+ *
+ * This constraint depends on malkusch/bav.
+ *
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Markus Malkusch <markus@malkusch.de>
  *
  * @see \malkusch\bav\BAV::isValidBank()
+ * @see Bic
+ * @see Konto
  * @api
  */
 class Blz extends Constraint

--- a/src/Symfony/Component/Validator/Constraints/BlzValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlzValidator.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\ValidatorException;
+use malkusch\bav\BAV;
+use malkusch\bav\BAVException;
+
+/**
+ * @author Markus Malkusch <markus@malkusch.de>
+ *
+ * @see BAV::isValidBank()
+ * @api
+ */
+class BlzValidator extends ConstraintValidator
+{
+    /**
+     * @var BAV
+     */
+    private $bav;
+    
+    /**
+     * {@inheritdoc}
+     * 
+     * @throws ValidatorException
+     */
+    public function initialize(ExecutionContextInterface $context)
+    {
+        try {
+            parent::initialize($context);
+            $this->bav = new BAV();
+        } catch (BAVException $e) {
+            throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+    
+    /**
+     * {@inheritdoc}
+     * 
+     * @throws ValidatorException
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        try {
+            if (!$constraint instanceof Blz) {
+                throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Blz');
+            }
+
+            if (null === $value || '' === $value) {
+                return;
+            }
+
+            if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+                throw new UnexpectedTypeException($value, 'string');
+            }
+
+            $value = (string) $value;
+
+            if (!$this->bav->isValidBank($value)) {
+                $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
+            }
+        } catch (BAVException $e) {
+            throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/BlzValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlzValidator.php
@@ -31,10 +31,10 @@ class BlzValidator extends ConstraintValidator
      * @var BAV
      */
     private $bav;
-    
+
     /**
      * {@inheritdoc}
-     * 
+     *
      * @throws ValidatorException
      */
     public function initialize(ExecutionContextInterface $context)
@@ -46,10 +46,10 @@ class BlzValidator extends ConstraintValidator
             throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
         }
     }
-    
+
     /**
      * {@inheritdoc}
-     * 
+     *
      * @throws ValidatorException
      */
     public function validate($value, Constraint $constraint)

--- a/src/Symfony/Component/Validator/Constraints/Konto.php
+++ b/src/Symfony/Component/Validator/Constraints/Konto.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validates a German bank account (Konto) for a given bank.
+ * 
+ * @Annotation
+ * @Target({"CLASS", "ANNOTATION"})
+ *
+ * @author Markus Malkusch <markus@malkusch.de>
+ *
+ * @see \malkusch\bav\BAV::isValidBankAccount()
+ * @api
+ */
+class Konto extends Constraint
+{
+    /**
+     * @var string Name of the BLZ property
+     */
+    public $blz;
+    
+    /**
+     * @var string Name of the bank account property
+     */
+    public $konto;
+    
+    public $message = 'This value is not a valid German bank id (BLZ).';
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredOptions()
+    {
+        return array('blz', 'konto');
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/Konto.php
+++ b/src/Symfony/Component/Validator/Constraints/Konto.php
@@ -15,13 +15,17 @@ use Symfony\Component\Validator\Constraint;
 
 /**
  * Validates a German bank account (Konto) for a given bank.
- * 
+ *
+ * This constraint depends on malkusch/bav.
+ *
  * @Annotation
  * @Target({"CLASS", "ANNOTATION"})
  *
  * @author Markus Malkusch <markus@malkusch.de>
  *
  * @see \malkusch\bav\BAV::isValidBankAccount()
+ * @see Blz
+ * @see Bic
  * @api
  */
 class Konto extends Constraint
@@ -30,14 +34,14 @@ class Konto extends Constraint
      * @var string Name of the BLZ property
      */
     public $blz;
-    
+
     /**
      * @var string Name of the bank account property
      */
     public $konto;
-    
+
     public $message = 'This value is not a valid German bank id (BLZ).';
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Constraints/KontoValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/KontoValidator.php
@@ -33,10 +33,10 @@ class KontoValidator extends ConstraintValidator
      * @var BAV
      */
     private $bav;
-    
+
     /**
      * {@inheritdoc}
-     * 
+     *
      * @throws ValidatorException
      */
     public function initialize(ExecutionContextInterface $context)
@@ -48,7 +48,7 @@ class KontoValidator extends ConstraintValidator
             throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
         }
     }
-    
+
     /**
      * @return string
      * @throws UnexpectedTypeException
@@ -73,12 +73,13 @@ class KontoValidator extends ConstraintValidator
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
             throw new UnexpectedTypeException($value, 'string');
         }
+
         return (string) $value;
     }
-    
+
     /**
      * {@inheritdoc}
-     * 
+     *
      * @throws ValidatorException
      */
     public function validate($value, Constraint $constraint)
@@ -95,14 +96,14 @@ class KontoValidator extends ConstraintValidator
             if (!is_object($value)) {
                 throw new UnexpectedTypeException($value, 'object');
             }
-            
+
             $blz = $this->getScalarProperty($value, $constraint->blz);
             $konto = $this->getScalarProperty($value, $constraint->konto);
-            
+
             if (empty($konto) && empty($blz)) {
                 return;
             }
-            
+
             if (!$this->bav->isValidBankAccount($blz, $konto)) {
                 $this->context->addViolation($constraint->message, array('{{ value }}' => $konto));
             }

--- a/src/Symfony/Component/Validator/Constraints/KontoValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/KontoValidator.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\ValidatorException;
+use Symfony\Component\Validator\Mapping\GetterMetadata;
+use Symfony\Component\Validator\Mapping\PropertyMetadata;
+use malkusch\bav\BAV;
+use malkusch\bav\BAVException;
+
+/**
+ * @author Markus Malkusch <markus@malkusch.de>
+ *
+ * @see BAV::isValidBankAccount()
+ * @api
+ */
+class KontoValidator extends ConstraintValidator
+{
+    /**
+     * @var BAV
+     */
+    private $bav;
+    
+    /**
+     * {@inheritdoc}
+     * 
+     * @throws ValidatorException
+     */
+    public function initialize(ExecutionContextInterface $context)
+    {
+        try {
+            parent::initialize($context);
+            $this->bav = new BAV();
+        } catch (BAVException $e) {
+            throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+    
+    /**
+     * @return string
+     * @throws UnexpectedTypeException
+     */
+    private function getScalarProperty($object, $property)
+    {
+        try {
+            $metadata = new GetterMetadata(get_class($object), $property);
+            $value = $metadata->getPropertyValue($object);
+        } catch (ValidatorException $e) {
+            try {
+                $metadata = new PropertyMetadata(get_class($object), $property);
+                $value = $metadata->getPropertyValue($object);
+            } catch (ValidatorException $e2) {
+                if (isset($object->$property)) {
+                    $value = $object->$property;
+                } else {
+                    throw $e;
+                }
+            }
+        }
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+        return (string) $value;
+    }
+    
+    /**
+     * {@inheritdoc}
+     * 
+     * @throws ValidatorException
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        try {
+            if (!$constraint instanceof Konto) {
+                throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Konto');
+            }
+
+            if (null === $value) {
+                return;
+            }
+
+            if (!is_object($value)) {
+                throw new UnexpectedTypeException($value, 'object');
+            }
+            
+            $blz = $this->getScalarProperty($value, $constraint->blz);
+            $konto = $this->getScalarProperty($value, $constraint->konto);
+            
+            if (empty($konto) && empty($blz)) {
+                return;
+            }
+            
+            if (!$this->bav->isValidBankAccount($blz, $konto)) {
+                $this->context->addViolation($constraint->message, array('{{ value }}' => $konto));
+            }
+        } catch (BAVException $e) {
+            throw new ValidatorException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicDEValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicDEValidatorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Bic;
+use Symfony\Component\Validator\Constraints\BicValidator;
+
+class BicDEValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $context;
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $this->validator = new BicValidator();
+        $this->validator->initialize($this->context);
+    }
+
+    public function testNullIsValid()
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate(null, new Bic());
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate('', new Bic());
+    }
+
+    /**
+     * @dataProvider getValidBics
+     */
+    public function testValidBics($bic)
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate($bic, new Bic(Bic::DE));
+    }
+
+    public function getValidBics()
+    {
+        return array(
+            array('VZVDDED1XXX'),
+            array('VZVDDED1'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidBics
+     */
+    public function testInvalidBics($bic)
+    {
+        $constraint = new Bic(array(
+            'value' => Bic::DE,
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $bic,
+            ));
+
+        $this->validator->validate($bic, $constraint);
+    }
+
+    public function getInvalidBics()
+    {
+        return array(
+            array('VZVDDED1~~~'),
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicDEValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicDEValidatorTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraints\Bic;
 use Symfony\Component\Validator\Constraints\BicValidator;
 
+/**
+ * @large
+ */
 class BicDEValidatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $context;

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlzValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlzValidatorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Blz;
+use Symfony\Component\Validator\Constraints\BlzValidator;
+
+class BlzValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $context;
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $this->validator = new BlzValidator();
+        $this->validator->initialize($this->context);
+    }
+
+    public function testNullIsValid()
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate(null, new Blz());
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate('', new Blz());
+    }
+
+    /**
+     * @dataProvider getValidBlzs
+     */
+    public function testValidBlzs($blz)
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate($blz, new Blz());
+    }
+
+    public function getValidBlzs()
+    {
+        return array(
+            array('70169464'),
+            array('10000000'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidBlzs
+     */
+    public function testInvalidBlzs($blz)
+    {
+        $constraint = new Blz(array(
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $blz,
+            ));
+
+        $this->validator->validate($blz, $constraint);
+    }
+
+    public function getInvalidBlzs()
+    {
+        return array(
+            array('12345'),
+            array('XXX'),
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/KontoValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/KontoValidatorTest.php
@@ -40,7 +40,7 @@ class KontoValidatorTest extends \PHPUnit_Framework_TestCase
         $entity = new \stdClass();
         $entity->blz = '';
         $entity->konto = '';
-        
+
         $this->validator->validate($entity, new Konto(array('blz' => 'blz', 'konto' => 'konto')));
     }
 
@@ -57,17 +57,17 @@ class KontoValidatorTest extends \PHPUnit_Framework_TestCase
     public function getValidKontos()
     {
         $cases = array();
-        
+
         $case1 = new \stdClass();
         $case1->blz = '70169464';
         $case1->konto = '1112';
         $cases[] = array($case1);
-        
+
         $case2 = new \stdClass();
         $case2->blz = '70169464';
         $case2->konto = '67067';
         $cases[] = array($case2);
-        
+
         return $cases;
     }
 
@@ -94,17 +94,17 @@ class KontoValidatorTest extends \PHPUnit_Framework_TestCase
     public function getInvalidKontos()
     {
         $cases = array();
-        
+
         $case1 = new \stdClass();
         $case1->blz = '70169464';
         $case1->konto = '1234';
         $cases[] = array($case1);
-        
+
         $case2 = new \stdClass();
         $case2->blz = '1234';
         $case2->konto = '1234';
         $cases[] = array($case2);
-        
+
         return $cases;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/KontoValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/KontoValidatorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Markus Malkusch <markus@malkusch.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Konto;
+use Symfony\Component\Validator\Constraints\KontoValidator;
+
+class KontoValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $context;
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $this->validator = new KontoValidator();
+        $this->validator->initialize($this->context);
+    }
+
+    public function testNullIsValid()
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate(null, new Konto(array('blz' => 'blz', 'konto' => 'konto')));
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $entity = new \stdClass();
+        $entity->blz = '';
+        $entity->konto = '';
+        
+        $this->validator->validate($entity, new Konto(array('blz' => 'blz', 'konto' => 'konto')));
+    }
+
+    /**
+     * @dataProvider getValidKontos
+     */
+    public function testValidKontos($entity)
+    {
+        $this->context->expects($this->never())->method('addViolation');
+
+        $this->validator->validate($entity, new Konto(array('blz' => 'blz', 'konto' => 'konto')));
+    }
+
+    public function getValidKontos()
+    {
+        $cases = array();
+        
+        $case1 = new \stdClass();
+        $case1->blz = '70169464';
+        $case1->konto = '1112';
+        $cases[] = array($case1);
+        
+        $case2 = new \stdClass();
+        $case2->blz = '70169464';
+        $case2->konto = '67067';
+        $cases[] = array($case2);
+        
+        return $cases;
+    }
+
+    /**
+     * @dataProvider getInvalidKontos
+     */
+    public function testInvalidKontos($entity)
+    {
+        $constraint = new Konto(array(
+            'blz' => 'blz',
+            'konto' => 'konto',
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $entity->konto,
+            ));
+
+        $this->validator->validate($entity, $constraint);
+    }
+
+    public function getInvalidKontos()
+    {
+        $cases = array();
+        
+        $case1 = new \stdClass();
+        $case1->blz = '70169464';
+        $case1->konto = '1234';
+        $cases[] = array($case1);
+        
+        $case2 = new \stdClass();
+        $case2->blz = '1234';
+        $case2->konto = '1234';
+        $cases[] = array($case2);
+        
+        return $cases;
+    }
+}

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -28,6 +28,7 @@
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0",
         "egulias/email-validator": "~1.0",
+        "malkusch/bav": "~1.0",
         "symfony/expression-language": "~2.4"
     },
     "suggest": {
@@ -39,6 +40,7 @@
         "symfony/config": "",
         "egulias/email-validator": "Strict (RFC compliant) email validation",
         "symfony/property-access": "For using the 2.4 Validator API",
+        "malkusch/bav": "For using German bank validation",
         "symfony/expression-language": "For using the 2.4 Expression validator"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | symfony/symfony-docs#3976 |
- [ ] submit changes to the documentation

Hi
I'm the author of malkusch/bav, a validation library for German bank accounts. This pull request is the integration of bav into Symfony's validation. You get those new constraints:
- `@Bic`
- `@Konto`
- `@Blz`

Enjoy!
