### PR TITLE
[Translator] Use quote to surround invalid locale

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -319,7 +319,7 @@ class Translator implements TranslatorInterface
     private function assertValidLocale($locale)
     {
         if (0 !== preg_match('/[^a-z0-9_\\.\\-]+/i', $locale, $match)) {
-            throw new \InvalidArgumentException(sprintf('Invalid locale: %s.', $locale));
+            throw new \InvalidArgumentException(sprintf('Invalid "%s" locale.', $locale));
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I got this message in one application (CLI):

```

  [InvalidArgumentException]  
  Invalid locale: en_US .     


```

It's not so easy to spot the issue.
