### PR TITLE
Remove Spaceless Blocks From Twig Templates

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -1,24 +1,19 @@
 {# Widgets #}
 
-{% block form_widget %}
-{% spaceless %}
+{% block form_widget -%}
     {% if compound %}
-        {{ block('form_widget_compound') }}
+        {{- block('form_widget_compound') -}}
     {% else %}
-        {{ block('form_widget_simple') }}
+        {{- block('form_widget_simple') -}}
     {% endif %}
-{% endspaceless %}
-{% endblock form_widget %}
+{%- endblock form_widget %}
 
-{% block form_widget_simple %}
-{% spaceless %}
-    {% set type = type|default('text') %}
+{% block form_widget_simple -%}
+    {% set type = type|default('text') -%}
     <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
-{% endspaceless %}
-{% endblock form_widget_simple %}
+{%- endblock form_widget_simple %}
 
-{% block form_widget_compound %}
-{% spaceless %}
+{% block form_widget_compound -%}
     <div {{ block('widget_container_attributes') }}>
         {% if form.parent is empty %}
             {{ form_errors(form) }}
@@ -26,8 +21,7 @@
         {{ block('form_rows') }}
         {{ form_rest(form) }}
     </div>
-{% endspaceless %}
-{% endblock form_widget_compound %}
+{%- endblock form_widget_compound %}
 
 {% block collection_widget %}
 {% spaceless %}
@@ -38,9 +32,9 @@
 {% endspaceless %}
 {% endblock collection_widget %}
 
-{% block textarea_widget %}
+{% block textarea_widget -%}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
-{% endblock textarea_widget %}
+{%- endblock textarea_widget %}
 
 {% block choice_widget %}
 {% spaceless %}
@@ -275,15 +269,13 @@
 {% endspaceless %}
 {% endblock repeated_row %}
 
-{% block form_row %}
-{% spaceless %}
+{% block form_row -%}
     <div>
         {{ form_label(form) }}
         {{ form_errors(form) }}
         {{ form_widget(form) }}
     </div>
-{% endspaceless %}
-{% endblock form_row %}
+{%- endblock form_row %}
 
 {% block button_row %}
 {% spaceless %}
@@ -299,13 +291,11 @@
 
 {# Misc #}
 
-{% block form %}
-{% spaceless %}
+{% block form -%}
     {{ form_start(form) }}
         {{ form_widget(form) }}
     {{ form_end(form) }}
-{% endspaceless %}
-{% endblock form %}
+{%- endblock form %}
 
 {% block form_start %}
 {% spaceless %}
@@ -361,13 +351,11 @@
 
 {# Support #}
 
-{% block form_rows %}
-{% spaceless %}
+{% block form_rows -%}
     {% for child in form %}
-        {{ form_row(child) }}
+        {{- form_row(child) -}}
     {% endfor %}
-{% endspaceless %}
-{% endblock form_rows %}
+{%- endblock form_rows %}
 
 {% block widget_attributes %}
 {% spaceless %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -247,35 +247,29 @@
     {{ form_end(form) }}
 {%- endblock form %}
 
-{% block form_start %}
-{% spaceless %}
+{% block form_start -%}
     {% set method = method|upper %}
-    {% if method in ["GET", "POST"] %}
+    {%- if method in ["GET", "POST"] -%}
         {% set form_method = method %}
-    {% else %}
+    {%- else -%}
         {% set form_method = "POST" %}
-    {% endif %}
+    {%- endif -%}
     <form name="{{ form.vars.name }}" method="{{ form_method|lower }}" action="{{ action }}"{% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}{% if multipart %} enctype="multipart/form-data"{% endif %}>
-    {% if form_method != method %}
+    {%- if form_method != method -%}
         <input type="hidden" name="_method" value="{{ method }}" />
-    {% endif %}
-{% endspaceless %}
-{% endblock form_start %}
+    {%- endif -%}
+{%- endblock form_start %}
 
-{% block form_end %}
-{% spaceless %}
+{% block form_end -%}
     {% if not render_rest is defined or render_rest %}
-        {{ form_rest(form) }}
-    {% endif %}
+        {{- form_rest(form) -}}
+    {% endif -%}
     </form>
-{% endspaceless %}
-{% endblock form_end %}
+{%- endblock form_end %}
 
-{% block form_enctype %}
-{% spaceless %}
+{% block form_enctype -%}
     {% if multipart %}enctype="multipart/form-data"{% endif %}
-{% endspaceless %}
-{% endblock form_enctype %}
+{%- endblock form_enctype %}
 
 {% block form_errors -%}
     {% if errors|length > 0 -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -23,43 +23,36 @@
     </div>
 {%- endblock form_widget_compound %}
 
-{% block collection_widget %}
-{% spaceless %}
-    {% if prototype is defined %}
+{% block collection_widget -%}
+    {% if prototype is defined -%}
         {% set attr = attr|merge({'data-prototype': form_row(prototype) }) %}
-    {% endif %}
-    {{ block('form_widget') }}
-{% endspaceless %}
-{% endblock collection_widget %}
+    {%- endif %}
+    {{- block('form_widget') -}}
+{%- endblock collection_widget %}
 
 {% block textarea_widget -%}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
 {%- endblock textarea_widget %}
 
-{% block choice_widget %}
-{% spaceless %}
+{% block choice_widget -%}
     {% if expanded %}
-        {{ block('choice_widget_expanded') }}
+        {{- block('choice_widget_expanded') -}}
     {% else %}
-        {{ block('choice_widget_collapsed') }}
+        {{- block('choice_widget_collapsed') -}}
     {% endif %}
-{% endspaceless %}
-{% endblock choice_widget %}
+{%- endblock choice_widget %}
 
-{% block choice_widget_expanded %}
-{% spaceless %}
+{% block choice_widget_expanded -%}
     <div {{ block('widget_container_attributes') }}>
-    {% for child in form %}
-        {{ form_widget(child) }}
-        {{ form_label(child) }}
-    {% endfor %}
+    {%- for child in form %}
+        {{- form_widget(child) -}}
+        {{- form_label(child) -}}
+    {% endfor -%}
     </div>
-{% endspaceless %}
 {% endblock choice_widget_expanded %}
 
-{% block choice_widget_collapsed %}
-{% spaceless %}
-    {% if required and empty_value is none and not empty_value_in_choices and not multiple %}
+{% block choice_widget_collapsed -%}
+    {% if required and empty_value is none and not empty_value_in_choices and not multiple -%}
         {% set required = false %}
     {% endif %}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
@@ -76,11 +69,9 @@
         {% set options = choices %}
         {{ block('choice_widget_options') }}
     </select>
-{% endspaceless %}
-{% endblock choice_widget_collapsed %}
+{%- endblock choice_widget_collapsed %}
 
-{% block choice_widget_options %}
-{% spaceless %}
+{% block choice_widget_options -%}
     {% for group_label, choice in options %}
         {% if choice is iterable %}
             <optgroup label="{{ group_label|trans({}, translation_domain) }}">
@@ -91,25 +82,19 @@
             <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
         {% endif %}
     {% endfor %}
-{% endspaceless %}
-{% endblock choice_widget_options %}
+{%- endblock choice_widget_options %}
 
-{% block checkbox_widget %}
-{% spaceless %}
+{% block checkbox_widget -%}
     <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
-{% endspaceless %}
-{% endblock checkbox_widget %}
+{%- endblock checkbox_widget %}
 
-{% block radio_widget %}
-{% spaceless %}
+{% block radio_widget -%}
     <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
-{% endspaceless %}
-{% endblock radio_widget %}
+{%- endblock radio_widget %}
 
-{% block datetime_widget %}
-{% spaceless %}
+{% block datetime_widget -%}
     {% if widget == 'single_text' %}
-        {{ block('form_widget_simple') }}
+        {{- block('form_widget_simple') -}}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             {{ form_errors(form.date) }}
@@ -118,14 +103,12 @@
             {{ form_widget(form.time) }}
         </div>
     {% endif %}
-{% endspaceless %}
-{% endblock datetime_widget %}
+{%- endblock datetime_widget %}
 
-{% block date_widget %}
-{% spaceless %}
+{% block date_widget -%}
     {% if widget == 'single_text' %}
-        {{ block('form_widget_simple') }}
-    {% else %}
+        {{- block('form_widget_simple') -}}
+    {% else -%}
         <div {{ block('widget_container_attributes') }}>
             {{ date_pattern|replace({
                 '{{ year }}':  form_widget(form.year),
@@ -133,141 +116,110 @@
                 '{{ day }}':   form_widget(form.day),
             })|raw }}
         </div>
-    {% endif %}
-{% endspaceless %}
-{% endblock date_widget %}
+    {%- endif %}
+{%- endblock date_widget %}
 
-{% block time_widget %}
-{% spaceless %}
+{% block time_widget -%}
     {% if widget == 'single_text' %}
-        {{ block('form_widget_simple') }}
-    {% else %}
+        {{- block('form_widget_simple') -}}
+    {% else -%}
         {% set vars = widget == 'text' ? { 'attr': { 'size': 1 }} : {} %}
         <div {{ block('widget_container_attributes') }}>
             {{ form_widget(form.hour, vars) }}{% if with_minutes %}:{{ form_widget(form.minute, vars) }}{% endif %}{% if with_seconds %}:{{ form_widget(form.second, vars) }}{% endif %}
         </div>
-    {% endif %}
-{% endspaceless %}
-{% endblock time_widget %}
+    {%- endif %}
+{%- endblock time_widget %}
 
-{% block number_widget %}
-{% spaceless %}
+{% block number_widget -%}
     {# type="number" doesn't work with floats #}
     {% set type = type|default('text') %}
-    {{ block('form_widget_simple') }}
-{% endspaceless %}
-{% endblock number_widget %}
+    {{- block('form_widget_simple') -}}
+{%- endblock number_widget %}
 
-{% block integer_widget %}
-{% spaceless %}
+{% block integer_widget -%}
     {% set type = type|default('number') %}
-    {{ block('form_widget_simple') }}
-{% endspaceless %}
-{% endblock integer_widget %}
+    {{- block('form_widget_simple') -}}
+{%- endblock integer_widget %}
 
-{% block money_widget %}
-{% spaceless %}
+{% block money_widget -%}
     {{ money_pattern|replace({ '{{ widget }}': block('form_widget_simple') })|raw }}
-{% endspaceless %}
-{% endblock money_widget %}
+{%- endblock money_widget %}
 
-{% block url_widget %}
-{% spaceless %}
+{% block url_widget -%}
     {% set type = type|default('url') %}
-    {{ block('form_widget_simple') }}
-{% endspaceless %}
-{% endblock url_widget %}
+    {{- block('form_widget_simple') -}}
+{%- endblock url_widget %}
 
-{% block search_widget %}
-{% spaceless %}
+{% block search_widget -%}
     {% set type = type|default('search') %}
-    {{ block('form_widget_simple') }}
-{% endspaceless %}
-{% endblock search_widget %}
+    {{- block('form_widget_simple') -}}
+{%- endblock search_widget %}
 
-{% block percent_widget %}
-{% spaceless %}
+{% block percent_widget -%}
     {% set type = type|default('text') %}
-    {{ block('form_widget_simple') }} %
-{% endspaceless %}
-{% endblock percent_widget %}
+    {{- block('form_widget_simple') -}} %
+{%- endblock percent_widget %}
 
-{% block password_widget %}
-{% spaceless %}
+{% block password_widget -%}
     {% set type = type|default('password') %}
     {{ block('form_widget_simple') }}
-{% endspaceless %}
-{% endblock password_widget %}
+{%- endblock password_widget %}
 
-{% block hidden_widget %}
-{% spaceless %}
+{% block hidden_widget -%}
     {% set type = type|default('hidden') %}
-    {{ block('form_widget_simple') }}
-{% endspaceless %}
-{% endblock hidden_widget %}
+    {{- block('form_widget_simple') -}}
+{%- endblock hidden_widget -%}
 
-{% block email_widget %}
-{% spaceless %}
+{% block email_widget -%}
     {% set type = type|default('email') %}
-    {{ block('form_widget_simple') }}
-{% endspaceless %}
-{% endblock email_widget %}
+    {{- block('form_widget_simple') -}}
+{%- endblock email_widget %}
 
-{% block button_widget %}
-{% spaceless %}
-    {% if label is empty %}
+{% block button_widget -%}
+    {% if label is empty -%}
         {% set label = name|humanize %}
-    {% endif %}
+    {%- endif -%}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ label|trans({}, translation_domain) }}</button>
-{% endspaceless %}
-{% endblock button_widget %}
+{%- endblock button_widget %}
 
-{% block submit_widget %}
-{% spaceless %}
+{% block submit_widget -%}
     {% set type = type|default('submit') %}
-    {{ block('button_widget') }}
-{% endspaceless %}
-{% endblock submit_widget %}
+    {{- block('button_widget') -}}
+{%- endblock submit_widget %}
 
-{% block reset_widget %}
-{% spaceless %}
+{% block reset_widget -%}
     {% set type = type|default('reset') %}
-    {{ block('button_widget') }}
-{% endspaceless %}
-{% endblock reset_widget %}
+    {{- block('button_widget') -}}
+{%- endblock reset_widget %}
 
 {# Labels #}
 
-{% block form_label %}
-{% spaceless %}
-    {% if label is not sameas(false) %}
-        {% if not compound %}
+{% block form_label -%}
+    {% if label is not sameas(false) -%}
+        {% if not compound -%}
             {% set label_attr = label_attr|merge({'for': id}) %}
-        {% endif %}
-        {% if required %}
+        {%- endif %}
+        {% if required -%}
             {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
-        {% endif %}
-        {% if label is empty %}
+        {%- endif %}
+        {% if label is empty -%}
             {% set label = name|humanize %}
-        {% endif %}
+        {%- endif -%}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
-    {% endif %}
-{% endspaceless %}
-{% endblock form_label %}
+    {%- endif %}
+{%- endblock form_label %}
 
 {% block button_label %}{% endblock %}
 
 {# Rows #}
 
-{% block repeated_row %}
-{% spaceless %}
+{% block repeated_row -%}
     {#
     No need to render the errors here, as all errors are mapped
     to the first child (see RepeatedTypeValidatorExtension).
     #}
-    {{ block('form_rows') }}
-{% endspaceless %}
-{% endblock repeated_row %}
+    {{- block('form_rows') -}}
+{%- endblock repeated_row %}
 
 {% block form_row -%}
     <div>
@@ -277,17 +229,15 @@
     </div>
 {%- endblock form_row %}
 
-{% block button_row %}
-{% spaceless %}
+{% block button_row -%}
     <div>
         {{ form_widget(form) }}
     </div>
-{% endspaceless %}
-{% endblock button_row %}
+{%- endblock button_row %}
 
-{% block hidden_row %}
+{% block hidden_row -%}
     {{ form_widget(form) }}
-{% endblock hidden_row %}
+{%- endblock hidden_row %}
 
 {# Misc #}
 
@@ -327,26 +277,22 @@
 {% endspaceless %}
 {% endblock form_enctype %}
 
-{% block form_errors %}
-{% spaceless %}
-    {% if errors|length > 0 %}
+{% block form_errors -%}
+    {% if errors|length > 0 -%}
     <ul>
-        {% for error in errors %}
+        {%- for error in errors -%}
             <li>{{ error.message }}</li>
-        {% endfor %}
+        {%- endfor -%}
     </ul>
-    {% endif %}
-{% endspaceless %}
-{% endblock form_errors %}
+    {%- endif %}
+{%- endblock form_errors %}
 
-{% block form_rest %}
-{% spaceless %}
-    {% for child in form %}
+{% block form_rest -%}
+    {% for child in form -%}
         {% if not child.rendered %}
-            {{ form_row(child) }}
+            {{- form_row(child) -}}
         {% endif %}
-    {% endfor %}
-{% endspaceless %}
+    {%- endfor %}
 {% endblock form_rest %}
 
 {# Support #}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -39,9 +39,7 @@
 {% endblock collection_widget %}
 
 {% block textarea_widget %}
-{% spaceless %}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
-{% endspaceless %}
 {% endblock textarea_widget %}
 
 {% block choice_widget %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -303,8 +303,7 @@
     {% endfor %}
 {%- endblock form_rows %}
 
-{% block widget_attributes %}
-{% spaceless %}
+{% block widget_attributes -%}
     id="{{ id }}" name="{{ full_name }}"
     {%- if read_only %} readonly="readonly"{% endif -%}
     {%- if disabled %} disabled="disabled"{% endif -%}
@@ -319,11 +318,9 @@
             {{- attrname }}="{{ attrvalue }}"
         {%- endif -%}
     {%- endfor -%}
-{% endspaceless %}
-{% endblock widget_attributes %}
+{%- endblock widget_attributes %}
 
-{% block widget_container_attributes %}
-{% spaceless %}
+{% block widget_container_attributes -%}
     {%- if id is not empty %}id="{{ id }}"{% endif -%}
     {%- for attrname, attrvalue in attr -%}
         {{- " " -}}
@@ -335,11 +332,9 @@
             {{- attrname }}="{{ attrvalue }}"
         {%- endif -%}
     {%- endfor -%}
-{% endspaceless %}
-{% endblock widget_container_attributes %}
+{%- endblock widget_container_attributes %}
 
-{% block button_attributes %}
-{% spaceless %}
+{% block button_attributes -%}
     id="{{ id }}" name="{{ full_name }}"{% if disabled %} disabled="disabled"{% endif -%}
     {%- for attrname, attrvalue in attr -%}
         {{- " " -}}
@@ -351,5 +346,4 @@
             {{- attrname }}="{{ attrvalue }}"
         {%- endif -%}
     {%- endfor -%}
-{% endspaceless %}
-{% endblock button_attributes %}
+{%- endblock button_attributes %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
@@ -12,25 +12,21 @@
     </tr>
 {%- endblock form_row %}
 
-{% block button_row %}
-{% spaceless %}
+{% block button_row -%}
     <tr>
         <td></td>
         <td>
-            {{ form_widget(form) }}
+            {{- form_widget(form) -}}
         </td>
     </tr>
-{% endspaceless %}
 {% endblock button_row %}
 
-{% block hidden_row %}
-{% spaceless %}
+{% block hidden_row -%}
     <tr style="display: none">
         <td colspan="2">
-            {{ form_widget(form) }}
+            {{- form_widget(form) -}}
         </td>
     </tr>
-{% endspaceless %}
 {% endblock hidden_row %}
 
 {% block form_widget_compound -%}
@@ -45,4 +41,4 @@
         {{- block('form_rows') -}}
         {{- form_rest(form) -}}
     </table>
-{% endblock form_widget_compound %}
+{%- endblock form_widget_compound %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
@@ -1,18 +1,16 @@
 {% use "form_div_layout.html.twig" %}
 
-{% block form_row %}
-{% spaceless %}
+{% block form_row -%}
     <tr>
         <td>
-            {{ form_label(form) }}
+            {{- form_label(form) -}}
         </td>
         <td>
-            {{ form_errors(form) }}
-            {{ form_widget(form) }}
+            {{- form_errors(form) -}}
+            {{- form_widget(form) -}}
         </td>
     </tr>
-{% endspaceless %}
-{% endblock form_row %}
+{%- endblock form_row %}
 
 {% block button_row %}
 {% spaceless %}
@@ -35,18 +33,16 @@
 {% endspaceless %}
 {% endblock hidden_row %}
 
-{% block form_widget_compound %}
-{% spaceless %}
+{% block form_widget_compound -%}
     <table {{ block('widget_container_attributes') }}>
-        {% if form.parent is empty and errors|length > 0 %}
+        {%- if form.parent is empty and errors|length > 0 -%}
         <tr>
             <td colspan="2">
-                {{ form_errors(form) }}
+                {{- form_errors(form) -}}
             </td>
         </tr>
-        {% endif %}
-        {{ block('form_rows') }}
-        {{ form_rest(form) }}
+        {%- endif %}
+        {{- block('form_rows') -}}
+        {{- form_rest(form) -}}
     </table>
-{% endspaceless %}
 {% endblock form_widget_compound %}

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -756,16 +756,4 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         // foo="foo"
         $this->assertContains('<div id="form" foo="foo">', $html);
     }
-
-    public function testWidgetContainerAttributeHiddenIfFalse()
-    {
-        $form = $this->factory->createNamed('form', 'form', null, array(
-            'attr' => array('foo' => false),
-        ));
-
-        $html = $this->renderWidget($form->createView());
-
-        // no foo
-        $this->assertContains('<div id="form">', $html);
-    }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1929,8 +1929,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
         $html = $this->renderWidget($form->createView());
 
-        // no foo
-        $this->assertSame('<input type="text" id="text" name="text" required="required" value="value" />', $html);
+        $this->assertNotContains('foo="', $html);
     }
 
     public function testButtonAttributes()
@@ -1966,8 +1965,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
         $html = $this->renderWidget($form->createView());
 
-        // no foo
-        $this->assertSame('<button type="button" id="button" name="button">[trans]Button[/trans]</button>', $html);
+        $this->assertNotContains('foo="', $html);
     }
 
     public function testTextareaWithWhitespaceOnlyContentRetainsValue()

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1970,9 +1970,6 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertSame('<button type="button" id="button" name="button">[trans]Button[/trans]</button>', $html);
     }
 
-    /**
-     * @group ticket-11277
-     */
     public function testTextareaWithWhitespaceOnlyContentRetainsValue()
     {
         $form = $this->factory->createNamed('textarea', 'textarea', '  ');
@@ -1982,9 +1979,6 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertContains('>  </textarea>', $html);
     }
 
-    /**
-     * @group ticket-11277
-     */
     public function testTextareaWithWhitespaceOnlyContentRetainsValueWhenRenderingForm()
     {
         $form = $this->factory->createBuilder('form', array('textarea' => '  '))

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1987,4 +1987,16 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
         $this->assertContains('>  </textarea>', $html);
     }
+
+    public function testWidgetContainerAttributeHiddenIfFalse()
+    {
+        $form = $this->factory->createNamed('form', 'form', null, array(
+            'attr' => array('foo' => false),
+        ));
+
+        $html = $this->renderWidget($form->createView());
+
+        // no foo
+        $this->assertNotContains('foo="', $html);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1969,4 +1969,30 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         // no foo
         $this->assertSame('<button type="button" id="button" name="button">[trans]Button[/trans]</button>', $html);
     }
+
+    /**
+     * @group ticket-11277
+     */
+    public function testTextareaWithWhitespaceOnlyContentRetainsValue()
+    {
+        $form = $this->factory->createNamed('textarea', 'textarea', '  ');
+
+        $html = $this->renderWidget($form->createView());
+
+        $this->assertContains('>  </textarea>', $html);
+    }
+
+    /**
+     * @group ticket-11277
+     */
+    public function testTextareaWithWhitespaceOnlyContentRetainsValueWhenRenderingForm()
+    {
+        $form = $this->factory->createBuilder('form', array('textarea' => '  '))
+            ->add('textarea', 'textarea')
+            ->getForm();
+
+        $html = $this->renderForm($form->createView());
+
+        $this->assertContains('>  </textarea>', $html);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -533,16 +533,4 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
         // foo="foo"
         $this->assertContains('<table id="form" foo="foo">', $html);
     }
-
-    public function testWidgetContainerAttributeHiddenIfFalse()
-    {
-        $form = $this->factory->createNamed('form', 'form', null, array(
-            'attr' => array('foo' => false),
-        ));
-
-        $html = $this->renderWidget($form->createView());
-
-        // no foo
-        $this->assertContains('<table id="form">', $html);
-    }
 }


### PR DESCRIPTION
Leaving it in can only mangle values from data bound to the form.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11277 |
| License | MIT |
| Doc PR |  |

The tests pass here, but it doesn't seem like any tests really cover the actual rendering.
