### PR TITLE
[Form] Trigger deprecation error on request submission

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
@@ -43,8 +43,7 @@ class BindRequestListener implements EventSubscriberInterface
             return;
         }
 
-        // Uncomment this as soon as the deprecation note should be shown
-        // trigger_error('Passing a Request instance to Form::submit() is deprecated since version 2.3 and will be disabled in 3.0. Call Form::process($request) instead.', E_USER_DEPRECATED);
+        trigger_error('Passing a Request instance to Form::submit() is deprecated since version 2.3 and will be disabled in 3.0. Call Form::handleRequest($request) instead.', E_USER_DEPRECATED);
 
         $name = $form->getConfig()->getName();
         $default = $form->getConfig()->getCompound() ? array() : null;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I think it's time to let the world know that one should use `handleRequest` to bind a `Request` object against a form.
This is true from Symfony 2.3 (as stated in the deprecation message).
I've also fixed the message, as it used to state that user should use inexistant method `Form::process()`.

What do you think @webmozart?
