### PR TITLE
[Serializer] Added a test for decoding xml with whitespaces

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -312,6 +312,29 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
     }
 
+    public function testDecodeIgnoreWhiteSpace()
+    {
+        $source = <<<XML
+<?xml version="1.0"?>
+<people>
+    <person>
+        <firstname>Benjamin</firstname>
+        <lastname>Alexandre</lastname>
+    </person>
+    <person>
+        <firstname>Damien</firstname>
+        <lastname>Clay</lastname>
+    </person>
+</people>
+XML;
+        $expected = array('person' => array(
+            array('firstname' => 'Benjamin', 'lastname' => 'Alexandre'),
+            array('firstname' => 'Damien', 'lastname' => 'Clay')
+        ));
+
+        $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
+    }
+
     public function testDecodeWithoutItemHash()
     {
         $obj = new ScalarDummy();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The PR https://github.com/symfony/symfony/commit/466a3d70b7972dbac20264c254351ca31ee5c476 introduced a BC break because white spaces were previously decoded as text nodes.

So this PR reverts it and adds a context option to configure it.
