### PR TITLE
Allow xdebug.file_link_format from php ini to work when xdebug extension is not loaded

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -35,15 +35,7 @@ class CodeExtension extends \Twig_Extension
      */
     public function __construct($fileLinkFormat, $rootDir, $charset)
     {
-        if (empty($fileLinkFormat)) {
-            $fileLinkFormat = ini_get('xdebug.file_link_format');
-
-            if (empty($fileLinkFormat)) {
-                $fileLinkFormat = get_cfg_var('xdebug.file_link_format');
-            }
-        }
-
-        $this->fileLinkFormat = $fileLinkFormat;
+        $this->fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         $this->rootDir = str_replace('\\', '/', dirname($rootDir)).'/';
         $this->charset = $charset;
     }

--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -35,7 +35,15 @@ class CodeExtension extends \Twig_Extension
      */
     public function __construct($fileLinkFormat, $rootDir, $charset)
     {
-        $this->fileLinkFormat = empty($fileLinkFormat) ? ini_get('xdebug.file_link_format') : $fileLinkFormat;
+        if (empty($fileLinkFormat)) {
+            $fileLinkFormat = ini_get('xdebug.file_link_format');
+
+            if (empty($fileLinkFormat)) {
+                $fileLinkFormat = get_cfg_var('xdebug.file_link_format');
+            }
+        }
+
+        $this->fileLinkFormat = $fileLinkFormat;
         $this->rootDir = str_replace('\\', '/', dirname($rootDir)).'/';
         $this->charset = $charset;
     }

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -349,7 +349,7 @@ EOF;
         $path = self::utf8Htmlize($path);
         $file = preg_match('#[^/\\\\]*$#', $path, $file) ? $file[0] : $path;
 
-        if ($linkFormat = ini_get('xdebug.file_link_format')) {
+        if (($linkFormat = ini_get('xdebug.file_link_format')) || ($linkFormat = get_cfg_var('xdebug.file_link_format'))) {
             $link = str_replace(array('%f', '%l'), array($path, $line), $linkFormat);
 
             return sprintf(' <a href="%s" title="Go to source">in %s line %d</a>', $link, $file, $line);

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -349,7 +349,7 @@ EOF;
         $path = self::utf8Htmlize($path);
         $file = preg_match('#[^/\\\\]*$#', $path, $file) ? $file[0] : $path;
 
-        if (($linkFormat = ini_get('xdebug.file_link_format')) || ($linkFormat = get_cfg_var('xdebug.file_link_format'))) {
+        if ($linkFormat = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')) {
             $link = str_replace(array('%f', '%l'), array($path, $line), $linkFormat);
 
             return sprintf(' <a href="%s" title="Go to source">in %s line %d</a>', $link, $file, $line);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? |  yes |
| New feature? |  no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11081 |
| License | MIT |
| Doc PR | N/A |

Complete the PR https://github.com/symfony/symfony/pull/11081
