### PR TITLE
Use separated function to resolve command and related arguments

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -29,13 +29,15 @@ class PhpExecutableFinder
     /**
      * Finds The PHP executable.
      *
+     * @param bool $includeArgs Whether or not include command arguments
+     *
      * @return string|false The PHP executable path or false if it cannot be found
      */
-    public function find()
+    public function find($includeArgs = true)
     {
         // HHVM support
         if (defined('HHVM_VERSION')) {
-            return (false !== ($hhvm = getenv('PHP_BINARY')) ? $hhvm : PHP_BINARY).' --php';
+            return (false !== ($hhvm = getenv('PHP_BINARY')) ? $hhvm : PHP_BINARY).($includeArgs ? ' '.implode(' ', $this->findArguments()) : '');
         }
 
         // PHP_BINARY return the current sapi executable
@@ -63,5 +65,22 @@ class PhpExecutableFinder
         }
 
         return $this->executableFinder->find('php', false, $dirs);
+    }
+
+    /**
+     * Finds the PHP executable arguments.
+     *
+     * @return array The PHP executable arguments
+     */
+    public function findArguments()
+    {
+        $arguments = array();
+
+        // HHVM support
+        if (defined('HHVM_VERSION')) {
+            $arguments[] = '--php';
+        }
+
+        return $arguments;
     }
 }

--- a/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
@@ -34,10 +34,43 @@ class PhpExecutableFinderTest extends \PHPUnit_Framework_TestCase
         //not executable PHP_PATH
         putenv('PHP_PATH=/not/executable/php');
         $this->assertFalse($f->find(), '::find() returns false for not executable PHP');
+        $this->assertFalse($f->find(false), '::find() returns false for not executable PHP');
 
         //executable PHP_PATH
         putenv('PHP_PATH='.$current);
         $this->assertEquals($f->find(), $current, '::find() returns the executable PHP');
+        $this->assertEquals($f->find(false), $current, '::find() returns the executable PHP');
+    }
+
+    /**
+     * tests find() with the env var PHP_PATH
+     */
+    public function testFindWithHHVM()
+    {
+        if (!defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Should be executed in HHVM context.');
+        }
+
+        $f = new PhpExecutableFinder();
+
+        $current = $f->find();
+
+        $this->assertEquals($f->find(), $current.' --php', '::find() returns the executable PHP');
+        $this->assertEquals($f->find(false), $current, '::find() returns the executable PHP');
+    }
+
+    /**
+     * tests find() with the env var PHP_PATH
+     */
+    public function testFindArguments()
+    {
+        $f = new PhpExecutableFinder();
+
+        if (defined('HHVM_VERSION')) {
+            $this->assertEquals($f->findArguments(), array('--php'), '::findArguments() returns HHVM arguments');
+        } else {
+            $this->assertEquals($f->findArguments(), array(), '::findArguments() returns no arguments');
+        }
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR split command and related arguments resolution into two distinct functions.

It will help to solve the HHVM issue sensiolabs/SensioDistributionBundle#150 .

Thanks,

Jérémy

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
