### PR TITLE
[Validator] Fixed object initializers in 2.5 version of the Validator

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Exception\BadMethodCallException;
 use Symfony\Component\Validator\Mapping\MetadataInterface;
 use Symfony\Component\Validator\Mapping\PropertyMetadataInterface;
+use Symfony\Component\Validator\ObjectInitializerInterface;
 use Symfony\Component\Validator\Util\PropertyPath;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
@@ -112,6 +113,13 @@ class ExecutionContext implements ExecutionContextInterface
      * @var array
      */
     private $validatedConstraints = array();
+
+    /**
+     * Stores which objects have been initialized.
+     *
+     * @var array
+     */
+    private $initializedObjects;
 
     /**
      * Creates a new execution context.
@@ -359,5 +367,37 @@ class ExecutionContext implements ExecutionContextInterface
     public function isConstraintValidated($cacheKey, $constraintHash)
     {
         return isset($this->validatedConstraints[$cacheKey.':'.$constraintHash]);
+    }
+
+    /**
+     * Marks that an object was initialized.
+     *
+     * @param string $cacheKey The hash of the object
+     *
+     * @internal Used by the validator engine. Should not be called by user
+     *           code.
+     *
+     * @see ObjectInitializerInterface
+     */
+    public function markObjectAsInitialized($cacheKey)
+    {
+        $this->initializedObjects[$cacheKey] = true;
+    }
+
+    /**
+     * Returns whether an object was initialized.
+     *
+     * @param string $cacheKey The hash of the object
+     *
+     * @return bool Whether the object was already initialized
+     *
+     * @internal Used by the validator engine. Should not be called by user
+     *           code.
+     *
+     * @see ObjectInitializerInterface
+     */
+    public function isObjectInitialized($cacheKey)
+    {
+        return isset($this->initializedObjects[$cacheKey]);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Entity.php
@@ -38,6 +38,7 @@ class Entity extends EntityParent implements EntityInterface
     public $reference2;
     private $internal;
     public $data = 'Overridden data';
+    public $initialized = false;
 
     public function __construct($internal = null)
     {

--- a/src/Symfony/Component/Validator/Tests/Validator/LegacyValidator2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/LegacyValidator2Dot5ApiTest.php
@@ -28,10 +28,10 @@ class LegacyValidator2Dot5ApiTest extends Abstract2Dot5ApiTest
         parent::setUp();
     }
 
-    protected function createValidator(MetadataFactoryInterface $metadataFactory)
+    protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
         $contextFactory = new LegacyExecutionContextFactory($metadataFactory, new DefaultTranslator());
 
-        return new LegacyValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory());
+        return new LegacyValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory(), $objectInitializers);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Validator/LegacyValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/LegacyValidatorLegacyApiTest.php
@@ -28,10 +28,10 @@ class LegacyValidatorLegacyApiTest extends AbstractLegacyApiTest
         parent::setUp();
     }
 
-    protected function createValidator(MetadataFactoryInterface $metadataFactory)
+    protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
         $contextFactory = new LegacyExecutionContextFactory($metadataFactory, new DefaultTranslator());
 
-        return new LegacyValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory());
+        return new LegacyValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory(), $objectInitializers);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidator2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidator2Dot5ApiTest.php
@@ -19,10 +19,10 @@ use Symfony\Component\Validator\Validator\RecursiveValidator;
 
 class RecursiveValidator2Dot5ApiTest extends Abstract2Dot5ApiTest
 {
-    protected function createValidator(MetadataFactoryInterface $metadataFactory)
+    protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
         $contextFactory = new ExecutionContextFactory(new DefaultTranslator());
 
-        return new RecursiveValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory());
+        return new RecursiveValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory(), $objectInitializers);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -21,9 +21,9 @@ use Symfony\Component\Validator\Validator as LegacyValidator;
 
 class ValidatorTest extends AbstractLegacyApiTest
 {
-    protected function createValidator(MetadataFactoryInterface $metadataFactory)
+    protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
-        return new LegacyValidator($metadataFactory, new ConstraintValidatorFactory(), new DefaultTranslator());
+        return new LegacyValidator($metadataFactory, new ConstraintValidatorFactory(), new DefaultTranslator(), 'validators', $objectInitializers);
     }
 
     /**

--- a/src/Symfony/Component/Validator/ValidationVisitor.php
+++ b/src/Symfony/Component/Validator/ValidationVisitor.php
@@ -129,16 +129,19 @@ class ValidationVisitor implements ValidationVisitorInterface, GlobalExecutionCo
                 return;
             }
 
+            // Initialize if the object wasn't initialized before
+            if (!isset($this->validatedObjects[$hash])) {
+                foreach ($this->objectInitializers as $initializer) {
+                    if (!$initializer instanceof ObjectInitializerInterface) {
+                        throw new \LogicException('Validator initializers must implement ObjectInitializerInterface.');
+                    }
+                    $initializer->initialize($value);
+                }
+            }
+
             // Remember validating this object before starting and possibly
             // traversing the object graph
             $this->validatedObjects[$hash][$group] = true;
-
-            foreach ($this->objectInitializers as $initializer) {
-                if (!$initializer instanceof ObjectInitializerInterface) {
-                    throw new \LogicException('Validator initializers must implement ObjectInitializerInterface.');
-                }
-                $initializer->initialize($value);
-            }
         }
 
         // Validate arrays recursively by default, otherwise every driver needs

--- a/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
@@ -15,6 +15,7 @@ use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextFactoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\MetadataFactoryInterface;
+use Symfony\Component\Validator\ObjectInitializerInterface;
 
 /**
  * Recursive implementation of {@link ValidatorInterface}.
@@ -40,21 +41,28 @@ class RecursiveValidator implements ValidatorInterface
     protected $validatorFactory;
 
     /**
+     * @var ObjectInitializerInterface[]
+     */
+    protected $objectInitializers;
+
+    /**
      * Creates a new validator.
      *
-     * @param ExecutionContextFactoryInterface    $contextFactory   The factory for
-     *                                                              creating new contexts
-     * @param MetadataFactoryInterface            $metadataFactory  The factory for
-     *                                                              fetching the metadata
-     *                                                              of validated objects
-     * @param ConstraintValidatorFactoryInterface $validatorFactory The factory for creating
-     *                                                              constraint validators
+     * @param ExecutionContextFactoryInterface    $contextFactory     The factory for
+     *                                                                creating new contexts
+     * @param MetadataFactoryInterface            $metadataFactory    The factory for
+     *                                                                fetching the metadata
+     *                                                                of validated objects
+     * @param ConstraintValidatorFactoryInterface $validatorFactory   The factory for creating
+     *                                                                constraint validators
+     * @param ObjectInitializerInterface[]        $objectInitializers The object initializers
      */
-    public function __construct(ExecutionContextFactoryInterface $contextFactory, MetadataFactoryInterface $metadataFactory, ConstraintValidatorFactoryInterface $validatorFactory)
+    public function __construct(ExecutionContextFactoryInterface $contextFactory, MetadataFactoryInterface $metadataFactory, ConstraintValidatorFactoryInterface $validatorFactory, array $objectInitializers = array())
     {
         $this->contextFactory = $contextFactory;
         $this->metadataFactory = $metadataFactory;
         $this->validatorFactory = $validatorFactory;
+        $this->objectInitializers = $objectInitializers;
     }
 
     /**
@@ -65,7 +73,8 @@ class RecursiveValidator implements ValidatorInterface
         return new RecursiveContextualValidator(
             $this->contextFactory->createContext($this, $root),
             $this->metadataFactory,
-            $this->validatorFactory
+            $this->validatorFactory,
+            $this->objectInitializers
         );
     }
 
@@ -77,7 +86,8 @@ class RecursiveValidator implements ValidatorInterface
         return new RecursiveContextualValidator(
             $context,
             $this->metadataFactory,
-            $this->validatorFactory
+            $this->validatorFactory,
+            $this->objectInitializers
         );
     }
 

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -411,9 +411,9 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         $contextFactory = new LegacyExecutionContextFactory($metadataFactory, $translator, $this->translationDomain);
 
         if (Validation::API_VERSION_2_5 === $apiVersion) {
-            return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory);
+            return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers);
         }
 
-        return new LegacyValidator($contextFactory, $metadataFactory, $validatorFactory);
+        return new LegacyValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11159 |
| License | MIT |
| Doc PR | - |

Object initializers were forgot in the 2.5 Validator API. This PR implements them.

A bug was fixed also in the old version which resulted in the initializers being called multiple times if an object was validated in multiple groups within the same validation run. This fix will be backported separately to older versions.
