### PR TITLE
[Console] added a way to dispatch events on any command

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -199,6 +199,23 @@ class Application
     }
 
     /**
+     * Public version of doRunCommand().
+     *
+     * If an event dispatcher has been attached to the application,
+     * events are also dispatched during the life-cycle of the command.
+     *
+     * @param Command         $command A Command instance
+     * @param InputInterface  $input   An Input instance
+     * @param OutputInterface $output  An Output instance
+     *
+     * @return int 0 if everything went fine, or an error code
+     */
+    public function runCommand(Command $command, InputInterface $input, OutputInterface $output)
+    {
+        return $this->doRunCommand($command, $input, $output);
+    }
+
+    /**
      * Set a helper set to be used with the command.
      *
      * @param HelperSet $helperSet The helper set

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added a Process helper
  * added a DebugFormatter helper
+ * added a way for events to be triggered on commands run from within other commands
 
 2.5.0
 -----

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -77,6 +77,40 @@ class ApplicationTester
     }
 
     /**
+     * Executes a specific command.
+     *
+     * Available options:
+     *
+     *  * interactive: Sets the input interactive flag
+     *  * decorated:   Sets the output decorated flag
+     *  * verbosity:   Sets the output verbosity flag
+     *
+     * @param array $input   An array of arguments and options
+     * @param array $options An array of options
+     *
+     * @return int     The command exit code
+     */
+    public function runCommand(array $input, $options = array())
+    {
+        $this->input = new ArrayInput($input);
+        if (isset($options['interactive'])) {
+            $this->input->setInteractive($options['interactive']);
+        }
+
+        $this->output = new StreamOutput(fopen('php://memory', 'w', false));
+        if (isset($options['decorated'])) {
+            $this->output->setDecorated($options['decorated']);
+        }
+        if (isset($options['verbosity'])) {
+            $this->output->setVerbosity($options['verbosity']);
+        }
+
+        $command = $this->application->find($input["command"]);
+
+        return $this->statusCode = $this->application->runCommand($command, $this->input, $this->output);
+    }
+
+    /**
      * Gets the display returned by the last execution of the application.
      *
      * @param bool    $normalize Whether to normalize end of lines to \n or not

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -907,6 +907,21 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(ConsoleCommandEvent::RETURN_CODE_DISABLED, $exitCode);
     }
 
+    public function testRunCommandWithDispatcher()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setDispatcher($this->getDispatcher());
+
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+            $output->write('foo.');
+        });
+
+        $tester = new ApplicationTester($application);
+        $tester->runCommand(array('command' => 'foo'));
+        $this->assertEquals('before.foo.after.', $tester->getDisplay());
+    }
+
     public function testTerminalDimensions()
     {
         $application = new Application();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | symfony/symfony-docs#4020 |

Console events do not run when they are expected to.

The [documentation](http://symfony.com/doc/current/components/console/introduction.html#calling-an-existing-command) recommends the following to execute an existing command

```
$command = $this->getApplication()->find('demo:greet');
$returnCode = $command->run($input, $output);
```

Then the [events section](http://symfony.com/doc/current/components/console/events.html#the-consoleevents-command-event) states the following (emphasis mine)
_Typical Purposes: Doing something before **any** command is run (like logging which command is going to be executed), or displaying something about the event to be executed._

However console events are only dispatched by Application::doRunCommand(), which is used for running the main command only. Leaving no way to run an additional command and have the events dispatched.

This commit is my attempt at allowing a command to be run with events with least disruption, but I think it would be better if the events were dispatched from within the Command class. But I guess that would be a 3.0 feature
