### PR TITLE
[BrowserKit] Fix browser kit redirect with ports

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -598,7 +598,7 @@ abstract class Client
 
     private function updateServerFromUri($server, $uri)
     {
-        $server['HTTP_HOST'] = parse_url($uri, PHP_URL_HOST);
+        $server['HTTP_HOST'] = $this->extractHost($uri);
         $scheme = parse_url($uri, PHP_URL_SCHEME);
         $server['HTTPS'] = null === $scheme ? $server['HTTPS'] : 'https' == $scheme;
         unset($server['HTTP_IF_NONE_MATCH'], $server['HTTP_IF_MODIFIED_SINCE']);

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -456,7 +456,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
 
         $client = new TestClient();
-        $client->followRedirects(false);
         $client->setNextResponse(new Response('', 302, array(
             'Location'    => 'http://www.example.com:8080/redirected',
         )));

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -452,7 +452,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $headers = array(
             'HTTP_HOST'       => 'www.example.com:8080',
             'HTTP_USER_AGENT' => 'Symfony2 BrowserKit',
-            'HTTPS'           => false
+            'HTTPS'           => false,
+            'HTTP_REFERER'    => 'http://www.example.com:8080/'
         );
 
         $client = new TestClient();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | No ticket opened |
| License | MIT |
| Doc PR | None |

Whilst using Mink to do automated tests, I encountered a problem where redirects with ports would not work as the port was removed in the `updateServerFromURI()` method. This PR fixes the problem.

During my testing I encountered `$client->followRedirects(false);` in the ClientTest class that was causing the redirectWithPort test to pass even though it should have been failing (Removing the line caused the test to correctly fail before the patch was written)
