### PR TITLE
[2.3][Form] Check if IntlDateFormatter constructor returned a valid object before using it

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -152,6 +152,8 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
      * Returns a preconfigured IntlDateFormatter instance
      *
      * @return \IntlDateFormatter
+     *
+     * @throws TransformationFailedException in case the date formatter can not be constructed.
      */
     protected function getIntlDateFormatter()
     {
@@ -162,6 +164,12 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $pattern = $this->pattern;
 
         $intlDateFormatter = new \IntlDateFormatter(\Locale::getDefault(), $dateFormat, $timeFormat, $timezone, $calendar, $pattern);
+
+        // new \intlDateFormatter may return null instead of false in case of failure, see https://bugs.php.net/bug.php?id=66323
+        if (!$intlDateFormatter) {
+            throw new TransformationFailedException(intl_get_error_message(), intl_get_error_code());
+        }
+
         $intlDateFormatter->setLenient(false);
 
         return $intlDateFormatter;

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -77,6 +77,12 @@ class DateType extends AbstractType
                 $calendar,
                 $pattern
             );
+
+            // new \intlDateFormatter may return null instead of false in case of failure, see https://bugs.php.net/bug.php?id=66323
+            if (!$formatter) {
+                throw new InvalidOptionsException(intl_get_error_message(), intl_get_error_code());
+            }
+
             $formatter->setLenient(false);
 
             if ('choice' === $options['widget']) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

`IntlDateFormatter` constructor [may return false](http://www.php.net/manual/en/intldateformatter.create.php#refsect1-intldateformatter.create-returnvalues). This patches avoids fatal errors in these cases 

This PR replaces #11334
