### PR TITLE
[Console] ProgressBar developer experience

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -71,6 +71,22 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAdvanceOverMax()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 10);
+        $bar->setCurrent(9);
+        $bar->advance();
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput('  9/10 [=========================>--]  90%').
+            $this->generateOutput(' 10/10 [============================] 100%').
+            $this->generateOutput(' 11/11 [============================] 100%'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
     public function testCustomizations()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 10);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #11184 |
| License | MIT |
| Doc PR | WIP |
## TODO
- [x] Create `getProgress/setProgress` methods to replace `getStep/setCurrent`
- [x] `ProgressBar::setCurrent` should auto-start the ProgressBar.
- [x] You should be able to pass `max` to `start`
- [x] `barCharOriginal` not needed. Logic can simply be part of `getBarChar`
- [x] `getStepWidth` is internal information that should not be public
- [x] when verbosity set to quiet, the progress bar does not even need to execute all the logic to generate output that is then thrown away
- [x] Allow to advance past max.
- [x] negative max needs to be validated
- [x] `getProgressPercent` should return float instead of int.
