### PR TITLE
[YAML] fixed parsing inline serialized PHP objects

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -213,6 +213,29 @@ class Inline
                 if (false !== $strpos = strpos($output, ' #')) {
                     $output = rtrim(substr($output, 0, $strpos));
                 }
+            } elseif (self::$objectSupport && '!!php/object:' === substr($scalar, $i, 13)) {
+                $openingBraces = 0;
+                $output = '';
+
+                // special handling for serialized PHP objects: use the first
+                // delimiter after all opening braces inside the serialized
+                // PHP object have been closed
+                for ($pos = $i + 12; $pos < strlen($scalar); $pos++) {
+                    if (0 === $openingBraces && in_array($scalar[$pos], $delimiters)) {
+                        $output = substr($scalar, $i, $pos - $i);
+                        $i += strlen($output);
+                        break;
+                    }
+
+                    switch ($scalar[$pos]) {
+                        case '{':
+                            $openingBraces++;
+                            break;
+                        case '}':
+                            $openingBraces--;
+                            break;
+                    }
+                }
             } elseif (preg_match('/^(.+?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {
                 $output = $match[1];
                 $i += strlen($output);

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -22,6 +22,23 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testParseInlinePhpObject()
+    {
+        $parsed = Inline::parse('{ key: "value", date: !!php/object:O:8:"DateTime":3:{s:4:"date";s:19:"2012-12-25 00:00:00";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/London";}, foo: "another value" }', true, true);
+        $expectedDatetime = new \DateTime('2012-12-25 00:00:00', new \DateTimeZone('Europe/London'));
+        $this->assertSame('value', $parsed['key']);
+        $this->assertEquals($expectedDatetime, $parsed['date']);
+        $this->assertSame('another value', $parsed['foo']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testParseInlinePhpObjectThrowsExceptionWhenObjectParsingIsDisabled()
+    {
+        Inline::parse('{ key: "value", date: !!php/object:O:8:"DateTime":3:{s:4:"date";s:19:"2012-12-25 00:00:00";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/London";}, foo: "another value" }', true);
+    }
+
     public function testDump()
     {
         $testsForDump = $this->getTestsForDump();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6498 |
| License | MIT |
| Doc PR |  |

Closing braces might have been mistaken as string delimiters when a
serialized PHP object was embedded in an inline YAML string since
the method to parse scalars that are included in a map, uses the "}"
and "," characters as delimiters. Therefore, when the scalar to be
parsed is serialized PHP object, the parser now search for opening
braces in the serialized string and starts searching for the string
delimiters after all opening braces have been closed.
