### PR TITLE
[MonologBridge] Ignore empty context/extra by default in the ConsoleFormatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "doctrine/dbal": "~2.2",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
-        "monolog/monolog": "~1.3",
+        "monolog/monolog": "~1.11",
         "propel/propel1": "1.6.*",
         "ircmaxell/password-compat": "1.0.*",
         "ocramius/proxy-manager": ">=0.3.1,<0.6-dev",

--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -26,6 +26,14 @@ class ConsoleFormatter extends LineFormatter
     /**
      * {@inheritdoc}
      */
+    public function __construct($format = null, $dateFormat = null, $allowInlineLineBreaks = false, $ignoreEmptyContextAndExtra = true)
+    {
+        parent::__construct($format, $dateFormat, $allowInlineLineBreaks, $ignoreEmptyContextAndExtra);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function format(array $record)
     {
         if ($record['level'] >= Logger::ERROR) {

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -113,14 +113,14 @@ class ConsoleHandlerTest extends \PHPUnit_Framework_TestCase
         $output
             ->expects($this->once())
             ->method('write')
-            ->with('<info>[2013-05-29 16:21:54] app.INFO:</info> My info message [] []'."\n")
+            ->with('<info>[2013-05-29 16:21:54] app.INFO:</info> My info message  '."\n")
         ;
 
         $errorOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
         $errorOutput
             ->expects($this->once())
             ->method('write')
-            ->with('<error>[2013-05-29 16:21:54] app.ERROR:</error> My error message [] []'."\n")
+            ->with('<error>[2013-05-29 16:21:54] app.ERROR:</error> My error message  '."\n")
         ;
 
         $output

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "monolog/monolog": "~1.3"
+        "monolog/monolog": "~1.11"
     },
     "require-dev": {
         "symfony/http-kernel": "~2.2",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This adds support for https://github.com/Seldaek/monolog/pull/388 and turns it on by default since the console output is arguably meant for humans and not for machine readable stuff it makes sense I believe. /cc @Tobion

**Note:** This depends on an unreleased version of monolog and should not be merged until 1.11 is out.
