### PR TITLE
[HttpFoundation] Fix to prevent magic bytes injection in JSONP responses... (CVE-2014-4671)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -111,7 +111,7 @@ class JsonResponse extends Response
             // Not using application/javascript for compatibility reasons with older browsers.
             $this->headers->set('Content-Type', 'text/javascript');
 
-            return $this->setContent(sprintf('%s(%s);', $this->callback, $this->data));
+            return $this->setContent(sprintf('/**/%s(%s);', $this->callback, $this->data));
         }
 
         // Only set the header when there is none or when it equals 'text/javascript' (from a previous update with callback)

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -155,7 +155,7 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
     {
         $response = JsonResponse::create(array('foo' => 'bar'))->setCallback('callback');
 
-        $this->assertEquals('callback({"foo":"bar"});', $response->getContent());
+        $this->assertEquals('/**/callback({"foo":"bar"});', $response->getContent());
         $this->assertEquals('text/javascript', $response->headers->get('Content-Type'));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no* |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
| CVE Ticket | [CVE-2014-4671](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-4671) |
| See Also | [Rosetta Flash](http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/) |

\* Unless you are parsing the response string manually, which you really shouldn't do anyway

**THIS IS A SECURITY FIX AND SHOULD BE MERGED SHORTLY**

This fix prevents attacks vectors where third-party browser plugins depends on ASCII magic bytes in order to execute a plugin. This is currently exploited with Flash using a carefully crafted JSONP response, allowing the execution of random SWF data from a domain with a vulnerable JSONP endpoint.

This security issue is mitigated by adding an empty comment right before the callback parameter. This does not affect the execution of the JSONP callback.
