### PR TITLE
Pass a Scope instance instead of a scope name when cloning a container in the GrahpvizDumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Scope;
 
 /**
  * GraphvizDumper dumps a service container as a graphviz file.
@@ -193,8 +194,8 @@ class GraphvizDumper extends Dumper
         $container->setDefinitions($this->container->getDefinitions());
         $container->setAliases($this->container->getAliases());
         $container->setResources($this->container->getResources());
-        foreach ($this->container->getScopes() as $scope) {
-            $container->addScope($scope);
+        foreach ($this->container->getScopes() as $scope => $parentScope) {
+            $container->addScope(new Scope($scope, $parentScope));
         }
         foreach ($this->container->getExtensions() as $extension) {
             $container->registerExtension($extension);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
@@ -62,4 +62,11 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
         $dumper = new GraphvizDumper($container);
         $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services14.dot')), $dumper->dump(), '->dump() dumps services');
     }
+
+    public function testDumpWithScopes()
+    {
+        $container = include self::$fixturesPath.'/containers/container18.php';
+        $dumper = new GraphvizDumper($container);
+        $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services18.dot')), $dumper->dump(), '->dump() dumps services');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container18.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container18.php
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Scope;
+
+$container = new ContainerBuilder();
+$container->addScope(new Scope('request'));
+$container->
+    register('foo', 'FooClass')->
+    setScope('request')
+;
+$container->compile();
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services18.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services18.dot
@@ -1,0 +1,8 @@
+digraph sc {
+  ratio="compress"
+  node [fontsize="11" fontname="Arial" shape="record"];
+  edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
+
+  node_foo [label="foo\nFooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11055 |
| License | MIT |
| Doc PR | - |
