### PR TITLE
Added cached Instantiator to be used in production instead of the Runtime version

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
@@ -22,6 +22,10 @@ use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\InstantiatorInt
 
 /**
  * Lazy loading proxy generator (Using cached Proxy to improve performance).
+ *
+ * @author Alex Moreno <alex.m.lopez@capgemini.com>
+ * @author Dries Vanlerberghe <dries.vanlerberghe@capgemini.com>
+ *
  */
 class CachedInstantiator implements InstantiatorInterface
 {

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @file
+ * CachedInstantiator class.
+ */
+
+namespace Symfony\Bridge\ProxyManager\LazyProxy\Instantiator;
+
+use ProxyManager\Configuration;
+use ProxyManager\Factory\LazyLoadingValueHolderFactory;
+use ProxyManager\FileLocator\FileLocator;
+use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
+use ProxyManager\Proxy\LazyLoadingInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\InstantiatorInterface;
+
+/**
+ * Lazy loading proxy generator (Using cached Proxy to improve performance).
+ */
+class CachedInstantiator implements InstantiatorInterface
+{
+  /**
+   * @var \ProxyManager\Factory\LazyLoadingValueHolderFactory
+   */
+  private $factory;
+
+  /**
+   * Constructor
+   */
+  public function __construct($proxies_path)
+  {
+    $config = new Configuration();
+    $config->setProxiesTargetDir($proxies_path);
+    $fileLocator = new FileLocator($config->getProxiesTargetDir());
+    $config->setGeneratorStrategy(new FileWriterGeneratorStrategy($fileLocator));
+
+    $this->factory = new LazyLoadingValueHolderFactory($config);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
+  {
+    return $this->factory->createProxy(
+      $definition->getClass(),
+      function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($realInstantiator) {
+        $wrappedInstance = call_user_func($realInstantiator);
+
+        $proxy->setProxyInitializer(null);
+
+        return true;
+      }
+    );
+  }
+}

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\InstantiatorInt
 class CachedInstantiator implements InstantiatorInterface
 {
     /**
-     * @var \ProxyManager\Factory\LazyLoadingValueHolderFactory
+     * @var LazyLoadingValueHolderFactory
      */
     private $factory;
 

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
@@ -25,7 +25,6 @@ use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\InstantiatorInt
  *
  * @author Alex Moreno <alex.m.lopez@capgemini.com>
  * @author Dries Vanlerberghe <dries.vanlerberghe@capgemini.com>
- *
  */
 class CachedInstantiator implements InstantiatorInterface
 {

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
@@ -20,38 +20,38 @@ use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\InstantiatorInt
  */
 class CachedInstantiator implements InstantiatorInterface
 {
-  /**
-   * @var \ProxyManager\Factory\LazyLoadingValueHolderFactory
-   */
-  private $factory;
+    /**
+     * @var \ProxyManager\Factory\LazyLoadingValueHolderFactory
+     */
+    private $factory;
 
-  /**
-   * Constructor
-   */
-  public function __construct($proxies_path)
-  {
-    $config = new Configuration();
-    $config->setProxiesTargetDir($proxies_path);
-    $fileLocator = new FileLocator($config->getProxiesTargetDir());
-    $config->setGeneratorStrategy(new FileWriterGeneratorStrategy($fileLocator));
+    /**
+     * Constructor
+     */
+    public function __construct($proxies_path)
+    {
+        $config = new Configuration();
+        $config->setProxiesTargetDir($proxies_path);
+        $fileLocator = new FileLocator($config->getProxiesTargetDir());
+        $config->setGeneratorStrategy(new FileWriterGeneratorStrategy($fileLocator));
 
-    $this->factory = new LazyLoadingValueHolderFactory($config);
-  }
+        $this->factory = new LazyLoadingValueHolderFactory($config);
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
-  {
-    return $this->factory->createProxy(
-      $definition->getClass(),
-      function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($realInstantiator) {
-        $wrappedInstance = call_user_func($realInstantiator);
+    /**
+     * {@inheritdoc}
+     */
+    public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
+    {
+        return $this->factory->createProxy(
+            $definition->getClass(),
+            function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($realInstantiator) {
+                $wrappedInstance = call_user_func($realInstantiator);
 
-        $proxy->setProxyInitializer(null);
+                $proxy->setProxyInitializer(null);
 
-        return true;
-      }
-    );
-  }
+                return true;
+            }
+        );
+    }
 }

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
@@ -1,7 +1,12 @@
 <?php
-/**
- * @file
- * CachedInstantiator class.
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Symfony\Bridge\ProxyManager\LazyProxy\Instantiator;
@@ -28,10 +33,10 @@ class CachedInstantiator implements InstantiatorInterface
     /**
      * Constructor
      */
-    public function __construct($proxies_path)
+    public function __construct($proxiesPath)
     {
         $config = new Configuration();
-        $config->setProxiesTargetDir($proxies_path);
+        $config->setProxiesTargetDir($proxiesPath);
         $fileLocator = new FileLocator($config->getProxiesTargetDir());
         $config->setGeneratorStrategy(new FileWriterGeneratorStrategy($fileLocator));
 

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/CachedInstantiator.php
@@ -32,6 +32,8 @@ class CachedInstantiator implements InstantiatorInterface
 
     /**
      * Constructor
+     *
+     * @param string $proxiesPath      Path where we'll store temporary the proxy files.
      */
     public function __construct($proxiesPath)
     {

--- a/src/Symfony/Bridge/ProxyManager/README.md
+++ b/src/Symfony/Bridge/ProxyManager/README.md
@@ -13,3 +13,14 @@ You can run the unit tests with the following command:
     $ phpunit
 
 [1]: https://github.com/Ocramius/ProxyManager
+
+How to use Lazy Loading
+---------
+
+Example code based in the one used in Drupal Symfony Inject:
+
+    if ($definition->isLazy()) {
+      $set_proxy_instantiator = TRUE;
+      $container_builder->setProxyInstantiator(new CachedInstantiator($proxies_path));
+      $definition->setLazy(true);
+    }

--- a/src/Symfony/Bridge/ProxyManager/README.md
+++ b/src/Symfony/Bridge/ProxyManager/README.md
@@ -13,6 +13,3 @@ You can run the unit tests with the following command:
     $ phpunit
 
 [1]: https://github.com/Ocramius/ProxyManager
-
-How to use Lazy Loading
----------

--- a/src/Symfony/Bridge/ProxyManager/README.md
+++ b/src/Symfony/Bridge/ProxyManager/README.md
@@ -16,11 +16,3 @@ You can run the unit tests with the following command:
 
 How to use Lazy Loading
 ---------
-
-Example code based in the one used in Drupal Symfony Inject:
-
-    if ($definition->isLazy()) {
-      $set_proxy_instantiator = TRUE;
-      $container_builder->setProxyInstantiator(new CachedInstantiator($proxies_path));
-      $definition->setLazy(true);
-    }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\ProxyManager\Tests\LazyProxy\Instantiator;
+
+use ProxyManager\Proxy\LazyLoadingInterface;
+use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\CachedInstantiator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Tests for {@see \Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\CachedInstantiator}
+ *
+ * @author Alex Moreno <alejandro.moreno@tdo.es>
+ *
+ * @covers \Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\CachedInstantiator
+ */
+class CachedInstantiatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CachedInstantiator
+     */
+    protected $instantiator;
+
+    /**
+     * @var String
+    */
+    protected $path = '.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->instantiator = new CachedInstantiator($this->path);
+    }
+
+    public function testInstantiateProxy()
+    {
+        $instance     = new \stdClass();
+        $container    = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $definition   = new Definition('stdClass');
+        $instantiator = function () use ($instance) {
+            return $instance;
+        };
+
+        /* @var $proxy \ProxyManager\Proxy\LazyLoadingInterface|\ProxyManager\Proxy\ValueHolderInterface */
+        $proxy = $this->instantiator->instantiateProxy($container, $definition, 'foo', $instantiator);
+
+        $this->assertInstanceOf('ProxyManager\Proxy\LazyLoadingInterface', $proxy);
+        $this->assertInstanceOf('ProxyManager\Proxy\ValueHolderInterface', $proxy);
+        $this->assertFalse($proxy->isProxyInitialized());
+
+        $proxy->initializeProxy();
+
+        $this->assertSame($instance, $proxy->getWrappedValueHolderValue());
+    }
+}

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Tests for {@see \Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\CachedInstantiator}
- *
  */
 class CachedInstantiatorTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
@@ -19,7 +19,8 @@ use Symfony\Component\DependencyInjection\Definition;
 /**
  * Tests for {@see \Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\CachedInstantiator}
  *
- * @author Alex Moreno <alejandro.moreno@tdo.es>
+ * @author Alex Moreno <alex.m.lopez@capgemini.com>
+ * @author Dries Vanlerberghe <dries.vanlerberghe@capgemini.com>
  *
  */
 class CachedInstantiatorTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
@@ -19,9 +19,6 @@ use Symfony\Component\DependencyInjection\Definition;
 /**
  * Tests for {@see \Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\CachedInstantiator}
  *
- * @author Alex Moreno <alex.m.lopez@capgemini.com>
- * @author Dries Vanlerberghe <dries.vanlerberghe@capgemini.com>
- *
  */
 class CachedInstantiatorTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
@@ -21,7 +21,6 @@ use Symfony\Component\DependencyInjection\Definition;
  *
  * @author Alex Moreno <alejandro.moreno@tdo.es>
  *
- * @covers \Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\CachedInstantiator
  */
 class CachedInstantiatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -31,16 +30,11 @@ class CachedInstantiatorTest extends \PHPUnit_Framework_TestCase
     protected $instantiator;
 
     /**
-     * @var String
-     */
-    protected $path = '.';
-
-    /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
-        $this->instantiator = new CachedInstantiator($this->path);
+        $this->instantiator = new CachedInstantiator('.');
     }
 
     public function testInstantiateProxy()

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/CachedInstantiatorTest.php
@@ -32,7 +32,7 @@ class CachedInstantiatorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @var String
-    */
+     */
     protected $path = '.';
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [Runtime Instantiator is dangerous to be used in Production, and you probably should not need to code your own implementation of a cached one everytime you need to use Lazy Loading. Solution, use this one instead.] |
| License | MIT |
| Doc PR |  |
