### PR TITLE
[Session Handlers] Properties protected to be able to extend them

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -21,17 +21,17 @@ class MemcacheSessionHandler implements \SessionHandlerInterface
     /**
      * @var \Memcache Memcache driver.
      */
-    private $memcache;
+    protected $memcache;
 
     /**
      * @var int     Time to live in seconds
      */
-    private $ttl;
+    protected $ttl;
 
     /**
      * @var string Key prefix for shared environments.
      */
-    private $prefix;
+    protected $prefix;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -26,17 +26,17 @@ class MemcachedSessionHandler implements \SessionHandlerInterface
     /**
      * @var \Memcached Memcached driver.
      */
-    private $memcached;
+    protected $memcached;
 
     /**
      * @var int     Time to live in seconds
      */
-    private $ttl;
+    protected $ttl;
 
     /**
      * @var string Key prefix for shared environments.
      */
-    private $prefix;
+    protected $prefix;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -21,17 +21,17 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
     /**
      * @var \Mongo
      */
-    private $mongo;
+    protected $mongo;
 
     /**
      * @var \MongoCollection
      */
-    private $collection;
+    protected $collection;
 
     /**
      * @var array
      */
-    private $options;
+    protected $options;
 
     /**
      * Constructor.
@@ -152,7 +152,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      *
      * @return \MongoCollection
      */
-    private function getCollection()
+    protected function getCollection()
     {
         if (null === $this->collection) {
             $this->collection = $this->mongo->selectCollection($this->options['database'], $this->options['collection']);

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -29,27 +29,27 @@ class PdoSessionHandler implements \SessionHandlerInterface
     /**
      * @var \PDO PDO instance
      */
-    private $pdo;
+    protected $pdo;
 
     /**
      * @var string Table name
      */
-    private $table;
+    protected $table;
 
     /**
      * @var string Column for session id
      */
-    private $idCol;
+    protected $idCol;
 
     /**
      * @var string Column for session data
      */
-    private $dataCol;
+    protected $dataCol;
 
     /**
      * @var string Column for timestamp
      */
-    private $timeCol;
+    protected $timeCol;
 
     /**
      * Constructor.
@@ -229,7 +229,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
      *
      * @return string|null The SQL string or null when not supported
      */
-    private function getMergeSql()
+    protected function getMergeSql()
     {
         $driver = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
 


### PR DESCRIPTION
Hello,

I need to override one method from the mongodb session handler, so, I would like to extend it to keep the other methods, but that's not really possible without copy/past some methods because of the "private" methods & attributes.

So, I changed all session handlers private attributes & methods to protected, to be able to extend them.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no    #Not really a new feature |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Regards,
Peekmo
