### PR TITLE
[Form] Fix #10658 Deprecate "read_only" option

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -374,7 +374,6 @@
 {% block widget_attributes %}
 {% spaceless %}
     id="{{ id }}" name="{{ full_name }}"
-    {%- if read_only %} readonly="readonly"{% endif -%}
     {%- if disabled %} disabled="disabled"{% endif -%}
     {%- if required %} required="required"{% endif -%}
     {%- for attrname, attrvalue in attr -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -1,5 +1,4 @@
-id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($read_only): ?>readonly="readonly" <?php endif ?>
-<?php if ($disabled): ?>disabled="disabled" <?php endif ?>
+id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($disabled): ?>disabled="disabled" <?php endif ?>
 <?php if ($required): ?>required="required" <?php endif ?>
 <?php foreach ($attr as $k => $v): ?>
 <?php if (in_array($v, array('placeholder', 'title'), true)): ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -72,7 +72,8 @@ class FormType extends BaseType
         parent::buildView($view, $form, $options);
 
         $name = $form->getName();
-        $readOnly = $options['read_only'];
+
+        $readOnly =  isset($view->vars['attr']['readonly']) && in_array($view->vars['attr']['readonly'], array('readonly', true));
 
         if ($view->parent) {
             if ('' === $name) {
@@ -80,13 +81,13 @@ class FormType extends BaseType
             }
 
             // Complex fields are read-only if they themselves or their parents are.
-            if (!$readOnly) {
-                $readOnly = $view->parent->vars['read_only'];
+            if (!$readOnly && (isset($view->parent->vars['attr']['readonly']) && in_array($view->parent->vars['attr']['readonly'], array('readonly', true)))) {
+                $view->vars['attr']['readonly'] = 'readonly';
             }
+
         }
 
         $view->vars = array_replace($view->vars, array(
-            'read_only'  => $readOnly,
             'errors'     => $form->getErrors(),
             'valid'      => $form->isSubmitted() ? $form->isValid() : true,
             'value'      => $form->getViewData(),
@@ -170,7 +171,7 @@ class FormType extends BaseType
             'data',
         ));
 
-        // BC clause for the "max_length" and "pattern" option
+        // BC clause for the "max_length", "pattern" and "read_only" option
         // Add these values to the "attr" option instead
         $defaultAttr = function (Options $options) {
             $attributes = array();
@@ -183,6 +184,10 @@ class FormType extends BaseType
                 $attributes['pattern'] = $options['pattern'];
             }
 
+            if (false !== $options['read_only']) {
+                $attributes['readonly'] = $options['read_only'];
+            }
+
             return $attributes;
         };
 
@@ -191,7 +196,7 @@ class FormType extends BaseType
             'empty_data'         => $emptyData,
             'trim'               => true,
             'required'           => true,
-            'read_only'          => false,
+            'read_only'          => false, //Deprecated use attr['readonly'] instead
             'max_length'         => null,
             'pattern'            => null,
             'property_path'      => null,

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -84,7 +84,6 @@ class FormType extends BaseType
             if (!$readOnly && (isset($view->parent->vars['attr']['readonly']) && in_array($view->parent->vars['attr']['readonly'], array('readonly', true)))) {
                 $view->vars['attr']['readonly'] = 'readonly';
             }
-
         }
 
         $view->vars = array_replace($view->vars, array(
@@ -184,9 +183,7 @@ class FormType extends BaseType
                 $attributes['pattern'] = $options['pattern'];
             }
 
-            if (false !== $options['read_only']) {
-                $attributes['readonly'] = $options['read_only'];
-            }
+            $attributes['readonly'] = $options['read_only'];
 
             return $attributes;
         };

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1294,7 +1294,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testReadOnly()
     {
         $form = $this->factory->createNamed('name', 'text', null, array(
-            'read_only' => true,
+            'attr' => array('readonly' => 'readonly'),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1899,8 +1899,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $form = $this->factory->createNamed('text', 'text', 'value', array(
             'required' => true,
             'disabled' => true,
-            'read_only' => true,
-            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
+            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar', 'readonly' => true),
         ));
 
         $html = $this->renderWidget($form->createView());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -102,22 +102,22 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('read_only' => true))
+        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('attr' => array('readonly' => 'readonly')))
             ->add('child', 'form')
             ->getForm()
             ->createView();
 
-        $this->assertTrue($view['child']->vars['read_only']);
+        $this->assertEquals('readonly', $view['child']->vars['attr']['readonly']);
     }
 
     public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
         $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form', array('read_only' => true))
+            ->add('child', 'form', array('attr' => array('readonly' => 'readonly')))
             ->getForm()
             ->createView();
 
-        $this->assertTrue($view['child']->vars['read_only']);
+        $this->assertEquals('readonly', $view['child']->vars['attr']['readonly']);
     }
 
     public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
@@ -127,7 +127,7 @@ class FormTypeTest extends BaseTypeTest
                 ->getForm()
                 ->createView();
 
-        $this->assertFalse($view['child']->vars['read_only']);
+        $this->assertArrayNotHasKey('readonly', $view['child']->vars['attr']);
     }
 
     public function testPassMaxLengthToView()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #10658 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3782 |
