### PR TITLE
[Debug] Fix tests on PHP 5.6

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -79,6 +79,7 @@ class DebugClassLoader
     {
         // Ensures we don't hit https://bugs.php.net/42098
         class_exists('Symfony\Component\Debug\ErrorHandler');
+        class_exists('Psr\Log\LogLevel');
 
         if (!is_array($functions = spl_autoload_functions())) {
             return;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

On PHP 5.6 [debug tests are failing](https://travis-ci.org/symfony/symfony/jobs/29118115#L357) with:

```
PHP Fatal error:  Class 'Psr\Log\LogLevel' not found in /home/travis/build/symfony/symfony/src/Symfony/Component/Debug/ErrorHandler.php on line 522
```

I think https://github.com/symfony/Debug/commit/4bd5484d456e6263acc6429fabea7e2fbc74fffc#diff-b91ca53d6ab50b804cb5783aaf1f9740R71 introduced the problem. Alternative fix would be to initialize the `$loggers` in a constructor.

ping @nicolas-grekas
