### PR TITLE
[CssSelector] Increase specificity factors

### DIFF
--- a/src/Symfony/Component/CssSelector/Node/Specificity.php
+++ b/src/Symfony/Component/CssSelector/Node/Specificity.php
@@ -23,8 +23,8 @@ namespace Symfony\Component\CssSelector\Node;
  */
 class Specificity
 {
-    const A_FACTOR = 100;
-    const B_FACTOR = 10;
+    const A_FACTOR = 10000;
+    const B_FACTOR = 100;
     const C_FACTOR = 1;
 
     /**

--- a/src/Symfony/Component/CssSelector/Tests/Node/SpecificityTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/SpecificityTest.php
@@ -24,7 +24,7 @@ class SpecificityTest extends \PHPUnit_Framework_TestCase
     /** @dataProvider getValueTestData */
     public function testPlusValue(Specificity $specificity, $value)
     {
-        $this->assertEquals($value + 123, $specificity->plus(new Specificity(1, 2, 3))->getValue());
+        $this->assertEquals($value + 10203, $specificity->plus(new Specificity(1, 2, 3))->getValue());
     }
 
     public function getValueTestData()
@@ -32,9 +32,9 @@ class SpecificityTest extends \PHPUnit_Framework_TestCase
         return array(
             array(new Specificity(0, 0, 0), 0),
             array(new Specificity(0, 0, 2), 2),
-            array(new Specificity(0, 3, 0), 30),
-            array(new Specificity(4, 0, 0), 400),
-            array(new Specificity(4, 3, 2), 432),
+            array(new Specificity(0, 3, 0), 300),
+            array(new Specificity(4, 0, 0), 40000),
+            array(new Specificity(4, 3, 2), 40302),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

TODO:
- [ ] fix the tests as they have not been updated yet

In the example here: http://www.w3.org/TR/selectors/#specificity a base of 10 is used, but it also notes:

> Concatenating the three numbers a-b-c **(in a number system with a large base)** gives the specificity.

This commit fixes some edge cases, for example 0,1,11 (=21) should still have lower specificity then 0,2,0 (=20). This changes the value to respectively 111 and 200. So it's not perfect better, but can handle 10x as much.

Or are there any reasons this wasn't done before?
