### PR TITLE
[WIP] Refactored argument resolving out of the ControllerResolver

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -36,6 +36,7 @@ use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\DependencyInjection\RegisterArgumentResolversPass;
 
 /**
  * Bundle.
@@ -88,6 +89,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new TranslationDumperPass());
         $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new SerializerPass());
+        $container->addCompilerPass(new RegisterArgumentResolversPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -14,6 +14,7 @@
             <argument type="service" id="service_container" />
             <argument type="service" id="controller_resolver" />
             <argument type="service" id="request_stack" />
+            <argument type="service" id="argument_resolver.manager" />
         </service>
 
         <service id="request_stack" class="Symfony\Component\HttpFoundation\RequestStack" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -17,6 +17,16 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
+        <service id="argument_resolver.manager" class="Symfony\Component\HttpKernel\Controller\ArgumentResolverManager" />
+
+        <service id="argument_resolver.request" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestArgumentResolver">
+            <tag name="kernel.argument_resolver" />
+        </service>
+
+        <service id="argument_resolver.request_attributes" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributesArgumentResolver">
+            <tag name="kernel.argument_resolver" />
+        </service>
+
         <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener">
             <tag name="kernel.event_subscriber" />
             <argument>%kernel.charset%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -65,12 +65,12 @@ class ControllerResolverTest extends BaseControllerResolverTest
 
         $resolver = $this->createControllerResolver(null, null, $container);
         $request = Request::create('/');
-        $request->attributes->set('_controller', 'foo:controllerMethod1');
+        $request->attributes->set('_controller', 'foo:controllerMethod');
 
         $controller = $resolver->getController($request);
 
         $this->assertInstanceOf(get_class($this), $controller[0]);
-        $this->assertSame('controllerMethod1', $controller[1]);
+        $this->assertSame('controllerMethod', $controller[1]);
     }
 
     public function testGetControllerInvokableService()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/asset": "~2.7|~3.0",
-        "symfony/dependency-injection" : "~2.7|~3.0",
+        "symfony/dependency-injection" : "~3.0",
         "symfony/config" : "~2.7|~3.0",
         "symfony/event-dispatcher": "~2.7|~3.0",
         "symfony/http-foundation": "~2.7|~3.0",

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.0.0
 -----
 
+ * added argument resolvers
+ * deprecated `Symfony\Component\HttpKernel\Controller\ControllerResolver#getArguments()` and `doGetArguments()`, use argument resolvers instead
  * removed `Symfony\Component\HttpKernel\Kernel::init()`
  * removed `Symfony\Component\HttpKernel\Kernel::isClassInActiveBundle()` and `Symfony\Component\HttpKernel\KernelInterface::isClassInActiveBundle()`
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestArgumentResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Resolves arguments typehinting for the Request object.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RequestArgumentResolver implements ArgumentResolverInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function accepts(Request $request, \ReflectionParameter $parameter)
+    {
+        $class = $parameter->getClass();
+        
+        return $class && $class->isInstance($request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter)
+    {
+        return $request;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestArgumentResolver.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 class RequestArgumentResolver implements ArgumentResolverInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function supports(Request $request, \ReflectionParameter $parameter)
     {
@@ -32,7 +32,7 @@ class RequestArgumentResolver implements ArgumentResolverInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function resolve(Request $request, \ReflectionParameter $parameter)
     {

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestArgumentResolver.php
@@ -24,10 +24,10 @@ class RequestArgumentResolver implements ArgumentResolverInterface
     /**
      * {@inheritDoc}
      */
-    public function accepts(Request $request, \ReflectionParameter $parameter)
+    public function supports(Request $request, \ReflectionParameter $parameter)
     {
         $class = $parameter->getClass();
-        
+
         return $class && $class->isInstance($request);
     }
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
@@ -24,9 +24,9 @@ class RequestAttributesArgumentResolver implements ArgumentResolverInterface
     /**
      * {@inheritDoc}
      */
-    public function accepts(Request $request, \ReflectionParameter $parameter)
+    public function supports(Request $request, \ReflectionParameter $parameter)
     {
-        return array_key_exists($parameter->name, $request->attributes->all());
+        return $request->attributes->has($parameter->name);
     }
 
     /**
@@ -34,8 +34,6 @@ class RequestAttributesArgumentResolver implements ArgumentResolverInterface
      */
     public function resolve(Request $request, \ReflectionParameter $parameter)
     {
-        $attributes = $request->attributes->all();
-
-        return $attributes[$parameter->name];
+        return $request->attributes->get($parameter->name);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Resolves arguments which names are equal to the name of a request attribute.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RequestAttributesArgumentResolver implements ArgumentResolverInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function accepts(Request $request, \ReflectionParameter $parameter)
+    {
+        return array_key_exists($parameter->name, $request->attributes->all());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter)
+    {
+        $attributes = $request->attributes->all();
+
+        return $attributes[$parameter->name];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 class RequestAttributesArgumentResolver implements ArgumentResolverInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function supports(Request $request, \ReflectionParameter $parameter)
     {
@@ -30,7 +30,7 @@ class RequestAttributesArgumentResolver implements ArgumentResolverInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function resolve(Request $request, \ReflectionParameter $parameter)
     {

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * An ArgumentResolverInterface implementation resolves the arguments of 
+ * controllers.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+interface ArgumentResolverInterface
+{
+    /**
+     * Checks if the current parameter can be resolved by this argument 
+     * resolver.
+     *
+     * @param Request              $request
+     * @param \ReflectionParameter $parameter
+     *
+     * @return Boolean
+     */
+    public function accepts(Request $request, \ReflectionParameter $parameter);
+
+    /**
+     * Resolves the current parameter into an argument.
+     *
+     * @param Request              $request
+     * @param \ReflectionParameter $parameter
+     * 
+     * @return mixed The resolved argument
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter);
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\HttpKernel\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * An ArgumentResolverInterface implementation resolves the arguments of 
+ * An ArgumentResolverInterface implementation resolves the arguments of
  * controllers.
  *
  * @author Wouter J <wouter@wouterj.nl>
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 interface ArgumentResolverInterface
 {
     /**
-     * Checks if the current parameter can be resolved by this argument 
+     * Checks if the current parameter can be resolved by this argument
      * resolver.
      *
      * @param Request              $request
@@ -30,14 +30,14 @@ interface ArgumentResolverInterface
      *
      * @return Boolean
      */
-    public function accepts(Request $request, \ReflectionParameter $parameter);
+    public function supports(Request $request, \ReflectionParameter $parameter);
 
     /**
      * Resolves the current parameter into an argument.
      *
      * @param Request              $request
      * @param \ReflectionParameter $parameter
-     * 
+     *
      * @return mixed The resolved argument
      */
     public function resolve(Request $request, \ReflectionParameter $parameter);

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
@@ -28,7 +28,7 @@ interface ArgumentResolverInterface
      * @param Request              $request
      * @param \ReflectionParameter $parameter
      *
-     * @return Boolean
+     * @return bool
      */
     public function supports(Request $request, \ReflectionParameter $parameter);
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverManager.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverManager.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The ArgumentResolverManager chains over the registered argument resolvers to
+ * resolve all controller arguments.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class ArgumentResolverManager
+{
+    /**
+     * @var ArgumentResolverInterface[]
+     */
+    protected $resolvers = array();
+
+    /**
+     * Adds an argument resolver.
+     *
+     * @param ArgumentResolverInterface $resolver
+     */
+    public function addResolver(ArgumentResolverInterface $resolver)
+    {
+        $this->resolvers[] = $resolver;
+    }
+
+    /**
+     * Returns the arguments to pass to the controller.
+     *
+     * @param Request  $request    A Request instance
+     * @param callable $controller A PHP callable
+     *
+     * @return array an array of arguments to pass to the controller
+     *
+     * @throws \RuntimeException When a parameter cannot be resolved
+     */
+    public function getArguments(Request $request, $controller)
+    {
+        if (is_array($controller)) {
+            $controllerReflection = new \ReflectionMethod($controller[0], $controller[1]);
+        } elseif (is_object($controller) && !$controller instanceof \Closure) {
+            $controllerReflection = new \ReflectionObject($controller);
+            $controllerReflection = $controllerReflection->getMethod('__invoke');
+        } else {
+            $controllerReflection = new \ReflectionFunction($controller);
+        }
+
+        $parameters = $controllerReflection->getParameters();
+        $arguments  = array();
+
+        foreach ($parameters as $parameter) {
+            foreach ($this->resolvers as $argumentResolver) {
+                if ($argumentResolver->accepts($request, $parameter)) {
+                    $arguments[] = $argumentResolver->resolve($request, $parameter);
+                    continue 2;
+                }
+            }
+
+            if ($parameter->isDefaultValueAvailable()) {
+                $arguments[] = $parameter->getDefaultValue();
+            } else {
+                if (is_array($controller)) {
+                    $repr = sprintf('%s::%s()', get_class($controller[0]), $controller[1]);
+                } elseif (is_object($controller)) {
+                    $repr = get_class($controller);
+                } else {
+                    $repr = $controller;
+                }
+
+                throw new \RuntimeException(sprintf('Controller "%s" requires that you provide a value for the "$%s" argument (because there is no default value and none of the argument resolvers could resolve its value).', $repr, $parameter->name));
+            }
+        }
+
+        return $arguments;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverManager.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverManager.php
@@ -31,7 +31,7 @@ class ArgumentResolverManager
      *
      * @param ArgumentResolverInterface $resolver
      */
-    public function addResolver(ArgumentResolverInterface $resolver)
+    public function add(ArgumentResolverInterface $resolver)
     {
         $this->resolvers[] = $resolver;
     }
@@ -48,6 +48,10 @@ class ArgumentResolverManager
      */
     public function getArguments(Request $request, $controller)
     {
+        if (!is_callable($controller)) {
+            throw new \InvalidArgumentException(sprintf('Expected a callable as second parameter, got "%s".', is_object($controller) ? get_class($controller) : gettype($controller)));
+        }
+
         if (is_array($controller)) {
             $controllerReflection = new \ReflectionMethod($controller[0], $controller[1]);
         } elseif (is_object($controller) && !$controller instanceof \Closure) {
@@ -62,7 +66,7 @@ class ArgumentResolverManager
 
         foreach ($parameters as $parameter) {
             foreach ($this->resolvers as $argumentResolver) {
-                if ($argumentResolver->accepts($request, $parameter)) {
+                if ($argumentResolver->supports($request, $parameter)) {
                     $arguments[] = $argumentResolver->resolve($request, $parameter);
                     continue 2;
                 }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -90,6 +90,8 @@ class ControllerResolver implements ControllerResolverInterface
      * {@inheritdoc}
      *
      * @api
+     *
+     * @deprecated Deprecated since Symfony 2.6, will be removed in Symfony 3.0. Use ArgumentResolvers instead
      */
     public function getArguments(Request $request, $controller)
     {
@@ -105,6 +107,9 @@ class ControllerResolver implements ControllerResolverInterface
         return $this->doGetArguments($request, $controller, $r->getParameters());
     }
 
+    /**
+     * @deprecated Deprecated since Symfony 2.6, will be removed in Symfony 3.0. Use ArgumentResolvers instead
+     */
     protected function doGetArguments(Request $request, $controller, array $parameters)
     {
         $attributes = $request->attributes->all();

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -87,57 +87,6 @@ class ControllerResolver implements ControllerResolverInterface
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @api
-     *
-     * @deprecated Deprecated since Symfony 2.6, will be removed in Symfony 3.0. Use ArgumentResolvers instead
-     */
-    public function getArguments(Request $request, $controller)
-    {
-        if (is_array($controller)) {
-            $r = new \ReflectionMethod($controller[0], $controller[1]);
-        } elseif (is_object($controller) && !$controller instanceof \Closure) {
-            $r = new \ReflectionObject($controller);
-            $r = $r->getMethod('__invoke');
-        } else {
-            $r = new \ReflectionFunction($controller);
-        }
-
-        return $this->doGetArguments($request, $controller, $r->getParameters());
-    }
-
-    /**
-     * @deprecated Deprecated since Symfony 2.6, will be removed in Symfony 3.0. Use ArgumentResolvers instead
-     */
-    protected function doGetArguments(Request $request, $controller, array $parameters)
-    {
-        $attributes = $request->attributes->all();
-        $arguments = array();
-        foreach ($parameters as $param) {
-            if (array_key_exists($param->name, $attributes)) {
-                $arguments[] = $attributes[$param->name];
-            } elseif ($param->getClass() && $param->getClass()->isInstance($request)) {
-                $arguments[] = $request;
-            } elseif ($param->isDefaultValueAvailable()) {
-                $arguments[] = $param->getDefaultValue();
-            } else {
-                if (is_array($controller)) {
-                    $repr = sprintf('%s::%s()', get_class($controller[0]), $controller[1]);
-                } elseif (is_object($controller)) {
-                    $repr = get_class($controller);
-                } else {
-                    $repr = $controller;
-                }
-
-                throw new \RuntimeException(sprintf('Controller "%s" requires that you provide a value for the "$%s" argument (because there is no default value or because there is a non optional argument after this one).', $repr, $param->name));
-            }
-        }
-
-        return $arguments;
-    }
-
-    /**
      * Returns a callable for the given controller.
      *
      * @param string $controller A Controller string

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
@@ -46,18 +46,4 @@ interface ControllerResolverInterface
      * @api
      */
     public function getController(Request $request);
-
-    /**
-     * Returns the arguments to pass to the controller.
-     *
-     * @param Request  $request    A Request instance
-     * @param callable $controller A PHP callable
-     *
-     * @return array An array of arguments to pass to the controller
-     *
-     * @throws \RuntimeException When value for argument given is not provided
-     *
-     * @api
-     */
-    public function getArguments(Request $request, $controller);
 }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverManager;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -39,10 +40,11 @@ class ContainerAwareHttpKernel extends HttpKernel
      * @param ContainerInterface          $container          A ContainerInterface instance
      * @param ControllerResolverInterface $controllerResolver A ControllerResolverInterface instance
      * @param RequestStack                $requestStack       A stack for master/sub requests
+     * @param ArgumentResolverManager     $argumentResolver An ArgumentResolverManager instance
      */
-    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver, RequestStack $requestStack = null)
+    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver, RequestStack $requestStack = null, ArgumentResolverManager $argumentResolver = null)
     {
-        parent::__construct($dispatcher, $controllerResolver, $requestStack);
+        parent::__construct($dispatcher, $controllerResolver, $requestStack, $argumentResolver);
 
         $this->container = $container;
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
@@ -39,8 +39,8 @@ class RegisterArgumentResolversPass implements CompilerPassInterface
     }
 
     /**
-    * {@inheritDoc}
-    */
+     * {@inheritdoc}
+     */
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition($this->managerService) && !$container->hasAlias($this->managerService)) {

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Compiler pass to register argument resolvers.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RegisterArgumentResolversPass implements CompilerPassInterface
+{
+    /**
+     * @var string
+     */
+    protected $managerService;
+
+    /**
+     * @var string
+     */
+    protected $resolverTag;
+
+    public function __construct($managerService = 'argument_resolver.manager', $resolverTag = 'kernel.argument_resolver')
+    {
+        $this->managerService = $managerService;
+        $this->resolverTag = $resolverTag;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition($this->managerService) && !$container->hasAlias($this->managerService)) {
+            return;
+        }
+
+        $definition = $container->findDefinition($this->managerService);
+
+        foreach ($container->findTaggedServiceIds($this->resolverTag) as $id => $resolvers) {
+            $definition->addMethodCall('addResolver', array(new Reference($id)));
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
@@ -25,12 +25,12 @@ class RegisterArgumentResolversPass implements CompilerPassInterface
     /**
      * @var string
      */
-    protected $managerService;
+    private $managerService;
 
     /**
      * @var string
      */
-    protected $resolverTag;
+    private $resolverTag;
 
     public function __construct($managerService = 'argument_resolver.manager', $resolverTag = 'kernel.argument_resolver')
     {
@@ -50,7 +50,7 @@ class RegisterArgumentResolversPass implements CompilerPassInterface
         $definition = $container->findDefinition($this->managerService);
 
         foreach ($container->findTaggedServiceIds($this->resolverTag) as $id => $resolvers) {
-            $definition->addMethodCall('addResolver', array(new Reference($id)));
+            $definition->addMethodCall('add', array(new Reference($id)));
         }
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -304,8 +304,8 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         if (null === $this->argumentResolver) {
             // to keep BC
             $this->argumentResolver = new ArgumentResolverManager();
-            $this->argumentResolver->addResolver(new ArgumentResolver\RequestArgumentResolver());
-            $this->argumentResolver->addResolver(new ArgumentResolver\RequestAttributesArgumentResolver());
+            $this->argumentResolver->add(new ArgumentResolver\RequestArgumentResolver());
+            $this->argumentResolver->add(new ArgumentResolver\RequestAttributesArgumentResolver());
         }
 
         return $this->argumentResolver;

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverManager;
+
+class ArgumentResolverManagerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $manager;
+    protected $resolver1;
+    protected $resolver2;
+    protected $request;
+
+    public function setUp()
+    {
+        $this->manager = new ArgumentResolverManager();
+        $this->resolver1 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface');
+        $this->resolver2 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface');
+        $this->manager->addResolver($this->resolver1);
+        $this->manager->addResolver($this->resolver2);
+
+        $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+    }
+
+    public function testGetArgumentsFirstResolverAccepts()
+    {
+        $this->resolver1->expects($this->any())->method('accepts')->will($this->returnValue(true)); 
+        $this->resolver1->expects($this->any())
+            ->method('resolve')
+            ->will($this->returnValue('resolved_value'));
+
+        $controller = $this->getControllerWithOneArgument();
+
+        $arguments = $this->manager->getArguments($this->request, $controller);
+        $this->assertEquals(array('resolved_value'), $arguments);
+    }
+
+    public function testGetArgumentsSecondResolverAccepts()
+    {
+        $this->resolver1->expects($this->any())->method('accepts')->will($this->returnValue(false));
+        $this->resolver2->expects($this->any())->method('accepts')->will($this->returnValue(true));
+        $this->resolver2->expects($this->any())
+            ->method('resolve')
+            ->will($this->returnValue('resolved_value'));
+
+        $controller = $this->getControllerWithOneArgument();
+
+        $arguments = $this->manager->getArguments($this->request, $controller);
+        $this->assertEquals(array('resolved_value'), $arguments);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGetArgumentsFailsIfNoResolverAccepts()
+    {
+        $this->resolver1->expects($this->any())->method('accepts')->will($this->returnValue(false));
+        $this->resolver2->expects($this->any())->method('accepts')->will($this->returnValue(false));
+
+        $controller = $this->getControllerWithOneArgument();
+        $this->manager->getArguments($this->request, $controller);
+    }
+
+    public function testGetArgumentResolvingMultipleArguments()
+    {
+        $this->resolver1->expects($this->any())
+            ->method('accepts')
+            ->will($this->onConsecutiveCalls(false, true, true));
+        $this->resolver1->expects($this->any())
+            ->method('resolve')
+            ->will($this->onConsecutiveCalls('1st resolved by 1', '2nd resolved by 1'));
+
+        $this->resolver2->expects($this->any())
+            ->method('accepts')
+            ->will($this->onConsecutiveCalls(true, false, true));
+        $this->resolver2->expects($this->any())
+            ->method('resolve')
+            ->will($this->onConsecutiveCalls('1st resolved by 2', '2nd resolved by 2'));
+
+        $controller = function ($a, $b, $c) { };
+
+        $arguments = $this->manager->getArguments($this->request, $controller);
+        $this->assertEquals(array('1st resolved by 2', '1st resolved by 1', '2nd resolved by 1'), $arguments);
+    }
+
+    public function testControllerWithOneOptionalArgumentWhichDoesNotMatch()
+    {
+        $this->resolver1->expects($this->any())->method('accepts')->will($this->returnValue(false));
+        $this->resolver2->expects($this->any())->method('accepts')->will($this->returnValue(false));
+
+        $arguments = $this->manager->getArguments($this->request, function ($a = 'default') { });
+        $this->assertEquals(array('default'), $arguments);
+    }
+
+    public function testControllerWithOneOptionalArgumentWhichDoMatch()
+    {
+        $this->resolver1->expects($this->any())->method('accepts')->will($this->returnValue(true));
+        $this->resolver1->expects($this->any())->method('resolve')->will($this->returnValue('resolved by 1'));
+        $this->resolver2->expects($this->any())->method('accepts')->will($this->returnValue(false));
+
+        $arguments = $this->manager->getArguments($this->request, function ($a = 'default') { });
+        $this->assertEquals(array('resolved by 1'), $arguments);
+    }
+
+    protected function getControllerWithOneArgument()
+    {
+        return function ($a) { };
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
@@ -25,15 +25,15 @@ class ArgumentResolverManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager = new ArgumentResolverManager();
         $this->resolver1 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface');
         $this->resolver2 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface');
-        $this->manager->addResolver($this->resolver1);
-        $this->manager->addResolver($this->resolver2);
+        $this->manager->add($this->resolver1);
+        $this->manager->add($this->resolver2);
 
         $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
     }
 
     public function testGetArgumentsFirstResolverAccepts()
     {
-        $this->resolver1->expects($this->any())->method('accepts')->will($this->returnValue(true)); 
+        $this->resolver1->expects($this->any())->method('accepts')->will($this->returnValue(true));
         $this->resolver1->expects($this->any())
             ->method('resolve')
             ->will($this->returnValue('resolved_value'));

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -52,9 +52,9 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
-        $request->attributes->set('_controller', array($this, 'controllerMethod1'));
+        $request->attributes->set('_controller', array($this, 'controllerMethod'));
         $controller = $resolver->getController($request);
-        $this->assertSame(array($this, 'controllerMethod1'), $controller);
+        $this->assertSame(array($this, 'controllerMethod'), $controller);
     }
 
     public function testGetControllerWithClassAndMethod()
@@ -62,9 +62,9 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
-        $request->attributes->set('_controller', array('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest', 'controllerMethod4'));
+        $request->attributes->set('_controller', array('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest', 'staticControllerMethod'));
         $controller = $resolver->getController($request);
-        $this->assertSame(array('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest', 'controllerMethod4'), $controller);
+        $this->assertSame(array('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest', 'staticControllerMethod'), $controller);
     }
 
     public function testGetControllerWithObjectAndMethodAsString()
@@ -72,7 +72,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
-        $request->attributes->set('_controller', 'Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest::controllerMethod1');
+        $request->attributes->set('_controller', 'Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest::controllerMethod');
         $controller = $resolver->getController($request);
         $this->assertInstanceOf('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest', $controller[0], '->getController() returns a PHP callable');
     }
@@ -132,67 +132,6 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testGetArguments()
-    {
-        $resolver = $this->createControllerResolver();
-
-        $request = Request::create('/');
-        $controller = array(new self(), 'testGetArguments');
-        $this->assertEquals(array(), $resolver->getArguments($request, $controller), '->getArguments() returns an empty array if the method takes no arguments');
-
-        $request = Request::create('/');
-        $request->attributes->set('foo', 'foo');
-        $controller = array(new self(), 'controllerMethod1');
-        $this->assertEquals(array('foo'), $resolver->getArguments($request, $controller), '->getArguments() returns an array of arguments for the controller method');
-
-        $request = Request::create('/');
-        $request->attributes->set('foo', 'foo');
-        $controller = array(new self(), 'controllerMethod2');
-        $this->assertEquals(array('foo', null), $resolver->getArguments($request, $controller), '->getArguments() uses default values if present');
-
-        $request->attributes->set('bar', 'bar');
-        $this->assertEquals(array('foo', 'bar'), $resolver->getArguments($request, $controller), '->getArguments() overrides default values if provided in the request attributes');
-
-        $request = Request::create('/');
-        $request->attributes->set('foo', 'foo');
-        $controller = function ($foo) {};
-        $this->assertEquals(array('foo'), $resolver->getArguments($request, $controller));
-
-        $request = Request::create('/');
-        $request->attributes->set('foo', 'foo');
-        $controller = function ($foo, $bar = 'bar') {};
-        $this->assertEquals(array('foo', 'bar'), $resolver->getArguments($request, $controller));
-
-        $request = Request::create('/');
-        $request->attributes->set('foo', 'foo');
-        $controller = new self();
-        $this->assertEquals(array('foo', null), $resolver->getArguments($request, $controller));
-        $request->attributes->set('bar', 'bar');
-        $this->assertEquals(array('foo', 'bar'), $resolver->getArguments($request, $controller));
-
-        $request = Request::create('/');
-        $request->attributes->set('foo', 'foo');
-        $request->attributes->set('foobar', 'foobar');
-        $controller = 'Symfony\Component\HttpKernel\Tests\Controller\some_controller_function';
-        $this->assertEquals(array('foo', 'foobar'), $resolver->getArguments($request, $controller));
-
-        $request = Request::create('/');
-        $request->attributes->set('foo', 'foo');
-        $request->attributes->set('foobar', 'foobar');
-        $controller = array(new self(), 'controllerMethod3');
-
-        try {
-            $resolver->getArguments($request, $controller);
-            $this->fail('->getArguments() throws a \RuntimeException exception if it cannot determine the argument value');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('\RuntimeException', $e, '->getArguments() throws a \RuntimeException exception if it cannot determine the argument value');
-        }
-
-        $request = Request::create('/');
-        $controller = array(new self(), 'controllerMethod5');
-        $this->assertEquals(array($request), $resolver->getArguments($request, $controller), '->getArguments() injects the request');
-    }
-
     public function testCreateControllerCanReturnAnyCallable()
     {
         $mock = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolver', array('createController'));
@@ -212,23 +151,11 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
     {
     }
 
-    public function controllerMethod1($foo)
+    public function controllerMethod($foo)
     {
     }
 
-    protected function controllerMethod2($foo, $bar = null)
-    {
-    }
-
-    protected function controllerMethod3($foo, $bar = null, $foobar)
-    {
-    }
-
-    protected static function controllerMethod4()
-    {
-    }
-
-    protected function controllerMethod5(Request $request)
+    protected static function staticControllerMethod()
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -96,9 +96,11 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
     protected function getHttpKernel($dispatcher, $controller)
     {
         $resolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
-        $resolver->expects($this->once())->method('getController')->will($this->returnValue($controller));
-        $resolver->expects($this->once())->method('getArguments')->will($this->returnValue(array()));
+        $resolver->expects($this->any())->method('getController')->will($this->returnValue($controller));
 
-        return new HttpKernel($dispatcher, $resolver);
+        $argumentResolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolverManager');
+        $argumentResolver->expects($this->any())->method('getArguments')->will($this->returnValue(array()));
+
+        return new HttpKernel($dispatcher, $resolver, null, $argumentResolver);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -42,7 +42,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $dispatcher = new EventDispatcher();
         $resolver = $this->getResolverMockFor($controller, $request);
         $stack = new RequestStack();
-        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack);
+        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack, $this->getArgumentsResolverMockFor($controller, $request));
 
         $actual = $kernel->handle($request, $type);
 
@@ -67,7 +67,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $dispatcher = new EventDispatcher();
         $resolver = $this->getResolverMockFor($controller, $request);
-        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack);
+        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack, $this->getArgumentsResolverMockFor($controller, $request));
 
         $kernel->handle($request, $type);
     }
@@ -95,7 +95,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
         $resolver = $this->getResolverMockFor($controller, $request);
         $stack = new RequestStack();
-        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack);
+        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack, $this->getArgumentsResolverMockFor($controller, $request));
 
         try {
             $kernel->handle($request, $type);
@@ -118,16 +118,21 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
     private function getResolverMockFor($controller, $request)
     {
         $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
-        $resolver->expects($this->once())
+        $resolver->expects($this->any())
             ->method('getController')
             ->with($request)
             ->will($this->returnValue($controller));
-        $resolver->expects($this->once())
+
+        return $resolver;
+    }
+
+    private function getArgumentsResolverMockFor($controller, $request)
+    {
+        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ArgumentsResolverManager');
+        $resolver->expects($this->any())
             ->method('getArguments')
             ->with($request, $controller)
             ->will($this->returnValue(array()));
-
-        return $resolver;
     }
 
     private function expectsSetRequestWithAt($container, $with, $at)

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -144,7 +144,7 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
     {
         $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
         $resolver
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getController')
             ->will($this->returnValue(function () {
                 ob_start();
@@ -152,13 +152,15 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
                 throw new \RuntimeException();
             }))
         ;
-        $resolver
-            ->expects($this->once())
+
+        $argumentResolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverManager');
+        $argumentResolver
+            ->expects($this->any())
             ->method('getArguments')
             ->will($this->returnValue(array()))
         ;
 
-        $kernel = new HttpKernel(new EventDispatcher(), $resolver);
+        $kernel = new HttpKernel(new EventDispatcher(), $resolver, null, $argumentResolver);
         $renderer = new InlineFragmentRenderer($kernel);
 
         // simulate a main request with output buffering


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #1547, #10710 |
| License | MIT |
| Doc PR | tbd |
# Todo
- [ ] Write docs
- [ ] Make BC
- [ ] Add priority
- [ ] Review
# BC

I've done my best to make this BC. It is now fully BC except from one case: If the logic in `ControllerResolver#getArguments()` is no longer used. If one would have used that method for custom argument resolving logic, it is no ignored. There should be a way that we can support both methods at the same time (in other words, create an argument resolver which uses the controller resolver).
# Thanks

A huge thanks to @Iltar for giving me the idea and helping me setting up this PR.
