### PR TITLE
Use findDefinition instead of getDefinition && hasAlias

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterListenersPass.php
@@ -50,7 +50,7 @@ class RegisterListenersPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition($this->dispatcherService) && !$container->hasAlias($this->dispatcherService)) {
+        if (!$container->findDefinition($this->dispatcherService)) {
             return;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |
