### PR TITLE
Added verbosity methods to NullOutput

### DIFF
--- a/src/Symfony/Component/Console/Output/NullOutput.php
+++ b/src/Symfony/Component/Console/Output/NullOutput.php
@@ -74,6 +74,26 @@ class NullOutput implements OutputInterface
     {
         return self::VERBOSITY_QUIET;
     }
+    
+    public function isQuiet()
+    {
+        return true;
+    }
+
+    public function isVerbose()
+    {
+        return false;
+    }
+
+    public function isVeryVerbose()
+    {
+        return false;
+    }
+
+    public function isDebug()
+    {
+        return false;
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
These 4 methods were not added to the OutputInterface because of BC, but they should still be implemented in all classes which implement that interface. Otherwise we have to do nasty tricks...

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
