### PR TITLE
[HttpFoundation] Fixed JsonResponse for IE 7-10

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -129,7 +129,7 @@ class JsonResponse extends Response
     }
 
     /**
-     * Updates the content and headers according to the JSON data and callback.
+     * Updates the content and headers according to the json data and callback.
      *
      * @return JsonResponse
      */
@@ -144,9 +144,15 @@ class JsonResponse extends Response
 
         // Only set the header when there is none or when it equals 'text/javascript' (from a previous update with callback)
         // in order to not overwrite a custom definition.
-        if (!$this->headers->has('Content-Type') || 'text/javascript' === $this->headers->get('Content-Type')) {
-            $this->headers->set('Content-Type', 'application/json');
+        if ($this->headers->has('Content-Type') && 'text/javascript' !== $this->headers->get('Content-Type')) {
+            return $this->setContent($this->data);
         }
+
+        // IE (7 to 10) doesn't support application/json
+        $isInternetExplorer = isset($_SERVER['HTTP_USER_AGENT']) && preg_match('/(?i)msie [1-9]/', $_SERVER['HTTP_USER_AGENT']);
+        $isOpera = isset($_SERVER['HTTP_USER_AGENT']) && false !== strpos($_SERVER['HTTP_USER_AGENT'], 'Opera');
+        $contentType = ($isInternetExplorer && !$isOpera) ? 'text/json' : 'application/json';
+        $this->headers->set('Content-Type', $contentType);
 
         return $this->setContent($this->data);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -201,4 +201,45 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
     {
         JsonResponse::create("\xB1\x31");
     }
+
+    /**
+     * @dataProvider validIeUserAgentsProvider
+     */
+    public function testValidInternetExplorerUserAgent($validIeUserAgent)
+    {
+        $_SERVER['HTTP_USER_AGENT'] = $validIeUserAgent;
+
+        $response = new JsonResponse(array());
+
+        $this->assertSame('text/json', $response->headers->get('Content-Type'));
+    }
+
+    /**
+     * @dataProvider invalidIeUserAgentsProvider
+     */
+    public function testInvalidInternetExplorerUserAgent($invalidIeUserAgent)
+    {
+        $_SERVER['HTTP_USER_AGENT'] = $invalidIeUserAgent;
+
+        $response = new JsonResponse(array());
+
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+    }
+
+    public function validIeUserAgentsProvider()
+    {
+        return array(
+            array('Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 6.0; en-US)'),
+            array('Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; SLCC1; .NET CLR 1.1.4322)'),
+            array('Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))'),
+            array('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)'),
+        );
+    }
+
+    public function invalidIeUserAgentsProvider()
+    {
+        return array(
+            array('Mozilla/4.0 (compatible; MSIE 6.0; X11; Linux i686; en) Opera 9.51'),
+        );
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 class JsonResponseTest extends \PHPUnit_Framework_TestCase
 {
@@ -207,11 +208,13 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidInternetExplorerUserAgent($validIeUserAgent)
     {
-        $_SERVER['HTTP_USER_AGENT'] = $validIeUserAgent;
+        $server['HTTP_USER_AGENT'] = $validIeUserAgent;
+        $request = Request::create('/', 'GET', array(), array(), array(), $server);
 
         $response = new JsonResponse(array());
+        $response->prepare($request);
 
-        $this->assertSame('text/json', $response->headers->get('Content-Type'));
+        $this->assertSame('text/json; charset=UTF-8', $response->headers->get('Content-Type'));
     }
 
     /**
@@ -219,9 +222,11 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidInternetExplorerUserAgent($invalidIeUserAgent)
     {
-        $_SERVER['HTTP_USER_AGENT'] = $invalidIeUserAgent;
+        $server['HTTP_USER_AGENT'] = $invalidIeUserAgent;
+        $request = Request::create('/', 'GET', array(), array(), array(), $server);
 
         $response = new JsonResponse(array());
+        $response->prepare($request);
 
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10693 |
| License | MIT |

Related to issue #10693: Internet Explorer doesn't support 'application/json' (it offers to download a document instead of printing the object).
This seems to affect the [versions 7 to 10](http://stackoverflow.com/questions/13943439/json-response-download-in-ie710). 

To fix this, IE has to be detected (beware of Opera which uses a similar user-agent) and a 'text/json' content type should be set.

To do:
- [x] Write a test
- [x] Actually test it on IE
