### PR TITLE
[Validator] Fixed group handling in composite constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -24,6 +24,8 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  *
  * Constraint instances are immutable and serializable.
  *
+ * @property array $groups The groups that the constraint belongs to
+ *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
@@ -47,11 +49,6 @@ abstract class Constraint
      * @var string
      */
     const PROPERTY_CONSTRAINT = 'property';
-
-    /**
-     * @var array
-     */
-    public $groups = array(self::DEFAULT_GROUP);
 
     /**
      * Initializes the constraint with options.
@@ -86,6 +83,10 @@ abstract class Constraint
     {
         $invalidOptions = array();
         $missingOptions = array_flip((array) $this->getRequiredOptions());
+        $knownOptions = get_object_vars($this);
+
+        // The "groups" option is added to the object lazily
+        $knownOptions['groups'] = true;
 
         if (is_array($options) && count($options) >= 1 && isset($options['value']) && !property_exists($this, 'value')) {
             $options[$this->getDefaultOption()] = $options['value'];
@@ -94,14 +95,14 @@ abstract class Constraint
 
         if (is_array($options) && count($options) > 0 && is_string(key($options))) {
             foreach ($options as $option => $value) {
-                if (property_exists($this, $option)) {
+                if (array_key_exists($option, $knownOptions)) {
                     $this->$option = $value;
                     unset($missingOptions[$option]);
                 } else {
                     $invalidOptions[] = $option;
                 }
             }
-        } elseif (null !== $options && ! (is_array($options) && count($options) === 0)) {
+        } elseif (null !== $options && !(is_array($options) && count($options) === 0)) {
             $option = $this->getDefaultOption();
 
             if (null === $option) {
@@ -110,7 +111,7 @@ abstract class Constraint
                 );
             }
 
-            if (property_exists($this, $option)) {
+            if (array_key_exists($option, $knownOptions)) {
                 $this->$option = $options;
                 unset($missingOptions[$option]);
             } else {
@@ -131,15 +132,56 @@ abstract class Constraint
                 array_keys($missingOptions)
             );
         }
-
-        $this->groups = (array) $this->groups;
     }
 
     /**
-     * Unsupported operation.
+     * Sets the value of a lazily initialized option.
+     *
+     * Corresponding properties are added to the object on first access. Hence
+     * this method will be called at most once per constraint instance and
+     * option name.
+     *
+     * @param string $option The option name
+     * @param mixed  $value  The value to set
+     *
+     * @throws InvalidOptionsException If an invalid option name is given
      */
     public function __set($option, $value)
     {
+        if ('groups' === $option) {
+            $this->groups = (array) $value;
+
+            return;
+        }
+
+        throw new InvalidOptionsException(sprintf('The option "%s" does not exist in constraint %s', $option, get_class($this)), array($option));
+    }
+
+    /**
+     * Returns the value of a lazily initialized option.
+     *
+     * Corresponding properties are added to the object on first access. Hence
+     * this method will be called at most once per constraint instance and
+     * option name.
+     *
+     * @param string $option The option name
+     *
+     * @return mixed The value of the option
+     *
+     * @throws InvalidOptionsException If an invalid option name is given
+     *
+     * @internal This method should not be used or overwritten in userland code.
+     *
+     * @since 2.6
+     */
+    public function __get($option)
+    {
+        if ('groups' === $option) {
+            $this->groups = array(self::DEFAULT_GROUP);
+
+            return $this->groups;
+        }
+
         throw new InvalidOptionsException(sprintf('The option "%s" does not exist in constraint %s', $option, get_class($this)), array($option));
     }
 
@@ -216,5 +258,24 @@ abstract class Constraint
     public function getTargets()
     {
         return self::PROPERTY_CONSTRAINT;
+    }
+
+    /**
+     * Optimizes the serialized value to minimize storage space.
+     *
+     * @return array The properties to serialize
+     *
+     * @internal This method may be replaced by an implementation of
+     *           {@link \Serializable} in the future. Please don't use or
+     *           overwrite it.
+     *
+     * @since 2.6
+     */
+    public function __sleep()
+    {
+        // Initialize "groups" option if it is not set
+        $this->__get('groups');
+
+        return array_keys(get_object_vars($this));
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/All.php
+++ b/src/Symfony/Component/Validator/Constraints/All.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
-
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
@@ -22,31 +19,9 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  *
  * @api
  */
-class All extends Constraint
+class All extends Composite
 {
     public $constraints = array();
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct($options = null)
-    {
-        parent::__construct($options);
-
-        if (!is_array($this->constraints)) {
-            $this->constraints = array($this->constraints);
-        }
-
-        foreach ($this->constraints as $constraint) {
-            if (!$constraint instanceof Constraint) {
-                throw new ConstraintDefinitionException(sprintf('The value %s is not an instance of Constraint in constraint %s', $constraint, __CLASS__));
-            }
-
-            if ($constraint instanceof Valid) {
-                throw new ConstraintDefinitionException(sprintf('The constraint Valid cannot be nested inside constraint %s. You can only declare the Valid constraint directly on a field or method.', __CLASS__));
-            }
-        }
-    }
 
     public function getDefaultOption()
     {
@@ -56,5 +31,10 @@ class All extends Constraint
     public function getRequiredOptions()
     {
         return array('constraints');
+    }
+
+    protected function getCompositeOption()
+    {
+        return 'constraints';
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -40,11 +40,10 @@ class AllValidator extends ConstraintValidator
         }
 
         $context = $this->context;
-        $group = $context->getGroup();
         $validator = $context->getValidator()->inContext($context);
 
         foreach ($value as $key => $element) {
-            $validator->atPath('['.$key.']')->validate($element, $constraint->constraints, $group);
+            $validator->atPath('['.$key.']')->validate($element, $constraint->constraints);
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  *
  * @api
  */
-class Collection extends Constraint
+class Collection extends Composite
 {
     public $fields = array();
     public $allowExtraFields = false;
@@ -42,6 +42,14 @@ class Collection extends Constraint
         }
 
         parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initializeNestedConstraints()
+    {
+        parent::initializeNestedConstraints();
 
         if (!is_array($this->fields)) {
             throw new ConstraintDefinitionException(sprintf('The option "fields" is expected to be an array in constraint %s', __CLASS__));
@@ -57,25 +65,16 @@ class Collection extends Constraint
             if (!$field instanceof Optional && !$field instanceof Required) {
                 $this->fields[$fieldName] = $field = new Required($field);
             }
-
-            if (!is_array($field->constraints)) {
-                $field->constraints = array($field->constraints);
-            }
-
-            foreach ($field->constraints as $constraint) {
-                if (!$constraint instanceof Constraint) {
-                    throw new ConstraintDefinitionException(sprintf('The value %s of the field %s is not an instance of Constraint in constraint %s', $constraint, $fieldName, __CLASS__));
-                }
-
-                if ($constraint instanceof Valid) {
-                    throw new ConstraintDefinitionException(sprintf('The constraint Valid cannot be nested inside constraint %s. You can only declare the Valid constraint directly on a field or method.', __CLASS__));
-                }
-            }
         }
     }
 
     public function getRequiredOptions()
     {
         return array('fields');
+    }
+
+    protected function getCompositeOption()
+    {
+        return 'fields';
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -49,7 +49,6 @@ class CollectionValidator extends ConstraintValidator
         // remove the initialize() method and pass the context as last argument
         // to validate() instead.
         $context = $this->context;
-        $group = $context->getGroup();
         $validator = $context->getValidator()->inContext($context);
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
@@ -60,7 +59,7 @@ class CollectionValidator extends ConstraintValidator
             if ($existsInArray || $existsInArrayAccess) {
                 if (count($fieldConstraint->constraints) > 0) {
                     $validator->atPath('['.$field.']')
-                        ->validate($value[$field], $fieldConstraint->constraints, $group);
+                        ->validate($value[$field], $fieldConstraint->constraints);
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
                 $context->buildViolation($constraint->missingFieldsMessage)

--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * A constraint that is composed of other constraints.
+ *
+ * You should never use the nested constraint instances anywhere else, because
+ * their groups are adapted when passed to the constructor of this class.
+ *
+ * If you want to create your own composite constraint, extend this class and
+ * let {@link getCompositeOption()} return the name of the property which
+ * contains the nested constraints.
+ *
+ * @since  2.6
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+abstract class Composite extends Constraint
+{
+    /**
+     * {@inheritdoc}
+     *
+     * The groups of the composite and its nested constraints are made
+     * consistent using the following strategy:
+     *
+     *   - If groups are passed explicitly to the composite constraint, but
+     *     not to the nested constraints, the options of the composite
+     *     constraint are copied to the nested constraints;
+     *
+     *   - If groups are passed explicitly to the nested constraints, but not
+     *     to the composite constraint, the groups of all nested constraints
+     *     are merged and used as groups for the composite constraint;
+     *
+     *   - If groups are passed explicitly to both the composite and its nested
+     *     constraints, the groups of the nested constraints must be a subset
+     *     of the groups of the composite constraint. If not, a
+     *     {@link ConstraintDefinitionException} is thrown.
+     *
+     * All this is done in the constructor, because constraints can then be
+     * cached. When constraints are loaded from the cache, no more group
+     * checks need to be done.
+     */
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+
+        $this->initializeNestedConstraints();
+
+        /** @var Constraint[] $nestedConstraints */
+        $compositeOption = $this->getCompositeOption();
+        $nestedConstraints = $this->$compositeOption;
+
+        if (!is_array($nestedConstraints)) {
+            $nestedConstraints = array($nestedConstraints);
+        }
+
+        foreach ($nestedConstraints as $constraint) {
+            if (!$constraint instanceof Constraint) {
+                throw new ConstraintDefinitionException(sprintf('The value %s is not an instance of Constraint in constraint %s', $constraint, get_class($this)));
+            }
+
+            if ($constraint instanceof Valid) {
+                throw new ConstraintDefinitionException(sprintf('The constraint Valid cannot be nested inside constraint %s. You can only declare the Valid constraint directly on a field or method.', get_class($this)));
+            }
+        }
+
+        if (!property_exists($this, 'groups')) {
+            $mergedGroups = array();
+
+            foreach ($nestedConstraints as $constraint) {
+                foreach ($constraint->groups as $group) {
+                    $mergedGroups[$group] = true;
+                }
+            }
+
+            $this->groups = array_keys($mergedGroups);
+            $this->$compositeOption = $nestedConstraints;
+
+            return;
+        }
+
+        foreach ($nestedConstraints as $constraint) {
+            if (property_exists($constraint, 'groups')) {
+                $excessGroups = array_diff($constraint->groups, $this->groups);
+
+                if (count($excessGroups) > 0) {
+                    throw new ConstraintDefinitionException(sprintf(
+                        'The group(s) "%s" passed to the constraint %s '.
+                        'should also be passed to its containing constraint %s',
+                        implode('", "', $excessGroups),
+                        get_class($constraint),
+                        get_class($this)
+                    ));
+                }
+            } else {
+                $constraint->groups = $this->groups;
+            }
+        }
+
+        $this->$compositeOption = $nestedConstraints;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Implicit group names are forwarded to nested constraints.
+     *
+     * @param string $group
+     */
+    public function addImplicitGroupName($group)
+    {
+        parent::addImplicitGroupName($group);
+
+        /** @var Constraint[] $nestedConstraints */
+        $nestedConstraints = $this->{$this->getCompositeOption()};
+
+        foreach ($nestedConstraints as $constraint) {
+            $constraint->addImplicitGroupName($group);
+        }
+    }
+
+    /**
+     * Returns the name of the property that contains the nested constraints.
+     *
+     * @return string The property name
+     */
+    abstract protected function getCompositeOption();
+
+    /**
+     * Initializes the nested constraints.
+     *
+     * This method can be overwritten in subclasses to clean up the nested
+     * constraints passed to the constructor.
+     *
+     * @see Collection::initializeNestedConstraints()
+     */
+    protected function initializeNestedConstraints()
+    {
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/Existence.php
+++ b/src/Symfony/Component/Validator/Constraints/Existence.php
@@ -11,16 +11,19 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
-
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class Existence extends Constraint
+abstract class Existence extends Composite
 {
     public $constraints = array();
 
     public function getDefaultOption()
+    {
+        return 'constraints';
+    }
+
+    protected function getCompositeOption()
     {
         return 'constraints';
     }

--- a/src/Symfony/Component/Validator/Constraints/LegacyAllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyAllValidator.php
@@ -40,10 +40,9 @@ class LegacyAllValidator extends ConstraintValidator
         }
 
         $context = $this->context;
-        $group = $context->getGroup();
 
         foreach ($value as $key => $element) {
-            $context->validateValue($element, $constraint->constraints, '['.$key.']', $group);
+            $context->validateValue($element, $constraint->constraints, '['.$key.']');
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LegacyCollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LegacyCollectionValidator.php
@@ -49,7 +49,6 @@ class LegacyCollectionValidator extends ConstraintValidator
         // remove the initialize() method and pass the context as last argument
         // to validate() instead.
         $context = $this->context;
-        $group = $context->getGroup();
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
             // bug fix issue #2779
@@ -58,7 +57,7 @@ class LegacyCollectionValidator extends ConstraintValidator
 
             if ($existsInArray || $existsInArrayAccess) {
                 if (count($fieldConstraint->constraints) > 0) {
-                    $context->validateValue($value[$field], $fieldConstraint->constraints, '['.$field.']', $group);
+                    $context->validateValue($value[$field], $fieldConstraint->constraints, '['.$field.']');
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
                 $context->addViolationAt('['.$field.']', $constraint->missingFieldsMessage, array(

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -154,4 +154,35 @@ class ConstraintTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('property', 'class'), $constraint->getTargets());
     }
+
+    public function testSerialize()
+    {
+        $constraint = new ConstraintA(array(
+            'property1' => 'foo',
+            'property2' => 'bar',
+        ));
+
+        $restoredConstraint = unserialize(serialize($constraint));
+
+        $this->assertEquals($constraint, $restoredConstraint);
+    }
+
+    public function testSerializeInitializesGroupsOption()
+    {
+        $constraintWithExplicitGroup = new ConstraintA(array(
+            'property1' => 'foo',
+            'property2' => 'bar',
+            'groups' => 'Default',
+        ));
+
+        $constraintWithoutExplicitGroup = new ConstraintA(array(
+            'property1' => 'foo',
+            'property2' => 'bar',
+        ));
+
+        $constraintWithExplicitGroup = unserialize(serialize($constraintWithExplicitGroup));
+        $constraintWithoutExplicitGroup = unserialize(serialize($constraintWithoutExplicitGroup));
+
+        $this->assertEquals($constraintWithExplicitGroup, $constraintWithoutExplicitGroup);
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -246,7 +246,7 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
         }
     }
 
-    protected function expectValidateValueAt($i, $propertyPath, $value, $constraints, $group)
+    protected function expectValidateValueAt($i, $propertyPath, $value, $constraints, $group = null)
     {
         switch ($this->getApiVersion()) {
             case Validation::API_VERSION_2_4:

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -54,7 +54,7 @@ class AllValidatorTest extends AbstractConstraintValidatorTest
         $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint), 'MyGroup');
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint));
         }
 
         $this->validator->validate($array, new All($constraint));
@@ -75,7 +75,7 @@ class AllValidatorTest extends AbstractConstraintValidatorTest
         $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint1, $constraint2), 'MyGroup');
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint1, $constraint2));
         }
 
         $this->validator->validate($array, new All($constraints));

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -48,7 +48,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
 
         $data = $this->prepareTestData(array('foo' => 'foobar'));
 
-        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint), 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint));
 
         $this->validator->validate($data, new Collection(array(
             'foo' => $constraint,
@@ -79,7 +79,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
         $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint), 'MyGroup');
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint));
         }
 
         $data = $this->prepareTestData($array);
@@ -109,7 +109,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
         $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->expectValidateValueAt($i++, '['.$key.']', $value, $constraints, 'MyGroup');
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, $constraints);
         }
 
         $data = $this->prepareTestData($array);
@@ -133,7 +133,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
             'baz' => 6,
         ));
 
-        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint), 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint));
 
         $this->validator->validate($data, new Collection(array(
             'fields' => array(
@@ -156,7 +156,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
 
         $constraint = new Range(array('min' => 4));
 
-        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint), 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint));
 
         $this->validator->validate($data, new Collection(array(
             'fields' => array(
@@ -176,7 +176,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
 
         $constraint = new Range(array('min' => 4));
 
-        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint), 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $data['foo'], array($constraint));
 
         $this->validator->validate($data, new Collection(array(
             'fields' => array(
@@ -254,7 +254,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
 
         $constraint = new Range(array('min' => 4));
 
-        $this->expectValidateValueAt(0, '[foo]', $array['foo'], array($constraint), 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $array['foo'], array($constraint));
 
         $data = $this->prepareTestData($array);
 
@@ -276,7 +276,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
             new Range(array('min' => 4)),
         );
 
-        $this->expectValidateValueAt(0, '[foo]', $array['foo'], $constraints, 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $array['foo'], $constraints);
 
         $data = $this->prepareTestData($array);
 
@@ -324,7 +324,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
 
         $constraint = new Range(array('min' => 4));
 
-        $this->expectValidateValueAt(0, '[foo]', $array['foo'], array($constraint), 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $array['foo'], array($constraint));
 
         $data = $this->prepareTestData($array);
 
@@ -346,7 +346,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
             new Range(array('min' => 4)),
         );
 
-        $this->expectValidateValueAt(0, '[foo]', $array['foo'], $constraints, 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $array['foo'], $constraints);
 
         $data = $this->prepareTestData($array);
 
@@ -365,7 +365,7 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
 
         $constraint = new Range(array('min' => 2));
 
-        $this->expectValidateValueAt(0, '[foo]', $value['foo'], array($constraint), 'MyGroup');
+        $this->expectValidateValueAt(0, '[foo]', $value['foo'], array($constraint));
 
         $this->validator->validate($value, new Collection(array(
             'fields' => array(

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Composite;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Valid;
+
+class ConcreteComposite extends Composite
+{
+    public $constraints;
+
+    protected function getCompositeOption()
+    {
+        return 'constraints';
+    }
+
+    public function getDefaultOption()
+    {
+        return 'constraints';
+    }
+
+}
+
+/**
+ * @since  2.6
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class CompositeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMergeNestedGroupsIfNoExplicitParentGroup()
+    {
+        $constraint = new ConcreteComposite(array(
+            new NotNull(array('groups' => 'Default')),
+            new NotBlank(array('groups' => array('Default', 'Strict'))),
+        ));
+
+        $this->assertEquals(array('Default', 'Strict'), $constraint->groups);
+        $this->assertEquals(array('Default'), $constraint->constraints[0]->groups);
+        $this->assertEquals(array('Default', 'Strict'), $constraint->constraints[1]->groups);
+    }
+
+    public function testSetImplicitNestedGroupsIfExplicitParentGroup()
+    {
+        $constraint = new ConcreteComposite(array(
+            'constraints' => array(
+                new NotNull(),
+                new NotBlank(),
+            ),
+            'groups' => array('Default', 'Strict'),
+        ));
+
+        $this->assertEquals(array('Default', 'Strict'), $constraint->groups);
+        $this->assertEquals(array('Default', 'Strict'), $constraint->constraints[0]->groups);
+        $this->assertEquals(array('Default', 'Strict'), $constraint->constraints[1]->groups);
+    }
+
+    public function testExplicitNestedGroupsMustBeSubsetOfExplicitParentGroups()
+    {
+        $constraint = new ConcreteComposite(array(
+            'constraints' => array(
+                new NotNull(array('groups' => 'Default')),
+                new NotBlank(array('groups' => 'Strict')),
+            ),
+            'groups' => array('Default', 'Strict'),
+        ));
+
+        $this->assertEquals(array('Default', 'Strict'), $constraint->groups);
+        $this->assertEquals(array('Default'), $constraint->constraints[0]->groups);
+        $this->assertEquals(array('Strict'), $constraint->constraints[1]->groups);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function testFailIfExplicitNestedGroupsNotSubsetOfExplicitParentGroups()
+    {
+        new ConcreteComposite(array(
+            'constraints' => array(
+                new NotNull(array('groups' => array('Default', 'Foobar'))),
+            ),
+            'groups' => array('Default', 'Strict'),
+        ));
+    }
+
+    public function testImplicitGroupNamesAreForwarded()
+    {
+        $constraint = new ConcreteComposite(array(
+            new NotNull(array('groups' => 'Default')),
+            new NotBlank(array('groups' => 'Strict')),
+        ));
+
+        $constraint->addImplicitGroupName('ImplicitGroup');
+
+        $this->assertEquals(array('Default', 'Strict', 'ImplicitGroup'), $constraint->groups);
+        $this->assertEquals(array('Default', 'ImplicitGroup'), $constraint->constraints[0]->groups);
+        $this->assertEquals(array('Strict'), $constraint->constraints[1]->groups);
+    }
+
+    public function testSingleConstraintsAccepted()
+    {
+        $nestedConstraint = new NotNull();
+        $constraint = new ConcreteComposite($nestedConstraint);
+
+        $this->assertEquals(array($nestedConstraint), $constraint->constraints);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function testFailIfNoConstraint()
+    {
+        new ConcreteComposite(array(
+            new NotNull(array('groups' => 'Default')),
+            'NotBlank',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function testValidCantBeNested()
+    {
+        new ConcreteComposite(array(
+            new Valid(),
+        ));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #4453 |
| License | MIT |
| Doc PR | - |

With this PR, it finally becomes possible to set the groups of nested constraints in All and Collection:

``` php
/**
 * @Assert\Collection({
 *     "foo" = @Assert\NotNull(groups = "Strict"),
 *     "bar" = @Assert\NotBlank(groups = "Regular"),
 * })
 */
private $attr;
```

The group logic is implemented as described in [this comment](https://github.com/symfony/symfony/pull/4453#issuecomment-16513727).

This PR supports the implementation of #9888 which should now become fairly simple.
