### PR TITLE
[twig] fix merge of the paths defined in several config files.

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -135,6 +135,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('auto_reload')->end()
                 ->scalarNode('optimizations')->end()
                 ->arrayNode('paths')
+                    ->useAttributeAsKey('name')
                     ->normalizeKeys(false)
                     ->beforeNormalization()
                         ->always()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Let's say I have two separate configs files in which I define `twig.paths`, or an extension that implements `PrependExtensionInterface` and prepend twig paths there. If we have only entry where the `paths` is defined everything works fine. But if there two or more we may ended with php fatal error:

```
Fatal error: Uncaught exception 'Twig_Error_Loader' with message 'The "0" directory does not exist.' in /home/vagrant/projects/Foo/vendor/twig/twig/lib/Twig/Loader/Filesystem.php on line 93
```
