### PR TITLE
Improve the HTTPS detection

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1123,7 +1123,7 @@ class Request
             return in_array(strtolower(current(explode(',', $proto))), array('https', 'on', 'ssl', '1'));
         }
 
-        return 'on' == strtolower($this->server->get('HTTPS')) || 1 == $this->server->get('HTTPS');
+        return 'on' == strtolower($this->server->get('HTTPS')) || 1 == $this->server->get('HTTPS') || 443 == $this->getPort();
     }
 
     /**


### PR DESCRIPTION
This PR was submitted on the symfony/HttpFoundation read-only repository and moved automatically to the main Symfony repository (closes symfony/HttpFoundation#16).

Alternative https detection, when some nginx servers don't set flag $_SERVER[HTTPS]=on, even though a connection is https.
