### PR TITLE
[HHVM] Access `STDIN`, `STDOUT` and `STDERR` from root namespace.

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -90,13 +90,13 @@ EOF
         $filename = $input->getArgument('filename');
 
         if (!$filename) {
-            if (0 !== ftell(STDIN)) {
+            if (0 !== ftell(\STDIN)) {
                 throw new \RuntimeException("Please provide a filename or pipe template content to STDIN.");
             }
 
             $template = '';
-            while (!feof(STDIN)) {
-                $template .= fread(STDIN, 1024);
+            while (!feof(\STDIN)) {
+                $template .= fread(\STDIN, 1024);
             }
 
             return $this->display($input, $output, array($this->validate($twig, $template, uniqid('sf_'))));
@@ -132,6 +132,7 @@ EOF
             $twig->setLoader($realLoader);
         } catch (\Twig_Error $e) {
             $twig->setLoader($realLoader);
+
             return array('template' => $template, 'file' => $file, 'valid' => false, 'exception' => $e);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -68,13 +68,13 @@ EOF
         $filename = $input->getArgument('filename');
 
         if (!$filename) {
-            if (0 !== ftell(STDIN)) {
+            if (0 !== ftell(\STDIN)) {
                 throw new \RuntimeException('Please provide a filename or pipe file content to STDIN.');
             }
 
             $content = '';
-            while (!feof(STDIN)) {
-                $content .= fread(STDIN, 1024);
+            while (!feof(\STDIN)) {
+                $content .= fread(\STDIN, 1024);
             }
 
             return $this->display($input, $output, array($this->validate($content)));

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -107,7 +107,7 @@ class DialogHelper extends InputAwareHelper
 
         $output->write($question);
 
-        $inputStream = $this->inputStream ?: STDIN;
+        $inputStream = $this->inputStream ?: \STDIN;
 
         if (null === $autocomplete || !$this->hasSttyAvailable()) {
             $ret = fgets($inputStream, 4096);
@@ -288,7 +288,7 @@ class DialogHelper extends InputAwareHelper
             $sttyMode = shell_exec('stty -g');
 
             shell_exec('stty -echo');
-            $value = fgets($this->inputStream ?: STDIN, 4096);
+            $value = fgets($this->inputStream ?: \STDIN, 4096);
             shell_exec(sprintf('stty %s', $sttyMode));
 
             if (false === $value) {

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -109,7 +109,7 @@ class QuestionHelper extends Helper
      */
     public function doAsk(OutputInterface $output, Question $question)
     {
-        $inputStream = $this->inputStream ?: STDIN;
+        $inputStream = $this->inputStream ?: \STDIN;
 
         $message = $question->getQuestion();
         if ($question instanceof ChoiceQuestion) {

--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -205,7 +205,7 @@ EOF;
             $line = readline($this->getPrompt());
         } else {
             $this->output->write($this->getPrompt());
-            $line = fgets(STDIN, 1024);
+            $line = fgets(\STDIN, 1024);
             $line = (!$line && strlen($line) == 0) ? false : rtrim($line);
         }
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProcessHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProcessHelperTest.php
@@ -65,12 +65,12 @@ EOT;
 
 EOT;
         $syntaxErrorOutputVerbose = <<<EOT
-  RUN  php -r "fwrite(STDERR, 'error message');usleep(50000);fwrite(STDOUT, 'out message');exit(252);"
+  RUN  php -r "fwrite(\\STDERR, 'error message');usleep(50000);fwrite(\\STDOUT, 'out message');exit(252);"
   RES  252 Command did not run successfully
 
 EOT;
         $syntaxErrorOutputDebug = <<<EOT
-  RUN  php -r "fwrite(STDERR, 'error message');usleep(50000);fwrite(STDOUT, 'out message');exit(252);"
+  RUN  php -r "fwrite(\\STDERR, 'error message');usleep(50000);fwrite(\\STDOUT, 'out message');exit(252);"
   ERR  error message
   OUT  out message
   RES  252 Command did not run successfully
@@ -84,11 +84,11 @@ EOT;
             array($successOutputVerbose, 'php -r "echo 42;"', StreamOutput::VERBOSITY_VERY_VERBOSE, null),
             array($successOutputDebug, 'php -r "echo 42;"', StreamOutput::VERBOSITY_DEBUG, null),
             array('', 'php -r "syntax error"', StreamOutput::VERBOSITY_VERBOSE, null),
-            array($syntaxErrorOutputVerbose, 'php -r "fwrite(STDERR, \'error message\');usleep(50000);fwrite(STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_VERY_VERBOSE, null),
-            array($syntaxErrorOutputDebug, 'php -r "fwrite(STDERR, \'error message\');usleep(50000);fwrite(STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_DEBUG, null),
-            array($errorMessage.PHP_EOL, 'php -r "fwrite(STDERR, \'error message\');usleep(50000);fwrite(STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_VERBOSE, $errorMessage),
-            array($syntaxErrorOutputVerbose.$errorMessage.PHP_EOL, 'php -r "fwrite(STDERR, \'error message\');usleep(50000);fwrite(STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_VERY_VERBOSE, $errorMessage),
-            array($syntaxErrorOutputDebug.$errorMessage.PHP_EOL, 'php -r "fwrite(STDERR, \'error message\');usleep(50000);fwrite(STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_DEBUG, $errorMessage),
+            array($syntaxErrorOutputVerbose, 'php -r "fwrite(\\STDERR, \'error message\');usleep(50000);fwrite(\\STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_VERY_VERBOSE, null),
+            array($syntaxErrorOutputDebug, 'php -r "fwrite(\\STDERR, \'error message\');usleep(50000);fwrite(\\STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_DEBUG, null),
+            array($errorMessage.PHP_EOL, 'php -r "fwrite(\\STDERR, \'error message\');usleep(50000);fwrite(\\STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_VERBOSE, $errorMessage),
+            array($syntaxErrorOutputVerbose.$errorMessage.PHP_EOL, 'php -r "fwrite(\\STDERR, \'error message\');usleep(50000);fwrite(\\STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_VERY_VERBOSE, $errorMessage),
+            array($syntaxErrorOutputDebug.$errorMessage.PHP_EOL, 'php -r "fwrite(\\STDERR, \'error message\');usleep(50000);fwrite(\\STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_DEBUG, $errorMessage),
             array($successOutputProcessDebug, array('php', '-r', 'echo 42;'), StreamOutput::VERBOSITY_DEBUG, null),
             array($successOutputDebug, new Process('php -r "echo 42;"'), StreamOutput::VERBOSITY_DEBUG, null),
         );

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -1023,7 +1023,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function pipesCodeProvider()
     {
         $variations = array(
-            'fwrite(STDOUT, $in = file_get_contents(\'php://stdin\')); fwrite(STDERR, $in);',
+            'fwrite(\STDOUT, $in = file_get_contents(\'php://stdin\')); fwrite(\STDERR, $in);',
             'include \''.__DIR__.'/PipeStdinInStdoutStdErrStreamSelect.php\';',
         );
 

--- a/src/Symfony/Component/Process/Tests/PipeStdinInStdoutStdErrStreamSelect.php
+++ b/src/Symfony/Component/Process/Tests/PipeStdinInStdoutStdErrStreamSelect.php
@@ -5,12 +5,12 @@ define('ERR_TIMEOUT', 2);
 define('ERR_READ_FAILED', 3);
 define('ERR_WRITE_FAILED', 4);
 
-$read = array(STDIN);
-$write = array(STDOUT, STDERR);
+$read = array(\STDIN);
+$write = array(\STDOUT, \STDERR);
 
-stream_set_blocking(STDIN, 0);
-stream_set_blocking(STDOUT, 0);
-stream_set_blocking(STDERR, 0);
+stream_set_blocking(\STDIN, 0);
+stream_set_blocking(\STDOUT, 0);
+stream_set_blocking(\STDERR, 0);
 
 $out = $err = '';
 while ($read || $write) {
@@ -25,37 +25,37 @@ while ($read || $write) {
         die(ERR_TIMEOUT);
     }
 
-    if (in_array(STDOUT, $w) && strlen($out) > 0) {
-         $written = fwrite(STDOUT, (binary) $out, 32768);
+    if (in_array(\STDOUT, $w) && strlen($out) > 0) {
+         $written = fwrite(\STDOUT, (binary) $out, 32768);
          if (false === $written) {
              die(ERR_WRITE_FAILED);
          }
          $out = (binary) substr($out, $written);
     }
     if (null === $read && strlen($out) < 1) {
-        $write = array_diff($write, array(STDOUT));
+        $write = array_diff($write, array(\STDOUT));
     }
 
-    if (in_array(STDERR, $w) && strlen($err) > 0) {
-         $written = fwrite(STDERR, (binary) $err, 32768);
+    if (in_array(\STDERR, $w) && strlen($err) > 0) {
+         $written = fwrite(\STDERR, (binary) $err, 32768);
          if (false === $written) {
              die(ERR_WRITE_FAILED);
          }
          $err = (binary) substr($err, $written);
     }
     if (null === $read && strlen($err) < 1) {
-        $write = array_diff($write, array(STDERR));
+        $write = array_diff($write, array(\STDERR));
     }
 
     if ($r) {
-        $str = fread(STDIN, 32768);
+        $str = fread(\STDIN, 32768);
         if (false !== $str) {
             $out .= $str;
             $err .= $str;
         }
-        if (false === $str || feof(STDIN)) {
+        if (false === $str || feof(\STDIN)) {
             $read = null;
-            if (!feof(STDIN)) {
+            if (!feof(\STDIN)) {
                 die(ERR_READ_FAILED);
             }
         }


### PR DESCRIPTION
HHVM does not support global constant lookup without the root namespace identifier (i.e. `\STDOUT`). It is a simple regex replace not touching strings and the Process components interface constants.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |
