### PR TITLE
fix signal handling in wait() on calls to stop()

### DIFF
--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -211,6 +211,11 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
         $this->markTestSkipped('Signal is not supported in sigchild environment');
     }
 
+    public function testRunProcessWithTimeout()
+    {
+        $this->markTestSkipped('Signal (required for timeout) is not supported in sigchild environment');
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
@@ -120,6 +120,21 @@ class SigchildEnabledProcessTest extends AbstractProcessTest
         parent::testStartAfterATimeout();
     }
 
+    public function testStopWithTimeoutIsActuallyWorking()
+    {
+        $this->markTestSkipped('Stopping with signal is not supported in sigchild environment');
+    }
+
+    public function testRunProcessWithTimeout()
+    {
+        $this->markTestSkipped('Signal (required for timeout) is not supported in sigchild environment');
+    }
+
+    public function testCheckTimeoutOnStartedProcess()
+    {
+        $this->markTestSkipped('Signal (required for timeout) is not supported in sigchild environment');
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -147,6 +147,50 @@ class SimpleProcessTest extends AbstractProcessTest
         parent::testSignalWithWrongNonIntSignal();
     }
 
+    public function testStopTerminatesProcessCleanly()
+    {
+        try {
+            $process = $this->getProcess('php -r "echo \'foo\'; sleep(1); echo \'bar\';"');
+            $process->run(function () use ($process) {
+                $process->stop();
+            });
+        } catch (RuntimeException $e) {
+            $this->fail('A call to stop() is not expected to cause wait() to throw a RuntimeException');
+        }
+    }
+
+    public function testKillSignalTerminatesProcessCleanly()
+    {
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. The process can not be signaled.');
+
+        try {
+            $process = $this->getProcess('php -r "echo \'foo\'; sleep(1); echo \'bar\';"');
+            $process->run(function () use ($process) {
+                if ($process->isRunning()) {
+                    $process->signal(SIGKILL);
+                }
+            });
+        } catch (RuntimeException $e) {
+            $this->fail('A call to signal() is not expected to cause wait() to throw a RuntimeException');
+        }
+    }
+
+    public function testTermSignalTerminatesProcessCleanly()
+    {
+        $this->expectExceptionIfPHPSigchild('Symfony\Component\Process\Exception\RuntimeException', 'This PHP has been compiled with --enable-sigchild. The process can not be signaled.');
+
+        try {
+            $process = $this->getProcess('php -r "echo \'foo\'; sleep(1); echo \'bar\';"');
+            $process->run(function () use ($process) {
+                if ($process->isRunning()) {
+                    $process->signal(SIGTERM);
+                }
+            });
+        } catch (RuntimeException $e) {
+            $this->fail('A call to signal() is not expected to cause wait() to throw a RuntimeException');
+        }
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -191,6 +191,13 @@ class SimpleProcessTest extends AbstractProcessTest
         }
     }
 
+    public function testStopWithTimeoutIsActuallyWorking()
+    {
+        $this->skipIfPHPSigchild();
+
+        parent::testStopWithTimeoutIsActuallyWorking();
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11286 |
| License | MIT |
| Doc PR |  |

`wait()` throws an exception when the process was terminated by a signal. This should not happen when the termination was requested by calling the `stop()` method (for example, inside a callback which is passed to `wait()`).
