### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 composer.phar
 autoload.php
 /vendor/
+.idea


### PR DESCRIPTION
Before adding this I had problems with git conflicts caused by files generated by PhpStorm, which caused some frustration for my then noob self. This is a while ago, so for what I know it might be that the official .gitignore-file has changed since then in a way that affects this issue. I see no reason why it would be useful to share .idea-files, but I'm no expert on the issue, so if there are reasons why the .idea shouldn't be in there then just ignore this proposal obviously :)
