### PR TITLE
[2.5][Form] solved dependency to ValidatorInterface, fix #11036

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Extension\Validator\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
@@ -38,22 +37,18 @@ class ValidationListener implements EventSubscriberInterface
     }
 
     /**
-     * @param  ValidatorInterface                                         $validator       The validator requires an instance of ValidatorInterface
-     *                                                                                     since 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
-     *                                                                                     until 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
-     * @param  ViolationMapperInterface                                   $violationMapper The ViolationMapper
-     * @throws \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @param ValidatorInterface|LegacyValidatorInterface $validator       The validator requires an instance of ValidatorInterface
+     *                                                                     since validator apiVersion 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
+     *                                                                     until validator apiVersion 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
+     * @param ViolationMapperInterface                    $violationMapper The ViolationMapper
      */
     public function __construct($validator, ViolationMapperInterface $violationMapper)
     {
-        if ($validator instanceof ValidatorInterface
-            || $validator instanceof LegacyValidatorInterface
-        ) {
-            $this->validator = $validator;
-        } else {
-            throw new InvalidArgumentException(sprintf('Validator must be instance of ValidatorInterface.'));
+        if (!$validator instanceof ValidatorInterface || !$validator instanceof LegacyValidatorInterface) {
+            throw new \InvalidArgumentException('Validator must be instance of ValidatorInterface.');
         }
 
+        $this->validator = $validator;
         $this->violationMapper = $violationMapper;
     }
 

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -37,10 +37,8 @@ class ValidationListener implements EventSubscriberInterface
     }
 
     /**
-     * @param ValidatorInterface|LegacyValidatorInterface $validator       The validator requires an instance of ValidatorInterface
-     *                                                                     since validator apiVersion 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
-     *                                                                     until validator apiVersion 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
-     * @param ViolationMapperInterface                    $violationMapper The ViolationMapper
+     * @param ValidatorInterface|LegacyValidatorInterface $validator
+     * @param ViolationMapperInterface                    $violationMapper
      */
     public function __construct($validator, ViolationMapperInterface $violationMapper)
     {

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -44,7 +44,7 @@ class ValidationListener implements EventSubscriberInterface
      */
     public function __construct($validator, ViolationMapperInterface $violationMapper)
     {
-        if (!$validator instanceof ValidatorInterface || !$validator instanceof LegacyValidatorInterface) {
+        if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
             throw new \InvalidArgumentException('Validator must be instance of ValidatorInterface.');
         }
 

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Form\Extension\Validator\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
@@ -35,9 +37,23 @@ class ValidationListener implements EventSubscriberInterface
         return array(FormEvents::POST_SUBMIT => 'validateForm');
     }
 
-    public function __construct(ValidatorInterface $validator, ViolationMapperInterface $violationMapper)
+    /**
+     * @param  ValidatorInterface                                         $validator       The validator requires an instance of ValidatorInterface
+     *                                                                                     since 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
+     *                                                                                     until 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
+     * @param  ViolationMapperInterface                                   $violationMapper The ViolationMapper
+     * @throws \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function __construct($validator, ViolationMapperInterface $violationMapper)
     {
-        $this->validator = $validator;
+        if ($validator instanceof ValidatorInterface
+            || $validator instanceof LegacyValidatorInterface
+        ) {
+            $this->validator = $validator;
+        } else {
+            throw new InvalidArgumentException(sprintf('Validator must be instance of ValidatorInterface.'));
+        }
+
         $this->violationMapper = $violationMapper;
     }
 

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -43,7 +43,7 @@ class ValidationListener implements EventSubscriberInterface
     public function __construct($validator, ViolationMapperInterface $violationMapper)
     {
         if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
-            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or deprecated Symfony\Component\Validator\ValidatorInterface');
+            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or Symfony\Component\Validator\ValidatorInterface');
         }
 
         $this->validator = $validator;

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -43,7 +43,7 @@ class ValidationListener implements EventSubscriberInterface
     public function __construct($validator, ViolationMapperInterface $violationMapper)
     {
         if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
-            throw new \InvalidArgumentException('Validator must be instance of ValidatorInterface.');
+            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or deprecated Symfony\Component\Validator\ValidatorInterface');
         }
 
         $this->validator = $validator;

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Extension\Validator\Type;
 
-use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapper;
 use Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener;
@@ -36,21 +35,17 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
     private $violationMapper;
 
     /**
-     * @param  ValidatorInterface                                         $validator The validator requires an instance of ValidatorInterface
-     *                                                                               since 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
-     *                                                                               until 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
-     * @throws \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @param ValidatorInterface|LegacyValidatorInterface $validator The validator requires an instance of ValidatorInterface
+     *                                                               since validator apiVersion 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
+     *                                                               until validator apiVersion 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
      */
     public function __construct($validator)
     {
-        if ($validator instanceof ValidatorInterface
-            || $validator instanceof LegacyValidatorInterface
-        ) {
-            $this->validator = $validator;
-        } else {
-            throw new InvalidArgumentException(sprintf('Validator must be instance of ValidatorInterface.'));
+        if (!$validator instanceof ValidatorInterface || !$validator instanceof LegacyValidatorInterface) {
+            throw new \InvalidArgumentException('Validator must be instance of ValidatorInterface.');
         }
 
+        $this->validator = $validator;
         $this->violationMapper = new ViolationMapper();
     }
 

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Form\Extension\Validator\Type;
 
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapper;
 use Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -33,9 +35,22 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
      */
     private $violationMapper;
 
-    public function __construct(ValidatorInterface $validator)
+    /**
+     * @param  ValidatorInterface                                         $validator The validator requires an instance of ValidatorInterface
+     *                                                                               since 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
+     *                                                                               until 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
+     * @throws \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function __construct($validator)
     {
-        $this->validator = $validator;
+        if ($validator instanceof ValidatorInterface
+            || $validator instanceof LegacyValidatorInterface
+        ) {
+            $this->validator = $validator;
+        } else {
+            throw new InvalidArgumentException(sprintf('Validator must be instance of ValidatorInterface.'));
+        }
+
         $this->violationMapper = new ViolationMapper();
     }
 

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -40,7 +40,7 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
     public function __construct($validator)
     {
         if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
-            throw new \InvalidArgumentException('Validator must be instance of ValidatorInterface.');
+            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or deprecated Symfony\Component\Validator\ValidatorInterface');
         }
 
         $this->validator = $validator;

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -40,7 +40,7 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
     public function __construct($validator)
     {
         if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
-            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or deprecated Symfony\Component\Validator\ValidatorInterface');
+            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or Symfony\Component\Validator\ValidatorInterface');
         }
 
         $this->validator = $validator;

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -35,9 +35,7 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
     private $violationMapper;
 
     /**
-     * @param ValidatorInterface|LegacyValidatorInterface $validator The validator requires an instance of ValidatorInterface
-     *                                                               since validator apiVersion 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
-     *                                                               until validator apiVersion 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
+     * @param ValidatorInterface|LegacyValidatorInterface $validator
      */
     public function __construct($validator)
     {

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -41,7 +41,7 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
      */
     public function __construct($validator)
     {
-        if (!$validator instanceof ValidatorInterface || !$validator instanceof LegacyValidatorInterface) {
+        if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
             throw new \InvalidArgumentException('Validator must be instance of ValidatorInterface.');
         }
 

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Extension\Validator;
 
-use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
 use Symfony\Component\Form\AbstractExtension;
 use Symfony\Component\Validator\Constraints\Valid;
@@ -28,27 +27,26 @@ class ValidatorExtension extends AbstractExtension
     private $validator;
 
     /**
-     * @param  ValidatorInterface                                         $validator The validator requires an instance of ValidatorInterface
-     *                                                                               since 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
-     *                                                                               until 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
-     * @throws \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @param ValidatorInterface|LegacyValidatorInterface $validator The validator requires an instance of ValidatorInterface
+     *                                                               since validator apiVersion 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
+     *                                                               until validator apiVersion 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
      */
     public function __construct($validator)
     {
-        // ValidatorInterface since 2.5
+        // since validator apiVersion 2.5
         if ($validator instanceof ValidatorInterface) {
             $this->validator = $validator;
 
             /** @var \Symfony\Component\Validator\Mapping\ClassMetadata $metadata */
             $metadata = $this->validator->getMetadataFor('Symfony\Component\Form\Form');
-        // ValidatorInterface until 2.4
+        // until validator apiVersion 2.4
         } elseif ($validator instanceof LegacyValidatorInterface) {
             $this->validator = $validator;
 
             /** @var \Symfony\Component\Validator\Mapping\ClassMetadata $metadata */
             $metadata = $this->validator->getMetadataFactory()->getMetadataFor('Symfony\Component\Form\Form');
         } else {
-            throw new InvalidArgumentException(sprintf('Validator must be instance of ValidatorInterface.'));
+            throw new \InvalidArgumentException('Validator must be instance of ValidatorInterface.');
         }
 
         // Register the form constraints in the validator programmatically.

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Form\Extension\Validator;
 
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
 use Symfony\Component\Form\AbstractExtension;
-use Symfony\Component\Validator\ValidatorInterface;
 use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
  * Extension supporting the Symfony2 Validator component in forms.
@@ -25,17 +27,35 @@ class ValidatorExtension extends AbstractExtension
 {
     private $validator;
 
-    public function __construct(ValidatorInterface $validator)
+    /**
+     * @param  ValidatorInterface                                         $validator The validator requires an instance of ValidatorInterface
+     *                                                                               since 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
+     *                                                                               until 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
+     * @throws \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function __construct($validator)
     {
-        $this->validator = $validator;
+        // ValidatorInterface since 2.5
+        if ($validator instanceof ValidatorInterface) {
+            $this->validator = $validator;
+
+            /** @var \Symfony\Component\Validator\Mapping\ClassMetadata $metadata */
+            $metadata = $this->validator->getMetadataFor('Symfony\Component\Form\Form');
+        // ValidatorInterface until 2.4
+        } elseif ($validator instanceof LegacyValidatorInterface) {
+            $this->validator = $validator;
+
+            /** @var \Symfony\Component\Validator\Mapping\ClassMetadata $metadata */
+            $metadata = $this->validator->getMetadataFactory()->getMetadataFor('Symfony\Component\Form\Form');
+        } else {
+            throw new InvalidArgumentException(sprintf('Validator must be instance of ValidatorInterface.'));
+        }
 
         // Register the form constraints in the validator programmatically.
         // This functionality is required when using the Form component without
         // the DIC, where the XML file is loaded automatically. Thus the following
         // code must be kept synchronized with validation.xml
 
-        /** @var \Symfony\Component\Validator\Mapping\ClassMetadata $metadata */
-        $metadata = $this->validator->getMetadataFactory()->getMetadataFor('Symfony\Component\Form\Form');
         $metadata->addConstraint(new Form());
         $metadata->addPropertyConstraint('children', new Valid());
     }

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Validator;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
 use Symfony\Component\Form\AbstractExtension;
 use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
@@ -35,16 +36,16 @@ class ValidatorExtension extends AbstractExtension
         if ($validator instanceof ValidatorInterface) {
             $this->validator = $validator;
 
-            /** @var \Symfony\Component\Validator\Mapping\ClassMetadata $metadata */
+            /** @var $metadata ClassMetadata */
             $metadata = $this->validator->getMetadataFor('Symfony\Component\Form\Form');
         // until validator apiVersion 2.4
         } elseif ($validator instanceof LegacyValidatorInterface) {
             $this->validator = $validator;
 
-            /** @var \Symfony\Component\Validator\Mapping\ClassMetadata $metadata */
+            /** @var $metadata ClassMetadata */
             $metadata = $this->validator->getMetadataFactory()->getMetadataFor('Symfony\Component\Form\Form');
         } else {
-            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or deprecated Symfony\Component\Validator\ValidatorInterface');
+            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or Symfony\Component\Validator\ValidatorInterface');
         }
 
         // Register the form constraints in the validator programmatically.

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -44,7 +44,7 @@ class ValidatorExtension extends AbstractExtension
             /** @var \Symfony\Component\Validator\Mapping\ClassMetadata $metadata */
             $metadata = $this->validator->getMetadataFactory()->getMetadataFor('Symfony\Component\Form\Form');
         } else {
-            throw new \InvalidArgumentException('Validator must be instance of ValidatorInterface.');
+            throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or deprecated Symfony\Component\Validator\ValidatorInterface');
         }
 
         // Register the form constraints in the validator programmatically.

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -27,9 +27,7 @@ class ValidatorExtension extends AbstractExtension
     private $validator;
 
     /**
-     * @param ValidatorInterface|LegacyValidatorInterface $validator The validator requires an instance of ValidatorInterface
-     *                                                               since validator apiVersion 2.5 instance of {@link Symfony\Component\Validator\Validator\ValidatorInterface}
-     *                                                               until validator apiVersion 2.4 instance of {@link Symfony\Component\Validator\ValidatorInterface}
+     * @param ValidatorInterface|LegacyValidatorInterface $validator
      */
     public function __construct($validator)
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -178,7 +178,7 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidValidatorInterface()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -158,4 +158,30 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->listener->validateForm(new FormEvent($form, null));
     }
+
+    public function testValidatorInterfaceSinceSymfony25()
+    {
+        // Mock of ValidatorInterface since 2.5
+        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+
+        $listener = new ValidationListener($validator, $this->violationMapper);
+        $this->assertAttributeSame($validator, 'validator', $listener);
+    }
+
+    public function testValidatorInterfaceUntilSymfony24()
+    {
+        // Mock of ValidatorInterface until 2.4
+        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+
+        $listener = new ValidationListener($validator, $this->violationMapper);
+        $this->assertAttributeSame($validator, 'validator', $listener);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function testInvalidValidatorInterface()
+    {
+        new ValidationListener(null, $this->violationMapper);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -161,7 +161,7 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testValidatorInterfaceSinceSymfony25()
     {
-        // Mock of ValidatorInterface since 2.5
+        // Mock of ValidatorInterface since apiVersion 2.5
         $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $listener = new ValidationListener($validator, $this->violationMapper);
@@ -170,7 +170,7 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testValidatorInterfaceUntilSymfony24()
     {
-        // Mock of ValidatorInterface until 2.4
+        // Mock of ValidatorInterface until apiVersion 2.4
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
 
         $listener = new ValidationListener($validator, $this->violationMapper);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -56,7 +56,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidValidatorInterface()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
+use Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension;
 use Symfony\Component\Validator\ConstraintViolationList;
 
 class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
@@ -34,6 +35,32 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
         // specific data is irrelevant
         $form->submit(array());
+    }
+
+    public function testValidatorInterfaceSinceSymfony25()
+    {
+        // Mock of ValidatorInterface since 2.5
+        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+
+        $formTypeValidatorExtension = new FormTypeValidatorExtension($validator);
+        $this->assertAttributeSame($validator, 'validator', $formTypeValidatorExtension);
+    }
+
+    public function testValidatorInterfaceUntilSymfony24()
+    {
+        // Mock of ValidatorInterface until 2.4
+        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+
+        $formTypeValidatorExtension = new FormTypeValidatorExtension($validator);
+        $this->assertAttributeSame($validator, 'validator', $formTypeValidatorExtension);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function testInvalidValidatorInterface()
+    {
+        new FormTypeValidatorExtension(null);
     }
 
     protected function createForm(array $options = array())

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -39,7 +39,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     public function testValidatorInterfaceSinceSymfony25()
     {
-        // Mock of ValidatorInterface since 2.5
+        // Mock of ValidatorInterface since apiVersion 2.5
         $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $formTypeValidatorExtension = new FormTypeValidatorExtension($validator);
@@ -48,7 +48,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     public function testValidatorInterfaceUntilSymfony24()
     {
-        // Mock of ValidatorInterface until 2.4
+        // Mock of ValidatorInterface until apiVersion 2.4
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
 
         $formTypeValidatorExtension = new FormTypeValidatorExtension($validator);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -22,7 +22,7 @@ class ValidatorExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $classMetaData = $this->createClassMetaDataMock();
 
-        // Mock of ValidatorInterface since 2.5
+        // Mock of ValidatorInterface since apiVersion 2.5
         $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $validator
@@ -49,7 +49,7 @@ class ValidatorExtensionTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($classMetaData))
         ;
 
-        // Mock of ValidatorInterface until 2.4
+        // Mock of ValidatorInterface until apiVersion 2.4
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
 
         $validator

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+* This file is part of the Symfony package.
+*
+* (c) Fabien Potencier <fabien@symfony.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Symfony\Component\Form\Tests\Extension\Validator;
+
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+
+/**
+ * @author sebastian blum <sb@sblum.de>
+ */
+class ValidatorExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidatorInterfaceSinceSymfony25()
+    {
+        $classMetaData = $this->createClassMetaDataMock();
+
+        // Mock of ValidatorInterface since 2.5
+        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+
+        $validator
+            ->expects($this->once())
+            ->method('getMetadataFor')
+            ->with($this->identicalTo('Symfony\Component\Form\Form'))
+            ->will($this->returnValue($classMetaData))
+        ;
+
+        $validatorExtension = new ValidatorExtension($validator);
+        $this->assertAttributeSame($validator, 'validator', $validatorExtension);
+    }
+
+    public function testValidatorInterfaceUntilSymfony24()
+    {
+        $classMetaData = $this->createClassMetaDataMock();
+
+        $metaDataFactory = $this->getMock('Symfony\Component\Validator\MetadataFactoryInterface');
+
+        $metaDataFactory
+            ->expects($this->once())
+            ->method('getMetadataFor')
+            ->with($this->identicalTo('Symfony\Component\Form\Form'))
+            ->will($this->returnValue($classMetaData))
+        ;
+
+        // Mock of ValidatorInterface until 2.4
+        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+
+        $validator
+            ->expects($this->once())
+            ->method('getMetadataFactory')
+            ->will($this->returnValue($metaDataFactory))
+        ;
+
+        $validatorExtension = new ValidatorExtension($validator);
+        $this->assertAttributeSame($validator, 'validator', $validatorExtension);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function testInvalidValidatorInterface()
+    {
+        new ValidatorExtension(null);
+    }
+
+    /**
+     * @return mixed
+     */
+    private function createClassMetaDataMock()
+    {
+        $classMetaData = $this->getMockBuilder('Symfony\Component\Validator\Mapping\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $classMetaData
+            ->expects($this->once())
+            ->method('addConstraint')
+            ->with($this->isInstanceOf('Symfony\Component\Form\Extension\Validator\Constraints\Form'));
+        $classMetaData
+            ->expects($this->once())
+            ->method('addPropertyConstraint')
+            ->with(
+                $this->identicalTo('children'),
+                $this->isInstanceOf('Symfony\Component\Validator\Constraints\Valid')
+            );
+
+        return $classMetaData;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -13,9 +13,6 @@ namespace Symfony\Component\Form\Tests\Extension\Validator;
 
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 
-/**
- * @author sebastian blum <sb@sblum.de>
- */
 class ValidatorExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testValidatorInterfaceSinceSymfony25()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -63,7 +63,7 @@ class ValidatorExtensionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidValidatorInterface()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | #11036, #11345 |
| License | MIT |
| Doc PR |  |

Since Symfony 2.5

The problem was that the form component has a hardcoded depencency to the deprecated validator component (api Version 2.4)
The pull request fixes the dependency to the validator component and supports now both implementations, apiVersion 2.5 and apiVersion 2.4 of the validator component.

@Symfony Core Members
please review the changes https://github.com/sebastianblum/symfony/blob/0a1e9c208f8730219bebf89f6696b246a0c88da7/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
I'm not sure if it was the right solution
