### PR TITLE
[Process] Fix tests when pcntl is not available.

### DIFF
--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -167,7 +167,7 @@ class SimpleProcessTest extends AbstractProcessTest
             $process = $this->getProcess('php -r "echo \'foo\'; sleep(1); echo \'bar\';"');
             $process->run(function () use ($process) {
                 if ($process->isRunning()) {
-                    $process->signal(SIGKILL);
+                    $process->signal(defined('SIGKILL') ? SIGKILL : 9);
                 }
             });
         } catch (RuntimeException $e) {
@@ -183,7 +183,7 @@ class SimpleProcessTest extends AbstractProcessTest
             $process = $this->getProcess('php -r "echo \'foo\'; sleep(1); echo \'bar\';"');
             $process->run(function () use ($process) {
                 if ($process->isRunning()) {
-                    $process->signal(SIGTERM);
+                    $process->signal(defined('SIGTERM') ? SIGTERM : 15);
                 }
             });
         } catch (RuntimeException $e) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

It's solved the same way in the [AbstractProcessTest](https://github.com/symfony/symfony/blob/3b837dc5c102b8210b7038029416c0524d5f458b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php#L602-L603).
