### PR TITLE
[HttpFoundation] [Response] replaced hard coded http status by constants

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1232,6 +1232,7 @@ class Response
     public function isRedirect($location = null)
     {
         $redirectStatusCodes = array(self::HTTP_CREATED, self::HTTP_MOVED_PERMANENTLY, self::HTTP_FOUND, self::HTTP_SEE_OTHER, self::HTTP_TEMPORARY_REDIRECT, self::HTTP_PERMANENTLY_REDIRECT);
+
         return in_array($this->statusCode, $redirectStatusCodes) && (null === $location ?: $location == $this->headers->get('Location'));
     }
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -80,6 +80,7 @@ class Response
     const HTTP_LOOP_DETECTED = 508;                                               // RFC5842
     const HTTP_NOT_EXTENDED = 510;                                                // RFC2774
     const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;                             // RFC6585
+    const HTTP_MAX_LIMIT = 600;
 
     /**
      * @var \Symfony\Component\HttpFoundation\ResponseHeaderBag
@@ -123,66 +124,66 @@ class Response
      * @var array
      */
     public static $statusTexts = array(
-        100 => 'Continue',
-        101 => 'Switching Protocols',
-        102 => 'Processing',            // RFC2518
-        200 => 'OK',
-        201 => 'Created',
-        202 => 'Accepted',
-        203 => 'Non-Authoritative Information',
-        204 => 'No Content',
-        205 => 'Reset Content',
-        206 => 'Partial Content',
-        207 => 'Multi-Status',          // RFC4918
-        208 => 'Already Reported',      // RFC5842
-        226 => 'IM Used',               // RFC3229
-        300 => 'Multiple Choices',
-        301 => 'Moved Permanently',
-        302 => 'Found',
-        303 => 'See Other',
-        304 => 'Not Modified',
-        305 => 'Use Proxy',
-        306 => 'Reserved',
-        307 => 'Temporary Redirect',
-        308 => 'Permanent Redirect',    // RFC7238
-        400 => 'Bad Request',
-        401 => 'Unauthorized',
-        402 => 'Payment Required',
-        403 => 'Forbidden',
-        404 => 'Not Found',
-        405 => 'Method Not Allowed',
-        406 => 'Not Acceptable',
-        407 => 'Proxy Authentication Required',
-        408 => 'Request Timeout',
-        409 => 'Conflict',
-        410 => 'Gone',
-        411 => 'Length Required',
-        412 => 'Precondition Failed',
-        413 => 'Request Entity Too Large',
-        414 => 'Request-URI Too Long',
-        415 => 'Unsupported Media Type',
-        416 => 'Requested Range Not Satisfiable',
-        417 => 'Expectation Failed',
-        418 => 'I\'m a teapot',                                               // RFC2324
-        422 => 'Unprocessable Entity',                                        // RFC4918
-        423 => 'Locked',                                                      // RFC4918
-        424 => 'Failed Dependency',                                           // RFC4918
-        425 => 'Reserved for WebDAV advanced collections expired proposal',   // RFC2817
-        426 => 'Upgrade Required',                                            // RFC2817
-        428 => 'Precondition Required',                                       // RFC6585
-        429 => 'Too Many Requests',                                           // RFC6585
-        431 => 'Request Header Fields Too Large',                             // RFC6585
-        500 => 'Internal Server Error',
-        501 => 'Not Implemented',
-        502 => 'Bad Gateway',
-        503 => 'Service Unavailable',
-        504 => 'Gateway Timeout',
-        505 => 'HTTP Version Not Supported',
-        506 => 'Variant Also Negotiates (Experimental)',                      // RFC2295
-        507 => 'Insufficient Storage',                                        // RFC4918
-        508 => 'Loop Detected',                                               // RFC5842
-        510 => 'Not Extended',                                                // RFC2774
-        511 => 'Network Authentication Required',                             // RFC6585
+        self::HTTP_CONTINUE => 'Continue',
+        self::HTTP_SWITCHING_PROTOCOLS => 'Switching Protocols',
+        self::HTTP_PROCESSING => 'Processing',                                                                                                  // RFC2518
+        self::HTTP_OK => 'OK',
+        self::HTTP_CREATED => 'Created',
+        self::HTTP_ACCEPTED => 'Accepted',
+        self::HTTP_NON_AUTHORITATIVE_INFORMATION => 'Non-Authoritative Information',
+        self::HTTP_NO_CONTENT => 'No Content',
+        self::HTTP_RESET_CONTENT => 'Reset Content',
+        self::HTTP_PARTIAL_CONTENT => 'Partial Content',
+        self::HTTP_MULTI_STATUS => 'Multi-Status',                                                                                              // RFC4918
+        self::HTTP_ALREADY_REPORTED => 'Already Reported',                                                                                      // RFC5842
+        self::HTTP_IM_USED => 'IM Used',                                                                                                        // RFC3229
+        self::HTTP_MULTIPLE_CHOICES => 'Multiple Choices',
+        self::HTTP_MOVED_PERMANENTLY => 'Moved Permanently',
+        self::HTTP_FOUND => 'Found',
+        self::HTTP_SEE_OTHER => 'See Other',
+        self::HTTP_NOT_MODIFIED => 'Not Modified',
+        self::HTTP_USE_PROXY => 'Use Proxy',
+        self::HTTP_RESERVED => 'Reserved',
+        self::HTTP_TEMPORARY_REDIRECT => 'Temporary Redirect',
+        self::HTTP_PERMANENTLY_REDIRECT => 'Permanent Redirect',                                                                                // RFC7238
+        self::HTTP_BAD_REQUEST => 'Bad Request',
+        self::HTTP_UNAUTHORIZED => 'Unauthorized',
+        self::HTTP_PAYMENT_REQUIRED => 'Payment Required',
+        self::HTTP_FORBIDDEN => 'Forbidden',
+        self::HTTP_NOT_FOUND => 'Not Found',
+        self::HTTP_METHOD_NOT_ALLOWED => 'Method Not Allowed',
+        self::HTTP_NOT_ACCEPTABLE => 'Not Acceptable',
+        self::HTTP_PROXY_AUTHENTICATION_REQUIRED => 'Proxy Authentication Required',
+        self::HTTP_REQUEST_TIMEOUT => 'Request Timeout',
+        self::HTTP_CONFLICT => 'Conflict',
+        self::HTTP_GONE => 'Gone',
+        self::HTTP_LENGTH_REQUIRED => 'Length Required',
+        self::HTTP_PRECONDITION_FAILED => 'Precondition Failed',
+        self::HTTP_REQUEST_ENTITY_TOO_LARGE => 'Request Entity Too Large',
+        self::HTTP_REQUEST_URI_TOO_LONG => 'Request-URI Too Long',
+        self::HTTP_UNSUPPORTED_MEDIA_TYPE => 'Unsupported Media Type',
+        self::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE => 'Requested Range Not Satisfiable',
+        self::HTTP_EXPECTATION_FAILED => 'Expectation Failed',
+        self::HTTP_I_AM_A_TEAPOT => 'I\'m a teapot',                                                                                            // RFC2324
+        self::HTTP_UNPROCESSABLE_ENTITY => 'Unprocessable Entity',                                                                              // RFC4918
+        self::HTTP_LOCKED => 'Locked',                                                                                                          // RFC4918
+        self::HTTP_FAILED_DEPENDENCY => 'Failed Dependency',                                                                                    // RFC4918
+        self::HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL => 'Reserved for WebDAV advanced collections expired proposal',    // RFC2817
+        self::HTTP_UPGRADE_REQUIRED => 'Upgrade Required',                                                                                      // RFC2817
+        self::HTTP_PRECONDITION_REQUIRED => 'Precondition Required',                                                                            // RFC6585
+        self::HTTP_TOO_MANY_REQUESTS => 'Too Many Requests',                                                                                    // RFC6585
+        self::HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE => 'Request Header Fields Too Large',                                                        // RFC6585
+        self::HTTP_INTERNAL_SERVER_ERROR => 'Internal Server Error',
+        self::HTTP_NOT_IMPLEMENTED => 'Not Implemented',
+        self::HTTP_BAD_GATEWAY => 'Bad Gateway',
+        self::HTTP_SERVICE_UNAVAILABLE => 'Service Unavailable',
+        self::HTTP_GATEWAY_TIMEOUT => 'Gateway Timeout',
+        self::HTTP_VERSION_NOT_SUPPORTED => 'HTTP Version Not Supported',
+        self::HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL => 'Variant Also Negotiates (Experimental)',                                            // RFC2295
+        self::HTTP_INSUFFICIENT_STORAGE => 'Insufficient Storage',                                                                              // RFC4918
+        self::HTTP_LOOP_DETECTED => 'Loop Detected',                                                                                            // RFC5842
+        self::HTTP_NOT_EXTENDED => 'Not Extended',                                                                                              // RFC2774
+        self::HTTP_NETWORK_AUTHENTICATION_REQUIRED => 'Network Authentication Required',                                                        // RFC6585
     );
 
     /**
@@ -196,7 +197,7 @@ class Response
      *
      * @api
      */
-    public function __construct($content = '', $status = 200, $headers = array())
+    public function __construct($content = '', $status = self::HTTP_OK, $headers = array())
     {
         $this->headers = new ResponseHeaderBag($headers);
         $this->setContent($content);
@@ -212,8 +213,8 @@ class Response
      *
      * Example:
      *
-     *     return Response::create($body, 200)
-     *         ->setSharedMaxAge(300);
+     *     return Response::create($body, self::HTTP_OK)
+     *         ->setSharedMaxAge(self::HTTP_MULTIPLE_CHOICES);
      *
      * @param mixed   $content The response content, see setContent()
      * @param int     $status  The response status code
@@ -221,7 +222,7 @@ class Response
      *
      * @return Response
      */
-    public static function create($content = '', $status = 200, $headers = array())
+    public static function create($content = '', $status = self::HTTP_OK, $headers = array())
     {
         return new static($content, $status, $headers);
     }
@@ -268,7 +269,7 @@ class Response
     {
         $headers = $this->headers;
 
-        if ($this->isInformational() || in_array($this->statusCode, array(204, 304))) {
+        if ($this->isInformational() || in_array($this->statusCode, array(self::HTTP_NO_CONTENT, self::HTTP_NOT_MODIFIED))) {
             $this->setContent(null);
             $headers->remove('Content-Type');
             $headers->remove('Content-Length');
@@ -560,7 +561,8 @@ class Response
      */
     public function isCacheable()
     {
-        if (!in_array($this->statusCode, array(200, 203, 300, 301, 302, 404, 410))) {
+        $cacheableStatusCodes = array(self::HTTP_OK, self::HTTP_NON_AUTHORITATIVE_INFORMATION, self::HTTP_MULTIPLE_CHOICES, self::HTTP_MOVED_PERMANENTLY, self::HTTP_FOUND, self::HTTP_NOT_FOUND, self::HTTP_GONE);
+        if (!in_array($this->statusCode, $cacheableStatusCodes)) {
             return false;
         }
 
@@ -1001,10 +1003,10 @@ class Response
     }
 
     /**
-     * Modifies the response so that it conforms to the rules defined for a 304 status code.
+     * Modifies the response so that it conforms to the rules defined for a self::HTTP_NOT_MODIFIED status code.
      *
      * This sets the status, removes the body, and discards any headers
-     * that MUST NOT be included in 304 responses.
+     * that MUST NOT be included in self::HTTP_NOT_MODIFIED responses.
      *
      * @return Response
      *
@@ -1014,10 +1016,10 @@ class Response
      */
     public function setNotModified()
     {
-        $this->setStatusCode(304);
+        $this->setStatusCode(self::HTTP_NOT_MODIFIED);
         $this->setContent(null);
 
-        // remove headers that MUST NOT be included with 304 Not Modified responses
+        // remove headers that MUST NOT be included with self::HTTP_NOT_MODIFIED Not Modified responses
         foreach (array('Allow', 'Content-Encoding', 'Content-Language', 'Content-Length', 'Content-MD5', 'Content-Type', 'Last-Modified') as $header) {
             $this->headers->remove($header);
         }
@@ -1079,7 +1081,7 @@ class Response
      * Determines if the Response validators (ETag, Last-Modified) match
      * a conditional value specified in the Request.
      *
-     * If the Response is not modified, it sets the status code to 304 and
+     * If the Response is not modified, it sets the status code to self::HTTP_NOT_MODIFIED and
      * removes the actual content by calling the setNotModified() method.
      *
      * @param Request $request A Request instance
@@ -1119,7 +1121,7 @@ class Response
      */
     public function isInvalid()
     {
-        return $this->statusCode < 100 || $this->statusCode >= 600;
+        return $this->statusCode < self::HTTP_CONTINUE || $this->statusCode >= self::HTTP_MAX_LIMIT;
     }
 
     /**
@@ -1131,7 +1133,7 @@ class Response
      */
     public function isInformational()
     {
-        return $this->statusCode >= 100 && $this->statusCode < 200;
+        return $this->statusCode >= self::HTTP_CONTINUE && $this->statusCode < self::HTTP_OK;
     }
 
     /**
@@ -1143,7 +1145,7 @@ class Response
      */
     public function isSuccessful()
     {
-        return $this->statusCode >= 200 && $this->statusCode < 300;
+        return $this->statusCode >= self::HTTP_OK && $this->statusCode < self::HTTP_MULTIPLE_CHOICES;
     }
 
     /**
@@ -1155,7 +1157,7 @@ class Response
      */
     public function isRedirection()
     {
-        return $this->statusCode >= 300 && $this->statusCode < 400;
+        return $this->statusCode >= self::HTTP_MULTIPLE_CHOICES && $this->statusCode < self::HTTP_BAD_REQUEST;
     }
 
     /**
@@ -1167,7 +1169,7 @@ class Response
      */
     public function isClientError()
     {
-        return $this->statusCode >= 400 && $this->statusCode < 500;
+        return $this->statusCode >= self::HTTP_BAD_REQUEST && $this->statusCode < self::HTTP_INTERNAL_SERVER_ERROR;
     }
 
     /**
@@ -1179,7 +1181,7 @@ class Response
      */
     public function isServerError()
     {
-        return $this->statusCode >= 500 && $this->statusCode < 600;
+        return $this->statusCode >= self::HTTP_INTERNAL_SERVER_ERROR && $this->statusCode < self::HTTP_MAX_LIMIT;
     }
 
     /**
@@ -1191,7 +1193,7 @@ class Response
      */
     public function isOk()
     {
-        return 200 === $this->statusCode;
+        return self::HTTP_OK === $this->statusCode;
     }
 
     /**
@@ -1203,7 +1205,7 @@ class Response
      */
     public function isForbidden()
     {
-        return 403 === $this->statusCode;
+        return self::HTTP_FORBIDDEN === $this->statusCode;
     }
 
     /**
@@ -1215,7 +1217,7 @@ class Response
      */
     public function isNotFound()
     {
-        return 404 === $this->statusCode;
+        return self::HTTP_NOT_FOUND === $this->statusCode;
     }
 
     /**
@@ -1229,7 +1231,8 @@ class Response
      */
     public function isRedirect($location = null)
     {
-        return in_array($this->statusCode, array(201, 301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
+        $redirectStatusCodes = array(self::HTTP_CREATED, self::HTTP_MOVED_PERMANENTLY, self::HTTP_FOUND, self::HTTP_SEE_OTHER, self::HTTP_TEMPORARY_REDIRECT, self::HTTP_PERMANENTLY_REDIRECT);
+        return in_array($this->statusCode, $redirectStatusCodes) && (null === $location ?: $location == $this->headers->get('Location'));
     }
 
     /**
@@ -1241,7 +1244,7 @@ class Response
      */
     public function isEmpty()
     {
-        return in_array($this->statusCode, array(204, 304));
+        return in_array($this->statusCode, array(self::HTTP_NO_CONTENT, self::HTTP_NOT_MODIFIED));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [] |

Http status were defined via constants but constants were not used in class so I replaced all calls to hard coded status by corresponding constant.
