### PR TITLE
[FrameworkBundle] avoid raising unexpected RuntimeException when specifying $_SERVER['KERNEL_DIR']

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -100,14 +100,17 @@ abstract class KernelTestCase extends \PHPUnit_Framework_TestCase
      */
     protected static function getKernelClass()
     {
-        $dir = $phpUnitDir = static::getPhpUnitXmlDir();
-
         if (isset($_SERVER['KERNEL_DIR'])) {
             $dir = $_SERVER['KERNEL_DIR'];
 
-            if (!is_dir($dir) && is_dir("$phpUnitDir/$dir")) {
-                $dir = "$phpUnitDir/$dir";
+            if (!is_dir($dir)) {
+                $phpUnitDir = static::getPhpUnitXmlDir();
+                if (is_dir("$phpUnitDir/$dir")) {
+                    $dir = "$phpUnitDir/$dir";
+                }
             }
+        } else {
+            $dir = static::getPhpUnitXmlDir();
         }
 
         $finder = new Finder();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Since v2.5.0 (exactly e778cf19cd60f677ead35d662f816adeaae429b4), all tests that use WebTestCase are to be errors "RuntimeException: Unable to guess the Kernel directory." even though $_SERVER['KERNEL_DIR'] is specified. This has been preventing another test runner (e.g. [MakeGood](https://github.com/piece/makegood)) from running tests for a Symfony application without overriding KernelTestCase::getPhpUnitXmlDir() as follows.

The bootstrap file for testing in the app directory:

``` php
<?php
...
$_SERVER['KERNEL_DIR'] = __DIR__;
require_once dirname(__DIR__) . '/var/bootstrap.php.cache';
```

console output:

``` console
PHPUnit 4.1.3 by Sebastian Bergmann.

EE

Acme\DemoBundle\Tests\Controller\DemoController
 [ ] Index
 [ ] Secure section

Time: 146 ms, Memory: 9.50Mb

There were 2 errors:

1) Acme\DemoBundle\Tests\Controller\DemoControllerTest::testIndex
RuntimeException: Unable to guess the Kernel directory.

/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php:56
/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php:103
/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php:156
/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php:137
/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php:33
/path/to/symfony-application/src/Acme/DemoBundle/Tests/Controller/DemoControllerTest.php:11
/path/to/eclipse/plugins/com.piece_framework.makegood.stagehandtestrunner_3.1.0.v201407050319/resources/php/vendor/piece/stagehand-testrunner/src/Runner/PHPUnitRunner.php:81
/path/to/eclipse/plugins/com.piece_framework.makegood.stagehandtestrunner_3.1.0.v201407050319/resources/php/vendor/piece/stagehand-testrunner/src/Process/TestRunner.php:100
/path/to/eclipse/plugins/com.piece_framework.makegood.stagehandtestrunner_3.1.0.v201407050319/resources/php/vendor/piece/stagehand-testrunner/src/CLI/TestRunnerApplication/Command/PluginCommand.php:149
/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:252
/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:887
/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:193
/path/to/symfony-application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:124
...
```
