### PR TITLE
[FrameworkBundle] Changed hard coded value to Response class constant (302)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -74,7 +74,7 @@ class Controller extends ContainerAware
      *
      * @return RedirectResponse
      */
-    public function redirect($url, $status = 302)
+    public function redirect($url, $status = Response::HTTP_FOUND)
     {
         return new RedirectResponse($url, $status);
     }


### PR DESCRIPTION
This PR was submitted on the symfony/FrameworkBundle read-only repository and moved automatically to the main Symfony repository (closes symfony/FrameworkBundle#9).

Replaced hard coded parameter value (code = 302) in redirect method by its equivalent value in Response object constants

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| License | MIT |
