### PR TITLE
[Config] Fixed failed config schema loads due to libxml_disable_entity_loader usage

### DIFF
--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -80,7 +80,8 @@ class XmlUtils
                     $valid = false;
                 }
             } elseif (!is_array($schemaOrCallable) && is_file((string) $schemaOrCallable)) {
-                $valid = @$dom->schemaValidate($schemaOrCallable);
+                $schemaSource = file_get_contents((string) $schemaOrCallable);
+                $valid = @$dom->schemaValidateSource($schemaSource);
             } else {
                 libxml_use_internal_errors($internalErrors);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11258 |
| License | MIT |
| Doc PR | N/A |

PR #10493 helped this issue, but it can still affect users that:
1.  Have libxml_disable_entity_loader set to true by default.
2.  Experience libxml_disable_entity_loader php bug https://bugs.php.net/bug.php?id=64938 

I used the same approach used in the DI xml validation.
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php#L452
