### PR TITLE
[SecurityBundle] error helper added symfony/symfony#11147

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -47,6 +47,8 @@
         <parameter key="security.validator.user_password.class">Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator</parameter>
 
         <parameter key="security.expression_language.class">Symfony\Component\Security\Core\Authorization\ExpressionLanguage</parameter>
+
+        <parameter key="security.authentication_utils.class">Symfony\Component\Security\Http\Authentication\AuthenticationUtils</parameter>
     </parameters>
 
     <services>
@@ -83,6 +85,10 @@
         <service id="security.user_checker" class="%security.user_checker.class%" public="false" />
 
         <service id="security.expression_language" class="%security.expression_language.class%" public="false" />
+
+        <service id="security.authentication_utils" class="%security.authentication_utils.class%">
+            <argument type="service" id="request_stack" />
+        </service>
 
         <!-- Authorization related services -->
         <service id="security.access.decision_manager" class="%security.access.decision_manager.class%" public="false">

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * added Symfony\Component\Security\Http\Authentication\AuthenticationUtils
+
 2.4.0
 -----
 

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authentication;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Extracts Security Errors from Request
+ *
+ * @author Boris Vujicic <boris.vujicic@gmail.com>
+ */
+class AuthenticationUtils
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @param bool $clearSession
+     * @return null|AuthenticationException
+     */
+    public function getLastAuthenticationError($clearSession = true)
+    {
+        $request = $this->getRequest();
+        $session = $request->getSession();
+        $authenticationException = null;
+
+        if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            $authenticationException = $request->attributes->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+        } elseif ($session !== null && $session->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            $authenticationException = $session->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+
+            if ($clearSession) {
+                $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
+            }
+
+        }
+
+        return $authenticationException;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastUsername()
+    {
+        $session = $this->getRequest()->getSession();
+
+        return null === $session ? '' : $session->get(SecurityContextInterface::LAST_USERNAME);
+    }
+
+    /**
+     * @return Request
+     * @throws \LogicException
+     */
+    private function getRequest()
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            throw new \LogicException('Request should exist so it can be processed for error.');
+        }
+
+        return $request;
+    }
+}


### PR DESCRIPTION
Added helper that extracts last authentication error and username.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [ #11147 ] |
| License | MIT |
| Doc PR | symfony/symfony-docs#3996 |
