### PR TITLE
[HttpKernel] Ensure the storage exists before purging it in ProfilerTest

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -79,9 +79,11 @@ class ProfilerTest extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        $this->storage->purge();
-        $this->storage = null;
+        if (null !== $this->storage) {
+            $this->storage->purge();
+            $this->storage = null;
 
-        @unlink($this->tmp);
+            @unlink($this->tmp);
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11319 |
| License | MIT |
| Doc PR | None |
