### PR TITLE
[HttpFoundation] MongoDbSessionHandler supports auto expiry via configurable expiry_field

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -137,8 +137,8 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
             $fields[$this->options['expiry_field']] = $expiry;
 
             $this->getCollection()->createIndex(
-                [$this->options['expiry_field'] => 1],
-                ['expireAfterSeconds' => 0]
+                array($this->options['expiry_field'] => 1),
+                array('expireAfterSeconds' => 0)
             );
         }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -132,14 +132,18 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
             $this->options['time_field'] => new \MongoDate(),
         );
 
+        /* Note: As discussed in the gc method of this class. You can utilise
+         * TTL collections in MongoDB 2.2+
+         * We are setting the "expiry_field as part of the write operation here
+         * You will need to create the index on your collection that expires documents
+         * at that time
+         * e.g.
+         * db.MySessionCollection.ensureIndex( { "expireAt": 1 }, { expireAfterSeconds: 0 } )
+         *
+         */
         if (false !== $this->options['expiry_field']) {
             $expiry = new \MongoDate(time() + (int) ini_get('session.gc_maxlifetime'));
             $fields[$this->options['expiry_field']] = $expiry;
-
-            $this->getCollection()->createIndex(
-                array($this->options['expiry_field'] => 1),
-                array('expireAfterSeconds' => 0)
-            );
         }
 
         $this->getCollection()->update(

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -110,7 +110,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
          *
          * See: http://docs.mongodb.org/manual/tutorial/expire-data/
          */
-        if ($this->options['expiry_field'] === false) {
+        if (false === $this->options['expiry_field']) {
             $time = new \MongoDate(time() - $maxlifetime);
 
             $this->getCollection()->remove(array(
@@ -132,7 +132,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
             $this->options['time_field'] => new \MongoDate(),
         );
 
-        if ($this->options['expiry_field'] !== false) {
+        if (false !== $this->options['expiry_field']) {
             $expiry = new \MongoDate(time() + (int) ini_get('session.gc_maxlifetime'));
             $fields[$this->options['expiry_field']] = $expiry;
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -110,7 +110,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
          *
          * See: http://docs.mongodb.org/manual/tutorial/expire-data/
          */
-        if ($this->options['expiry_field'] == false) {
+        if ($this->options['expiry_field'] === false) {
             $time = new \MongoDate(time() - $maxlifetime);
 
             $this->getCollection()->remove(array(
@@ -132,7 +132,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
             $this->options['time_field'] => new \MongoDate(),
         );
 
-        if ($this->options['expiry_field'] != false) {
+        if ($this->options['expiry_field'] !== false) {
             $expiry = new \MongoDate(time() + (int) ini_get('session.gc_maxlifetime'));
             $fields[$this->options['expiry_field']] = $expiry;
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -137,7 +137,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
             $fields[$this->options['expiry_field']] = $expiry;
 
             $this->getCollection()->createIndex(
-                [$this->options['time_field'] => 1],
+                [$this->options['expiry_field'] => 1],
                 ['expireAfterSeconds' => 0]
             );
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -134,12 +134,11 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
 
         /* Note: As discussed in the gc method of this class. You can utilise
          * TTL collections in MongoDB 2.2+
-         * We are setting the "expiry_field as part of the write operation here
+         * We are setting the "expiry_field" as part of the write operation here
          * You will need to create the index on your collection that expires documents
          * at that time
          * e.g.
          * db.MySessionCollection.ensureIndex( { "expireAt": 1 }, { expireAfterSeconds: 0 } )
-         *
          */
         if (false !== $this->options['expiry_field']) {
             $expiry = new \MongoDate(time() + (int) ini_get('session.gc_maxlifetime'));

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -110,14 +110,14 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
          *
          * See: http://docs.mongodb.org/manual/tutorial/expire-data/
          */
-        if (false === $this->options['expiry_field']) {
-            $time = new \MongoDate(time() - $maxlifetime);
-
-            $this->getCollection()->remove(array(
-                $this->options['time_field'] => array('$lt' => $time),
-            ));
-
+        if (false !== $this->options['expiry_field']) {
+            return true;
         }
+        $time = new \MongoDate(time() - $maxlifetime);
+
+        $this->getCollection()->remove(array(
+            $this->options['time_field'] => array('$lt' => $time),
+        ));
 
         return true;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -198,10 +198,10 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             ->method('remove')
             ->will($this->returnCallback(function ($criteria) use ($that) {
                 $that->assertInstanceOf('MongoDate', $criteria[$that->options['time_field']]['$lt']);
-                $that->assertGreaterThanOrEqual(time() - -1, $criteria[$that->options['time_field']]['$lt']->sec);
+                $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['time_field']]['$lt']->sec);
             }));
 
-        $this->assertTrue($this->storage->gc(-1));
+        $this->assertTrue($this->storage->gc(1));
     }
 
     public function testGcWhenUsingExpiresField()
@@ -230,10 +230,10 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             ->method('remove')
             ->will($this->returnCallback(function ($criteria) use ($that) {
                 $that->assertInstanceOf('MongoDate', $criteria[$that->options['time_field']]['$lt']);
-                $that->assertGreaterThanOrEqual(time() - -1, $criteria[$that->options['time_field']]['$lt']->sec);
+                $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['time_field']]['$lt']->sec);
             }));
 
-        $this->assertTrue($this->storage->gc(-1));
+        $this->assertTrue($this->storage->gc(1));
     }
 
     private function createMongoCollectionMock()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -215,18 +215,12 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $collection = $this->createMongoCollectionMock();
 
         $this->mongo->expects($this->never())
-            ->method('selectCollection')
-            ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->method('selectCollection');
 
         $that = $this;
 
         $collection->expects($this->never())
-            ->method('remove')
-            ->will($this->returnCallback(function ($criteria) use ($that) {
-                $that->assertInstanceOf('MongoDate', $criteria[$that->options['time_field']]['$lt']);
-                $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['time_field']]['$lt']->sec);
-            }));
+            ->method('remove');
 
         $this->assertTrue($this->storage->gc(1));
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -134,7 +134,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
         $collection->expects($this->once())
             ->method('createIndex')
-            ->with([$this->options['time_field'] => 1], ['expireAfterSeconds' => 0])
+            ->with([$this->options['expiry_field'] => 1], ['expireAfterSeconds' => 0])
             ->willReturn(true);
 
         $this->assertTrue($this->storage->write('foo', 'bar'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -132,11 +132,6 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
                 $data = $updateData['$set'];
             }));
 
-        $collection->expects($this->once())
-            ->method('createIndex')
-            ->with(array($this->options['expiry_field'] => 1), array('expireAfterSeconds' => 0))
-            ->willReturn(true);
-
         $this->assertTrue($this->storage->write('foo', 'bar'));
 
         $this->assertEquals('bar', $data[$this->options['data_field']]->bin);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -134,7 +134,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
         $collection->expects($this->once())
             ->method('createIndex')
-            ->with([$this->options['expiry_field'] => 1], ['expireAfterSeconds' => 0])
+            ->with(array($this->options['expiry_field'] => 1), array('expireAfterSeconds' => 0))
             ->willReturn(true);
 
         $this->assertTrue($this->storage->write('foo', 'bar'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11508 |
| License | MIT |
| Doc PR | no |

ToDo
- [x] Fix Tests

Looking for feedback on this early PR.

This adds a config option that disables the PHP GC method call from doing anything,
It also means that the write method sets up the auto expiring index.

Ref: #11508
