### PR TITLE
[Process] Use correct test for empty string in UnixPipes

### DIFF
--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -335,11 +335,11 @@ class ProcessPipes
             $type = array_search($pipe, $this->pipes);
 
             $data = '';
-            while ($dataread = fread($pipe, self::CHUNK_SIZE)) {
+            while ('' !== $dataread = (string) fread($pipe, self::CHUNK_SIZE)) {
                 $data .= $dataread;
             }
 
-            if ($data) {
+            if ('' !== $data) {
                 $read[$type] = $data;
             }
 

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -306,6 +306,12 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($p->getOutput());
     }
 
+    public function testZeroAsOutput(){
+        $p = $this->getProcess('printf 0');
+        $p->run();
+        $this->assertSame('0', $p->getOutput());
+    }
+
     public function testExitCodeCommandFailed()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {


### PR DESCRIPTION
Process sometimes omit `0` as the test use PHP's equality to check read string. This PR correctly check for empty string.

Fix for `master` branch also available in this repository.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
