### PR TITLE
Fix issue described in #11421

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -59,8 +59,7 @@ class ExecutableFinder
                 if (is_dir($path)) {
                     $dirs[] = $path;
                 } else {
-                    $file = str_replace(dirname($path), '', $path);
-                    if ($file == $name && is_executable($path)) {
+                    if (basename($path) == $name && is_executable($path)) {
                         return $path;
                     }
                 }

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -120,12 +120,12 @@ class ExecutableFinderTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Requires the PHP_BINARY constant');
         }
 
-        $execPath = __DIR__.DIRECTORY_SEPARATOR.'SignalListener.php';
+        $execPath = __DIR__.'/SignalListener.php';
 
         $this->setPath('');
         ini_set('open_basedir', PHP_BINARY.PATH_SEPARATOR.'/');
 
-        $finder = new ExecutableFinder;
+        $finder = new ExecutableFinder();
         $result = $finder->find($this->getPhpBinaryName(), false);
 
         $this->assertSamePath(PHP_BINARY, $result);

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -110,6 +110,27 @@ class ExecutableFinderTest extends \PHPUnit_Framework_TestCase
         $this->assertSamePath(PHP_BINARY, $result);
     }
 
+    public function testFindProcessInOpenBasedir()
+    {
+        if (ini_get('open_basedir')) {
+            $this->markTestSkipped('Cannot test when open_basedir is set');
+        }
+
+        if (!defined('PHP_BINARY')) {
+            $this->markTestSkipped('Requires the PHP_BINARY constant');
+        }
+
+        $execPath = __DIR__.DIRECTORY_SEPARATOR.'SignalListener.php';
+
+        $this->setPath('');
+        ini_set('open_basedir', PHP_BINARY.PATH_SEPARATOR.'/');
+
+        $finder = new ExecutableFinder;
+        $result = $finder->find($this->getPhpBinaryName(), false);
+
+        $this->assertSamePath(PHP_BINARY, $result);
+    }
+
     private function assertSamePath($expected, $tested)
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11421 |
| License | MIT |
| Doc PR | NA |

This pull request fixes the issue described in #11421.  It also adds a test for the issue.  The issue is present in 2.0 forward, but I decided to fix it on the 2.3 branch so that I could also write a test for it (2.0 had no tests for the Process component, and 2.1 and 2.2 didn't have tests for the `ExecutableFinder` class).
