### PR TITLE
[Validator] Constraint validators now use the 2.5 API

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -718,6 +718,7 @@ class FrameworkExtension extends Extension
             switch ($config['api']) {
                 case '2.4':
                     $api = Validation::API_VERSION_2_4;
+                    $container->setParameter('validator.validator_factory.class', $container->getParameter('validator.legacy_validator_factory.class'));
                     break;
                 case '2.5':
                     $api = Validation::API_VERSION_2_5;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -11,6 +11,7 @@
         <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache</parameter>
         <parameter key="validator.mapping.cache.prefix" />
         <parameter key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory</parameter>
+        <parameter key="validator.legacy_validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\LegacyConstraintValidatorFactory</parameter>
         <parameter key="validator.expression.class">Symfony\Component\Validator\Constraints\ExpressionValidator</parameter>
         <parameter key="validator.email.class">Symfony\Component\Validator\Constraints\EmailValidator</parameter>
     </parameters>

--- a/src/Symfony/Bundle/FrameworkBundle/Validator/LegacyConstraintValidatorFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Validator/LegacyConstraintValidatorFactory.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Validator;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Like {@link ConstraintValidatorFactory}, but aware of services compatible
+ * with the 2.4 API.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Kris Wallsmith <kris@symfony.com>
+ *
+ * @see ConstraintValidatorFactory
+ */
+class LegacyConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
+{
+    const BASE_NAMESPACE = 'Symfony\\Component\\Validator\\Constraints';
+
+    protected $container;
+    protected $validators;
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container  The service container
+     * @param array              $validators An array of validators
+     */
+    public function __construct(ContainerInterface $container, array $validators = array())
+    {
+        $this->container = $container;
+        $this->validators = $validators;
+    }
+
+    /**
+     * Returns the validator for the supplied constraint.
+     *
+     * @param Constraint $constraint A constraint
+     *
+     * @return ConstraintValidatorInterface A validator for the supplied constraint
+     *
+     * @throws UnexpectedTypeException When the validator is not an instance of ConstraintValidatorInterface
+     */
+    public function getInstance(Constraint $constraint)
+    {
+        $name = $constraint->validatedBy();
+
+        if (!isset($this->validators[$name])) {
+            switch (get_class($constraint)) {
+                case self::BASE_NAMESPACE.'\\All':
+                    $name = self::BASE_NAMESPACE.'\\LegacyAllValidator';
+                    break;
+                case self::BASE_NAMESPACE.'\\Choice':
+                    $name = self::BASE_NAMESPACE.'\\LegacyChoiceValidator';
+                    break;
+                case self::BASE_NAMESPACE.'\\Collection':
+                    $name = self::BASE_NAMESPACE.'\\LegacyCollectionValidator';
+                    break;
+                case self::BASE_NAMESPACE.'\\Count':
+                    $name = self::BASE_NAMESPACE.'\\LegacyCountValidator';
+                    break;
+                case self::BASE_NAMESPACE.'\\Length':
+                    $name = self::BASE_NAMESPACE.'\\LegacyLengthValidator';
+                    break;
+            }
+
+            $this->validators[$name] = new $name();
+        } elseif (is_string($this->validators[$name])) {
+            $this->validators[$name] = $this->container->get($this->validators[$name]);
+        }
+
+        if (!$this->validators[$name] instanceof ConstraintValidatorInterface) {
+            throw new UnexpectedTypeException($this->validators[$name], 'Symfony\Component\Validator\ConstraintValidatorInterface');
+        }
+
+        return $this->validators[$name];
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -44,9 +44,7 @@ class AllValidator extends ConstraintValidator
         $validator = $context->getValidator()->inContext($context);
 
         foreach ($value as $key => $element) {
-            foreach ($constraint->constraints as $constr) {
-                $validator->atPath('['.$key.']')->validate($element, $constr, $group);
-            }
+            $validator->atPath('['.$key.']')->validate($element, $constraint->constraints, $group);
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -39,7 +39,7 @@ class CountValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->exactMessage)
                 ->setParameter('{{ count }}', $count)
                 ->setParameter('{{ limit }}', $constraint->min)
-                ->setValue($value)
+                ->setInvalidValue($value)
                 ->setPlural((int) $constraint->min)
                 ->addViolation();
 
@@ -50,7 +50,7 @@ class CountValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->maxMessage)
                 ->setParameter('{{ count }}', $count)
                 ->setParameter('{{ limit }}', $constraint->max)
-                ->setValue($value)
+                ->setInvalidValue($value)
                 ->setPlural((int) $constraint->max)
                 ->addViolation();
 
@@ -61,7 +61,7 @@ class CountValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->minMessage)
                 ->setParameter('{{ count }}', $count)
                 ->setParameter('{{ limit }}', $constraint->min)
-                ->setValue($value)
+                ->setInvalidValue($value)
                 ->setPlural((int) $constraint->min)
                 ->addViolation();
         }

--- a/src/Symfony/Component/Validator/Constraints/LegacyAllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyAllValidator.php
@@ -43,9 +43,7 @@ class LegacyAllValidator extends ConstraintValidator
         $group = $context->getGroup();
 
         foreach ($value as $key => $element) {
-            foreach ($constraint->constraints as $constr) {
-                $context->validateValue($element, $constr, '['.$key.']', $group);
-            }
+            $context->validateValue($element, $constraint->constraints, '['.$key.']', $group);
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LegacyAllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyAllValidator.php
@@ -18,9 +18,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @api
+ * @deprecated Deprecated since version 2.5.3, to be removed in 3.0.
  */
-class AllValidator extends ConstraintValidator
+class LegacyAllValidator extends ConstraintValidator
 {
     /**
      * {@inheritdoc}
@@ -41,11 +41,10 @@ class AllValidator extends ConstraintValidator
 
         $context = $this->context;
         $group = $context->getGroup();
-        $validator = $context->getValidator()->inContext($context);
 
         foreach ($value as $key => $element) {
             foreach ($constraint->constraints as $constr) {
-                $validator->atPath('['.$key.']')->validate($element, $constr, $group);
+                $context->validateValue($element, $constr, '['.$key.']', $group);
             }
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/LegacyChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyChoiceValidator.php
@@ -70,13 +70,13 @@ class LegacyChoiceValidator extends ConstraintValidator
             $count = count($value);
 
             if ($constraint->min !== null && $count < $constraint->min) {
-                $this->context->addViolation($constraint->minMessage, array('{{ limit }}' => $constraint->min), null, (int) $constraint->min);
+                $this->context->addViolation($constraint->minMessage, array('{{ limit }}' => $constraint->min), $value, (int) $constraint->min);
 
                 return;
             }
 
             if ($constraint->max !== null && $count > $constraint->max) {
-                $this->context->addViolation($constraint->maxMessage, array('{{ limit }}' => $constraint->max), null, (int) $constraint->max);
+                $this->context->addViolation($constraint->maxMessage, array('{{ limit }}' => $constraint->max), $value, (int) $constraint->max);
 
                 return;
             }

--- a/src/Symfony/Component/Validator/Constraints/LegacyChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyChoiceValidator.php
@@ -23,9 +23,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @api
+ * @deprecated Deprecated since version 2.5.3, to be removed in 3.0.
  */
-class ChoiceValidator extends ConstraintValidator
+class LegacyChoiceValidator extends ConstraintValidator
 {
     /**
      * {@inheritdoc}
@@ -63,35 +63,25 @@ class ChoiceValidator extends ConstraintValidator
         if ($constraint->multiple) {
             foreach ($value as $_value) {
                 if (!in_array($_value, $choices, $constraint->strict)) {
-                    $this->context->buildViolation($constraint->multipleMessage)
-                        ->setParameter('{{ value }}', $_value)
-                        ->addViolation();
+                    $this->context->addViolation($constraint->multipleMessage, array('{{ value }}' => $_value));
                 }
             }
 
             $count = count($value);
 
             if ($constraint->min !== null && $count < $constraint->min) {
-                $this->context->buildViolation($constraint->minMessage)
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setPlural((int) $constraint->min)
-                    ->addViolation();
+                $this->context->addViolation($constraint->minMessage, array('{{ limit }}' => $constraint->min), null, (int) $constraint->min);
 
                 return;
             }
 
             if ($constraint->max !== null && $count > $constraint->max) {
-                $this->context->buildViolation($constraint->maxMessage)
-                    ->setParameter('{{ limit }}', $constraint->max)
-                    ->setPlural((int) $constraint->max)
-                    ->addViolation();
+                $this->context->addViolation($constraint->maxMessage, array('{{ limit }}' => $constraint->max), null, (int) $constraint->max);
 
                 return;
             }
         } elseif (!in_array($value, $choices, $constraint->strict)) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $value)
-                ->addViolation();
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LegacyCollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyCollectionValidator.php
@@ -52,13 +52,13 @@ class LegacyCollectionValidator extends ConstraintValidator
         $group = $context->getGroup();
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
-            if (
-                // bug fix issue #2779
-                (is_array($value) && array_key_exists($field, $value)) ||
-                ($value instanceof \ArrayAccess && $value->offsetExists($field))
-            ) {
-                foreach ($fieldConstraint->constraints as $constr) {
-                    $context->validateValue($value[$field], $constr, '['.$field.']', $group);
+            // bug fix issue #2779
+            $existsInArray = is_array($value) && array_key_exists($field, $value);
+            $existsInArrayAccess = $value instanceof \ArrayAccess && $value->offsetExists($field);
+
+            if ($existsInArray || $existsInArrayAccess) {
+                if (count($fieldConstraint->constraints) > 0) {
+                    $context->validateValue($value[$field], $fieldConstraint->constraints, '['.$field.']', $group);
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
                 $context->addViolationAt('['.$field.']', $constraint->missingFieldsMessage, array(

--- a/src/Symfony/Component/Validator/Constraints/LegacyCountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyCountValidator.php
@@ -17,8 +17,10 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated Deprecated since version 2.5.3, to be removed in 3.0.
  */
-class CountValidator extends ConstraintValidator
+class LegacyCountValidator extends ConstraintValidator
 {
     /**
      * {@inheritdoc}
@@ -36,34 +38,28 @@ class CountValidator extends ConstraintValidator
         $count = count($value);
 
         if ($constraint->min == $constraint->max && $count != $constraint->min) {
-            $this->context->buildViolation($constraint->exactMessage)
-                ->setParameter('{{ count }}', $count)
-                ->setParameter('{{ limit }}', $constraint->min)
-                ->setValue($value)
-                ->setPlural((int) $constraint->min)
-                ->addViolation();
+            $this->context->addViolation($constraint->exactMessage, array(
+                '{{ count }}' => $count,
+                '{{ limit }}' => $constraint->min,
+            ), $value, (int) $constraint->min);
 
             return;
         }
 
         if (null !== $constraint->max && $count > $constraint->max) {
-            $this->context->buildViolation($constraint->maxMessage)
-                ->setParameter('{{ count }}', $count)
-                ->setParameter('{{ limit }}', $constraint->max)
-                ->setValue($value)
-                ->setPlural((int) $constraint->max)
-                ->addViolation();
+            $this->context->addViolation($constraint->maxMessage, array(
+                '{{ count }}' => $count,
+                '{{ limit }}' => $constraint->max,
+            ), $value, (int) $constraint->max);
 
             return;
         }
 
         if (null !== $constraint->min && $count < $constraint->min) {
-            $this->context->buildViolation($constraint->minMessage)
-                ->setParameter('{{ count }}', $count)
-                ->setParameter('{{ limit }}', $constraint->min)
-                ->setValue($value)
-                ->setPlural((int) $constraint->min)
-                ->addViolation();
+            $this->context->addViolation($constraint->minMessage, array(
+                '{{ count }}' => $count,
+                '{{ limit }}' => $constraint->min,
+            ), $value, (int) $constraint->min);
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LegacyLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyLengthValidator.php
@@ -17,8 +17,10 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated Deprecated since version 2.5.3, to be removed in 3.0.
  */
-class LengthValidator extends ConstraintValidator
+class LegacyLengthValidator extends ConstraintValidator
 {
     /**
      * {@inheritdoc}
@@ -48,34 +50,28 @@ class LengthValidator extends ConstraintValidator
         }
 
         if ($constraint->min == $constraint->max && $length != $constraint->min) {
-            $this->context->buildViolation($constraint->exactMessage)
-                ->setParameter('{{ value }}', $stringValue)
-                ->setParameter('{{ limit }}', $constraint->min)
-                ->setValue($value)
-                ->setPlural((int) $constraint->min)
-                ->addViolation();
+            $this->context->addViolation($constraint->exactMessage, array(
+                '{{ value }}' => $stringValue,
+                '{{ limit }}' => $constraint->min,
+            ), $value, (int) $constraint->min);
 
             return;
         }
 
         if (null !== $constraint->max && $length > $constraint->max) {
-            $this->context->buildViolation($constraint->maxMessage)
-                ->setParameter('{{ value }}', $stringValue)
-                ->setParameter('{{ limit }}', $constraint->max)
-                ->setValue($value)
-                ->setPlural((int) $constraint->max)
-                ->addViolation();
+            $this->context->addViolation($constraint->maxMessage, array(
+                '{{ value }}' => $stringValue,
+                '{{ limit }}' => $constraint->max,
+            ), $value, (int) $constraint->max);
 
             return;
         }
 
         if (null !== $constraint->min && $length < $constraint->min) {
-            $this->context->buildViolation($constraint->minMessage)
-                ->setParameter('{{ value }}', $stringValue)
-                ->setParameter('{{ limit }}', $constraint->min)
-                ->setValue($value)
-                ->setPlural((int) $constraint->min)
-                ->addViolation();
+            $this->context->addViolation($constraint->minMessage, array(
+                '{{ value }}' => $stringValue,
+                '{{ limit }}' => $constraint->min,
+            ), $value, (int) $constraint->min);
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -51,7 +51,7 @@ class LengthValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->exactMessage)
                 ->setParameter('{{ value }}', $stringValue)
                 ->setParameter('{{ limit }}', $constraint->min)
-                ->setValue($value)
+                ->setInvalidValue($value)
                 ->setPlural((int) $constraint->min)
                 ->addViolation();
 
@@ -62,7 +62,7 @@ class LengthValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->maxMessage)
                 ->setParameter('{{ value }}', $stringValue)
                 ->setParameter('{{ limit }}', $constraint->max)
-                ->setValue($value)
+                ->setInvalidValue($value)
                 ->setPlural((int) $constraint->max)
                 ->addViolation();
 
@@ -73,7 +73,7 @@ class LengthValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->minMessage)
                 ->setParameter('{{ value }}', $stringValue)
                 ->setParameter('{{ limit }}', $constraint->min)
-                ->setValue($value)
+                ->setInvalidValue($value)
                 ->setPlural((int) $constraint->min)
                 ->addViolation();
         }

--- a/src/Symfony/Component/Validator/LegacyConstraintValidatorFactory.php
+++ b/src/Symfony/Component/Validator/LegacyConstraintValidatorFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator;
+
+use Symfony\Component\Validator\Constraints\ExpressionValidator;
+
+/**
+ * Backwards compatible implementation of the {@link ConstraintValidatorFactoryInterface}.
+ *
+ * This class uses legacy constraint validators where possible to ensure
+ * compatibility with the 2.4 validator API.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated Deprecated since version 2.5.3, to be removed in 3.0.
+ */
+class LegacyConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
+{
+    protected $validators = array();
+
+    private $propertyAccessor;
+
+    public function __construct($propertyAccessor = null)
+    {
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInstance(Constraint $constraint)
+    {
+        switch (get_class($constraint)) {
+            case __NAMESPACE__.'\\Constraints\\All':
+                $className = __NAMESPACE__.'\\Constraints\\LegacyAllValidator';
+                break;
+            case __NAMESPACE__.'\\Constraints\\Choice':
+                $className = __NAMESPACE__.'\\Constraints\\LegacyChoiceValidator';
+                break;
+            case __NAMESPACE__.'\\Constraints\\Collection':
+                $className = __NAMESPACE__.'\\Constraints\\LegacyCollectionValidator';
+                break;
+            case __NAMESPACE__.'\\Constraints\\Count':
+                $className = __NAMESPACE__.'\\Constraints\\LegacyCountValidator';
+                break;
+            case __NAMESPACE__.'\\Constraints\\Length':
+                $className = __NAMESPACE__.'\\Constraints\\LegacyLengthValidator';
+                break;
+            default:
+                $className = $constraint->validatedBy();
+                break;
+        }
+
+        if (!isset($this->validators[$className])) {
+            $this->validators[$className] = 'validator.expression' === $className
+                ? new ExpressionValidator($this->propertyAccessor)
+                : new $className();
+        }
+
+        return $this->validators[$className];
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\AbstractComparisonValidator;
 
 class ComparisonTest_Class
 {

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -32,30 +32,15 @@ class ComparisonTest_Class
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
-abstract class AbstractComparisonValidatorTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractComparisonValidatorTestCase extends AbstractConstraintValidatorTest
 {
-    private $validator;
-    private $context;
-
-    protected function setUp()
-    {
-        $this->validator = $this->createValidator();
-        $this->context = $this->getMockBuilder('Symfony\Component\Validator\ExecutionContext')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->validator->initialize($this->context);
-    }
-
     /**
-     * @return AbstractComparisonValidator
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
-    abstract protected function createValidator();
-
     public function testThrowsConstraintExceptionIfNoValueOrProperty()
     {
-        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
-
         $comparison = $this->createConstraint(array());
+
         $this->validator->validate('some value', $comparison);
     }
 
@@ -66,16 +51,11 @@ abstract class AbstractComparisonValidatorTestCase extends \PHPUnit_Framework_Te
      */
     public function testValidComparisonToValue($dirtyValue, $comparisonValue)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = $this->createConstraint(array('value' => $comparisonValue));
 
-        $this->context->expects($this->any())
-            ->method('getPropertyPath')
-            ->will($this->returnValue('property1'));
-
         $this->validator->validate($dirtyValue, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -95,19 +75,13 @@ abstract class AbstractComparisonValidatorTestCase extends \PHPUnit_Framework_Te
         $constraint = $this->createConstraint(array('value' => $comparedValue));
         $constraint->message = 'Constraint Message';
 
-        $this->context->expects($this->any())
-            ->method('getPropertyPath')
-            ->will($this->returnValue('property1'));
-
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('Constraint Message', array(
-                '{{ value }}' => $comparedValueString,
-                '{{ compared_value }}' => $comparedValueString,
-                '{{ compared_value_type }}' => $comparedValueType
-            ));
-
         $this->validator->validate($dirtyValue, $constraint);
+
+        $this->assertViolation('Constraint Message', array(
+            '{{ value }}' => $comparedValueString,
+            '{{ compared_value }}' => $comparedValueString,
+            '{{ compared_value_type }}' => $comparedValueType
+        ));
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -1,0 +1,298 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Context\LegacyExecutionContext;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\PropertyMetadata;
+use Symfony\Component\Validator\Tests\Fixtures\StubGlobalExecutionContext;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ExecutionContextInterface
+     */
+    protected $context;
+
+    /**
+     * @var ConstraintValidatorInterface
+     */
+    protected $validator;
+
+    protected $group;
+
+    protected $metadata;
+
+    protected $object;
+
+    protected $value;
+
+    protected $root;
+
+    protected $propertyPath;
+
+    protected function setUp()
+    {
+        $this->group = 'MyGroup';
+        $this->metadata = null;
+        $this->object = null;
+        $this->value = 'InvalidValue';
+        $this->root = 'root';
+        $this->propertyPath = 'property.path';
+        $this->context = $this->createContext();
+        $this->validator = $this->createValidator();
+        $this->validator->initialize($this->context);
+    }
+
+    protected function createContext()
+    {
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+
+        if (Validation::API_VERSION_2_4 === $this->getApiVersion()) {
+            return $this->getMockBuilder('Symfony\Component\Validator\ExecutionContext')
+                ->setConstructorArgs(array(
+                    new StubGlobalExecutionContext($this->root),
+                    $translator,
+                    null,
+                    $this->metadata,
+                    $this->value,
+                    $this->group,
+                    $this->propertyPath
+                ))
+                ->setMethods(array('validate', 'validateValue'))
+                ->getMock();
+        }
+
+        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $contextualValidator = $this->getMock('Symfony\Component\Validator\Validator\ContextualValidatorInterface');
+
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_5:
+                $context = new ExecutionContext(
+                    $validator,
+                    $this->root,
+                    $translator
+                );
+                break;
+            case Validation::API_VERSION_2_5_BC:
+                $context = new LegacyExecutionContext(
+                    $validator,
+                    $this->root,
+                    $this->getMock('Symfony\Component\Validator\MetadataFactoryInterface'),
+                    $translator
+                );
+                break;
+            default:
+                throw new \RuntimeException('Invalid API version');
+        }
+
+        $context->setGroup($this->group);
+        $context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+
+        $validator->expects($this->any())
+            ->method('inContext')
+            ->with($context)
+            ->will($this->returnValue($contextualValidator));
+
+        return $context;
+    }
+
+    protected function createViolation($message, array $parameters = array(), $propertyPath = 'property.path', $invalidValue = 'InvalidValue', $plural = null, $code = null)
+    {
+        return new ConstraintViolation(
+            null,
+            $message,
+            $parameters,
+            $this->root,
+            $propertyPath,
+            $invalidValue,
+            $plural,
+            $code
+        );
+    }
+
+    protected function setGroup($group)
+    {
+        $this->group = $group;
+
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_4:
+                $this->context = $this->createContext();
+                $this->validator->initialize($this->context);
+                break;
+            case Validation::API_VERSION_2_5:
+            case Validation::API_VERSION_2_5_BC:
+                $this->context->setGroup($group);
+                break;
+        }
+    }
+
+    protected function setObject($object)
+    {
+        $this->object = $object;
+        $this->metadata = is_object($object)
+            ? new ClassMetadata(get_class($object))
+            : null;
+
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_4:
+                $this->context = $this->createContext();
+                $this->validator->initialize($this->context);
+                break;
+            case Validation::API_VERSION_2_5:
+            case Validation::API_VERSION_2_5_BC:
+                $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+                break;
+        }
+    }
+
+    protected function setProperty($object, $property)
+    {
+        $this->object = $object;
+        $this->metadata = is_object($object)
+            ? new PropertyMetadata(get_class($object), $property)
+            : null;
+
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_4:
+                $this->context = $this->createContext();
+                $this->validator->initialize($this->context);
+                break;
+            case Validation::API_VERSION_2_5:
+            case Validation::API_VERSION_2_5_BC:
+                $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+                break;
+        }
+    }
+
+    protected function setValue($value)
+    {
+        $this->value = $value;
+
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_4:
+                $this->context = $this->createContext();
+                $this->validator->initialize($this->context);
+                break;
+            case Validation::API_VERSION_2_5:
+            case Validation::API_VERSION_2_5_BC:
+                $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+                break;
+        }
+    }
+
+    protected function setRoot($root)
+    {
+        $this->root = $root;
+        $this->context = $this->createContext();
+        $this->validator->initialize($this->context);
+    }
+
+    protected function setPropertyPath($propertyPath)
+    {
+        $this->propertyPath = $propertyPath;
+
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_4:
+                $this->context = $this->createContext();
+                $this->validator->initialize($this->context);
+                break;
+            case Validation::API_VERSION_2_5:
+            case Validation::API_VERSION_2_5_BC:
+                $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+                break;
+        }
+    }
+
+    protected function expectValidateAt($i, $propertyPath, $value, $group)
+    {
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_4:
+                $this->context->expects($this->at($i))
+                    ->method('validate')
+                    ->with($value, $propertyPath, $group);
+                break;
+            case Validation::API_VERSION_2_5:
+            case Validation::API_VERSION_2_5_BC:
+                $validator = $this->context->getValidator()->inContext($this->context);
+                $validator->expects($this->at(2 * $i))
+                    ->method('atPath')
+                    ->with($propertyPath)
+                    ->will($this->returnValue($validator));
+                $validator->expects($this->at(2 * $i + 1))
+                    ->method('validate')
+                    ->with($value, array(), $group);
+                break;
+        }
+    }
+
+    protected function expectValidateValueAt($i, $propertyPath, $value, $constraints, $group)
+    {
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_4:
+                $this->context->expects($this->at($i))
+                    ->method('validateValue')
+                    ->with($value, $constraints, $propertyPath, $group);
+                break;
+            case Validation::API_VERSION_2_5:
+            case Validation::API_VERSION_2_5_BC:
+                $contextualValidator = $this->context->getValidator()->inContext($this->context);
+                $contextualValidator->expects($this->at(2 * $i))
+                    ->method('atPath')
+                    ->with($propertyPath)
+                    ->will($this->returnValue($contextualValidator));
+                $contextualValidator->expects($this->at(2 * $i + 1))
+                    ->method('validate')
+                    ->with($value, $constraints, $group);
+                break;
+        }
+    }
+
+    protected function assertNoViolation()
+    {
+        $this->assertCount(0, $this->context->getViolations());
+    }
+
+    protected function assertViolation($message, array $parameters = array(), $propertyPath = 'property.path', $invalidValue = 'InvalidValue', $plural = null, $code = null)
+    {
+        $violations = $this->context->getViolations();
+
+        $this->assertCount(1, $violations);
+        $this->assertEquals($this->createViolation($message, $parameters, $propertyPath, $invalidValue, $plural, $code), $violations[0]);
+    }
+
+    protected function assertViolations(array $expected)
+    {
+        $violations = $this->context->getViolations();
+
+        $this->assertCount(count($expected), $violations);
+
+        $i = 0;
+
+        foreach ($expected as $violation) {
+            $this->assertEquals($violation, $violations[$i++]);
+        }
+    }
+
+    abstract protected function getApiVersion();
+
+    abstract protected function createValidator();
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -15,35 +15,25 @@ use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\AllValidator;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Validation;
 
-class AllValidatorTest extends \PHPUnit_Framework_TestCase
+class AllValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new AllValidator();
-        $this->validator->initialize($this->context);
-
-        $this->context->expects($this->any())
-            ->method('getGroup')
-            ->will($this->returnValue('MyGroup'));
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->validator = null;
-        $this->context = null;
+        return new AllValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new All(new Range(array('min' => 4))));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -61,18 +51,15 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $constraint = new Range(array('min' => 4));
 
-        $i = 1;
+        $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->context->expects($this->at($i++))
-                ->method('validateValue')
-                ->with($value, $constraint, '['.$key.']', 'MyGroup');
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint), 'MyGroup');
         }
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($array, new All($constraint));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -84,21 +71,16 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         $constraint2 = new NotNull();
 
         $constraints = array($constraint1, $constraint2);
-        $i = 1;
+
+        $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->context->expects($this->at($i++))
-                ->method('validateValue')
-                ->with($value, $constraint1, '['.$key.']', 'MyGroup');
-            $this->context->expects($this->at($i++))
-                ->method('validateValue')
-                ->with($value, $constraint2, '['.$key.']', 'MyGroup');
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint1, $constraint2), 'MyGroup');
         }
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($array, new All($constraints));
+
+        $this->assertNoViolation();
     }
 
     public function getValidArguments()

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
@@ -13,39 +13,33 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Blank;
 use Symfony\Component\Validator\Constraints\BlankValidator;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validation;
 
-class BlankValidatorTest extends \PHPUnit_Framework_TestCase
+class BlankValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new BlankValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new BlankValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Blank());
+
+        $this->assertNoViolation();
     }
 
     public function testBlankIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Blank());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -57,13 +51,12 @@ class BlankValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $value,
-            ));
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation(
+            'myMessage',
+            array('{{ value }}' => $value)
+        );
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Blank;
 use Symfony\Component\Validator\Constraints\BlankValidator;
-use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validation;
 
 class BlankValidatorTest extends AbstractConstraintValidatorTest

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\CardScheme;
 use Symfony\Component\Validator\Constraints\CardSchemeValidator;
+use Symfony\Component\Validator\Validation;
 
-class CardSchemeValidatorTest extends \PHPUnit_Framework_TestCase
+class CardSchemeValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new CardSchemeValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new CardSchemeValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new CardScheme(array('schemes' => array())));
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new CardScheme(array('schemes' => array())));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -53,10 +46,9 @@ class CardSchemeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidNumbers($scheme, $number)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($number, new CardScheme(array('schemes' => $scheme)));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -64,10 +56,14 @@ class CardSchemeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidNumbers($scheme, $number)
     {
-        $this->context->expects($this->once())
-            ->method('addViolation');
+        $constraint = new CardScheme(array(
+            'schemes' => $scheme,
+            'message' => 'myMessage',
+        ));
 
-        $this->validator->validate($number, new CardScheme(array('schemes' => $scheme)));
+        $this->validator->validate($number, $constraint);
+
+        $this->assertViolation('myMessage', array());
     }
 
     public function getValidNumbers()

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -13,37 +13,29 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\ChoiceValidator;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Validation;
 
 function choice_callback()
 {
     return array('foo', 'bar');
 }
 
-class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
+class ChoiceValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new ChoiceValidator();
+    }
 
     public static function staticCallback()
     {
         return array('foo', 'bar');
-    }
-
-    protected function setUp()
-    {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new ChoiceValidator();
-        $this->validator->initialize($this->context);
-
-        $this->context->expects($this->any())
-            ->method('getClassName')
-            ->will($this->returnValue(__CLASS__));
-    }
-
-    protected function tearDown()
-    {
-        $this->context = null;
-        $this->validator = null;
     }
 
     /**
@@ -61,10 +53,9 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Choice(array('choices' => array('foo', 'bar'))));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -87,20 +78,18 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $constraint = new Choice(array('choices' => array('foo', 'bar')));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('bar', $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testValidChoiceCallbackFunction()
     {
         $constraint = new Choice(array('callback' => __NAMESPACE__.'\choice_callback'));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('bar', $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testValidChoiceCallbackClosure()
@@ -109,30 +98,30 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             return array('foo', 'bar');
         }));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('bar', $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testValidChoiceCallbackStaticMethod()
     {
         $constraint = new Choice(array('callback' => array(__CLASS__, 'staticCallback')));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('bar', $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testValidChoiceCallbackContextMethod()
     {
+        // search $this for "staticCallback"
+        $this->setObject($this);
+
         $constraint = new Choice(array('callback' => 'staticCallback'));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('bar', $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testMultipleChoices()
@@ -142,10 +131,9 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'multiple' => true,
         ));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(array('baz', 'bar'), $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testInvalidChoice()
@@ -155,13 +143,11 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => 'baz',
-            ), null, null);
-
         $this->validator->validate('baz', $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => 'baz',
+        ));
     }
 
     public function testInvalidChoiceMultiple()
@@ -172,13 +158,11 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'multiple' => true,
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => 'baz',
-            ));
-
         $this->validator->validate(array('foo', 'baz'), $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => 'baz',
+        ));
     }
 
     public function testTooFewChoices()
@@ -190,13 +174,15 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'minMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ limit }}' => 2,
-            ), null, 2);
+        $value = array('foo');
 
-        $this->validator->validate(array('foo'), $constraint);
+        $this->setValue($value);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ limit }}' => 2,
+        ), 'property.path', $value, 2);
     }
 
     public function testTooManyChoices()
@@ -208,13 +194,15 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'maxMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ limit }}' => 2,
-            ), null, 2);
+        $value = array('foo', 'bar', 'moo');
 
-        $this->validator->validate(array('foo', 'bar', 'moo'), $constraint);
+        $this->setValue($value);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ limit }}' => 2,
+        ), 'property.path', $value, 2);
     }
 
     public function testNonStrict()
@@ -224,11 +212,10 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'strict' => false,
         ));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('2', $constraint);
         $this->validator->validate(2, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testStrictAllowsExactValue()
@@ -238,10 +225,9 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'strict' => true,
         ));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(2, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testStrictDisallowsDifferentType()
@@ -252,13 +238,11 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => '2',
-            ));
-
         $this->validator->validate('2', $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => '2',
+        ));
     }
 
     public function testNonStrictWithMultipleChoices()
@@ -269,10 +253,9 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'strict' => false
         ));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(array('2', 3), $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testStrictWithMultipleChoices()
@@ -284,12 +267,10 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'multipleMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => '3',
-            ));
-
         $this->validator->validate(array(2, '3'), $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => '3',
+        ));
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\ChoiceValidator;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Validation;
 
 function choice_callback()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorCustomArrayObjectTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorCustomArrayObjectTest.php
@@ -11,63 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-/**
- * This class is a hand written simplified version of PHP native `ArrayObject`
- * class, to show that it behaves differently than the PHP native implementation.
- */
-class CustomArrayObject implements \ArrayAccess, \IteratorAggregate, \Countable, \Serializable
-{
-    private $array;
-
-    public function __construct(array $array = null)
-    {
-        $this->array = $array ?: array();
-    }
-
-    public function offsetExists($offset)
-    {
-        return array_key_exists($offset, $this->array);
-    }
-
-    public function offsetGet($offset)
-    {
-        return $this->array[$offset];
-    }
-
-    public function offsetSet($offset, $value)
-    {
-        if (null === $offset) {
-            $this->array[] = $value;
-        } else {
-            $this->array[$offset] = $value;
-        }
-    }
-
-    public function offsetUnset($offset)
-    {
-        unset($this->array[$offset]);
-    }
-
-    public function getIterator()
-    {
-        return new \ArrayIterator($this->array);
-    }
-
-    public function count()
-    {
-        return count($this->array);
-    }
-
-    public function serialize()
-    {
-        return serialize($this->array);
-    }
-
-    public function unserialize($serialized)
-    {
-        $this->array = (array) unserialize((string) $serialized);
-    }
-}
+use Symfony\Component\Validator\Tests\Fixtures\CustomArrayObject;
 
 class CollectionValidatorCustomArrayObjectTest extends CollectionValidatorTest
 {

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -17,51 +17,44 @@ use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Required;
+use Symfony\Component\Validator\Validation;
 
-abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
+abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new CollectionValidator();
-        $this->validator->initialize($this->context);
-
-        $this->context->expects($this->any())
-            ->method('getGroup')
-            ->will($this->returnValue('MyGroup'));
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new CollectionValidator();
     }
 
     abstract protected function prepareTestData(array $contents);
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
-
         $this->validator->validate(null, new Collection(array('fields' => array(
             'foo' => new Range(array('min' => 4)),
         ))));
+
+        $this->assertNoViolation();
     }
 
     public function testFieldsAsDefaultOption()
     {
+        $constraint = new Range(array('min' => 4));
+
         $data = $this->prepareTestData(array('foo' => 'foobar'));
 
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
+        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint), 'MyGroup');
 
         $this->validator->validate($data, new Collection(array(
-            'foo' => new Range(array('min' => 4)),
+            'foo' => $constraint,
         )));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -82,18 +75,14 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => 3,
             'bar' => 5,
         );
-        $i = 1;
+
+        $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->context->expects($this->at($i++))
-                ->method('validateValue')
-                ->with($value, $constraint, '['.$key.']', 'MyGroup');
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint), 'MyGroup');
         }
 
         $data = $this->prepareTestData($array);
-
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
 
         $this->validator->validate($data, new Collection(array(
             'fields' => array(
@@ -101,6 +90,8 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 'bar' => $constraint,
             ),
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testWalkMultipleConstraints()
@@ -114,20 +105,14 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => 3,
             'bar' => 5,
         );
-        $i = 1;
+
+        $i = 0;
 
         foreach ($array as $key => $value) {
-            foreach ($constraints as $constraint) {
-                $this->context->expects($this->at($i++))
-                    ->method('validateValue')
-                    ->with($value, $constraint, '['.$key.']', 'MyGroup');
-            }
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, $constraints, 'MyGroup');
         }
 
         $data = $this->prepareTestData($array);
-
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
 
         $this->validator->validate($data, new Collection(array(
             'fields' => array(
@@ -135,27 +120,31 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 'bar' => $constraints,
             )
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testExtraFieldsDisallowed()
     {
+        $constraint = new Range(array('min' => 4));
+
         $data = $this->prepareTestData(array(
             'foo' => 5,
             'baz' => 6,
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolationAt')
-            ->with('[baz]', 'myMessage', array(
-                '{{ field }}' => 'baz'
-            ));
+        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint), 'MyGroup');
 
         $this->validator->validate($data, new Collection(array(
             'fields' => array(
-                'foo' => new Range(array('min' => 4)),
+                'foo' => $constraint,
             ),
             'extraFieldsMessage' => 'myMessage',
         )));
+
+        $this->assertViolation('myMessage', array(
+            '{{ field }}' => 'baz'
+        ), 'property.path[baz]', 6);
     }
 
     // bug fix
@@ -165,16 +154,17 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => null,
         ));
 
-        $constraint = new Collection(array(
+        $constraint = new Range(array('min' => 4));
+
+        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint), 'MyGroup');
+
+        $this->validator->validate($data, new Collection(array(
             'fields' => array(
-                'foo' => new Range(array('min' => 4)),
+                'foo' => $constraint,
             ),
-        ));
+        )));
 
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
-
-        $this->validator->validate($data, $constraint);
+        $this->assertNoViolation();
     }
 
     public function testExtraFieldsAllowed()
@@ -184,54 +174,52 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'bar' => 6,
         ));
 
-        $constraint = new Collection(array(
+        $constraint = new Range(array('min' => 4));
+
+        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint), 'MyGroup');
+
+        $this->validator->validate($data, new Collection(array(
             'fields' => array(
-                'foo' => new Range(array('min' => 4)),
+                'foo' => $constraint,
             ),
             'allowExtraFields' => true,
-        ));
+        )));
 
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
-
-        $this->validator->validate($data, $constraint);
+        $this->assertNoViolation();
     }
 
     public function testMissingFieldsDisallowed()
     {
         $data = $this->prepareTestData(array());
 
-        $constraint = new Collection(array(
+        $constraint = new Range(array('min' => 4));
+
+        $this->validator->validate($data, new Collection(array(
             'fields' => array(
-                'foo' => new Range(array('min' => 4)),
+                'foo' => $constraint,
             ),
             'missingFieldsMessage' => 'myMessage',
-        ));
+        )));
 
-        $this->context->expects($this->once())
-            ->method('addViolationAt')
-            ->with('[foo]', 'myMessage', array(
-                '{{ field }}' => 'foo',
-            ));
-
-        $this->validator->validate($data, $constraint);
+        $this->assertViolation('myMessage', array(
+            '{{ field }}' => 'foo'
+        ), 'property.path[foo]', null);
     }
 
     public function testMissingFieldsAllowed()
     {
         $data = $this->prepareTestData(array());
 
-        $constraint = new Collection(array(
+        $constraint = new Range(array('min' => 4));
+
+        $this->validator->validate($data, new Collection(array(
             'fields' => array(
-                'foo' => new Range(array('min' => 4)),
+                'foo' => $constraint,
             ),
             'allowMissingFields' => true,
-        ));
+        )));
 
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
-
-        $this->validator->validate($data, $constraint);
+        $this->assertNoViolation();
     }
 
     public function testOptionalFieldPresent()
@@ -240,24 +228,22 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => null,
         ));
 
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
-
         $this->validator->validate($data, new Collection(array(
             'foo' => new Optional(),
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testOptionalFieldNotPresent()
     {
         $data = $this->prepareTestData(array());
 
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
-
         $this->validator->validate($data, new Collection(array(
             'foo' => new Optional(),
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testOptionalFieldSingleConstraint()
@@ -268,18 +254,15 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new Range(array('min' => 4));
 
-        $this->context->expects($this->once())
-            ->method('validateValue')
-            ->with($array['foo'], $constraint, '[foo]', 'MyGroup');
-
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
+        $this->expectValidateValueAt(0, '[foo]', $array['foo'], array($constraint), 'MyGroup');
 
         $data = $this->prepareTestData($array);
 
         $this->validator->validate($data, new Collection(array(
             'foo' => new Optional($constraint),
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testOptionalFieldMultipleConstraints()
@@ -292,22 +275,16 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             new NotNull(),
             new Range(array('min' => 4)),
         );
-        $i = 1;
 
-        foreach ($constraints as $constraint) {
-            $this->context->expects($this->at($i++))
-                ->method('validateValue')
-                ->with($array['foo'], $constraint, '[foo]', 'MyGroup');
-        }
-
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
+        $this->expectValidateValueAt(0, '[foo]', $array['foo'], $constraints, 'MyGroup');
 
         $data = $this->prepareTestData($array);
 
         $this->validator->validate($data, new Collection(array(
             'foo' => new Optional($constraints),
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testRequiredFieldPresent()
@@ -316,23 +293,16 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => null,
         ));
 
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
-
         $this->validator->validate($data, new Collection(array(
             'foo' => new Required(),
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testRequiredFieldNotPresent()
     {
         $data = $this->prepareTestData(array());
-
-        $this->context->expects($this->once())
-            ->method('addViolationAt')
-            ->with('[foo]', 'myMessage', array(
-                '{{ field }}' => 'foo',
-            ));
 
         $this->validator->validate($data, new Collection(array(
             'fields' => array(
@@ -340,6 +310,11 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ),
             'missingFieldsMessage' => 'myMessage',
         )));
+
+
+        $this->assertViolation('myMessage', array(
+            '{{ field }}' => 'foo'
+        ), 'property.path[foo]', null);
     }
 
     public function testRequiredFieldSingleConstraint()
@@ -350,18 +325,15 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new Range(array('min' => 4));
 
-        $this->context->expects($this->once())
-            ->method('validateValue')
-            ->with($array['foo'], $constraint, '[foo]', 'MyGroup');
-
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
+        $this->expectValidateValueAt(0, '[foo]', $array['foo'], array($constraint), 'MyGroup');
 
         $data = $this->prepareTestData($array);
 
         $this->validator->validate($data, new Collection(array(
             'foo' => new Required($constraint),
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testRequiredFieldMultipleConstraints()
@@ -374,22 +346,16 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             new NotNull(),
             new Range(array('min' => 4)),
         );
-        $i = 1;
 
-        foreach ($constraints as $constraint) {
-            $this->context->expects($this->at($i++))
-                ->method('validateValue')
-                ->with($array['foo'], $constraint, '[foo]', 'MyGroup');
-        }
-
-        $this->context->expects($this->never())
-            ->method('addViolationAt');
+        $this->expectValidateValueAt(0, '[foo]', $array['foo'], $constraints, 'MyGroup');
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($array, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'foo' => new Required($constraints),
         )));
+
+        $this->assertNoViolation();
     }
 
     public function testObjectShouldBeLeftUnchanged()
@@ -398,9 +364,13 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => 3
         ));
 
+        $constraint = new Range(array('min' => 2));
+
+        $this->expectValidateValueAt(0, '[foo]', $value['foo'], array($constraint), 'MyGroup');
+
         $this->validator->validate($value, new Collection(array(
             'fields' => array(
-                'foo' => new Range(array('min' => 2)),
+                'foo' => $constraint,
             )
         )));
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -311,7 +311,6 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
             'missingFieldsMessage' => 'myMessage',
         )));
 
-
         $this->assertViolation('myMessage', array(
             '{{ field }}' => 'foo'
         ), 'property.path[foo]', null);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorCountableTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorCountableTest.php
@@ -11,20 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-class CountValidatorCountableTest_Countable implements \Countable
-{
-    private $content;
-
-    public function __construct(array $content)
-    {
-        $this->content = $content;
-    }
-
-    public function count()
-    {
-        return count($this->content);
-    }
-}
+use Symfony\Component\Validator\Tests\Fixtures\Countable;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -33,6 +20,6 @@ class CountValidatorCountableTest extends CountValidatorTest
 {
     protected function createCollection(array $content)
     {
-        return new CountValidatorCountableTest_Countable($content);
+        return new Countable($content);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -13,36 +13,30 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\CountValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class CountValidatorTest extends \PHPUnit_Framework_TestCase
+abstract class CountValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new CountValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new CountValidator();
     }
 
     abstract protected function createCollection(array $content);
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Count(6));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -93,11 +87,10 @@ abstract class CountValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValuesMax($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Count(array('max' => 3));
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -105,11 +98,10 @@ abstract class CountValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValuesMin($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Count(array('min' => 5));
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -117,11 +109,10 @@ abstract class CountValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValuesExact($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Count(4);
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -134,14 +125,12 @@ abstract class CountValidatorTest extends \PHPUnit_Framework_TestCase
             'maxMessage' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', $this->identicalTo(array(
-                '{{ count }}' => count($value),
-                '{{ limit }}' => 4,
-            )), $value, 4);
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ count }}' => count($value),
+            '{{ limit }}' => 4,
+        ), 'property.path', $value, 4);
     }
 
     /**
@@ -154,14 +143,12 @@ abstract class CountValidatorTest extends \PHPUnit_Framework_TestCase
             'minMessage' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', $this->identicalTo(array(
-                '{{ count }}' => count($value),
-                '{{ limit }}' => 4,
-            )), $value, 4);
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ count }}' => count($value),
+            '{{ limit }}' => 4,
+        ), 'property.path', $value, 4);
     }
 
     /**
@@ -175,14 +162,12 @@ abstract class CountValidatorTest extends \PHPUnit_Framework_TestCase
             'exactMessage' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', $this->identicalTo(array(
+        $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
             '{{ count }}' => count($value),
             '{{ limit }}' => 4,
-        )), $value, 4);
-
-        $this->validator->validate($value, $constraint);
+        ), 'property.path', $value, 4);
     }
 
     public function testDefaultOption()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -14,41 +14,39 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Country;
 use Symfony\Component\Validator\Constraints\CountryValidator;
+use Symfony\Component\Validator\Validation;
 
-class CountryValidatorTest extends \PHPUnit_Framework_TestCase
+class CountryValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
     protected function setUp()
     {
         IntlTestHelper::requireFullIntl($this);
 
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new CountryValidator();
-        $this->validator->initialize($this->context);
+        parent::setUp();
     }
 
-    protected function tearDown()
+    protected function getApiVersion()
     {
-        $this->context = null;
-        $this->validator = null;
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new CountryValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Country());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Country());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -64,10 +62,9 @@ class CountryValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidCountries($country)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($country, new Country());
+
+        $this->assertNoViolation();
     }
 
     public function getValidCountries()
@@ -88,13 +85,11 @@ class CountryValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $country,
-            ));
-
         $this->validator->validate($country, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $country,
+        ));
     }
 
     public function getInvalidCountries()
@@ -113,9 +108,9 @@ class CountryValidatorTest extends \PHPUnit_Framework_TestCase
         \Locale::setDefault('en_GB');
 
         $existingCountry = 'GB';
-        $this->context->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate($existingCountry, new Country());
+
+        $this->assertNoViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -14,41 +14,39 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Currency;
 use Symfony\Component\Validator\Constraints\CurrencyValidator;
+use Symfony\Component\Validator\Validation;
 
-class CurrencyValidatorTest extends \PHPUnit_Framework_TestCase
+class CurrencyValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
     protected function setUp()
     {
         IntlTestHelper::requireFullIntl($this);
 
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new CurrencyValidator();
-        $this->validator->initialize($this->context);
+        parent::setUp();
     }
 
-    protected function tearDown()
+    protected function getApiVersion()
     {
-        $this->context = null;
-        $this->validator = null;
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new CurrencyValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Currency());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Currency());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -64,10 +62,9 @@ class CurrencyValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidCurrencies($currency)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($currency, new Currency());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -76,10 +73,10 @@ class CurrencyValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidCurrenciesWithCountrySpecificLocale($currency)
     {
         \Locale::setDefault('en_GB');
-        $this->context->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate($currency, new Currency());
+
+        $this->assertNoViolation();
     }
 
     public function getValidCurrencies()
@@ -102,13 +99,11 @@ class CurrencyValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $currency,
-            ));
-
         $this->validator->validate($currency, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $currency,
+        ));
     }
 
     public function getInvalidCurrencies()

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -13,47 +13,39 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\DateTimeValidator;
+use Symfony\Component\Validator\Validation;
 
-class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
+class DateTimeValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new DateTimeValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new DateTimeValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new DateTime());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new DateTime());
+
+        $this->assertNoViolation();
     }
 
     public function testDateTimeClassIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(new \DateTime(), new DateTime());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -69,10 +61,9 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidDateTimes($dateTime)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($dateTime, new DateTime());
+
+        $this->assertNoViolation();
     }
 
     public function getValidDateTimes()
@@ -93,13 +84,11 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $dateTime,
-            ));
-
         $this->validator->validate($dateTime, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $dateTime,
+        ));
     }
 
     public function getInvalidDateTimes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -13,47 +13,39 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Date;
 use Symfony\Component\Validator\Constraints\DateValidator;
+use Symfony\Component\Validator\Validation;
 
-class DateValidatorTest extends \PHPUnit_Framework_TestCase
+class DateValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new DateValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new DateValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Date());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Date());
+
+        $this->assertNoViolation();
     }
 
     public function testDateTimeClassIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(new \DateTime(), new Date());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -69,10 +61,9 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidDates($date)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($date, new Date());
+
+        $this->assertNoViolation();
     }
 
     public function getValidDates()
@@ -93,13 +84,11 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $date,
-            ));
-
         $this->validator->validate($date, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $date,
+        ));
     }
 
     public function getInvalidDates()

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\EmailValidator;
+use Symfony\Component\Validator\Validation;
 
-class EmailValidatorTest extends \PHPUnit_Framework_TestCase
+class EmailValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new EmailValidator(false);
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new EmailValidator(false);
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Email());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Email());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -61,10 +54,9 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidEmails($email)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($email, new Email());
+
+        $this->assertNoViolation();
     }
 
     public function getValidEmails()
@@ -85,13 +77,11 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $email,
-            ));
-
         $this->validator->validate($email, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $email,
+        ));
     }
 
     public function getInvalidEmails()
@@ -105,9 +95,10 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testStrict()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
+        $constraint = new Email(array('strict' => true));
 
-        $this->validator->validate('example@localhost', new Email(array('strict' => true)));
+        $this->validator->validate('example@localhost', $constraint);
+
+        $this->assertNoViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Constraints\EqualToValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
 class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
     protected function createValidator()
     {
         return new EqualToValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -14,184 +14,139 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
+use Symfony\Component\Validator\Tests\Fixtures\Entity;
+use Symfony\Component\Validator\Validation;
 
-class ExpressionValidatorTest extends \PHPUnit_Framework_TestCase
+class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new ExpressionValidator(PropertyAccess::createPropertyAccessor());
-        $this->validator->initialize($this->context);
-
-        $this->context->expects($this->any())
-            ->method('getClassName')
-            ->will($this->returnValue(__CLASS__));
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new ExpressionValidator(PropertyAccess::createPropertyAccessor());
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Expression('value == 1'));
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Expression('value == 1'));
+
+        $this->assertNoViolation();
     }
 
     public function testSucceedingExpressionAtObjectLevel()
     {
-        $constraint = new Expression('this.property == 1');
+        $constraint = new Expression('this.data == 1');
 
-        $object = (object) array('property' => '1');
+        $object = new Entity();
+        $object->data = '1';
 
-        $this->context->expects($this->any())
-            ->method('getPropertyName')
-            ->will($this->returnValue(null));
-
-        $this->context->expects($this->never())
-            ->method('addViolation');
+        $this->setObject($object);
 
         $this->validator->validate($object, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testFailingExpressionAtObjectLevel()
     {
         $constraint = new Expression(array(
-            'expression' => 'this.property == 1',
+            'expression' => 'this.data == 1',
             'message' => 'myMessage',
         ));
 
-        $object = (object) array('property' => '2');
+        $object = new Entity();
+        $object->data = '2';
 
-        $this->context->expects($this->any())
-            ->method('getPropertyName')
-            ->will($this->returnValue(null));
-
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage');
+        $this->setObject($object);
 
         $this->validator->validate($object, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     public function testSucceedingExpressionAtPropertyLevel()
     {
-        $constraint = new Expression('value == this.expected');
+        $constraint = new Expression('value == this.data');
 
-        $object = (object) array('expected' => '1');
+        $object = new Entity();
+        $object->data = '1';
 
-        $this->context->expects($this->any())
-            ->method('getPropertyName')
-            ->will($this->returnValue('property'));
-
-        $this->context->expects($this->any())
-            ->method('getPropertyPath')
-            ->will($this->returnValue('property'));
-
-        $this->context->expects($this->any())
-            ->method('getRoot')
-            ->will($this->returnValue($object));
-
-        $this->context->expects($this->never())
-            ->method('addViolation');
+        $this->setRoot($object);
+        $this->setPropertyPath('data');
+        $this->setProperty($object, 'data');
 
         $this->validator->validate('1', $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testFailingExpressionAtPropertyLevel()
     {
         $constraint = new Expression(array(
-            'expression' => 'value == this.expected',
+            'expression' => 'value == this.data',
             'message' => 'myMessage',
         ));
 
-        $object = (object) array('expected' => '1');
+        $object = new Entity();
+        $object->data = '1';
 
-        $this->context->expects($this->any())
-            ->method('getPropertyName')
-            ->will($this->returnValue('property'));
-
-        $this->context->expects($this->any())
-            ->method('getPropertyPath')
-            ->will($this->returnValue('property'));
-
-        $this->context->expects($this->any())
-            ->method('getRoot')
-            ->will($this->returnValue($object));
-
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage');
+        $this->setRoot($object);
+        $this->setPropertyPath('data');
+        $this->setProperty($object, 'data');
 
         $this->validator->validate('2', $constraint);
+
+        $this->assertViolation('myMessage', array(), 'data');
     }
 
     public function testSucceedingExpressionAtNestedPropertyLevel()
     {
-        $constraint = new Expression('value == this.expected');
+        $constraint = new Expression('value == this.data');
 
-        $object = (object) array('expected' => '1');
-        $root = (object) array('nested' => $object);
+        $object = new Entity();
+        $object->data = '1';
 
-        $this->context->expects($this->any())
-            ->method('getPropertyName')
-            ->will($this->returnValue('property'));
+        $root = new Entity();
+        $root->reference = $object;
 
-        $this->context->expects($this->any())
-            ->method('getPropertyPath')
-            ->will($this->returnValue('nested.property'));
-
-        $this->context->expects($this->any())
-            ->method('getRoot')
-            ->will($this->returnValue($root));
-
-        $this->context->expects($this->never())
-            ->method('addViolation');
+        $this->setRoot($root);
+        $this->setPropertyPath('reference.data');
+        $this->setProperty($object, 'data');
 
         $this->validator->validate('1', $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testFailingExpressionAtNestedPropertyLevel()
     {
         $constraint = new Expression(array(
-            'expression' => 'value == this.expected',
+            'expression' => 'value == this.data',
             'message' => 'myMessage',
         ));
 
-        $object = (object) array('expected' => '1');
-        $root = (object) array('nested' => $object);
+        $object = new Entity();
+        $object->data = '1';
 
-        $this->context->expects($this->any())
-            ->method('getPropertyName')
-            ->will($this->returnValue('property'));
+        $root = new Entity();
+        $root->reference = $object;
 
-        $this->context->expects($this->any())
-            ->method('getPropertyPath')
-            ->will($this->returnValue('nested.property'));
-
-        $this->context->expects($this->any())
-            ->method('getRoot')
-            ->will($this->returnValue($root));
-
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage');
+        $this->setRoot($root);
+        $this->setPropertyPath('reference.data');
+        $this->setProperty($object, 'data');
 
         $this->validator->validate('2', $constraint);
+
+        $this->assertViolation('myMessage', array(), 'reference.data');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FalseValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FalseValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\False;
 use Symfony\Component\Validator\Constraints\FalseValidator;
+use Symfony\Component\Validator\Validation;
 
-class FalseValidatorTest extends \PHPUnit_Framework_TestCase
+class FalseValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new FalseValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new FalseValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new False());
+
+        $this->assertNoViolation();
     }
 
     public function testFalseIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(false, new False());
+
+        $this->assertNoViolation();
     }
 
     public function testTrueIsInvalid()
@@ -54,10 +47,8 @@ class FalseValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array());
-
         $this->validator->validate(true, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
@@ -26,12 +26,10 @@ class FileValidatorPathTest extends FileValidatorTest
             'notFoundMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ file }}' => 'foobar',
-            ));
-
         $this->validator->validate('foobar', $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ file }}' => 'foobar',
+        ));
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
 class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
     protected function createValidator()
     {
         return new GreaterThanOrEqualValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\GreaterThanValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
 class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
     protected function createValidator()
     {
         return new GreaterThanValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -13,31 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Iban;
 use Symfony\Component\Validator\Constraints\IbanValidator;
+use Symfony\Component\Validator\Validation;
 
-class IbanValidatorTest extends \PHPUnit_Framework_TestCase
+class IbanValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new IbanValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new IbanValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())->method('addViolation');
-
         $this->validator->validate(null, new Iban());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())->method('addViolation');
-
         $this->validator->validate('', new Iban());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -45,9 +46,9 @@ class IbanValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIbans($iban)
     {
-        $this->context->expects($this->never())->method('addViolation');
-
         $this->validator->validate($iban, new Iban());
+
+        $this->assertNoViolation();
     }
 
     public function getValidIbans()
@@ -160,13 +161,11 @@ class IbanValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $iban,
-            ));
-
         $this->validator->validate($iban, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $iban,
+        ));
     }
 
     public function getInvalidIbans()

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\IdenticalTo;
 use Symfony\Component\Validator\Constraints\IdenticalToValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
 class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
     protected function createValidator()
     {
         return new IdenticalToValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -13,8 +13,9 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Component\Validator\Constraints\ImageValidator;
+use Symfony\Component\Validator\Validation;
 
-class ImageValidatorTest extends \PHPUnit_Framework_TestCase
+class ImageValidatorTest extends AbstractConstraintValidatorTest
 {
     protected $context;
     protected $validator;
@@ -23,11 +24,20 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
     protected $imageLandscape;
     protected $imagePortrait;
 
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new ImageValidator();
+    }
+
     protected function setUp()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new ImageValidator();
-        $this->validator->initialize($this->context);
+        parent::setUp();
+
         $this->image = __DIR__.'/Fixtures/test.gif';
         $this->imageLandscape = __DIR__.'/Fixtures/test_landscape.gif';
         $this->imagePortrait = __DIR__.'/Fixtures/test_portrait.gif';
@@ -35,33 +45,27 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Image());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Image());
+
+        $this->assertNoViolation();
     }
 
     public function testValidImage()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($this->image, new Image());
+
+        $this->assertNoViolation();
     }
 
     public function testValidSize()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Image(array(
             'minWidth' => 1,
             'maxWidth' => 2,
@@ -70,6 +74,8 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->validator->validate($this->image, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testWidthTooSmall()
@@ -79,14 +85,12 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'minWidthMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ width }}' => '2',
-                '{{ min_width }}' => '3',
-            ));
-
         $this->validator->validate($this->image, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ width }}' => '2',
+            '{{ min_width }}' => '3',
+        ));
     }
 
     public function testWidthTooBig()
@@ -96,14 +100,12 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxWidthMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ width }}' => '2',
-                '{{ max_width }}' => '1',
-            ));
-
         $this->validator->validate($this->image, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ width }}' => '2',
+            '{{ max_width }}' => '1',
+        ));
     }
 
     public function testHeightTooSmall()
@@ -113,14 +115,12 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'minHeightMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ height }}' => '2',
-                '{{ min_height }}' => '3',
-            ));
-
         $this->validator->validate($this->image, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ height }}' => '2',
+            '{{ min_height }}' => '3',
+        ));
     }
 
     public function testHeightTooBig()
@@ -130,14 +130,12 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxHeightMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ height }}' => '2',
-                '{{ max_height }}' => '1',
-            ));
-
         $this->validator->validate($this->image, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ height }}' => '2',
+            '{{ max_height }}' => '1',
+        ));
     }
 
     /**
@@ -195,14 +193,12 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'minRatioMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ ratio }}' => 1,
-                '{{ min_ratio }}' => 2,
-            ));
-
         $this->validator->validate($this->image, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ ratio }}' => 1,
+            '{{ min_ratio }}' => 2,
+        ));
     }
 
     public function testRatioTooBig()
@@ -212,14 +208,12 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxRatioMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ ratio }}' => 1,
-                '{{ max_ratio }}' => 0.5,
-            ));
-
         $this->validator->validate($this->image, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ ratio }}' => 1,
+            '{{ max_ratio }}' => 0.5,
+        ));
     }
 
     /**
@@ -253,14 +247,12 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'allowSquareMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ width }}' => 2,
-                '{{ height }}' => 2,
-            ));
-
         $this->validator->validate($this->image, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ width }}' => 2,
+            '{{ height }}' => 2,
+        ));
     }
 
     public function testLandscapeNotAllowed()
@@ -270,14 +262,12 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'allowLandscapeMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ width }}' => 2,
-                '{{ height }}' => 1,
-            ));
-
         $this->validator->validate($this->imageLandscape, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ width }}' => 2,
+            '{{ height }}' => 1,
+        ));
     }
 
     public function testPortraitNotAllowed()
@@ -287,13 +277,11 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'allowPortraitMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ width }}' => 1,
-                '{{ height }}' => 2,
-            ));
-
         $this->validator->validate($this->imagePortrait, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ width }}' => 1,
+            '{{ height }}' => 2,
+        ));
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Ip;
 use Symfony\Component\Validator\Constraints\IpValidator;
+use Symfony\Component\Validator\Validation;
 
-class IpValidatorTest extends \PHPUnit_Framework_TestCase
+class IpValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new IpValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new IpValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Ip());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Ip());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -61,7 +54,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidValidatorVersion()
     {
-        $ip = new Ip(array(
+        new Ip(array(
             'version' => 666,
         ));
     }
@@ -71,12 +64,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIpsV4($ip)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($ip, new Ip(array(
             'version' => Ip::V4,
         )));
+
+        $this->assertNoViolation();
     }
 
     public function getValidIpsV4()
@@ -98,12 +90,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIpsV6($ip)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($ip, new Ip(array(
             'version' => Ip::V6,
         )));
+
+        $this->assertNoViolation();
     }
 
     public function getValidIpsV6()
@@ -136,12 +127,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIpsAll($ip)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($ip, new Ip(array(
             'version' => Ip::ALL,
         )));
+
+        $this->assertNoViolation();
     }
 
     public function getValidIpsAll()
@@ -159,13 +149,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidIpsV4()
@@ -193,13 +181,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidPrivateIpsV4()
@@ -221,13 +207,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidReservedIpsV4()
@@ -249,13 +233,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidPublicIpsV4()
@@ -273,13 +255,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidIpsV6()
@@ -311,13 +291,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidPrivateIpsV6()
@@ -339,13 +317,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidReservedIpsV6()
@@ -366,13 +342,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidPublicIpsV6()
@@ -390,13 +364,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidIpsAll()
@@ -414,13 +386,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidPrivateIpsAll()
@@ -438,13 +408,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidReservedIpsAll()
@@ -462,13 +430,11 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $ip,
-            ));
-
         $this->validator->validate($ip, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $ip,
+        ));
     }
 
     public function getInvalidPublicIpsAll()

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
@@ -13,20 +13,21 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Isbn;
 use Symfony\Component\Validator\Constraints\IsbnValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @see https://en.wikipedia.org/wiki/Isbn
  */
-class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
+class IsbnValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    public function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new IsbnValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new IsbnValidator();
     }
 
     public function getValidIsbn10()
@@ -116,21 +117,19 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
     public function testNullIsValid()
     {
         $constraint = new Isbn(true);
-        $this->context
-            ->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
         $constraint = new Isbn(true);
-        $this->context
-            ->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate('', $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -139,6 +138,7 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
     public function testExpectsStringCompatibleType()
     {
         $constraint = new Isbn(true);
+
         $this->validator->validate(new \stdClass(), $constraint);
     }
 
@@ -147,12 +147,13 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIsbn10($isbn)
     {
-        $constraint = new Isbn(array('type' => 'isbn10'));
-        $this->context
-            ->expects($this->never())
-            ->method('addViolation');
+        $constraint = new Isbn(array(
+            'type' => 'isbn10'
+        ));
 
         $this->validator->validate($isbn, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -160,13 +161,14 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIsbn10($isbn)
     {
-        $constraint = new Isbn(array('type' => 'isbn10'));
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->isbn10Message);
+        $constraint = new Isbn(array(
+            'type' => 'isbn10',
+            'isbn10Message' => 'myMessage',
+        ));
 
         $this->validator->validate($isbn, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     /**
@@ -175,11 +177,10 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidIsbn13($isbn)
     {
         $constraint = new Isbn(array('type' => 'isbn13'));
-        $this->context
-            ->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate($isbn, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -187,13 +188,14 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIsbn13($isbn)
     {
-        $constraint = new Isbn(array('type' => 'isbn13'));
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->isbn13Message);
+        $constraint = new Isbn(array(
+            'type' => 'isbn13',
+            'isbn13Message' => 'myMessage',
+        ));
 
         $this->validator->validate($isbn, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     /**
@@ -202,11 +204,10 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidIsbn($isbn)
     {
         $constraint = new Isbn();
-        $this->context
-            ->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate($isbn, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -214,12 +215,12 @@ class IsbnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIsbn($isbn)
     {
-        $constraint = new Isbn();
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->bothIsbnMessage);
+        $constraint = new Isbn(array(
+            'bothIsbnMessage' => 'myMessage',
+        ));
 
         $this->validator->validate($isbn, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
@@ -13,20 +13,21 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Issn;
 use Symfony\Component\Validator\Constraints\IssnValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @see https://en.wikipedia.org/wiki/Issn
  */
-class IssnValidatorTest extends \PHPUnit_Framework_TestCase
+class IssnValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    public function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new IssnValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new IssnValidator();
     }
 
     public function getValidLowerCasedIssn()
@@ -110,21 +111,19 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
     public function testNullIsValid()
     {
         $constraint = new Issn();
-        $this->context
-            ->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
         $constraint = new Issn();
-        $this->context
-            ->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate('', $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -141,13 +140,14 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testCaseSensitiveIssns($issn)
     {
-        $constraint = new Issn(array('caseSensitive' => true));
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->message);
+        $constraint = new Issn(array(
+            'caseSensitive' => true,
+            'message' => 'myMessage',
+        ));
 
         $this->validator->validate($issn, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     /**
@@ -155,13 +155,14 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequireHyphenIssns($issn)
     {
-        $constraint = new Issn(array('requireHyphen' => true));
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->message);
+        $constraint = new Issn(array(
+            'requireHyphen' => true,
+            'message' => 'myMessage',
+        ));
 
         $this->validator->validate($issn, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     /**
@@ -170,11 +171,10 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidIssn($issn)
     {
         $constraint = new Issn();
-        $this->context
-            ->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate($issn, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -182,13 +182,13 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidFormatIssn($issn)
     {
-        $constraint = new Issn();
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->message);
+        $constraint = new Issn(array(
+            'message' => 'myMessage',
+        ));
 
         $this->validator->validate($issn, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     /**
@@ -196,13 +196,13 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidValueIssn($issn)
     {
-        $constraint = new Issn();
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->message);
+        $constraint = new Issn(array(
+            'message' => 'myMessage',
+        ));
 
         $this->validator->validate($issn, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     /**
@@ -210,11 +210,12 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIssn($issn)
     {
-        $constraint = new Issn();
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation');
+        $constraint = new Issn(array(
+            'message' => 'myMessage',
+        ));
 
         $this->validator->validate($issn, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -14,41 +14,39 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Language;
 use Symfony\Component\Validator\Constraints\LanguageValidator;
+use Symfony\Component\Validator\Validation;
 
-class LanguageValidatorTest extends \PHPUnit_Framework_TestCase
+class LanguageValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new LanguageValidator();
+    }
 
     protected function setUp()
     {
         IntlTestHelper::requireFullIntl($this);
 
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new LanguageValidator();
-        $this->validator->initialize($this->context);
-    }
-
-    protected function tearDown()
-    {
-        $this->context = null;
-        $this->validator = null;
+        parent::setUp();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Language());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Language());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -64,10 +62,9 @@ class LanguageValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidLanguages($language)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($language, new Language());
+
+        $this->assertNoViolation();
     }
 
     public function getValidLanguages()
@@ -88,13 +85,11 @@ class LanguageValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $language,
-            ));
-
         $this->validator->validate($language, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $language,
+        ));
     }
 
     public function getInvalidLanguages()
@@ -109,11 +104,11 @@ class LanguageValidatorTest extends \PHPUnit_Framework_TestCase
     {
         \Locale::setDefault('fr_FR');
         $existingLanguage = 'en';
-        $this->context->expects($this->never())
-            ->method('addViolation');
 
         $this->validator->validate($existingLanguage, new Language(array(
             'message' => 'aMessage'
         )));
+
+        $this->assertNoViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyAllValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyAllValidator2Dot4ApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LegacyAllValidator;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyAllValidator2Dot4ApiTest extends AllValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new LegacyAllValidator();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyAllValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyAllValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyAllValidatorLegacyApiTest extends AllValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyBlankValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyBlankValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyBlankValidator2Dot4ApiTest extends BlankValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyBlankValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyBlankValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyBlankValidatorLegacyApiTest extends BlankValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCallbackValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCallbackValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCallbackValidator2Dot4ApiTest extends CallbackValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCallbackValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCallbackValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCallbackValidatorLegacyApiTest extends CallbackValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCardSchemeValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCardSchemeValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCardSchemeValidator2Dot4ApiTest extends CardSchemeValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCardSchemeValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCardSchemeValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCardSchemeValidatorLegacyApiTest extends CardSchemeValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyChoiceValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyChoiceValidator2Dot4ApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LegacyChoiceValidator;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyChoiceValidator2Dot4ApiTest extends ChoiceValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new LegacyChoiceValidator();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyChoiceValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyChoiceValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyChoiceValidatorLegacyApiTest extends ChoiceValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorArray2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorArray2Dot4ApiTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LegacyCollectionValidator;
+use Symfony\Component\Validator\Validation;
+
+class LegacyCollectionValidatorArray2Dot4ApiTest extends CollectionValidatorArrayTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new LegacyCollectionValidator();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorArrayLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorArrayLegacyApiTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+class LegacyCollectionValidatorArrayLegacyApiTest extends CollectionValidatorArrayTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorArrayObject2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorArrayObject2Dot4ApiTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LegacyCollectionValidator;
+use Symfony\Component\Validator\Validation;
+
+class LegacyCollectionValidatorArrayObject2Dot4ApiTest extends CollectionValidatorArrayObjectTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new LegacyCollectionValidator();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorArrayObjectLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorArrayObjectLegacyApiTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+class LegacyCollectionValidatorArrayObjectLegacyApiTest extends CollectionValidatorArrayObjectTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorCustomArrayObject2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorCustomArrayObject2Dot4ApiTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LegacyCollectionValidator;
+use Symfony\Component\Validator\Validation;
+
+class LegacyCollectionValidatorCustomArrayObject2Dot4ApiTest extends CollectionValidatorCustomArrayObjectTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new LegacyCollectionValidator();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorCustomArrayObjectLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCollectionValidatorCustomArrayObjectLegacyApiTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+class LegacyCollectionValidatorCustomArrayObjectLegacyApiTest extends CollectionValidatorCustomArrayObjectTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCountValidatorArray2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCountValidatorArray2Dot4ApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LegacyCountValidator;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCountValidatorArray2Dot4ApiTest extends CountValidatorArrayTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new LegacyCountValidator();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCountValidatorArrayLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCountValidatorArrayLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCountValidatorArrayLegacyApiTest extends CountValidatorArrayTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCountValidatorCountable2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCountValidatorCountable2Dot4ApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LegacyCountValidator;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCountValidatorCountable2Dot4ApiTest extends CountValidatorCountableTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new LegacyCountValidator();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCountValidatorCountableLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCountValidatorCountableLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCountValidatorCountableLegacyApiTest extends CountValidatorCountableTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCurrencyValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCurrencyValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCurrencyValidator2Dot4ApiTest extends CurrencyValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyCurrencyValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyCurrencyValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyCurrencyValidatorLegacyApiTest extends CurrencyValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyDateTimeValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyDateTimeValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyDateTimeValidator2Dot4ApiTest extends DateTimeValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyDateTimeValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyDateTimeValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyDateTimeValidatorLegacyApiTest extends DateTimeValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyDateValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyDateValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyDateValidator2Dot4ApiTest extends DateValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyDateValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyDateValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyDateValidatorLegacyApiTest extends DateValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyEmailValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyEmailValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyEmailValidator2Dot4ApiTest extends EmailValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyEmailValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyEmailValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyEmailValidatorLegacyApiTest extends EmailValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyEqualToValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyEqualToValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyEqualToValidator2Dot4ApiTest extends EqualToValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyEqualToValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyEqualToValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyEqualToValidatorLegacyApiTest extends EqualToValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyExpressionValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyExpressionValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyExpressionValidator2Dot4ApiTest extends ExpressionValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyExpressionValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyExpressionValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyExpressionValidatorLegacyApiTest extends ExpressionValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyFalseValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyFalseValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyFalseValidator2Dot4ApiTest extends FalseValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyFalseValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyFalseValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyFalseValidatorLegacyApiTest extends FalseValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyFileValidatorObject2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyFileValidatorObject2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyFileValidatorObject2Dot4ApiTest extends FileValidatorObjectTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyFileValidatorObjectLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyFileValidatorObjectLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyFileValidatorObjectLegacyApiTest extends FileValidatorObjectTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyFileValidatorPath2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyFileValidatorPath2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyFileValidatorPath2Dot4ApiTest extends FileValidatorPathTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyFileValidatorPathLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyFileValidatorPathLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyFileValidatorPathLegacyApiTest extends FileValidatorPathTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyGreaterThanOrEqualValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyGreaterThanOrEqualValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyGreaterThanOrEqualValidator2Dot4ApiTest extends GreaterThanOrEqualValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyGreaterThanOrEqualValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyGreaterThanOrEqualValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyGreaterThanOrEqualValidatorLegacyApiTest extends GreaterThanOrEqualValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyGreaterThanValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyGreaterThanValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyGreaterThanValidator2Dot4ApiTest extends GreaterThanValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyGreaterThanValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyGreaterThanValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyGreaterThanValidatorLegacyApiTest extends GreaterThanValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIbanValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIbanValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIbanValidator2Dot4ApiTest extends IbanValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIbanValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIbanValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIbanValidatorLegacyApiTest extends IbanValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIdenticalToValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIdenticalToValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIdenticalToValidator2Dot4ApiTest extends IdenticalToValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIdenticalToValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIdenticalToValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIdenticalToValidatorLegacyApiTest extends IdenticalToValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyImageValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyImageValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyImageValidator2Dot4ApiTest extends ImageValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyImageValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyImageValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyImageValidatorLegacyApiTest extends ImageValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIpValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIpValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIpValidator2Dot4ApiTest extends IpValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIpValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIpValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIpValidatorLegacyApiTest extends IpValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIsbnValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIsbnValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIsbnValidator2Dot4ApiTest extends IsbnValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIsbnValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIsbnValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIsbnValidatorLegacyApiTest extends IsbnValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIssnValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIssnValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIssnValidator2Dot4ApiTest extends IssnValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyIssnValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyIssnValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyIssnValidatorLegacyApiTest extends IssnValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLanguageValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLanguageValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLanguageValidator2Dot4ApiTest extends LanguageValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLanguageValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLanguageValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLanguageValidatorLegacyApiTest extends LanguageValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLengthValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLengthValidator2Dot4ApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LegacyLengthValidator;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLengthValidator2Dot4ApiTest extends LengthValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new LegacyLengthValidator();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLengthValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLengthValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLengthValidatorLegacyApiTest extends LengthValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLessThanOrEqualValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLessThanOrEqualValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLessThanOrEqualValidator2Dot4ApiTest extends LessThanOrEqualValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLessThanOrEqualValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLessThanOrEqualValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLessThanOrEqualValidatorLegacyApiTest extends LessThanOrEqualValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLessThanValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLessThanValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLessThanValidator2Dot4ApiTest extends LessThanValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLessThanValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLessThanValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLessThanValidatorLegacyApiTest extends LessThanValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLocaleValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLocaleValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLocaleValidator2Dot4ApiTest extends LocaleValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLocaleValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLocaleValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLocaleValidatorLegacyApiTest extends LocaleValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLuhnValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLuhnValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLuhnValidator2Dot4ApiTest extends LuhnValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyLuhnValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyLuhnValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyLuhnValidatorLegacyApiTest extends LuhnValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotBlankValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotBlankValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNotBlankValidator2Dot4ApiTest extends NotBlankValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotBlankValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotBlankValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNotBlankValidatorLegacyApiTest extends NotBlankValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotEqualToValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotEqualToValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNotEqualToValidator2Dot4ApiTest extends NotEqualToValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotEqualToValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotEqualToValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNotEqualToValidatorLegacyApiTest extends NotEqualToValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotIdenticalToValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotIdenticalToValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNotIdenticalToValidator2Dot4ApiTest extends NotIdenticalToValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotIdenticalToValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotIdenticalToValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNotIdenticalToValidatorLegacyApiTest extends NotIdenticalToValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotNullValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotNullValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNotNullValidator2Dot4ApiTest extends NotNullValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotNullValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNotNullValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNotNullValidatorLegacyApiTest extends NotNullValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNullValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNullValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNullValidator2Dot4ApiTest extends NullValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyNullValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyNullValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyNullValidatorLegacyApiTest extends NullValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyRangeValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyRangeValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyRangeValidator2Dot4ApiTest extends RangeValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyRangeValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyRangeValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyRangeValidatorLegacyApiTest extends RangeValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyRegexValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyRegexValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyRegexValidator2Dot4ApiTest extends RegexValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyRegexValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyRegexValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyRegexValidatorLegacyApiTest extends RegexValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyTimeValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyTimeValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyTimeValidator2Dot4ApiTest extends TimeValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyTimeValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyTimeValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyTimeValidatorLegacyApiTest extends TimeValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyTrueValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyTrueValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyTrueValidator2Dot4ApiTest extends TrueValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyTrueValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyTrueValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyTrueValidatorLegacyApiTest extends TrueValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyTypeValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyTypeValidator2Dot4ApiTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyTypeValidator2Dot4ApiTest extends TypeValidatorTest
+{
+    /**
+     * PhpUnit calls data providers of test suites before launching the test
+     * suite. If this property is not replicated in every test class, only one
+     * file will ever be created and stored in TypeValidatorTest::$file. After
+     * the execution of the first TypeValidator test case, tearDownAfterClass()
+     * is called and closes the file. Hence the resource is not available
+     * anymore in the other TypeValidator test cases.
+     */
+    protected static $file;
+
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyTypeValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyTypeValidatorLegacyApiTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyTypeValidatorLegacyApiTest extends TypeValidatorTest
+{
+    protected static $file;
+
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyUrlValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyUrlValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyUrlValidator2Dot4ApiTest extends UrlValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyUrlValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyUrlValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyUrlValidatorLegacyApiTest extends UrlValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyUuidValidator2Dot4ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyUuidValidator2Dot4ApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyUuidValidator2Dot4ApiTest extends UrlValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LegacyUuidValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LegacyUuidValidatorLegacyApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LegacyUuidValidatorLegacyApiTest extends UuidValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5_BC;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\LengthValidator;
+use Symfony\Component\Validator\Validation;
 
-class LengthValidatorTest extends \PHPUnit_Framework_TestCase
+class LengthValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new LengthValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new LengthValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Length(6));
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Length(6));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -111,11 +104,10 @@ class LengthValidatorTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('mb_strlen does not exist');
         }
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Length(array('min' => 5));
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -127,11 +119,10 @@ class LengthValidatorTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('mb_strlen does not exist');
         }
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Length(array('max' => 3));
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -143,11 +134,10 @@ class LengthValidatorTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('mb_strlen does not exist');
         }
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Length(4);
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -164,14 +154,12 @@ class LengthValidatorTest extends \PHPUnit_Framework_TestCase
             'minMessage' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', $this->identicalTo(array(
-                '{{ value }}' => (string) $value,
-                '{{ limit }}' => 4,
-            )), $this->identicalTo($value), 4);
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => (string) $value,
+            '{{ limit }}' => 4,
+        ), 'property.path', $value, 4);
     }
 
     /**
@@ -188,14 +176,12 @@ class LengthValidatorTest extends \PHPUnit_Framework_TestCase
             'maxMessage' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', $this->identicalTo(array(
-                '{{ value }}' => (string) $value,
-                '{{ limit }}' => 4,
-            )), $this->identicalTo($value), 4);
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => (string) $value,
+            '{{ limit }}' => 4,
+        ), 'property.path', $value, 4);
     }
 
     /**
@@ -213,14 +199,12 @@ class LengthValidatorTest extends \PHPUnit_Framework_TestCase
             'exactMessage' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', $this->identicalTo(array(
-                '{{ value }}' => (string) $value,
-                '{{ limit }}' => 4,
-            )), $this->identicalTo($value), 4);
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => (string) $value,
+            '{{ limit }}' => 4,
+        ), 'property.path', $value, 4);
     }
 
     public function testConstraintGetDefaultOption()

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Constraints\LessThanOrEqualValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
 class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
     protected function createValidator()
     {
         return new LessThanOrEqualValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\LessThan;
 use Symfony\Component\Validator\Constraints\LessThanValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
 class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
     protected function createValidator()
     {
         return new LessThanValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -14,41 +14,39 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Locale;
 use Symfony\Component\Validator\Constraints\LocaleValidator;
+use Symfony\Component\Validator\Validation;
 
-class LocaleValidatorTest extends \PHPUnit_Framework_TestCase
+class LocaleValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new LocaleValidator();
+    }
 
     protected function setUp()
     {
         IntlTestHelper::requireIntl($this);
 
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new LocaleValidator();
-        $this->validator->initialize($this->context);
-    }
-
-    protected function tearDown()
-    {
-        $this->context = null;
-        $this->validator = null;
+        parent::setUp();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Locale());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Locale());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -64,10 +62,9 @@ class LocaleValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidLocales($locale)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($locale, new Locale());
+
+        $this->assertNoViolation();
     }
 
     public function getValidLocales()
@@ -90,13 +87,11 @@ class LocaleValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $locale,
-            ));
-
         $this->validator->validate($locale, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $locale,
+        ));
     }
 
     public function getInvalidLocales()

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Luhn;
 use Symfony\Component\Validator\Constraints\LuhnValidator;
+use Symfony\Component\Validator\Validation;
 
-class LuhnValidatorTest extends \PHPUnit_Framework_TestCase
+class LuhnValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new LuhnValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new LuhnValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Luhn());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Luhn());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -53,10 +46,9 @@ class LuhnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidNumbers($number)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($number, new Luhn());
+
+        $this->assertNoViolation();
     }
 
     public function getValidNumbers()
@@ -88,13 +80,13 @@ class LuhnValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidNumbers($number)
     {
-        $constraint = new Luhn();
-
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->message);
+        $constraint = new Luhn(array(
+            'message' => 'myMessage',
+        ));
 
         $this->validator->validate($number, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     public function getInvalidNumbers()

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -13,23 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotBlankValidator;
+use Symfony\Component\Validator\Validation;
 
-class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
+class NotBlankValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new NotBlankValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new NotBlankValidator();
     }
 
     /**
@@ -37,10 +32,9 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValues($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($value, new NotBlank());
+
+        $this->assertNoViolation();
     }
 
     public function getValidValues()
@@ -60,11 +54,9 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage');
-
         $this->validator->validate(null, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     public function testBlankIsInvalid()
@@ -73,11 +65,9 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage');
-
         $this->validator->validate('', $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     public function testFalseIsInvalid()
@@ -86,11 +76,9 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage');
-
         $this->validator->validate(false, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 
     public function testEmptyArrayIsInvalid()
@@ -99,10 +87,8 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage');
-
         $this->validator->validate(array(), $constraint);
+
+        $this->assertViolation('myMessage');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\NotEqualTo;
 use Symfony\Component\Validator\Constraints\NotEqualToValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
 class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
     protected function createValidator()
     {
         return new NotEqualToValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\NotIdenticalTo;
 use Symfony\Component\Validator\Constraints\NotIdenticalToValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */
 class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
     protected function createValidator()
     {
         return new NotIdenticalToValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
@@ -13,23 +13,18 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\NotNullValidator;
+use Symfony\Component\Validator\Validation;
 
-class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
+class NotNullValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new NotNullValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new NotNullValidator();
     }
 
     /**
@@ -37,10 +32,9 @@ class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValues($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($value, new NotNull());
+
+        $this->assertNoViolation();
     }
 
     public function getValidValues()
@@ -59,11 +53,8 @@ class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-            ));
-
         $this->validator->validate(null, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NullValidatorTest.php
@@ -13,31 +13,25 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Null;
 use Symfony\Component\Validator\Constraints\NullValidator;
+use Symfony\Component\Validator\Validation;
 
-class NullValidatorTest extends \PHPUnit_Framework_TestCase
+class NullValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new NullValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new NullValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Null());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -49,13 +43,11 @@ class NullValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $readableValue,
-            ));
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $readableValue,
+        ));
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -13,25 +13,25 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\RangeValidator;
+use Symfony\Component\Validator\Validation;
 
-class RangeValidatorTest extends \PHPUnit_Framework_TestCase
+class RangeValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new RangeValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new RangeValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Range(array('min' => 10, 'max' => 20)));
+
+        $this->assertNoViolation();
     }
 
     public function getTenToTwenty()
@@ -73,11 +73,10 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValuesMin($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Range(array('min' => 10));
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -85,11 +84,10 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValuesMax($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Range(array('max' => 20));
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -97,11 +95,10 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValuesMinMax($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Range(array('min' => 10, 'max' => 20));
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -114,14 +111,12 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
             'minMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', $this->identicalTo(array(
-                '{{ value }}' => $value,
-                '{{ limit }}' => 10,
-        )));
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $value,
+            '{{ limit }}' => 10,
+        ));
     }
 
     /**
@@ -134,14 +129,12 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
             'maxMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', $this->identicalTo(array(
-                '{{ value }}' => $value,
-                '{{ limit }}' => 20,
-            )));
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $value,
+            '{{ limit }}' => 20,
+        ));
     }
 
     /**
@@ -156,14 +149,12 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
             'maxMessage' => 'myMaxMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMaxMessage', $this->identicalTo(array(
-                '{{ value }}' => $value,
-                '{{ limit }}' => 20,
-            )));
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMaxMessage', array(
+            '{{ value }}' => $value,
+            '{{ limit }}' => 20,
+        ));
     }
 
     /**
@@ -178,14 +169,12 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
             'maxMessage' => 'myMaxMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMinMessage', $this->identicalTo(array(
+        $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMinMessage', array(
             '{{ value }}' => $value,
             '{{ limit }}' => 10,
-        )));
-
-        $this->validator->validate($value, $constraint);
+        ));
     }
 
     public function getInvalidValues()
@@ -207,14 +196,12 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
             'minMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => 9,
-                '{{ limit }}' => 10,
-            ));
-
         $this->validator->validate(9, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => 9,
+            '{{ limit }}' => 10,
+        ));
     }
 
     public function testMaxMessageIsSet()
@@ -225,13 +212,11 @@ class RangeValidatorTest extends \PHPUnit_Framework_TestCase
             'maxMessage' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => 21,
-                '{{ limit }}' => 20,
-            ));
-
         $this->validator->validate(21, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => 21,
+            '{{ limit }}' => 20,
+        ));
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\RegexValidator;
+use Symfony\Component\Validator\Validation;
 
-class RegexValidatorTest extends \PHPUnit_Framework_TestCase
+class RegexValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new RegexValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new RegexValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Regex(array('pattern' => '/^[0-9]+$/')));
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Regex(array('pattern' => '/^[0-9]+$/')));
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -61,11 +54,10 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValues($value)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Regex(array('pattern' => '/^[0-9]+$/'));
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function getValidValues()
@@ -88,13 +80,11 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $value,
-            ));
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $value,
+        ));
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -13,47 +13,39 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Time;
 use Symfony\Component\Validator\Constraints\TimeValidator;
+use Symfony\Component\Validator\Validation;
 
-class TimeValidatorTest extends \PHPUnit_Framework_TestCase
+class TimeValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new TimeValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new TimeValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Time());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Time());
+
+        $this->assertNoViolation();
     }
 
     public function testDateTimeClassIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(new \DateTime(), new Time());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -69,10 +61,9 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidTimes($time)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($time, new Time());
+
+        $this->assertNoViolation();
     }
 
     public function getValidTimes()
@@ -93,13 +84,11 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $time,
-            ));
-
         $this->validator->validate($time, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $time,
+        ));
     }
 
     public function getInvalidTimes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/TrueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TrueValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\True;
 use Symfony\Component\Validator\Constraints\TrueValidator;
+use Symfony\Component\Validator\Validation;
 
-class TrueValidatorTest extends \PHPUnit_Framework_TestCase
+class TrueValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new TrueValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new TrueValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new True());
+
+        $this->assertNoViolation();
     }
 
     public function testTrueIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(true, new True());
+
+        $this->assertNoViolation();
     }
 
     public function testFalseIsInvalid()
@@ -54,11 +47,8 @@ class TrueValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-            ));
-
         $this->validator->validate(false, $constraint);
+
+        $this->assertViolation('myMessage');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -13,49 +13,53 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\TypeValidator;
+use Symfony\Component\Validator\Validation;
 
-class TypeValidatorTest extends \PHPUnit_Framework_TestCase
+class TypeValidatorTest extends AbstractConstraintValidatorTest
 {
     protected static $file;
 
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new TypeValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new TypeValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
+        $constraint = new Type(array('type' => 'integer'));
 
-        $this->validator->validate(null, new Type(array('type' => 'integer')));
+        $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyIsValidIfString()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
+        $constraint = new Type(array('type' => 'string'));
 
-        $this->validator->validate('', new Type(array('type' => 'string')));
+        $this->validator->validate('', $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyIsInvalidIfNoString()
     {
-        $this->context->expects($this->once())
-            ->method('addViolation');
+        $constraint = new Type(array(
+            'type' => 'integer',
+            'message' => 'myMessage',
+        ));
 
-        $this->validator->validate('', new Type(array('type' => 'integer')));
+        $this->validator->validate('', $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => '',
+            '{{ type }}' => 'integer',
+        ));
     }
 
     /**
@@ -63,12 +67,11 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValues($value, $type)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Type(array('type' => $type));
 
         $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function getValidValues()
@@ -118,14 +121,12 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $valueAsString,
-                '{{ type }}' => $type,
-            ));
-
         $this->validator->validate($value, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $valueAsString,
+            '{{ type }}' => $type,
+        ));
     }
 
     public function getInvalidValues()
@@ -167,17 +168,18 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function createFile()
     {
-        if (!self::$file) {
-            self::$file = fopen(__FILE__, 'r');
+        if (!static::$file) {
+            static::$file = fopen(__FILE__, 'r');
         }
 
-        return self::$file;
+        return static::$file;
     }
 
     public static function tearDownAfterClass()
     {
-        if (self::$file) {
-            fclose(self::$file);
+        if (static::$file) {
+            fclose(static::$file);
+            static::$file = null;
         }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -13,39 +13,32 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Constraints\UrlValidator;
+use Symfony\Component\Validator\Validation;
 
-class UrlValidatorTest extends \PHPUnit_Framework_TestCase
+class UrlValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new UrlValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new UrlValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Url());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Url());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -61,10 +54,9 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidUrls($url)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($url, new Url());
+
+        $this->assertNoViolation();
     }
 
     public function getValidUrls()
@@ -128,13 +120,11 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('myMessage', array(
-                '{{ value }}' => $url,
-            ));
-
         $this->validator->validate($url, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $url,
+        ));
     }
 
     public function getInvalidUrls()
@@ -163,14 +153,13 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testCustomProtocolIsValid($url)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Url(array(
             'protocols' => array('ftp', 'file', 'git')
         ));
 
         $this->validator->validate($url, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function getValidCustomUrls()

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -13,42 +13,35 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Uuid;
 use Symfony\Component\Validator\Constraints\UuidValidator;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Colin O'Dell <colinodell@gmail.com>
  */
-class UuidValidatorTest extends \PHPUnit_Framework_TestCase
+class UuidValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected $context;
-    protected $validator;
-
-    protected function setUp()
+    protected function getApiVersion()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $this->validator = new UuidValidator();
-        $this->validator->initialize($this->context);
+        return Validation::API_VERSION_2_5;
     }
 
-    protected function tearDown()
+    protected function createValidator()
     {
-        $this->context = null;
-        $this->validator = null;
+        return new UuidValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate(null, new Uuid());
+
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate('', new Uuid());
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -64,10 +57,9 @@ class UuidValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidStrictUuids($uuid)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($uuid, new Uuid());
+
+        $this->assertNoViolation();
     }
 
     public function getValidStrictUuids()
@@ -89,13 +81,11 @@ class UuidValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'testMessage'
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation')
-            ->with('testMessage', array(
-                '{{ value }}' => $uuid,
-            ));
-
         $this->validator->validate($uuid, $constraint);
+
+        $this->assertViolation('testMessage', array(
+            '{{ value }}' => $uuid,
+        ));
     }
 
     public function getInvalidStrictUuids()
@@ -119,14 +109,13 @@ class UuidValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testVersionConstraintIsValid($uuid)
     {
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $constraint = new Uuid(array(
             'versions' => array(Uuid::V1_MAC, Uuid::V4_RANDOM)
         ));
 
         $this->validator->validate($uuid, $constraint);
+
+        $this->assertNoViolation();
     }
 
     /**
@@ -135,13 +124,15 @@ class UuidValidatorTest extends \PHPUnit_Framework_TestCase
     public function testVersionConstraintIsInvalid($uuid)
     {
         $constraint = new Uuid(array(
-            'versions' => array(Uuid::V2_DCE, Uuid::V3_MD5)
+            'versions' => array(Uuid::V2_DCE, Uuid::V3_MD5),
+            'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation');
-
         $this->validator->validate($uuid, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $uuid,
+        ));
     }
 
     /**
@@ -153,10 +144,9 @@ class UuidValidatorTest extends \PHPUnit_Framework_TestCase
             'strict' => false
         ));
 
-        $this->context->expects($this->never())
-            ->method('addViolation');
-
         $this->validator->validate($uuid, $constraint);
+
+        $this->assertNoViolation();
     }
 
     public function getValidNonStrictUuids()
@@ -181,13 +171,15 @@ class UuidValidatorTest extends \PHPUnit_Framework_TestCase
     public function testInvalidNonStrictUuids($uuid)
     {
         $constraint = new Uuid(array(
-            'strict' => false
+            'strict' => false,
+            'message' => 'myMessage',
         ));
 
-        $this->context->expects($this->once())
-            ->method('addViolation');
-
         $this->validator->validate($uuid, $constraint);
+
+        $this->assertViolation('myMessage', array(
+            '{{ value }}' => $uuid,
+        ));
     }
 
     public function getInvalidNonStrictUuids()

--- a/src/Symfony/Component/Validator/Tests/ExecutionContextTest.php
+++ b/src/Symfony/Component/Validator/Tests/ExecutionContextTest.php
@@ -13,10 +13,10 @@ namespace Symfony\Component\Validator\Tests;
 
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\All;
-use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ExecutionContext;
+use Symfony\Component\Validator\LegacyConstraintValidatorFactory;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\ValidationVisitor;
 
@@ -313,7 +313,7 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
             '[name]'
         );
 
-        $visitor = new ValidationVisitor('Root', $this->metadataFactory, new ConstraintValidatorFactory(), $this->translator);
+        $visitor = new ValidationVisitor('Root', $this->metadataFactory, new LegacyConstraintValidatorFactory(), $this->translator);
         $context = new ExecutionContext($visitor, $this->translator, self::TRANS_DOMAIN);
         $context->validateValue($data, $constraints);
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Countable.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Countable.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class Countable implements \Countable
+{
+    private $content;
+
+    public function __construct(array $content)
+    {
+        $this->content = $content;
+    }
+
+    public function count()
+    {
+        return count($this->content);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/CustomArrayObject.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/CustomArrayObject.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+/**
+ * This class is a hand written simplified version of PHP native `ArrayObject`
+ * class, to show that it behaves differently than the PHP native implementation.
+ */
+class CustomArrayObject implements \ArrayAccess, \IteratorAggregate, \Countable, \Serializable
+{
+    private $array;
+
+    public function __construct(array $array = null)
+    {
+        $this->array = $array ?: array();
+    }
+
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->array);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->array[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (null === $offset) {
+            $this->array[] = $value;
+        } else {
+            $this->array[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->array[$offset]);
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->array);
+    }
+
+    public function count()
+    {
+        return count($this->array);
+    }
+
+    public function serialize()
+    {
+        return serialize($this->array);
+    }
+
+    public function unserialize($serialized)
+    {
+        $this->array = (array) unserialize((string) $serialized);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/StubGlobalExecutionContext.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/StubGlobalExecutionContext.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\GlobalExecutionContextInterface;
+use Symfony\Component\Validator\ValidationVisitorInterface;
+
+/**
+ * @since  2.5.3
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated
+ */
+class StubGlobalExecutionContext implements GlobalExecutionContextInterface
+{
+    private $violations;
+
+    private $root;
+
+    private $visitor;
+
+    function __construct($root = null, ValidationVisitorInterface $visitor = null)
+    {
+        $this->violations = new ConstraintViolationList();
+        $this->root = $root;
+        $this->visitor = $visitor;
+    }
+
+    public function getViolations()
+    {
+        return $this->violations;
+    }
+
+    public function setRoot($root)
+    {
+        $this->root = $root;
+    }
+
+    public function getRoot()
+    {
+        return $this->root;
+    }
+
+    public function setVisitor(ValidationVisitorInterface $visitor)
+    {
+        $this->visitor = $visitor;
+    }
+
+    public function getVisitor()
+    {
+        return $this->visitor;
+    }
+
+    public function getValidatorFactory()
+    {
+    }
+
+    public function getMetadataFactory()
+    {
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Validator/LegacyValidator2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/LegacyValidator2Dot5ApiTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Validator\Tests\Validator;
 
-use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\LegacyExecutionContextFactory;
 use Symfony\Component\Validator\DefaultTranslator;
+use Symfony\Component\Validator\LegacyConstraintValidatorFactory;
 use Symfony\Component\Validator\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validator\LegacyValidator;
 
@@ -31,7 +31,8 @@ class LegacyValidator2Dot5ApiTest extends Abstract2Dot5ApiTest
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
         $contextFactory = new LegacyExecutionContextFactory($metadataFactory, new DefaultTranslator());
+        $validatorFactory = new LegacyConstraintValidatorFactory();
 
-        return new LegacyValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory(), $objectInitializers);
+        return new LegacyValidator($contextFactory, $metadataFactory, $validatorFactory, $objectInitializers);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Validator/LegacyValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/LegacyValidatorLegacyApiTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Validator\Tests\Validator;
 
-use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\LegacyExecutionContextFactory;
 use Symfony\Component\Validator\DefaultTranslator;
+use Symfony\Component\Validator\LegacyConstraintValidatorFactory;
 use Symfony\Component\Validator\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validator\LegacyValidator;
 
@@ -31,7 +31,8 @@ class LegacyValidatorLegacyApiTest extends AbstractLegacyApiTest
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
         $contextFactory = new LegacyExecutionContextFactory($metadataFactory, new DefaultTranslator());
+        $validatorFactory = new LegacyConstraintValidatorFactory();
 
-        return new LegacyValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory(), $objectInitializers);
+        return new LegacyValidator($contextFactory, $metadataFactory, $validatorFactory, $objectInitializers);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidator2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidator2Dot5ApiTest.php
@@ -22,7 +22,8 @@ class RecursiveValidator2Dot5ApiTest extends Abstract2Dot5ApiTest
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
         $contextFactory = new ExecutionContextFactory(new DefaultTranslator());
+        $validatorFactory = new ConstraintValidatorFactory();
 
-        return new RecursiveValidator($contextFactory, $metadataFactory, new ConstraintValidatorFactory(), $objectInitializers);
+        return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $objectInitializers);
     }
 }

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ArrayCache;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextFactory;
 use Symfony\Component\Validator\Context\LegacyExecutionContextFactory;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\ValidatorException;
@@ -379,7 +380,7 @@ class ValidatorBuilder implements ValidatorBuilderInterface
             $metadataFactory = new ClassMetadataFactory($loader, $this->metadataCache);
         }
 
-        $validatorFactory = $this->validatorFactory ?: new ConstraintValidatorFactory($this->propertyAccessor);
+        $validatorFactory = $this->validatorFactory;
         $translator = $this->translator ?: new DefaultTranslator();
         $apiVersion = $this->apiVersion;
 
@@ -390,14 +391,20 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         if (Validation::API_VERSION_2_4 === $apiVersion) {
+            $validatorFactory = $validatorFactory ?: new ConstraintValidatorFactory($this->propertyAccessor);
+
             return new ValidatorV24($metadataFactory, $validatorFactory, $translator, $this->translationDomain, $this->initializers);
         }
 
-        $contextFactory = new LegacyExecutionContextFactory($metadataFactory, $translator, $this->translationDomain);
-
         if (Validation::API_VERSION_2_5 === $apiVersion) {
+            $contextFactory = new ExecutionContextFactory($metadataFactory, $translator, $this->translationDomain);
+            $validatorFactory = $validatorFactory ?: new ConstraintValidatorFactory($this->propertyAccessor);
+
             return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers);
         }
+
+        $contextFactory = new LegacyExecutionContextFactory($metadataFactory, $translator, $this->translationDomain);
+        $validatorFactory = $validatorFactory ?: new LegacyConstraintValidatorFactory($this->propertyAccessor);
 
         return new LegacyValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers);
     }

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -397,7 +397,7 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         if (Validation::API_VERSION_2_5 === $apiVersion) {
-            $contextFactory = new ExecutionContextFactory($metadataFactory, $translator, $this->translationDomain);
+            $contextFactory = new ExecutionContextFactory($translator, $this->translationDomain);
             $validatorFactory = $validatorFactory ?: new ConstraintValidatorFactory($this->propertyAccessor);
 
             return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

See the comments in #11049 for the origin of this PR.

Currently, the 2.5 API needs to use `LegacyExecutionContextFactory` because the constraint validators rely on methods from the old `ExecutionContext` class (like `validate()`, `validateValue()`). Consequently it is impossible to switch to the pure 2.5 API and check whether all calls to deprecated methods were removed from application code. This is fixed now.

This PR also introduces a complete test suite to test each constraint validator against all three APIs: 2.4, 2.5-BC and 2.5. Currently, some tests are not executed yet when running the complete test suite is run. I expect this to be fixed soon (ticket: sebastianbergmann/phpunit#529, pr: sebastianbergmann/phpunit#1327).
