### PR TITLE
[Composer] Add PHPUnit as deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ before_script:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
     - sudo locale-gen fr_FR.UTF-8 && sudo update-locale
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "5.3.3" ]; then phpunit --self-update; fi;'
 
 script:
-    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || false
-    - echo "Running tests requiring tty"; phpunit --group tty
+    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; vendor/bin/phpunit --exclude-group tty,benchmark {};' || false
+    - echo "Running tests requiring tty"; vendor/bin/phpunit --group tty

--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -6,7 +6,7 @@ if (version_compare(PHP_VERSION, '5.4', '>=') && gc_enabled()) {
     gc_disable();
 }
 
-$loader = require_once __DIR__.'/vendor/autoload.php';
+$loader = require __DIR__.'/vendor/autoload.php';
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "symfony/yaml": "self.version"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.2",
         "doctrine/orm": "~2.2,>=2.2.3",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -20,6 +20,7 @@
         "doctrine/common": "~2.2"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/stopwatch": "~2.2",
         "symfony/dependency-injection": "~2.0",
         "symfony/form": "~2.2",

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -20,6 +20,7 @@
         "monolog/monolog": "~1.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/http-kernel": "~2.2",
         "symfony/console": "~2.3",
         "symfony/event-dispatcher": "~2.2"

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -23,6 +23,7 @@
         "propel/propel1": "1.6.*"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/stopwatch": "~2.2"
     },
     "autoload": {

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -20,6 +20,9 @@
         "symfony/dependency-injection": "~2.3",
         "ocramius/proxy-manager": ">=0.3.1,<0.6-dev"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": {
             "Symfony\\Bridge\\ProxyManager\\": ""

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -19,6 +19,9 @@
         "php": ">=5.3.3",
         "swiftmailer/swiftmailer": ">=4.2.0,<5.1-dev"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "suggest": {
         "symfony/http-kernel": ""
     },

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -21,6 +21,7 @@
         "twig/twig": "~1.12"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/form": "~2.2",
         "symfony/http-kernel": "~2.2",
         "symfony/routing": "~2.2",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -32,6 +32,7 @@
         "doctrine/annotations": "~1.0"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/finder": "~2.0",
         "symfony/security": "~2.4",
         "symfony/form": "~2.3",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -21,6 +21,7 @@
         "symfony/http-kernel": "~2.2"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/framework-bundle": "~2.2",
         "symfony/twig-bundle": "~2.2",
         "symfony/validator": "~2.2",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -21,6 +21,7 @@
         "symfony/http-kernel": "~2.1"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/stopwatch": "~2.2",
         "symfony/dependency-injection": "~2.0",
         "symfony/config": "~2.2",

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -22,6 +22,7 @@
         "symfony/twig-bridge": "~2.2"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/config": "~2.2",
         "symfony/dependency-injection": "~2.0",
         "symfony/stopwatch": "~2.2"

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -20,6 +20,7 @@
         "symfony/dom-crawler": "~2.0"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/process": "~2.0",
         "symfony/css-selector": "~2.0"
     },

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -20,6 +20,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/finder": "~2.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -19,6 +19,9 @@
         "php": ">=5.3.3",
         "symfony/filesystem": "~2.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Config\\": "" }
     },

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/event-dispatcher": "~2.1",
         "symfony/process": "~2.1",
         "psr/log": "~1.0"

--- a/src/Symfony/Component/CssSelector/composer.json
+++ b/src/Symfony/Component/CssSelector/composer.json
@@ -22,6 +22,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\CssSelector\\": "" }
     },

--- a/src/Symfony/Component/Debug/composer.json
+++ b/src/Symfony/Component/Debug/composer.json
@@ -20,6 +20,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/http-kernel": "~2.1",
         "symfony/http-foundation": "~2.1"
     },

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/yaml": "~2.0",
         "symfony/config": "~2.2",
         "symfony/expression-language": "~2.4"

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/css-selector": "~2.0"
     },
     "suggest": {

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/dependency-injection": "~2.0",
         "symfony/config": "~2.0",
         "symfony/stopwatch": "~2.2",

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\ExpressionLanguage\\": "" }
     },

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Filesystem\\": "" }
     },

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Finder\\": "" }
     },

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -23,6 +23,7 @@
         "symfony/property-access": "~2.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/validator": "~2.2",
         "symfony/http-foundation": "~2.2",
         "symfony/http-kernel": "~2.4",

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/expression-language": "~2.4"
     },
     "autoload": {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -23,6 +23,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/browser-kit": "~2.2",
         "symfony/class-loader": "~2.1",
         "symfony/config": "~2.0",

--- a/src/Symfony/Component/Intl/composer.json
+++ b/src/Symfony/Component/Intl/composer.json
@@ -28,6 +28,7 @@
         "symfony/icu": "~1.0-RC"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/filesystem": ">=2.1"
     },
     "suggest": {

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -19,6 +19,9 @@
         "php": ">=5.3.3",
         "symfony/intl": ">=2.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Locale\\": "" }
     },

--- a/src/Symfony/Component/OptionsResolver/composer.json
+++ b/src/Symfony/Component/OptionsResolver/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\OptionsResolver\\": "" }
     },

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Process\\": "" }
     },

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\PropertyAccess\\": "" }
     },

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/config": "~2.2",
         "symfony/yaml": "~2.0",
         "symfony/expression-language": "~2.4",

--- a/src/Symfony/Component/Security/Acl/composer.json
+++ b/src/Symfony/Component/Security/Acl/composer.json
@@ -20,6 +20,7 @@
         "symfony/security-core": "~2.4"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "doctrine/common": "~2.2",
         "doctrine/dbal": "~2.2",
         "psr/log": "~1.0"

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/event-dispatcher": "~2.1",
         "symfony/expression-language": "~2.4",
         "symfony/http-foundation": "~2.4",

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -20,6 +20,7 @@
         "symfony/security-core": "~2.4"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/http-foundation": "~2.1"
     },
     "suggest": {

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -23,6 +23,7 @@
         "symfony/http-kernel": "~2.4"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/routing": "~2.2",
         "symfony/security-csrf": "~2.4",
         "psr/log": "~1.0"

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -28,6 +28,7 @@
         "symfony/security-http": "self.version"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/routing": "~2.2",
         "symfony/validator": "~2.2",
         "doctrine/common": "~2.2",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Serializer\\": "" }
     },

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Stopwatch\\": "" }
     },

--- a/src/Symfony/Component/Templating/composer.json
+++ b/src/Symfony/Component/Templating/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "psr/log": "~1.0"
     },
     "suggest": {

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/config": "~2.0",
         "symfony/yaml": "~2.2"
     },

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -20,6 +20,7 @@
         "symfony/translation": "~2.0"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable",
         "symfony/http-foundation": "~2.1",
         "symfony/intl": "~2.3",
         "symfony/yaml": "~2.0",

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7@stable"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Yaml\\": "" }
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | TODO |

This PR adds PHPUnit as dev dependencies for all packages. I have fixed it as stable not sure if it is the right choice.

I know fabpot considers PHPUnit as an external tool regarding #5748 but all tests are designed around it and cannot work without it, so, IMO it is really a dev dependency. Additionally, it will simplify new comers to execute the test suite regarding the DX initiative.
