### PR TITLE
[Routing] simplify the XML schema file

### DIFF
--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -29,7 +29,7 @@
       <xsd:element name="default" nillable="true" type="element" />
       <xsd:element name="requirement" type="element" />
       <xsd:element name="option" type="element" />
-      <xsd:element name="condition" type="condition" />
+      <xsd:element name="condition" type="xsd:string" />
     </xsd:choice>
   </xsd:group>
 
@@ -62,9 +62,4 @@
       </xsd:extension>
     </xsd:simpleContent>
   </xsd:complexType>
-
-  <xsd:simpleType name="condition">
-    <xsd:restriction base="xsd:string">
-    </xsd:restriction>
-  </xsd:simpleType>
 </xsd:schema>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Conditions that are defined for certain routes are just simple strings.
Thus, there is no need to use a dedicated element when xsd:string does
the same (as mentioned by @tobion in #11394).
