### PR TITLE
[Validator] Backported #11410 to 2.3: Object initializers are called only once per object

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Fixtures/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Entity.php
@@ -35,6 +35,7 @@ class Entity extends EntityParent implements EntityInterface
     public $reference;
     private $internal;
     public $data = 'Overridden data';
+    public $initialized = false;
 
     public function __construct($internal = null)
     {

--- a/src/Symfony/Component/Validator/ValidationVisitor.php
+++ b/src/Symfony/Component/Validator/ValidationVisitor.php
@@ -127,16 +127,19 @@ class ValidationVisitor implements ValidationVisitorInterface, GlobalExecutionCo
                 return;
             }
 
+            // Initialize if the object wasn't initialized before
+            if (!isset($this->validatedObjects[$hash])) {
+                foreach ($this->objectInitializers as $initializer) {
+                    if (!$initializer instanceof ObjectInitializerInterface) {
+                        throw new \LogicException('Validator initializers must implement ObjectInitializerInterface.');
+                    }
+                    $initializer->initialize($value);
+                }
+            }
+
             // Remember validating this object before starting and possibly
             // traversing the object graph
             $this->validatedObjects[$hash][$group] = true;
-
-            foreach ($this->objectInitializers as $initializer) {
-                if (!$initializer instanceof ObjectInitializerInterface) {
-                    throw new \LogicException('Validator initializers must implement ObjectInitializerInterface.');
-                }
-                $initializer->initialize($value);
-            }
         }
 
         // Validate arrays recursively by default, otherwise every driver needs


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Before, object initializers were called multiple times if an object was validated in different groups in the same validation run. The initializers, however, are not aware of the current validation group, so calling them more than once does not make sense.

Now, object initializers are called exactly once per validated object.

See #11410
