### PR TITLE
[EventDispatcher] don't count empty listeners

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -74,7 +74,7 @@ class EventDispatcher implements EventDispatcherInterface
             }
         }
 
-        return $this->sorted;
+        return array_filter($this->sorted);
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -23,6 +23,9 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
     const preBar = 'pre.bar';
     const postBar = 'post.bar';
 
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcher
+     */
     private $dispatcher;
 
     private $listener;
@@ -260,6 +263,28 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher->addListener('bug.62976', new CallableClass());
         $dispatcher->removeListener('bug.62976', function () {});
         $this->assertTrue($dispatcher->hasListeners('bug.62976'));
+    }
+
+    public function testHasListenersWhenAddedCallbackListenerIsRemoved()
+    {
+        $listener = function () {};
+        $this->dispatcher->addListener('foo', $listener);
+        $this->dispatcher->removeListener('foo', $listener);
+        $this->assertFalse($this->dispatcher->hasListeners());
+    }
+
+    public function testGetListenersWhenAddedCallbackListenerIsRemoved()
+    {
+        $listener = function () {};
+        $this->dispatcher->addListener('foo', $listener);
+        $this->dispatcher->removeListener('foo', $listener);
+        $this->assertSame(array(), $this->dispatcher->getListeners());
+    }
+
+    public function testHasListenersWithoutEventsReturnsFalseAfterHasListenersWithEventHasBeenCalled()
+    {
+        $this->assertFalse($this->dispatcher->hasListeners('foo'));
+        $this->assertFalse($this->dispatcher->hasListeners());
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11444 |
| License | MIT |
| Doc PR |  |

When event listeners for certain events are removed from the event
dispatcher, empty arrays are not being removed. Therefore, counting
on empty arrays leads to wrong results of the hasListeners() method.

Thanks to @mlindenb for discovering this an proposing a solution.
