### PR TITLE
[Form] added the ability to use a closure for collection item 'options'

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
@@ -29,7 +30,7 @@ class ResizeFormListener implements EventSubscriberInterface
     protected $type;
 
     /**
-     * @var array
+     * @var array|\Closure
      */
     protected $options;
 
@@ -50,7 +51,7 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     private $deleteEmpty;
 
-    public function __construct($type, array $options = array(), $allowAdd = false, $allowDelete = false, $deleteEmpty = false)
+    public function __construct($type, $options = array(), $allowAdd = false, $allowDelete = false, $deleteEmpty = false)
     {
         $this->type = $type;
         $this->allowAdd = $allowAdd;
@@ -91,7 +92,7 @@ class ResizeFormListener implements EventSubscriberInterface
         foreach ($data as $name => $value) {
             $form->add($name, $this->type, array_replace(array(
                 'property_path' => '['.$name.']',
-            ), $this->options));
+            ), CollectionType::normalizeOptions($this->options, $value)));
         }
     }
 
@@ -123,7 +124,7 @@ class ResizeFormListener implements EventSubscriberInterface
                 if (!$form->has($name)) {
                     $form->add($name, $this->type, array_replace(array(
                         'property_path' => '['.$name.']',
-                    ), $this->options));
+                    ), CollectionType::normalizeOptions($this->options, $value)));
                 }
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -81,6 +81,7 @@ class CollectionType extends AbstractType
                 return function ($data) use ($value) {
                     $options = $value($data);
                     $options['block_name'] = 'entry';
+
                     return $options;
                 };
             } else {
@@ -116,7 +117,7 @@ class CollectionType extends AbstractType
     /**
      * This is a utility method used specifically by this class and its ResizeFormListener for getting dynamic options
      * for each child in this collection based off of the data provided.
-     * 
+     *
      * @param array|\Closure $options
      * @param $data
      * @return mixed

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -29,7 +29,7 @@ class CollectionType extends AbstractType
         if ($options['allow_add'] && $options['prototype']) {
             $prototype = $builder->create($options['prototype_name'], $options['type'], array_replace(array(
                 'label' => $options['prototype_name'].'label__',
-            ), $options['options']));
+            ), self::normalizeOptions($options['options'], null)));
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 
@@ -75,7 +75,17 @@ class CollectionType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $optionsNormalizer = function (Options $options, $value) {
-            $value['block_name'] = 'entry';
+            // If this is a closure, a wrapped closure needs to be returned in order
+            // to call the closure when needed, and still force the block_name
+            if ($value instanceof \Closure) {
+                return function ($data) use ($value) {
+                    $options = $value($data);
+                    $options['block_name'] = 'entry';
+                    return $options;
+                };
+            } else {
+                $value['block_name'] = 'entry';
+            }
 
             return $value;
         };
@@ -101,5 +111,22 @@ class CollectionType extends AbstractType
     public function getName()
     {
         return 'collection';
+    }
+
+    /**
+     * This is a utility method used specifically by this class and its ResizeFormListener for getting dynamic options
+     * for each child in this collection based off of the data provided.
+     * 
+     * @param array|\Closure $options
+     * @param $data
+     * @return mixed
+     */
+    public static function normalizeOptions($options, $data)
+    {
+        if ($options instanceof \Closure) {
+            return $options($data);
+        }
+
+        return $options;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -274,4 +274,28 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertSame('__test__label__', $form->createView()->vars['prototype']->vars['label']);
     }
+
+    public function testOptionsClosure()
+    {
+        $form = $this->factory->create('collection', array(), array(
+            'type'           => 'text',
+            'allow_add'      => true,
+            'prototype'      => true,
+            'prototype_name' => '__test__',
+            'options'        => function ($data) {
+                    return array(
+                        'disabled'  => $data === 'disabled',
+                    );
+                }
+        ));
+
+        $form->setData(array('disabled', 'enabled'));
+        $form->submit(array('disabled', 'some testing data'));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+
+        $this->assertTrue($form->get('0')->isDisabled());
+        $this->assertFalse($form->get('1')->isDisabled());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11467 |
| License | MIT |
| Doc PR | in progress |

For the Doc PR, I didn't find in the Symfony docs which version something new would go into if accepted, so if someone would like to elaborate on that so I can [add the version it was introduced in to the docs I updated](https://github.com/Limelyte/symfony-docs/commit/b459473e2aa9f983cefdde89dd62fecf7576fa1c), that'd be fantastic!

And looks like according to @fabpot I missed some whitespace. I don't make pull requests that require changes after-the-fact often, but if I applied that patch and force pushed would commit b916dc8 be removed from the PR and the new one added? I think I remember some weird behavior with that
