### PR TITLE
[Validator] prevent unnecessary calls inside ExecutionContext

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -184,8 +184,8 @@ class ExecutionContext implements ExecutionContextInterface
             $message,
             $parameters,
             $this->root,
-            $this->getPropertyPath(),
-            $this->getValue(),
+            $this->propertyPath,
+            $this->value,
             null,
             null
         ));
@@ -201,8 +201,8 @@ class ExecutionContext implements ExecutionContextInterface
             $message,
             $parameters,
             $this->root,
-            $this->getPropertyPath(),
-            $this->getValue(),
+            $this->propertyPath,
+            $this->value,
             $this->translator,
             $this->translationDomain
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

Small performance improvement by preventing calls to `PropertyPath::append($this->propertyPath, $subPath)` when not needed.
