### PR TITLE
[Form] Automated label generation for forms

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -120,7 +120,7 @@ class Configuration implements ConfigurationInterface
                     ->info('form configuration')
                     ->canBeEnabled()
                     ->children()
-                        ->scalarNode('auto_label')->defaultNull()->end()
+                        ->scalarNode('auto_label')->end()
                         ->arrayNode('csrf_protection')
                             ->treatFalseLike(array('enabled' => false))
                             ->treatTrueLike(array('enabled' => true))

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -120,6 +120,7 @@ class Configuration implements ConfigurationInterface
                     ->info('form configuration')
                     ->canBeEnabled()
                     ->children()
+                        ->scalarNode('auto_label')->defaultNull()->end()
                         ->arrayNode('csrf_protection')
                             ->treatFalseLike(array('enabled' => false))
                             ->treatTrueLike(array('enabled' => true))

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -177,6 +177,11 @@ class FrameworkExtension extends Extension
             $config['form']['csrf_protection']['enabled'] = $config['csrf_protection']['enabled'];
         }
 
+        if ($config['form']['auto_label'] !== null) {
+            $loader->load('form_auto_label.xml');
+            $container->setParameter('form.type_extension.auto_label.auto_label', $config['form']['auto_label']);
+        }
+
         if ($this->isConfigEnabled($container, $config['form']['csrf_protection'])) {
             $loader->load('form_csrf.xml');
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -177,7 +177,7 @@ class FrameworkExtension extends Extension
             $config['form']['csrf_protection']['enabled'] = $config['csrf_protection']['enabled'];
         }
 
-        if ($config['form']['auto_label'] !== null) {
+        if (array_key_exists('auto_label', $config['form'])) {
             $loader->load('form_auto_label.xml');
             $container->setParameter('form.type_extension.auto_label.auto_label', $config['form']['auto_label']);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_auto_label.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_auto_label.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="form.type_extension.auto_label" class="Symfony\Component\Form\Extension\AutoLabel\Type\AutoLabelTypeExtension">
+            <tag name="form.type_extension" alias="form" />
+            <argument>%form.type_extension.auto_label.auto_label%</argument>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/Form/Extension/AutoLabel/AutoLabelExtension.php
+++ b/src/Symfony/Component/Form/Extension/AutoLabel/AutoLabelExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\AutoLabel;
+
+use Symfony\Component\Form\AbstractExtension;
+
+/**
+ * Extension for automated label generation.
+ *
+ * @since  2.7
+ * @author Alexandre Salomé <alexandre.salome@gmail.com>
+ */
+class AutoLabelExtension extends AbstractExtension
+{
+    /**
+     * @var string
+     */
+    private $autoLabel;
+
+    /**
+     * Constructs a new form extension.
+     *
+     * The argument "autoLabel" can have placeholders:
+     *
+     * - %type%    : the form type name (ex: text, choice, date)
+     * - %name%    : the name of the form (ex: firstname)
+     * - %fullname%: the full name of the form (ex: user_firstname)
+     *
+     * @param string $autoLabel a default label for forms
+     */
+    public function __construct($autoLabel)
+    {
+        $this->autoLabel = $autoLabel;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadTypeExtensions()
+    {
+        return array(
+            new Type\AutoLabelTypeExtension($this->autoLabel)
+        );
+    }
+}

--- a/src/Symfony/Component/Form/Extension/AutoLabel/Type/AutoLabelTypeExtension.php
+++ b/src/Symfony/Component/Form/Extension/AutoLabel/Type/AutoLabelTypeExtension.php
@@ -59,24 +59,25 @@ class AutoLabelTypeExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if ($options['label'] === null) {
+        if (null === $options['label']) {
             $autoLabel = $options['auto_label'];
             $parent    = $form->getParent();
             $fullname  = $form->getName();
 
             while ($parent) {
-                if ($autoLabel === null) {
+                if (null === $autoLabel) {
                     $autoLabel = $parent->getConfig()->getOption('auto_label');
                 }
                 $fullname = $parent->getName().'_'.$fullname;
                 $parent   = $parent->getParent();
             }
 
-            if ($autoLabel === null) {
+            if (null === $autoLabel) {
                 $autoLabel = $this->autoLabel;
             }
 
-            if ($autoLabel !== null) {
+
+            if (null !== $autoLabel) {
                 $view->vars['label'] = strtr($autoLabel, array(
                     '%name%'     => $form->getName(),
                     '%fullname%' => $fullname,

--- a/src/Symfony/Component/Form/Extension/AutoLabel/Type/AutoLabelTypeExtension.php
+++ b/src/Symfony/Component/Form/Extension/AutoLabel/Type/AutoLabelTypeExtension.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\AutoLabel\Type;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Extension for automated label generation.
+ *
+ * @since  2.7
+ * @author Alexandre Salomé <alexandre.salome@gmail.com>
+ */
+class AutoLabelTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * @var string
+     */
+    private $autoLabel;
+
+    /**
+     * Constructs a new type extension.
+     *
+     * The argument "autoLabel" can have placeholders:
+     *
+     * - %type%    : the form type name (ex: text, choice, date)
+     * - %name%    : the name of the form (ex: firstname)
+     * - %fullname%: the full name of the form (ex: user_firstname)
+     *
+     * @param string $autoLabel a default label for forms
+     */
+    public function __construct($autoLabel = 'form.%type%.label.%name%')
+    {
+        $this->autoLabel = $autoLabel;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return 'form';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if ($options['auto_label'] !== null && $options['label'] === null) {
+            $fullname = $form->getName();
+            $parent   = $form->getParent();
+            while ($parent) {
+                $fullname = $parent->getName().'_'.$fullname;
+                $parent   = $parent->getParent();
+            }
+
+            $view->vars['label'] = strtr($options['auto_label'], array(
+                '%name%'     => $form->getName(),
+                '%fullname%' => $fullname,
+                '%type%'     => $form->getConfig()->getType()->getName(),
+            ));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'auto_label' => $this->autoLabel
+        ));
+    }
+}

--- a/src/Symfony/Component/Form/Extension/AutoLabel/Type/AutoLabelTypeExtension.php
+++ b/src/Symfony/Component/Form/Extension/AutoLabel/Type/AutoLabelTypeExtension.php
@@ -59,19 +59,30 @@ class AutoLabelTypeExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if ($options['auto_label'] !== null && $options['label'] === null) {
-            $fullname = $form->getName();
-            $parent   = $form->getParent();
+        if ($options['label'] === null) {
+            $autoLabel = $options['auto_label'];
+            $parent    = $form->getParent();
+            $fullname  = $form->getName();
+
             while ($parent) {
+                if ($autoLabel === null) {
+                    $autoLabel = $parent->getConfig()->getOption('auto_label');
+                }
                 $fullname = $parent->getName().'_'.$fullname;
                 $parent   = $parent->getParent();
             }
 
-            $view->vars['label'] = strtr($options['auto_label'], array(
-                '%name%'     => $form->getName(),
-                '%fullname%' => $fullname,
-                '%type%'     => $form->getConfig()->getType()->getName(),
-            ));
+            if ($autoLabel === null) {
+                $autoLabel = $this->autoLabel;
+            }
+
+            if ($autoLabel !== null) {
+                $view->vars['label'] = strtr($autoLabel, array(
+                    '%name%'     => $form->getName(),
+                    '%fullname%' => $fullname,
+                    '%type%'     => $form->getConfig()->getType()->getName(),
+                ));
+            }
         }
     }
 
@@ -81,7 +92,7 @@ class AutoLabelTypeExtension extends AbstractTypeExtension
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'auto_label' => $this->autoLabel
+            'auto_label' => null
         ));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/AutoLabel/AutoLabelExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/AutoLabel/AutoLabelExtensionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\AutoLabel;
+
+use Symfony\Component\Form\Extension\AutoLabel\AutoLabelExtension;
+
+/**
+ * @covers Symfony\Component\Form\Extension\AutoLabel\AutoLabelExtension
+ */
+class AutoLabelExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AutoLabelExtension
+     */
+    private $extension;
+
+    public function setUp()
+    {
+        $this->extension = new AutoLabelExtension('foo');
+    }
+
+    public function testLoadTypeExtensions()
+    {
+        $typeExtensions = $this->extension->getTypeExtensions('form');
+
+        $this->assertInternalType('array', $typeExtensions);
+        $this->assertCount(1, $typeExtensions);
+        $this->assertInstanceOf('Symfony\Component\Form\Extension\AutoLabel\Type\AutoLabelTypeExtension', array_shift($typeExtensions));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/AutoLabel/Type/AutoLabelTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/AutoLabel/Type/AutoLabelTypeExtensionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\AutoLabel\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Form\Extension\AutoLabel\AutoLabelExtension;
+
+class FormTypeAutoLabelExtensionTest_ChildType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('name', 'text');
+    }
+
+    public function getName()
+    {
+        return 'auto_label_test';
+    }
+}
+
+class FormTypeAutoLabelExtensionTest extends TypeTestCase
+{
+    protected function getExtensions()
+    {
+        return array_merge(parent::getExtensions(), array(
+            new AutoLabelExtension('form.%type%.label.%name%'),
+        ));
+    }
+
+    public function testDefaultLabelGeneration()
+    {
+        $view = $this->factory->createNamed('firstname', 'text')->createView();
+        $this->assertEquals('form.text.label.firstname', $view->vars['label']);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/AutoLabel/Type/AutoLabelTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/AutoLabel/Type/AutoLabelTypeExtensionTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Extension\AutoLabel\AutoLabelExtension;
 
-class FormTypeAutoLabelExtensionTest_ChildType extends AbstractType
+class AutoLabelTypeExtensionTest_ChildType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -29,7 +29,7 @@ class FormTypeAutoLabelExtensionTest_ChildType extends AbstractType
     }
 }
 
-class FormTypeAutoLabelExtensionTest extends TypeTestCase
+class AutoLabelTypeExtensionTest extends TypeTestCase
 {
     protected function getExtensions()
     {
@@ -70,11 +70,11 @@ class FormTypeAutoLabelExtensionTest extends TypeTestCase
 
     public function testInheritedOption()
     {
-        $builder = $this->factory->createNamedBuilder('firstname', 'form', array(
+        $builder = $this->factory->createNamedBuilder('user', 'form', null, array(
             'auto_label' => '%type%.%fullname%'
         ));
 
         $view = $builder->add('firstname', 'text')->getForm()->createView();
-        $this->assertEquals('form.firstname', $view['firstname']->vars['label']);
+        $this->assertEquals('text.user_firstname', $view['firstname']->vars['label']);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/AutoLabel/Type/AutoLabelTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/AutoLabel/Type/AutoLabelTypeExtensionTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form\Tests\Extension\AutoLabel\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Extension\AutoLabel\AutoLabelExtension;
 
@@ -35,13 +34,47 @@ class FormTypeAutoLabelExtensionTest extends TypeTestCase
     protected function getExtensions()
     {
         return array_merge(parent::getExtensions(), array(
-            new AutoLabelExtension('form.%type%.label.%name%'),
+            new AutoLabelExtension('%fullname%.%name%.%type%'),
         ));
     }
 
     public function testDefaultLabelGeneration()
     {
         $view = $this->factory->createNamed('firstname', 'text')->createView();
-        $this->assertEquals('form.text.label.firstname', $view->vars['label']);
+        $this->assertEquals('firstname.firstname.text', $view->vars['label']);
+    }
+
+    public function testFullnameGeneration()
+    {
+        $view = $this->factory
+            ->createBuilder('form')
+            ->add('form', 'form', array('auto_label' => '%fullname%'))
+            ->getForm()
+            ->createView()
+        ;
+
+        $this->assertEquals('form_form', $view['form']->vars['label']);
+    }
+
+    public function testForcedGeneration()
+    {
+        $view = $this->factory->createNamed('firstname', 'text', null, array('auto_label' => '%fullname%'))->createView();
+        $this->assertEquals('firstname', $view->vars['label']);
+    }
+
+    public function testOverridenLabelGeneration()
+    {
+        $view = $this->factory->createNamed('firstname', 'text', null, array('auto_label' => 'foo.%name%'))->createView();
+        $this->assertEquals('foo.firstname', $view->vars['label']);
+    }
+
+    public function testInheritedOption()
+    {
+        $builder = $this->factory->createNamedBuilder('firstname', 'form', array(
+            'auto_label' => '%type%.%fullname%'
+        ));
+
+        $view = $builder->add('firstname', 'text')->getForm()->createView();
+        $this->assertEquals('form.firstname', $view['firstname']->vars['label']);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | TBD |
| Fixed tickets | Not a fix, but discussed in #11298 |
| License | MIT |
| Doc PR | TBD |
| standard edition PR | TBD |

Discussion started in #11298

This PR is about adding an option to automate the label generation for forms:

``` yaml
# app/config/config.yml
framework:
    form:
        # auto_label: ~                      # enable the extension
        # auto_label: form.%%type%%.%%name%% # set the auto_label globally, but allow overriding per form
```

This option would be useful for big I18Ned applications with standardized label form translations. We could also add an option for a default **translation_domain**.

``` yaml
    form:
        translation_domain: "form"
```

I started this work as a third-party extension, because most applications don't need it, so the footprint is null for them.

What is your advice on it?
- [x] Inherit auto-label from parent
- [ ] Create the documentation PR
- [ ] Create the standard edition PR
