### PR TITLE
[Console] Return $this in phpdocs in chained Question methods

### DIFF
--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -49,7 +49,7 @@ class ChoiceQuestion extends Question
      *
      * @param bool    $multiselect
      *
-     * @return ChoiceQuestion The current instance
+     * @return $this The current instance
      */
     public function setMultiselect($multiselect)
     {
@@ -74,7 +74,7 @@ class ChoiceQuestion extends Question
      *
      * @param string $prompt
      *
-     * @return ChoiceQuestion The current instance
+     * @return $this The current instance
      */
     public function setPrompt($prompt)
     {

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -74,7 +74,7 @@ class Question
      *
      * @param bool    $hidden
      *
-     * @return Question The current instance
+     * @return $this The current instance
      *
      * @throws \LogicException In case the autocompleter is also used
      */
@@ -104,7 +104,7 @@ class Question
      *
      * @param bool    $fallback
      *
-     * @return Question The current instance
+     * @return $this The current instance
      */
     public function setHiddenFallback($fallback)
     {
@@ -128,7 +128,7 @@ class Question
      *
      * @param null|array|Traversable $values
      *
-     * @return Question The current instance
+     * @return $this The current instance
      *
      * @throws \InvalidArgumentException
      * @throws \LogicException
@@ -155,7 +155,7 @@ class Question
      *
      * @param null|callable $validator
      *
-     * @return Question The current instance
+     * @return $this The current instance
      */
     public function setValidator($validator)
     {
@@ -181,7 +181,7 @@ class Question
      *
      * @param null|int     $attempts
      *
-     * @return Question The current instance
+     * @return $this The current instance
      *
      * @throws \InvalidArgumentException In case the number of attempts is invalid.
      */
@@ -215,7 +215,7 @@ class Question
      *
      * @param string|Closure $normalizer
      *
-     * @return Question The current instance
+     * @return $this The current instance
      */
     public function setNormalizer($normalizer)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |

So any IDE (or Scrutinizer etc) can understand that it isn't necessarily a Question instance, but when called on ChoiceQuestion or ConfirmationQuestion, it will return that class also.

This probably could be done to a lot of other chained functions, but I wanted to know if you are okay with this, and if it's okay to submit to 2.5, or should it be at master instead?
