### PR TITLE
server:run command: provide more error information

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -98,10 +98,20 @@ EOF
         if (OutputInterface::VERBOSITY_VERBOSE > $output->getVerbosity()) {
             $process->disableOutput();
         }
-        
+
         $this
             ->getHelper('process')
             ->run($output, $process, null, null, OutputInterface::VERBOSITY_VERBOSE);
+
+        if (!$process->isSuccessful()) {
+            $output->writeln('<error>Built-in server terminated unexpectedly</error>');
+
+            if ($process->isOutputDisabled()) {
+                $output->writeln('<error>Run the command again with -v option for more details</error>');
+            }
+        }
+
+        return $process->getExitCode();
     }
 
     private function createPhpProcessBuilder(InputInterface $input, OutputInterface $output, $env)


### PR DESCRIPTION
The server:run command didn't provide many information when the executed command exited unexpectedly. Now, the process' exit code is passed through and an error message is displayed.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This is, for example, useful, if you provide an invalid ip address/hostname on which the server couldn't listen.
