### PR TITLE
[DX] Added line feed to container alias description (text descriptor)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -273,7 +273,7 @@ class TextDescriptor extends Descriptor
      */
     protected function describeContainerAlias(Alias $alias, array $options = array())
     {
-        $this->writeText(sprintf('This service is an alias for the service <info>%s</info>', (string) $alias), $options);
+        $this->writeText(sprintf("This service is an alias for the service <info>%s</info>\n", (string) $alias), $options);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | N/A |

This PR just adds a line feed at the end of the alias service description delivered by the ContainerDebugCommand. Tests are passing because expected outputs are trimmed before comparison (which IMO is not a really good thing, but hey...)
