### PR TITLE
[BrowserKit] Fixed relative redirects for ambiguous paths

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -296,7 +296,7 @@ abstract class Client
 
         $uri = $this->getAbsoluteUri($uri);
 
-        if (isset($server['HTTP_HOST'])) {
+        if (!empty($server['HTTP_HOST'])) {
             $uri = preg_replace('{^(https?\://)'.preg_quote($this->extractHost($uri)).'}', '${1}'.$server['HTTP_HOST'], $uri);
         }
 

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -367,6 +367,19 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testFollowRelativeRedirect()
+    {
+        $client = new TestClient();
+        $client->setNextResponse(new Response('', 302, array('Location' => '/redirected')));
+        $client->request('GET', 'http://www.example.com/foo/foobar');
+        $this->assertEquals('http://www.example.com/redirected', $client->getRequest()->getUri(), '->followRedirect() follows a redirect if any');
+
+        $client = new TestClient();
+        $client->setNextResponse(new Response('', 302, array('Location' => '/redirected:1234')));
+        $client->request('GET', 'http://www.example.com/foo/foobar');
+        $this->assertEquals('http://www.example.com/redirected:1234', $client->getRequest()->getUri(), '->followRedirect() follows relative urls');
+    }
+
     public function testFollowRedirectWithMaxRedirects()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This fixes a problem I discovered today during Mink testing: I have a route with a slug and id, separated by colon (`/{slug}:{id}`). When the `HTTP_HOST` is being normalized it only checks for array key existence, not emptyness. In this case it was `false` due to the `parse_url` call in `updateServerFromUri`, which cannot handle this case:

```
$> php -r "var_dump(parse_url('/redirect', PHP_URL_HOST));"                                                                               NULL

$> php -r "var_dump(parse_url('/redirect:1234', PHP_URL_HOST));"                                                                          bool(false)
```

So now the url becomes `http:///redirect:1234`, because of the missing host.
