### PR TITLE
[WebProfilerBundle][Form] Add information about form synchronization err...

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -421,8 +421,17 @@
                 <div class="toggle-icon empty"></div>
             {% endif %}
             {{ name }}
-            {% if data.errors is defined and data.errors|length > 0 %}
-            <div class="badge-error">{{ data.errors|length }}</div>
+
+            {% set errorsCount = 0 %}
+            {% if data.errors is defined %}
+                {% set errorsCount = errorsCount + data.errors|length %}
+            {% endif %}
+            {% if data.synchronization_failure_cause is defined %}
+                {% set errorsCount = errorsCount + 1 %}
+            {% endif %}
+
+            {% if errorsCount > 0 %}
+            <div class="badge-error">{{ errorsCount }}</div>
             {% endif %}
         </div>
 
@@ -485,6 +494,26 @@
                 </tr>
                 {% endfor %}
             </table>
+        </div>
+        {% endif %}
+
+        {% if data.synchronization_failure_cause is defined %}
+        <div class="errors">
+            <h3>
+                <a class="toggle-button" data-toggle-target-id="{{ data.id }}-synchronized" href="#">
+                    Synchronization failure
+                    <span class="toggle-icon"></span>
+                </a>
+            </h3>
+
+            <div id="{{ data.id }}-synchronized">
+                <table>
+                    <tr>
+                        <th width="180">Cause</th>
+                        <td>{{ data.synchronization_failure_cause }}</td>
+                    </tr>
+                </table>
+            </div>
         </div>
         {% endif %}
 

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -152,6 +152,11 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
             $this->data['nb_errors'] += count($this->dataByForm[$hash]['errors']);
         }
 
+        // Count synchronization failures
+        if (isset($this->dataByForm[$hash]['synchronization_failure_cause'])) {
+            $this->data['nb_errors'] += 1;
+        }
+
         foreach ($form as $child) {
             $this->collectSubmittedData($child);
         }

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\DataCollector;
 
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
@@ -133,6 +134,10 @@ class FormDataExtractor implements FormDataExtractorInterface
         }
 
         $data['synchronized'] = $this->valueExporter->exportValue($form->isSynchronized());
+
+        if ($form instanceof Form && null !== $form->getSynchronizationFailureCause()) {
+            $data['synchronization_failure_cause'] = $form->getSynchronizationFailureCause()->getMessage();
+        }
 
         return $data;
     }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -123,10 +123,10 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Whether the data in model, normalized and view format is
      * synchronized. Data may not be synchronized if transformation errors
-     * occur.
-     * @var bool
+     * occur. This field stores cause of synchronization failure.
+     * @var TransformationFailedException
      */
-    private $synchronized = true;
+    private $synchronizationFailureCause = null;
 
     /**
      * Whether the form's data has been initialized.
@@ -634,7 +634,7 @@ class Form implements \IteratorAggregate, FormInterface
                 $viewData = $this->normToView($normData);
             }
         } catch (TransformationFailedException $e) {
-            $this->synchronized = false;
+            $this->synchronizationFailureCause = $e;
 
             // If $viewData was not yet set, set it to $submittedData so that
             // the erroneous data is accessible on the form.
@@ -711,7 +711,17 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function isSynchronized()
     {
-        return $this->synchronized;
+        return null === $this->synchronizationFailureCause;
+    }
+
+    /**
+     * @return TransformationFailedException
+     *
+     * @internal Should not be called by user code.
+     */
+    public function getSynchronizationFailureCause()
+    {
+        return $this->synchronizationFailureCause;
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -495,6 +495,7 @@ class FormDataCollectorTest extends \PHPUnit_Framework_TestCase
         $form1 = $this->createForm('form1');
         $childForm1 = $this->createForm('child1');
         $form2 = $this->createForm('form2');
+        $form3 = $this->createForm('form3');
 
         $form1->add($childForm1);
 
@@ -510,6 +511,10 @@ class FormDataCollectorTest extends \PHPUnit_Framework_TestCase
             ->method('extractSubmittedData')
             ->with($form2)
             ->will($this->returnValue(array('errors' => array('baz'))));
+        $this->dataExtractor->expects($this->at(3))
+            ->method('extractSubmittedData')
+            ->with($form3)
+            ->will($this->returnValue(array('errors' => array(), 'synchronization_failure_cause' => 'Failure!')));
 
         $this->dataCollector->collectSubmittedData($form1);
 
@@ -521,6 +526,10 @@ class FormDataCollectorTest extends \PHPUnit_Framework_TestCase
         $data = $this->dataCollector->getData();
         $this->assertSame(4, $data['nb_errors']);
 
+        $this->dataCollector->collectSubmittedData($form3);
+
+        $data = $this->dataCollector->getData();
+        $this->assertSame(5, $data['nb_errors']);
     }
 
     private function createForm($name)

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -379,6 +379,11 @@ class FormDataExtractorTest extends \PHPUnit_Framework_TestCase
 
         $form->submit('Foobar');
 
+        $submittedData = $this->dataExtractor->extractSubmittedData($form);
+
+        $this->assertSynchronizationFailureCause('Fail!', $submittedData);
+        unset($submittedData['synchronization_failure_cause']);
+
         $this->assertSame(array(
             'submitted_data' => array(
                 'norm' => "'Foobar'",
@@ -386,7 +391,7 @@ class FormDataExtractorTest extends \PHPUnit_Framework_TestCase
             ),
             'errors' => array(),
             'synchronized' => 'false',
-        ), $this->dataExtractor->extractSubmittedData($form));
+        ), $submittedData);
     }
 
     public function testExtractViewVariables()
@@ -423,5 +428,14 @@ class FormDataExtractorTest extends \PHPUnit_Framework_TestCase
     private function createBuilder($name, array $options = array())
     {
         return new FormBuilder($name, null, $this->dispatcher, $this->factory, $options);
+    }
+
+    private function assertSynchronizationFailureCause($expectedCause, $submittedData)
+    {
+        $this->assertTrue(
+            isset($submittedData['synchronization_failure_cause']),
+            'cause of synchronization failure was not be extracted'
+        );
+        $this->assertContains($expectedCause, $submittedData['synchronization_failure_cause']);
     }
 }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -618,6 +618,10 @@ class SimpleFormTest extends AbstractFormTest
         $form->submit('foobar');
 
         $this->assertFalse($form->isSynchronized());
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Form\\Exception\\TransformationFailedException',
+            $form->getSynchronizationFailureCause()
+        );
     }
 
     public function testNotSynchronizedIfModelReverseTransformationFailed()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9891, #9989, #5607 |
| License | MIT |
| Doc PR |  |

When form data transformation fails, the origin error message is lost. This error shouldn't be shown to user, because this is technical error, so maybe a good idea is to show transformation failures in web profiler in `form` panel below `errors` section?

There are no BC-breaks in this PR, I have added public internal method to `Symfony\Component\Form\Form` class, that returns `TransformationFailedException`, it is used by `FormDataExtractor`. `Symfony\Component\Form\FormInterface` has not been touched by me, because that would be a BC-break.
