### PR TITLE
[2.3] [Validator] Fix UserPassword validator translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -176,7 +176,7 @@
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user current password.</source>
-                <target>This value should be the user current password.</target>
+                <target>This value should be the user's current password.</target>
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | None |
| License | MIT |

Fixes the UserPassword translation message only for 2.3 as discussed in symfony/symfony#11383.
