### PR TITLE
[BrowserKit] Fixed server HTTP_HOST port uri conversion

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -304,7 +304,11 @@ abstract class Client
         $uri = $this->getAbsoluteUri($uri);
 
         if (isset($server['HTTP_HOST'])) {
-            $uri = preg_replace('{^(https?\://)'.parse_url($uri, PHP_URL_HOST).'}', '${1}'.$server['HTTP_HOST'], $uri);
+            if ($port = parse_url($uri, PHP_URL_PORT)) {
+                $port = ':'.$port;
+            }
+
+            $uri = preg_replace('{^(https?\://)'.parse_url($uri, PHP_URL_HOST).$port.'}', '${1}'.$server['HTTP_HOST'], $uri);
         }
 
         if (isset($server['HTTPS'])) {

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -210,6 +210,24 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.example.com/foo/bar', $client->getRequest()->getUri(), '->request() uses the previous request for relative URLs');
     }
 
+    public function testRequestURIConversionByServerHost()
+    {
+        $client = new TestClient();
+
+        $server = array('HTTP_HOST' => 'www.example.com:8000');
+        $parameters = array();
+        $files = array();
+
+        $client->request('GET', 'http://example.com', $parameters, $files, $server);
+        $this->assertEquals('http://www.example.com:8000', $client->getRequest()->getUri(), '->request() uses HTTP_HOST to add port');
+
+        $client->request('GET', 'http://example.com:8888', $parameters, $files, $server);
+        $this->assertEquals('http://www.example.com:8000', $client->getRequest()->getUri(), '->request() uses HTTP_HOST to modify existing port');
+
+        $client->request('GET', 'http://example.com:8000', $parameters, $files, $server);
+        $this->assertEquals('http://www.example.com:8000', $client->getRequest()->getUri(), '->request() uses HTTP_HOST respects correct set port');
+    }
+
     public function testRequestReferer()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This will fix URI conversion using the HTTP_HOST server header.

Steps to reproduce:

```
$client = new TestClient();
$server = array('HTTP_HOST' => 'example.com:8000');
$client->request('GET', 'http://example.com:8000', [], [], $server);

echo $client->getRequest()->getUri(); 
// outputs:  http://example.com:8000:8000
// expected: http://example.com:8000
```

We discovered this issue during [mink](https://github.com/Behat/Mink) testing using [goutte](https://github.com/fabpot/goutte) on a non standard port.
