### PR TITLE
[Form][Validator] All index items after children are to be considered grand-children when resolving ViolationPath

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -70,9 +70,17 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
                         break;
                     }
 
-                    $this->elements[] = $elements[$i];
-                    $this->isIndex[] = true;
-                    $this->mapsForm[] = true;
+                    // All the following index items (regardless if .children is
+                    // explicitly used) are children and grand-children
+                    for (; $i < $l && $path->isIndex($i); ++$i) {
+                        $this->elements[] = $elements[$i];
+                        $this->isIndex[] = true;
+                        $this->mapsForm[] = true;
+                    }
+
+                    // Rewind the pointer as the last element above didn't match
+                    // (even if the pointer was moved forward)
+                    --$i;
                 } elseif ('data' === $elements[$i] && $path->isProperty($i)) {
                     // Skip element "data"
                     ++$i;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -712,14 +712,14 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
             array(self::LEVEL_2, 'address', '[address]', 'street', '[office][street]', 'data[address][office][street].prop'),
 
             // Edge cases which must not occur
-            array(self::LEVEL_1, 'address', 'address', 'street', 'street', 'children[address][street]'),
-            array(self::LEVEL_1, 'address', 'address', 'street', 'street', 'children[address][street].prop'),
-            array(self::LEVEL_1, 'address', 'address', 'street', '[street]', 'children[address][street]'),
-            array(self::LEVEL_1, 'address', 'address', 'street', '[street]', 'children[address][street].prop'),
-            array(self::LEVEL_1, 'address', '[address]', 'street', 'street', 'children[address][street]'),
-            array(self::LEVEL_1, 'address', '[address]', 'street', 'street', 'children[address][street].prop'),
-            array(self::LEVEL_1, 'address', '[address]', 'street', '[street]', 'children[address][street]'),
-            array(self::LEVEL_1, 'address', '[address]', 'street', '[street]', 'children[address][street].prop'),
+            array(self::LEVEL_2, 'address', 'address', 'street', 'street', 'children[address][street]'),
+            array(self::LEVEL_2, 'address', 'address', 'street', 'street', 'children[address][street].prop'),
+            array(self::LEVEL_2, 'address', 'address', 'street', '[street]', 'children[address][street]'),
+            array(self::LEVEL_2, 'address', 'address', 'street', '[street]', 'children[address][street].prop'),
+            array(self::LEVEL_2, 'address', '[address]', 'street', 'street', 'children[address][street]'),
+            array(self::LEVEL_2, 'address', '[address]', 'street', 'street', 'children[address][street].prop'),
+            array(self::LEVEL_2, 'address', '[address]', 'street', '[street]', 'children[address][street]'),
+            array(self::LEVEL_2, 'address', '[address]', 'street', '[street]', 'children[address][street].prop'),
 
             array(self::LEVEL_0, 'address', 'person.address', 'street', 'street', 'children[person].children[address].children[street]'),
             array(self::LEVEL_0, 'address', 'person.address', 'street', 'street', 'children[person].children[address].data.street'),

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationPathTest.php
@@ -30,7 +30,8 @@ class ViolationPathTest extends \PHPUnit_Framework_TestCase
             )),
             array('children[address][street]', array(
                 array('address', true, true),
-            ), 'children[address]'),
+                array('street', true, true),
+            ), 'children[address].children[street]'),
             array('children[address].data', array(
                 array('address', true, true),
             ), 'children[address]'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | unsure, see note below |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11458 |
| License | MIT |
| Doc PR | - |
#### Possible BC Break

The old behavior had unit test cases specifically testing the case of a grand-children form. However, this behavior is not documented anywhere and the fix seems to have no adverse effects on form validation. `Symfony\Component\Form\FormInterface` implements `ArrayAccess`, therefore, semantically speaking, `children[direct_child].children[grand_children]` and `children[direct_child][grand_children]` are equivalent. `offsetGet` is expected to fetch an element from `children`. I do not see why both were not considered equivalent when resolving the ViolationPath.

This commit will indeed change how some errors are mapped. However since the old mapping is (in my opinion) a bug...
