### PR TITLE
[Translation] Added unescaping of ids in PoFileLoader

### DIFF
--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -157,7 +157,7 @@ class PoFileLoader extends ArrayLoader implements LoaderInterface
     private function addMessage(array &$messages, array $item)
     {
         if (is_array($item['translated'])) {
-            $messages[$item['ids']['singular']] = stripcslashes($item['translated'][0]);
+            $messages[stripcslashes($item['ids']['singular'])] = stripcslashes($item['translated'][0]);
             if (isset($item['ids']['plural'])) {
                 $plurals = $item['translated'];
                 // PO are by definition indexed so sort by index.
@@ -169,10 +169,10 @@ class PoFileLoader extends ArrayLoader implements LoaderInterface
                 $empties = array_fill(0, $count+1, '-');
                 $plurals += $empties;
                 ksort($plurals);
-                $messages[$item['ids']['plural']] = stripcslashes(implode('|', $plurals));
+                $messages[stripcslashes($item['ids']['plural'])] = stripcslashes(implode('|', $plurals));
             }
         } elseif (!empty($item['ids']['singular'])) {
-              $messages[$item['ids']['singular']] = stripcslashes($item['translated']);
+              $messages[stripcslashes($item['ids']['singular'])] = stripcslashes($item['translated']);
         }
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -76,6 +76,21 @@ class PoFileLoaderTest extends \PHPUnit_Framework_TestCase
         $resource = __DIR__.'/../fixtures/escaped-id.po';
         $catalogue = $loader->load($resource, 'en', 'domain1');
 
-        $this->assertEquals(array('escaped "foo"' => 'escaped "bar"'), $catalogue->all('domain1'));
+        $messages = $catalogue->all('domain1');
+        $this->assertArrayHasKey('escaped "foo"', $messages);
+        $this->assertEquals('escaped "bar"', $messages['escaped "foo"']);
+    }
+
+    public function testEscapedIdPlurals()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../fixtures/escaped-id-plurals.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $messages = $catalogue->all('domain1');
+        $this->assertArrayHasKey('escaped "foo"', $messages);
+        $this->assertArrayHasKey('escaped "foos"', $messages);
+        $this->assertEquals('escaped "bar"', $messages['escaped "foo"']);
+        $this->assertEquals('escaped "bar"|escaped "bars"', $messages['escaped "foos"']);
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -69,4 +69,13 @@ class PoFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
     }
+
+    public function testEscapedId()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../fixtures/escaped-id.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals(array('escaped "foo"' => 'escaped "bar"'), $catalogue->all('domain1'));
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/escaped-id-plurals.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/escaped-id-plurals.po
@@ -5,4 +5,6 @@ msgstr ""
 "Language: en\n"
 
 msgid "escaped \"foo\""
-msgstr "escaped \"bar\""
+msgid_plural "escaped \"foos\""
+msgstr[0] "escaped \"bar\""
+msgstr[1] "escaped \"bars\""

--- a/src/Symfony/Component/Translation/Tests/fixtures/escaped-id.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/escaped-id.po
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+
+msgid "escaped \"foo\""
+msgstr "escaped \"bar\""


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Although it is not directly described in gettext docs, _msgid_ should be unescaped too. The other reason to unescape _msgid_ is symmetry between `PoFileLoader` and `PoFileDumper`. The dumper escapes both _msgid_ and _msgstr_ values, but the loader unescapes only _msgstr_.
