### PR TITLE
[SecurityBundle] error helper added symfony/symfony#11147

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -47,6 +47,8 @@
         <parameter key="security.validator.user_password.class">Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator</parameter>
 
         <parameter key="security.expression_language.class">Symfony\Component\Security\Core\Authorization\ExpressionLanguage</parameter>
+
+        <parameter key="security.authentication_error_helper.class">Symfony\Component\Security\Core\Util\AuthenticationErrorHelper</parameter>
     </parameters>
 
     <services>
@@ -83,6 +85,10 @@
         <service id="security.user_checker" class="%security.user_checker.class%" public="false" />
 
         <service id="security.expression_language" class="%security.expression_language.class%" public="false" />
+
+        <service id="security.authentication_error_helper" class="%security.authentication_error_helper.class%">
+            <argument type="service" id="request_stack" />
+        </service>
 
         <!-- Authorization related services -->
         <service id="security.access.decision_manager" class="%security.access.decision_manager.class%" public="false">

--- a/src/Symfony/Component/Security/Core/Util/AuthenticationErrorHelper.php
+++ b/src/Symfony/Component/Security/Core/Util/AuthenticationErrorHelper.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Util;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+/**
+ * Extracts Security Errors from Request
+ *
+ * @author Boris Vujicic <boris.vujicic@gmail.com>
+ */
+class AuthenticationErrorHelper
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @param bool $clearSession
+     * @return string
+     */
+    public function getLastAuthenticationError($clearSession = true)
+    {
+        $request = $this->getRequest();
+        $session = $request->getSession();
+
+        if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            $msg = $request->attributes->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+        } elseif ($session !== null && $session->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            $msg = $session->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+
+            if ($clearSession) {
+                $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
+            }
+
+        }
+
+        return $msg;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastUsername()
+    {
+        $session = $this->getRequest()->getSession();
+
+        return $session === null ? '' : $session->get(SecurityContextInterface::LAST_USERNAME);
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Request
+     * @throws \LogicException
+     */
+    private function getRequest()
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            throw new \LogicException('Request should exist so it can be processed for error.');
+        }
+
+        return $request;
+    }
+} 


### PR DESCRIPTION
Added helper that extracts last authentication error and username.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [11147] |
| License | MIT |
| Doc PR | --- |
