### PR TITLE
[Routing] Add matched and default parameters to redirect responses

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -164,7 +164,9 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
             $status = $this->handleRouteRequirements($pathinfo, $name, $route);
 
             if (self::ROUTE_MATCH === $status[0]) {
-                return $status[1];
+                $attributes = array_replace($matches, $hostMatches, (array) $status[1]);
+
+                return $this->mergeDefaults($attributes, $route->getDefaults());
             }
 
             if (self::REQUIREMENT_MISMATCH === $status[0]) {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -29,7 +29,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
+            $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
+            return $ret;
         }
 
         if (0 === strpos($pathinfo, '/bar')) {
@@ -40,7 +41,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     goto not_bar;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array ());
+                return $ret;
             }
             not_bar:
 
@@ -51,7 +53,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     goto not_barhead;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array ());
+                return $ret;
             }
             not_barhead:
 
@@ -61,24 +64,28 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if (0 === strpos($pathinfo, '/test/baz')) {
                 // baz
                 if ($pathinfo === '/test/baz') {
-                    return array('_route' => 'baz');
+                    $ret = array('_route' => 'baz');
+                    return $ret;
                 }
 
                 // baz2
                 if ($pathinfo === '/test/baz.html') {
-                    return array('_route' => 'baz2');
+                    $ret = array('_route' => 'baz2');
+                    return $ret;
                 }
 
                 // baz3
                 if ($pathinfo === '/test/baz3/') {
-                    return array('_route' => 'baz3');
+                    $ret = array('_route' => 'baz3');
+                    return $ret;
                 }
 
             }
 
             // baz4
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
+                return $ret;
             }
 
             // baz5
@@ -88,7 +95,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     goto not_baz5;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array ());
+                return $ret;
             }
             not_baz5:
 
@@ -99,7 +107,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     goto not_bazbaz6;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array ());
+                return $ret;
             }
             not_bazbaz6:
 
@@ -107,47 +116,55 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         // foofoo
         if ($pathinfo === '/foofoo') {
-            return array (  'def' => 'test',  '_route' => 'foofoo',);
+            $ret = array (  'def' => 'test',  '_route' => 'foofoo',);
+            return $ret;
         }
 
         // quoter
         if (preg_match('#^/(?P<quoter>[\']+)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array ());
+            $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array ());
+            return $ret;
         }
 
         // space
         if ($pathinfo === '/spa ce') {
-            return array('_route' => 'space');
+            $ret = array('_route' => 'space');
+            return $ret;
         }
 
         if (0 === strpos($pathinfo, '/a')) {
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo1
                 if (preg_match('#^/a/b\'b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array ());
+                    return $ret;
                 }
 
                 // bar1
                 if (preg_match('#^/a/b\'b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array ());
+                    return $ret;
                 }
 
             }
 
             // overridden
             if (preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array ());
+                return $ret;
             }
 
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo2
                 if (preg_match('#^/a/b\'b/(?P<foo1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array ());
+                    return $ret;
                 }
 
                 // bar2
                 if (preg_match('#^/a/b\'b/(?P<bar1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array ());
+                    return $ret;
                 }
 
             }
@@ -157,40 +174,47 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/multi')) {
             // helloWorld
             if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?P<who>[^/]++))?$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
+                return $ret;
             }
 
             // overridden2
             if ($pathinfo === '/multi/new') {
-                return array('_route' => 'overridden2');
+                $ret = array('_route' => 'overridden2');
+                return $ret;
             }
 
             // hey
             if ($pathinfo === '/multi/hey/') {
-                return array('_route' => 'hey');
+                $ret = array('_route' => 'hey');
+                return $ret;
             }
 
         }
 
         // foo3
         if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array ());
+            $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array ());
+            return $ret;
         }
 
         // bar3
         if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array ());
+            $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array ());
+            return $ret;
         }
 
         if (0 === strpos($pathinfo, '/aba')) {
             // ababa
             if ($pathinfo === '/ababa') {
-                return array('_route' => 'ababa');
+                $ret = array('_route' => 'ababa');
+                return $ret;
             }
 
             // foo4
             if (preg_match('#^/aba/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array ());
+                return $ret;
             }
 
         }
@@ -200,12 +224,14 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route1
             if ($pathinfo === '/route1') {
-                return array('_route' => 'route1');
+                $ret = array('_route' => 'route1');
+                return $ret;
             }
 
             // route2
             if ($pathinfo === '/c2/route2') {
-                return array('_route' => 'route2');
+                $ret = array('_route' => 'route2');
+                return $ret;
             }
 
         }
@@ -213,7 +239,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
             // route3
             if ($pathinfo === '/c2/route3') {
-                return array('_route' => 'route3');
+                $ret = array('_route' => 'route3');
+                return $ret;
             }
 
         }
@@ -221,7 +248,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route4
             if ($pathinfo === '/route4') {
-                return array('_route' => 'route4');
+                $ret = array('_route' => 'route4');
+                return $ret;
             }
 
         }
@@ -229,36 +257,42 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route5
             if ($pathinfo === '/route5') {
-                return array('_route' => 'route5');
+                $ret = array('_route' => 'route5');
+                return $ret;
             }
 
         }
 
         // route6
         if ($pathinfo === '/route6') {
-            return array('_route' => 'route6');
+            $ret = array('_route' => 'route6');
+            return $ret;
         }
 
         if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#si', $host, $hostMatches)) {
             if (0 === strpos($pathinfo, '/route1')) {
                 // route11
                 if ($pathinfo === '/route11') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+                    $ret = $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+                    return $ret;
                 }
 
                 // route12
                 if ($pathinfo === '/route12') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+                    $ret = $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+                    return $ret;
                 }
 
                 // route13
                 if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+                    $ret = $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+                    return $ret;
                 }
 
                 // route14
                 if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
+                    $ret = $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
+                    return $ret;
                 }
 
             }
@@ -268,7 +302,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route15
             if (0 === strpos($pathinfo, '/route15') && preg_match('#^/route15/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array ());
+                return $ret;
             }
 
         }
@@ -276,12 +311,14 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/route1')) {
             // route16
             if (0 === strpos($pathinfo, '/route16') && preg_match('#^/route16/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
+                return $ret;
             }
 
             // route17
             if ($pathinfo === '/route17') {
-                return array('_route' => 'route17');
+                $ret = array('_route' => 'route17');
+                return $ret;
             }
 
         }
@@ -289,18 +326,21 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/a')) {
             // a
             if ($pathinfo === '/a/a...') {
-                return array('_route' => 'a');
+                $ret = array('_route' => 'a');
+                return $ret;
             }
 
             if (0 === strpos($pathinfo, '/a/b')) {
                 // b
                 if (preg_match('#^/a/b/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array ());
+                    return $ret;
                 }
 
                 // c
                 if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array ());
+                    return $ret;
                 }
 
             }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -29,7 +29,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
+            $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
+            return $ret;
         }
 
         if (0 === strpos($pathinfo, '/bar')) {
@@ -40,7 +41,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     goto not_bar;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array ());
+                return $ret;
             }
             not_bar:
 
@@ -51,7 +53,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     goto not_barhead;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array ());
+                return $ret;
             }
             not_barhead:
 
@@ -61,32 +64,36 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             if (0 === strpos($pathinfo, '/test/baz')) {
                 // baz
                 if ($pathinfo === '/test/baz') {
-                    return array('_route' => 'baz');
+                    $ret = array('_route' => 'baz');
+                    return $ret;
                 }
 
                 // baz2
                 if ($pathinfo === '/test/baz.html') {
-                    return array('_route' => 'baz2');
+                    $ret = array('_route' => 'baz2');
+                    return $ret;
                 }
 
                 // baz3
                 if (rtrim($pathinfo, '/') === '/test/baz3') {
+                    $ret = array('_route' => 'baz3');
                     if (substr($pathinfo, -1) !== '/') {
-                        return $this->redirect($pathinfo.'/', 'baz3');
+                        return array_replace($ret, $this->redirect($pathinfo.'/', 'baz3'));
                     }
 
-                    return array('_route' => 'baz3');
+                    return $ret;
                 }
 
             }
 
             // baz4
             if (preg_match('#^/test/(?P<foo>[^/]++)/?$#s', $pathinfo, $matches)) {
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
                 if (substr($pathinfo, -1) !== '/') {
-                    return $this->redirect($pathinfo.'/', 'baz4');
+                    return array_replace($ret, $this->redirect($pathinfo.'/', 'baz4'));
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
+                return $ret;
             }
 
             // baz5
@@ -96,7 +103,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     goto not_baz5;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array ());
+                return $ret;
             }
             not_baz5:
 
@@ -107,7 +115,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     goto not_bazbaz6;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array ());
+                return $ret;
             }
             not_bazbaz6:
 
@@ -115,47 +124,55 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         // foofoo
         if ($pathinfo === '/foofoo') {
-            return array (  'def' => 'test',  '_route' => 'foofoo',);
+            $ret = array (  'def' => 'test',  '_route' => 'foofoo',);
+            return $ret;
         }
 
         // quoter
         if (preg_match('#^/(?P<quoter>[\']+)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array ());
+            $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array ());
+            return $ret;
         }
 
         // space
         if ($pathinfo === '/spa ce') {
-            return array('_route' => 'space');
+            $ret = array('_route' => 'space');
+            return $ret;
         }
 
         if (0 === strpos($pathinfo, '/a')) {
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo1
                 if (preg_match('#^/a/b\'b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array ());
+                    return $ret;
                 }
 
                 // bar1
                 if (preg_match('#^/a/b\'b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array ());
+                    return $ret;
                 }
 
             }
 
             // overridden
             if (preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array ());
+                return $ret;
             }
 
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo2
                 if (preg_match('#^/a/b\'b/(?P<foo1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array ());
+                    return $ret;
                 }
 
                 // bar2
                 if (preg_match('#^/a/b\'b/(?P<bar1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array ());
+                    return $ret;
                 }
 
             }
@@ -165,44 +182,51 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/multi')) {
             // helloWorld
             if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?P<who>[^/]++))?$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
+                return $ret;
             }
 
             // overridden2
             if ($pathinfo === '/multi/new') {
-                return array('_route' => 'overridden2');
+                $ret = array('_route' => 'overridden2');
+                return $ret;
             }
 
             // hey
             if (rtrim($pathinfo, '/') === '/multi/hey') {
+                $ret = array('_route' => 'hey');
                 if (substr($pathinfo, -1) !== '/') {
-                    return $this->redirect($pathinfo.'/', 'hey');
+                    return array_replace($ret, $this->redirect($pathinfo.'/', 'hey'));
                 }
 
-                return array('_route' => 'hey');
+                return $ret;
             }
 
         }
 
         // foo3
         if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array ());
+            $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array ());
+            return $ret;
         }
 
         // bar3
         if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array ());
+            $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array ());
+            return $ret;
         }
 
         if (0 === strpos($pathinfo, '/aba')) {
             // ababa
             if ($pathinfo === '/ababa') {
-                return array('_route' => 'ababa');
+                $ret = array('_route' => 'ababa');
+                return $ret;
             }
 
             // foo4
             if (preg_match('#^/aba/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array ());
+                return $ret;
             }
 
         }
@@ -212,12 +236,14 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route1
             if ($pathinfo === '/route1') {
-                return array('_route' => 'route1');
+                $ret = array('_route' => 'route1');
+                return $ret;
             }
 
             // route2
             if ($pathinfo === '/c2/route2') {
-                return array('_route' => 'route2');
+                $ret = array('_route' => 'route2');
+                return $ret;
             }
 
         }
@@ -225,7 +251,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
             // route3
             if ($pathinfo === '/c2/route3') {
-                return array('_route' => 'route3');
+                $ret = array('_route' => 'route3');
+                return $ret;
             }
 
         }
@@ -233,7 +260,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route4
             if ($pathinfo === '/route4') {
-                return array('_route' => 'route4');
+                $ret = array('_route' => 'route4');
+                return $ret;
             }
 
         }
@@ -241,36 +269,42 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route5
             if ($pathinfo === '/route5') {
-                return array('_route' => 'route5');
+                $ret = array('_route' => 'route5');
+                return $ret;
             }
 
         }
 
         // route6
         if ($pathinfo === '/route6') {
-            return array('_route' => 'route6');
+            $ret = array('_route' => 'route6');
+            return $ret;
         }
 
         if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#si', $host, $hostMatches)) {
             if (0 === strpos($pathinfo, '/route1')) {
                 // route11
                 if ($pathinfo === '/route11') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+                    $ret = $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+                    return $ret;
                 }
 
                 // route12
                 if ($pathinfo === '/route12') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+                    $ret = $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+                    return $ret;
                 }
 
                 // route13
                 if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+                    $ret = $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+                    return $ret;
                 }
 
                 // route14
                 if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
+                    $ret = $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
+                    return $ret;
                 }
 
             }
@@ -280,7 +314,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route15
             if (0 === strpos($pathinfo, '/route15') && preg_match('#^/route15/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array ());
+                return $ret;
             }
 
         }
@@ -288,12 +323,14 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/route1')) {
             // route16
             if (0 === strpos($pathinfo, '/route16') && preg_match('#^/route16/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
+                return $ret;
             }
 
             // route17
             if ($pathinfo === '/route17') {
-                return array('_route' => 'route17');
+                $ret = array('_route' => 'route17');
+                return $ret;
             }
 
         }
@@ -301,18 +338,21 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/a')) {
             // a
             if ($pathinfo === '/a/a...') {
-                return array('_route' => 'a');
+                $ret = array('_route' => 'a');
+                return $ret;
             }
 
             if (0 === strpos($pathinfo, '/a/b')) {
                 // b
                 if (preg_match('#^/a/b/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array ());
+                    return $ret;
                 }
 
                 // c
                 if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array ());
+                    $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array ());
+                    return $ret;
                 }
 
             }
@@ -321,22 +361,26 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         // secure
         if ($pathinfo === '/secure') {
+            $ret = array('_route' => 'secure');
+
             $requiredSchemes = array (  'https' => 0,);
             if (!isset($requiredSchemes[$this->context->getScheme()])) {
-                return $this->redirect($pathinfo, 'secure', key($requiredSchemes));
+                return array_replace($ret, $this->redirect($pathinfo, 'secure', key($requiredSchemes)));
             }
 
-            return array('_route' => 'secure');
+            return $ret;
         }
 
         // nonsecure
         if ($pathinfo === '/nonsecure') {
+            $ret = array('_route' => 'nonsecure');
+
             $requiredSchemes = array (  'http' => 0,);
             if (!isset($requiredSchemes[$this->context->getScheme()])) {
-                return $this->redirect($pathinfo, 'nonsecure', key($requiredSchemes));
+                return array_replace($ret, $this->redirect($pathinfo, 'nonsecure', key($requiredSchemes)));
             }
 
-            return array('_route' => 'nonsecure');
+            return $ret;
         }
 
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -30,19 +30,22 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/rootprefix')) {
             // static
             if ($pathinfo === '/rootprefix/test') {
-                return array('_route' => 'static');
+                $ret = array('_route' => 'static');
+                return $ret;
             }
 
             // dynamic
             if (preg_match('#^/rootprefix/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'dynamic')), array ());
+                $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'dynamic')), array ());
+                return $ret;
             }
 
         }
 
         // with-condition
         if ($pathinfo === '/with-condition' && ($context->getMethod() == "GET")) {
-            return array('_route' => 'with-condition');
+            $ret = array('_route' => 'with-condition');
+            return $ret;
         }
 
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -68,4 +68,19 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         ;
         $matcher->match('/foo');
     }
+
+    public function testRedirectWithParams()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo/{bar}', array(), array(), array(), '', array('https')));
+
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext()));
+        $matcher
+            ->expects($this->once())
+            ->method('redirect')
+            ->with('/foo/baz', 'foo', 'https')
+            ->will($this->returnValue(array('_route' => 'foo')))
+        ;
+        $this->assertEquals(array('_route' => 'foo', 'bar' => 'baz'), $matcher->match('/foo/baz'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I ran into an issue recently. We're using security expressions and we're matching against route params. Since redirect didn't add matched route params to redirect response, firewall wasn't matching rule and was throwing AccessDenied exception. This patch adds matched and defaults to redirect params.

Code could be improved to return straight away if there won't be redirect.
