### PR TITLE
[DX] Easier template customizing with a query parameter

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -51,8 +51,14 @@ class ExceptionController
 
         $code = $exception->getStatusCode();
 
+        // allow the developer to see the real template with ?_real_template=1
+        $debug = $this->debug;
+        if ($debug && $request->query->get('_real_template')) {
+            $debug = false;
+        }
+
         return new Response($this->twig->render(
-            $this->findTemplate($request, $_format, $code, $this->debug),
+            $this->findTemplate($request, $_format, $code, $debug),
             array(
                 'status_code'    => $code,
                 'status_text'    => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -51,10 +51,23 @@ class ExceptionController
 
         $code = $exception->getStatusCode();
 
+        $originalRequest = $request->attributes->get('original_request');
+
         // allow the developer to see the real template with ?_real_template=1
         $debug = $this->debug;
-        if ($debug && $request->query->get('_real_template')) {
+        if ($debug && $originalRequest && $originalRequest->query->get('_real_template')) {
             $debug = false;
+        }
+
+        // determine if we're able to show the link to view the true error template
+        $showErrorTemplateLink = false;
+        $errorTemplateParams = array();
+        if ($originalRequest && $originalRequest->isMethod('GET')) {
+            $showErrorTemplateLink = true;
+            $errorTemplateParams = array_merge(
+                $request->query->all(),
+                array('_real_template' => 1)
+            );
         }
 
         return new Response($this->twig->render(
@@ -65,6 +78,8 @@ class ExceptionController
                 'exception'      => $exception,
                 'logger'         => $logger,
                 'currentContent' => $currentContent,
+                'showErrorTemplateLink' => $showErrorTemplateLink,
+                'errorTemplateParams'   => $errorTemplateParams,
             )
         ));
     }

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception_full.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception_full.html.twig
@@ -11,3 +11,9 @@
 {% block body %}
     {% include 'TwigBundle:Exception:exception.html.twig' %}
 {% endblock %}
+
+{% block header_right %}
+    <span class="sf-reset">
+        <a href="?_real_template=1" title="Render the true error page that your end users will see">Render True Error Page</a>
+    </span>
+{% endblock %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception_full.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception_full.html.twig
@@ -13,7 +13,14 @@
 {% endblock %}
 
 {% block header_right %}
+    {% if showErrorTemplateLink %}
     <span class="sf-reset">
-        <a href="?_real_template=1" title="Render the true error page that your end users will see">Render True Error Page</a>
+        <a href="?{{ errorTemplateParams|url_encode }}"
+           title="Render the true error page that your end users will see"
+           onclick="alert('If you don\'t see an error page after the refresh, see: http://symfony.com/doc/current/cookbook/controller/error_pages.html');"
+        >
+            Render True Error Page
+        </a>
     </span>
+    {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
@@ -31,6 +31,8 @@
                                     </span>
                                 </span>
                             </button>
+
+                            {% block header_right %}{% endblock %}
                         </div>
                    </form>
                 </div>

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -114,6 +114,7 @@ class ExceptionListener implements EventSubscriberInterface
             '_controller' => $this->controller,
             'exception' => FlattenException::create($exception),
             'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
+            'original_request' => $request,
             // keep for BC -- as $format can be an argument of the controller callable
             // see src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
             // @deprecated in 2.4, to be removed in 3.0


### PR DESCRIPTION
Hi guys!

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7446, #1486 |
| License | MIT |
| Doc PR | TODO |

This follows #7446. Here's a screenshot:

![screen shot 2014-07-05 at 2 38 34 pm](https://cloud.githubusercontent.com/assets/121003/3487411/fa8ec816-047b-11e4-886b-8ebe7959eefc.png)

When you click the link, voila! You see your real error template. It works by adding a `_real_template=1` query parameter, which the `ExceptionController` looks for.

The styling is a little rough on the link, as is the text, so I'm open to suggestions.

**TODOS**
- [ ] Open up a docs PR once we're settled on approach

Thanks!
