### PR TITLE
[DoctrineBridge][DI] use a service for cache instance

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -330,42 +330,57 @@ abstract class AbstractDoctrineExtension extends Extension
                 return $cacheDriverServiceId;
             case 'memcache':
                 $memcacheClass = !empty($cacheDriver['class']) ? $cacheDriver['class'] : '%'.$this->getObjectManagerElementName('cache.memcache.class').'%';
-                $memcacheInstanceClass = !empty($cacheDriver['instance_class']) ? $cacheDriver['instance_class'] : '%'.$this->getObjectManagerElementName('cache.memcache_instance.class').'%';
-                $memcacheHost = !empty($cacheDriver['host']) ? $cacheDriver['host'] : '%'.$this->getObjectManagerElementName('cache.memcache_host').'%';
-                $memcachePort = !empty($cacheDriver['port']) || (isset($cacheDriver['port']) && $cacheDriver['port'] === 0)  ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.memcache_port').'%';
                 $cacheDef = new Definition($memcacheClass);
-                $memcacheInstance = new Definition($memcacheInstanceClass);
-                $memcacheInstance->addMethodCall('connect', array(
-                    $memcacheHost, $memcachePort
-                ));
-                $container->setDefinition($this->getObjectManagerElementName(sprintf('%s_memcache_instance', $objectManagerName)), $memcacheInstance);
-                $cacheDef->addMethodCall('setMemcache', array(new Reference($this->getObjectManagerElementName(sprintf('%s_memcache_instance', $objectManagerName)))));
+                $memcacheInstanceName = $this->getObjectManagerElementName(sprintf('%s_memcache_instance', $objectManagerName));
+                if (! empty($cacheDriver['instance_id'])) {
+                    $container->setAlias($memcacheInstanceName, new Alias($cacheDriver['instance_id'], false));
+                } else {
+                    $memcacheInstanceClass = !empty($cacheDriver['instance_class']) ? $cacheDriver['instance_class'] : '%'.$this->getObjectManagerElementName('cache.memcache_instance.class').'%';
+                    $memcacheHost = !empty($cacheDriver['host']) ? $cacheDriver['host'] : '%'.$this->getObjectManagerElementName('cache.memcache_host').'%';
+                    $memcachePort = !empty($cacheDriver['port']) || (isset($cacheDriver['port']) && $cacheDriver['port'] === 0)  ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.memcache_port').'%';
+                    $memcacheInstance = new Definition($memcacheInstanceClass);
+                    $memcacheInstance->addMethodCall('connect', array(
+                        $memcacheHost, $memcachePort
+                    ));
+                    $container->setDefinition($memcacheInstanceName, $memcacheInstance);
+                }
+                $cacheDef->addMethodCall('setMemcache', array(new Reference($memcacheInstanceName)));
                 break;
             case 'memcached':
                 $memcachedClass = !empty($cacheDriver['class']) ? $cacheDriver['class'] : '%'.$this->getObjectManagerElementName('cache.memcached.class').'%';
-                $memcachedInstanceClass = !empty($cacheDriver['instance_class']) ? $cacheDriver['instance_class'] : '%'.$this->getObjectManagerElementName('cache.memcached_instance.class').'%';
-                $memcachedHost = !empty($cacheDriver['host']) ? $cacheDriver['host'] : '%'.$this->getObjectManagerElementName('cache.memcached_host').'%';
-                $memcachedPort = !empty($cacheDriver['port']) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.memcached_port').'%';
                 $cacheDef = new Definition($memcachedClass);
-                $memcachedInstance = new Definition($memcachedInstanceClass);
-                $memcachedInstance->addMethodCall('addServer', array(
-                    $memcachedHost, $memcachedPort
-                ));
-                $container->setDefinition($this->getObjectManagerElementName(sprintf('%s_memcached_instance', $objectManagerName)), $memcachedInstance);
-                $cacheDef->addMethodCall('setMemcached', array(new Reference($this->getObjectManagerElementName(sprintf('%s_memcached_instance', $objectManagerName)))));
+                $memcachedInstanceName = $this->getObjectManagerElementName(sprintf('%s_memcached_instance', $objectManagerName));
+                if (! empty($cacheDriver['instance_id'])) {
+                    $container->setAlias($memcachedInstanceName, new Alias($cacheDriver['instance_id'], false));
+                } else {
+                    $memcachedInstanceClass = !empty($cacheDriver['instance_class']) ? $cacheDriver['instance_class'] : '%'.$this->getObjectManagerElementName('cache.memcached_instance.class').'%';
+                    $memcachedHost = !empty($cacheDriver['host']) ? $cacheDriver['host'] : '%'.$this->getObjectManagerElementName('cache.memcached_host').'%';
+                    $memcachedPort = !empty($cacheDriver['port']) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.memcached_port').'%';
+                    $memcachedInstance = new Definition($memcachedInstanceClass);
+                    $memcachedInstance->addMethodCall('addServer', array(
+                        $memcachedHost, $memcachedPort
+                    ));
+                    $container->setDefinition($memcachedInstanceName, $memcachedInstance);
+                }
+                $cacheDef->addMethodCall('setMemcached', array(new Reference($memcachedInstanceName)));
                 break;
-             case 'redis':
+            case 'redis':
                 $redisClass = !empty($cacheDriver['class']) ? $cacheDriver['class'] : '%'.$this->getObjectManagerElementName('cache.redis.class').'%';
-                $redisInstanceClass = !empty($cacheDriver['instance_class']) ? $cacheDriver['instance_class'] : '%'.$this->getObjectManagerElementName('cache.redis_instance.class').'%';
-                $redisHost = !empty($cacheDriver['host']) ? $cacheDriver['host'] : '%'.$this->getObjectManagerElementName('cache.redis_host').'%';
-                $redisPort = !empty($cacheDriver['port']) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.redis_port').'%';
                 $cacheDef = new Definition($redisClass);
-                $redisInstance = new Definition($redisInstanceClass);
-                $redisInstance->addMethodCall('connect', array(
-                    $redisHost, $redisPort
-                ));
-                $container->setDefinition($this->getObjectManagerElementName(sprintf('%s_redis_instance', $objectManagerName)), $redisInstance);
-                $cacheDef->addMethodCall('setRedis', array(new Reference($this->getObjectManagerElementName(sprintf('%s_redis_instance', $objectManagerName)))));
+                $redisInstanceName = $this->getObjectManagerElementName(sprintf('%s_redis_instance', $objectManagerName));
+                if (! empty($cacheDriver['instance_id'])) {
+                    $container->setAlias($redisInstanceName, new Alias($cacheDriver['instance_id'], false));
+                } else {
+                    $redisInstanceClass = !empty($cacheDriver['instance_class']) ? $cacheDriver['instance_class'] : '%'.$this->getObjectManagerElementName('cache.redis_instance.class').'%';
+                    $redisHost = !empty($cacheDriver['host']) ? $cacheDriver['host'] : '%'.$this->getObjectManagerElementName('cache.redis_host').'%';
+                    $redisPort = !empty($cacheDriver['port']) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.redis_port').'%';
+                    $redisInstance = new Definition($redisInstanceClass);
+                    $redisInstance->addMethodCall('connect', array(
+                        $redisHost, $redisPort
+                    ));
+                    $container->setDefinition($redisInstanceName, $redisInstance);
+                }
+                $cacheDef->addMethodCall('setRedis', array(new Reference($redisInstanceName)));
                 break;
             case 'apc':
             case 'array':


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
## What?

I've improved the way the memcache/redis cache driver for Doctrine can be configured.
## Why?

In the current implementation, to create (e.g.) a redis connection one have to define under doctrine ORM something like this:

``` yaml
doctrine:
    orm:
        entity_managers:
            default:
                query_cache_driver:
                    type:                  redis
                    host:                  cache-server.example.com
                    port:                  12345
#                  instance_class: Redis # default value
#                  class:                 Doctrine\Common\Cache\RedisCache
```

This way, the DI component, allocate a `new Redis` object, start a new connection, and bind it to the CacheDriver with a (carefully generated) namespace.

The complication starts if you use Redis for multiple services and in many different context. To reuse the same connection, you have to create a service and use it in multiple places:

``` xml
        <service id="acme.connection" class="Redis">
            <call method="connect">
                <argument>cache-server.example.com</argument>
                <argument>12345</argument>
            </call>
        </service>

        <service id="acme.redis" class="Doctrine\Common\Cache\RedisCache">
            <call method="setRedis">
                <argument type="service" id="acme.connection"/>
            </call>
        </service>
```

Then you do:

``` yml
doctrine:
    orm:
        entity_managers:
            default:
                query_cache_driver:
                    type: service
                    id:     acme.redis
```

But this introduce another problem: the namespace is not set (or set only once) and then, the service `acme.redis` cannot be used in multiple content unless you are absolutely sure that no cache collision happens. In my experience collisions always happens, since there are multiple instance/version of the same project on a staging/production server.
## How?

To solve the issue, it is enough to provide a way to set the connection instance to the cache driver. I've modified the DI so that the following can be used for multiple configuration:

``` xml
        <!-- same connection from the example above -->
        <service id="acme.connection" class="Redis">
            <call method="connect">
                <argument>cache-server.example.com</argument>
                <argument>12345</argument>
            </call>
        </service>
```

``` yaml
doctrine:
    orm:
        entity_managers:
            default:
                query_cache_driver:
                    type:                  redis
                    instance_id:       acme.connection
            # another em just to show the usage
            another:
                query_cache_driver:
                    type:                  redis
                    instance_id:       acme.connection

```

Now, the connection is created once and namespaces are no longer an issue, since a cache profile is created for each context.
## Todo:

I've used the new name `instance_id` to be consistent with `instance_class`, but this require a new configuration entry. Maybe, we can just reuse the `id` entry.

Also, It would be nice if someone would point me to the right place for the new documentation (docs? cookbook?).
### Checklist:
- [ ] gather feedback for my changes
- [ ] submit changes to the doctrine bundle (required only if not using the `id` entry)
- [ ] submit changes to the documentation
