### PR TITLE
[CssSelector] Rename Specificity->compare() to compareTo()

### DIFF
--- a/src/Symfony/Component/CssSelector/Node/Specificity.php
+++ b/src/Symfony/Component/CssSelector/Node/Specificity.php
@@ -83,7 +83,7 @@ class Specificity
      * @param Specificity $specificity
      * @return int
      */
-    public function compare(Specificity $specificity)
+    public function compareTo(Specificity $specificity)
     {
         if ($this->a !== $specificity->a) {
             return $this->a > $specificity->a ? 1 : -1;

--- a/src/Symfony/Component/CssSelector/Tests/Node/SpecificityTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/SpecificityTest.php
@@ -39,9 +39,9 @@ class SpecificityTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @dataProvider getCompareTestData */
-    public function testCompare(Specificity $a, Specificity $b, $result)
+    public function testCompareTo(Specificity $a, Specificity $b, $result)
     {
-        $this->assertEquals($result, $a->compare($b));
+        $this->assertEquals($result, $a->compareTo($b));
     }
 
     public function getCompareTestData()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11404 |
| License | MIT |
| Doc PR | - |

Update for #11404 as proposed in the comments. `compareTo` was suggested as a better name then `compare`. 
