### PR TITLE
[Routing][Tests] Run PhpGeneratorDumper tests in separate process

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\Generator\Dumper\PhpGeneratorDumper;
 use Symfony\Component\Routing\RequestContext;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class PhpGeneratorDumperTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
Due to the single process nature of PHP, the test produces a FatalError with PHP 5.4.29. Adding the PHPUnit annotation to run the tests in separate processes fixes the problem.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |
