### PR TITLE
[2.3][Form] Check if IntlDateFormatter constructor returned a valid object before using it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ before_script:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "5.3.3" ]; then phpunit --self-update; fi;'
 
 script:
-    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};' || false
+    - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};'
     - echo "Running tests requiring tty"; phpunit --group tty

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -50,7 +50,7 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
 
         parent::__construct(fopen($outputStream, 'w'), $verbosity, $decorated, $formatter);
 
-        $this->stderr = new StreamOutput(fopen('php://stderr', 'w'), $verbosity, $decorated, $formatter);
+        $this->stderr = new StreamOutput(fopen('php://stderr', 'w'), $verbosity, $decorated, $this->getFormatter());
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
@@ -20,5 +20,6 @@ class ConsoleOutputTest extends \PHPUnit_Framework_TestCase
     {
         $output = new ConsoleOutput(Output::VERBOSITY_QUIET, true);
         $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity(), '__construct() takes the verbosity as its first argument');
+        $this->assertSame($output->getFormatter(), $output->getErrorOutput()->getFormatter(), '__construct() takes a formatter or null as the third argument');
     }
 }

--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -98,34 +98,23 @@ class Link
             return $this->currentUri;
         }
 
-        // only an anchor
+        // an anchor
         if ('#' === $uri[0]) {
-            $baseUri = $this->currentUri;
-            if (false !== $pos = strpos($baseUri, '#')) {
-                $baseUri = substr($baseUri, 0, $pos);
-            }
-
-            return $baseUri.$uri;
+            return $this->cleanupAnchor($this->currentUri).$uri;
         }
 
-        // only a query string
+        $baseUri = $this->cleanupUri($this->currentUri);
+
         if ('?' === $uri[0]) {
-            $baseUri = $this->currentUri;
-
-            // remove the query string from the current URI
-            if (false !== $pos = strpos($baseUri, '?')) {
-                $baseUri = substr($baseUri, 0, $pos);
-            }
-
             return $baseUri.$uri;
         }
 
         // absolute URL with relative schema
         if (0 === strpos($uri, '//')) {
-            return preg_replace('#^([^/]*)//.*$#', '$1', $this->currentUri).$uri;
+            return preg_replace('#^([^/]*)//.*$#', '$1', $baseUri).$uri;
         }
 
-        $baseUri = preg_replace('#^(.*?//[^/]*)(?:\/.*)?$#', '$1', $this->currentUri);
+        $baseUri = preg_replace('#^(.*?//[^/]*)(?:\/.*)?$#', '$1', $baseUri);
 
         // absolute path
         if ('/' === $uri[0]) {
@@ -193,5 +182,49 @@ class Link
         }
 
         $this->node = $node;
+    }
+
+    /**
+     * Removes the query string and the anchor from the given uri.
+     *
+     * @param  string $uri The uri to clean
+     *
+     * @return string
+     */
+    private function cleanupUri($uri)
+    {
+        return $this->cleanupQuery($this->cleanupAnchor($uri));
+    }
+
+    /**
+     * Remove the query string from the uri.
+     *
+     * @param $uri
+     *
+     * @return array
+     */
+    private function cleanupQuery($uri)
+    {
+        if (false !== $pos = strpos($uri, '?')) {
+            return substr($uri, 0, $pos);
+        }
+
+        return $uri;
+    }
+
+    /**
+     * Remove the anchor from the uri.
+     *
+     * @param $uri
+     *
+     * @return string
+     */
+    private function cleanupAnchor($uri)
+    {
+        if (false !== $pos = strpos($uri, '#')) {
+            return substr($uri, 0, $pos);
+        }
+
+        return $uri;
     }
 }

--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -24,10 +24,12 @@ class Link
      * @var \DOMNode A \DOMNode instance
      */
     protected $node;
+
     /**
      * @var string The method to use for the link
      */
     protected $method;
+
     /**
      * @var string The URI of the page where the link is embedded (or the base href)
      */
@@ -187,7 +189,7 @@ class Link
     /**
      * Removes the query string and the anchor from the given uri.
      *
-     * @param  string $uri The uri to clean
+     * @param string $uri The uri to clean
      *
      * @return string
      */
@@ -199,9 +201,9 @@ class Link
     /**
      * Remove the query string from the uri.
      *
-     * @param $uri
+     * @param string $uri
      *
-     * @return array
+     * @return string
      */
     private function cleanupQuery($uri)
     {
@@ -215,7 +217,7 @@ class Link
     /**
      * Remove the anchor from the uri.
      *
-     * @param $uri
+     * @param string $uri
      *
      * @return string
      */

--- a/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
@@ -101,7 +101,9 @@ class LinkTest extends \PHPUnit_Framework_TestCase
 
             array('', 'http://localhost/bar/', 'http://localhost/bar/'),
             array('#', 'http://localhost/bar/', 'http://localhost/bar/#'),
+            array('#bar', 'http://localhost/bar?a=b', 'http://localhost/bar?a=b#bar'),
             array('#bar', 'http://localhost/bar/#foo', 'http://localhost/bar/#bar'),
+            array('?a=b', 'http://localhost/bar#foo', 'http://localhost/bar?a=b'),
             array('?a=b', 'http://localhost/bar/', 'http://localhost/bar/?a=b'),
 
             array('http://login.foo.com/foo', 'http://localhost/bar/', 'http://login.foo.com/foo'),
@@ -135,6 +137,8 @@ class LinkTest extends \PHPUnit_Framework_TestCase
             array('../../', 'http://localhost/', 'http://localhost/'),
             array('../../', 'http://localhost', 'http://localhost/'),
 
+            array('/foo', 'http://localhost?bar=1', 'http://localhost/foo'),
+            array('/foo', 'http://localhost#bar', 'http://localhost/foo'),
             array('/foo', 'file:///', 'file:///foo'),
             array('/foo', 'file:///bar/baz', 'file:///foo'),
             array('foo', 'file:///', 'file:///foo'),

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -97,7 +97,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $value = $this->getIntlDateFormatter()->format((int) $dateTime->format('U'));
 
         if (intl_get_error_code() != 0) {
-            throw new TransformationFailedException(intl_get_error_message());
+            throw new TransformationFailedException(intl_get_error_message(), intl_get_error_code());
         }
 
         return $value;
@@ -127,7 +127,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $timestamp = $this->getIntlDateFormatter()->parse($value);
 
         if (intl_get_error_code() != 0) {
-            throw new TransformationFailedException(intl_get_error_message());
+            throw new TransformationFailedException(intl_get_error_message(), intl_get_error_code());
         }
 
         try {
@@ -152,6 +152,8 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
      * Returns a preconfigured IntlDateFormatter instance
      *
      * @return \IntlDateFormatter
+     *
+     * @throws TransformationFailedException in case the date formatter can not be constructed.
      */
     protected function getIntlDateFormatter()
     {
@@ -162,6 +164,12 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $pattern = $this->pattern;
 
         $intlDateFormatter = new \IntlDateFormatter(\Locale::getDefault(), $dateFormat, $timeFormat, $timezone, $calendar, $pattern);
+
+        // new \intlDateFormatter may return null instead of false in case of failure, see https://bugs.php.net/bug.php?id=66323
+        if (!$intlDateFormatter) {
+            throw new TransformationFailedException(intl_get_error_message(), intl_get_error_code());
+        }
+
         $intlDateFormatter->setLenient(false);
 
         return $intlDateFormatter;

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -77,6 +77,12 @@ class DateType extends AbstractType
                 $calendar,
                 $pattern
             );
+
+            // new \intlDateFormatter may return null instead of false in case of failure, see https://bugs.php.net/bug.php?id=66323
+            if (!$formatter) {
+                throw new InvalidOptionsException(intl_get_error_message(), intl_get_error_code());
+            }
+
             $formatter->setLenient(false);
 
             if ('choice' === $options['widget']) {

--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -157,7 +157,7 @@ class PoFileLoader extends ArrayLoader implements LoaderInterface
     private function addMessage(array &$messages, array $item)
     {
         if (is_array($item['translated'])) {
-            $messages[$item['ids']['singular']] = stripcslashes($item['translated'][0]);
+            $messages[stripcslashes($item['ids']['singular'])] = stripcslashes($item['translated'][0]);
             if (isset($item['ids']['plural'])) {
                 $plurals = $item['translated'];
                 // PO are by definition indexed so sort by index.
@@ -169,10 +169,10 @@ class PoFileLoader extends ArrayLoader implements LoaderInterface
                 $empties = array_fill(0, $count+1, '-');
                 $plurals += $empties;
                 ksort($plurals);
-                $messages[$item['ids']['plural']] = stripcslashes(implode('|', $plurals));
+                $messages[stripcslashes($item['ids']['plural'])] = stripcslashes(implode('|', $plurals));
             }
         } elseif (!empty($item['ids']['singular'])) {
-              $messages[$item['ids']['singular']] = stripcslashes($item['translated']);
+              $messages[stripcslashes($item['ids']['singular'])] = stripcslashes($item['translated']);
         }
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -76,4 +76,28 @@ class PoFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
     }
+
+    public function testEscapedId()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../fixtures/escaped-id.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $messages = $catalogue->all('domain1');
+        $this->assertArrayHasKey('escaped "foo"', $messages);
+        $this->assertEquals('escaped "bar"', $messages['escaped "foo"']);
+    }
+
+    public function testEscapedIdPlurals()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../fixtures/escaped-id-plurals.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $messages = $catalogue->all('domain1');
+        $this->assertArrayHasKey('escaped "foo"', $messages);
+        $this->assertArrayHasKey('escaped "foos"', $messages);
+        $this->assertEquals('escaped "bar"', $messages['escaped "foo"']);
+        $this->assertEquals('escaped "bar"|escaped "bars"', $messages['escaped "foos"']);
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/escaped-id-plurals.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/escaped-id-plurals.po
@@ -1,0 +1,10 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+
+msgid "escaped \"foo\""
+msgid_plural "escaped \"foos\""
+msgstr[0] "escaped \"bar\""
+msgstr[1] "escaped \"bars\""

--- a/src/Symfony/Component/Translation/Tests/fixtures/escaped-id.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/escaped-id.po
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+
+msgid "escaped \"foo\""
+msgstr "escaped \"bar\""

--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -246,6 +246,62 @@
                 <source>This value is not a valid currency.</source>
                 <target>Questo valore non è una valuta valida.</target>
             </trans-unit>
+            <trans-unit id="65">
+                <source>This value should be equal to {{ compared_value }}.</source>
+                <target>Questo valore dovrebbe essere uguale a {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="66">
+                <source>This value should be greater than {{ compared_value }}.</source>
+                <target>Questo valore dovrebbe essere maggiore di {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="67">
+                <source>This value should be greater than or equal to {{ compared_value }}.</source>
+                <target>Questo valore dovrebbe essere maggiore o uguale a {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="68">
+                <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
+                <target>Questo valore dovrebbe essere identico a {{ compared_value_type }} {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="69">
+                <source>This value should be less than {{ compared_value }}.</source>
+                <target>Questo valore dovrebbe essere minore di {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="70">
+                <source>This value should be less than or equal to {{ compared_value }}.</source>
+                <target>Questo valore dovrebbe essere minore o uguale a {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="71">
+                <source>This value should not be equal to {{ compared_value }}.</source>
+                <target>Questo valore dovrebbe essere diverso da {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="72">
+                <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
+                <target>Questo valore dovrebbe essere diverso da {{ compared_value_type }} {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="73">
+                <source>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
+                <target>Il rapporto di aspetto dell'immagine è troppo grande ({{ ratio }}). Il rapporto massimo consentito è {{ max_ratio }}.</target>
+            </trans-unit>
+            <trans-unit id="74">
+                <source>The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
+                <target>Il rapporto di aspetto dell'immagine è troppo piccolo ({{ ratio }}). Il rapporto minimo consentito è {{ min_ratio }}.</target>
+            </trans-unit>
+            <trans-unit id="75">
+                <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
+                <target>L'immagine è quadrata ({{ width }}x{{ height }}px). Le immagini quadrate non sono consentite.</target>
+            </trans-unit>
+            <trans-unit id="76">
+                <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
+                <target>L'immagine è orizzontale ({{ width }}x{{ height }}px). Le immagini orizzontali non sono consentite.</target>
+            </trans-unit>
+            <trans-unit id="77">
+                <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
+                <target>L'immagine è verticale ({{ width }}x{{ height }}px). Le immagini verticali non sono consentite.</target>
+            </trans-unit>
+            <trans-unit id="78">
+                <source>An empty file is not allowed.</source>
+                <target>Un file vuoto non è consentito.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

`IntlDateFormatter` constructor [may return false](http://www.php.net/manual/en/intldateformatter.create.php#refsect1-intldateformatter.create-returnvalues). This patches avoids fatal errors in these cases 
