### PR TITLE
[SecurityBundle] fix constructor argument index

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -102,7 +102,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         $listenerId = 'security.authentication.listener.rememberme.'.$id;
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.rememberme'));
         $listener->replaceArgument(1, new Reference($rememberMeServicesId));
-        $listener->replaceArgument(4, $config['catch_exceptions']);
+        $listener->replaceArgument(5, $config['catch_exceptions']);
 
         return array($authProviderId, $listenerId, $defaultEntryPoint);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -223,7 +223,7 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testRememberMeThrowExceptionsDefault()
     {
         $container = $this->getContainer('container1');
-        $this->assertTrue($container->getDefinition('security.authentication.listener.rememberme.secure')->getArgument(4));
+        $this->assertTrue($container->getDefinition('security.authentication.listener.rememberme.secure')->getArgument(5));
     }
 
     public function testRememberMeThrowExceptions()
@@ -231,7 +231,7 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
         $container = $this->getContainer('remember_me_options');
         $service = $container->getDefinition('security.authentication.listener.rememberme.main');
         $this->assertEquals('security.authentication.rememberme.services.persistent.main', $service->getArgument(1));
-        $this->assertFalse($service->getArgument(4));
+        $this->assertFalse($service->getArgument(5));
     }
 
     protected function getContainer($file)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10793 |
| License | MIT |
| Doc PR |  |

As @excelwebzone pointed out in fb9dc6a, `catchExceptions` is the 6th
argument of the RememberMeListener constructor.
