### PR TITLE
[Validator] Fixed memory leak in ValidatorBuilder

### DIFF
--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Validator;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ArrayCache;
@@ -367,20 +366,6 @@ class ValidatorBuilder implements ValidatorBuilderInterface
 
             if ($this->annotationReader) {
                 $loaders[] = new AnnotationLoader($this->annotationReader);
-
-                AnnotationRegistry::registerLoader(function ($class) {
-                    if (0 === strpos($class, __NAMESPACE__.'\\Constraints\\')) {
-                        $file = str_replace(__NAMESPACE__.'\\Constraints\\', __DIR__.'/Constraints/', $class).'.php';
-
-                        if (is_file($file)) {
-                            require_once $file;
-
-                            return true;
-                        }
-                    }
-
-                    return false;
-                });
             }
 
             $loader = null;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11236 |
| License | MIT |
| Doc PR | - |

In 23534ca6ab4a107a5e801e710fb3c07b1a8874d9, the following code was introduced in `ValidatorBuilder::getValidator()`:

``` php
AnnotationRegistry::registerLoader(function ($class) {
    if (0 === strpos($class, __NAMESPACE__.'\\Constraints\\')) {
        $file = str_replace(__NAMESPACE__.'\\Constraints\\', __DIR__.'/Constraints/', $class).'.php';

        if (is_file($file)) {
            require_once $file;

            return true;
        }
    }

    return false;
});
```

`AnnotationRegistry::registerLoader()` stores all loaders in a global array. Every time that `getValidator()` is called, a new closure is put onto the loader stack, referencing `$this` (i.e. the ValidatorBuilder) and consequently preventing the ValidatorBuilder (and its references) from being garbage-collected.

The call to `registerLoader()` did not exist in 2.4 and I can't find a reason why it should be there. All tests are green without that code. I suppose I used it for debugging and then forgot to remove it again, so I'm removing it here.
