### PR TITLE
[DependencyInjection] fixed missing 'factory-class' attribute in XmlDumper output

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -120,6 +120,9 @@ class XmlDumper extends Dumper
         if ($definition->getFactoryMethod()) {
             $service->setAttribute('factory-method', $definition->getFactoryMethod());
         }
+        if ($definition->getFactoryClass()) {
+            $service->setAttribute('factory-class', $definition->getFactoryClass());
+        }
         if ($definition->getFactoryService()) {
             $service->setAttribute('factory-service', $definition->getFactoryService());
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -6,7 +6,7 @@
     <parameter key="foo">bar</parameter>
   </parameters>
   <services>
-    <service id="foo" class="Bar\FooClass" factory-method="getInstance">
+    <service id="foo" class="Bar\FooClass" factory-method="getInstance" factory-class="Bar\FooClass">
       <tag name="foo" foo="foo"/>
       <tag name="foo" bar="bar"/>
       <argument>foo</argument>
@@ -35,7 +35,7 @@
       <argument>%foo_bar%</argument>
       <configurator service="foo.baz" method="configure"/>
     </service>
-    <service id="foo.baz" class="%baz_class%" factory-method="getInstance">
+    <service id="foo.baz" class="%baz_class%" factory-method="getInstance" factory-class="%baz_class%">
       <configurator class="%baz_class%" method="configureStatic1"/>
     </service>
     <service id="foo_bar" class="%foo_class%" scope="prototype"/>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Symfony\Component\DependencyInjection\Dumper\XmlDumper didn't write 'factory-class' XML attribute for definitions on which setFactoryClass() was called.

This caused the Container[Builder] to throw an exception when the relevant service is being requested/initiated after loading the dumped XML:

`Uncaught Exception Symfony\Component\DependencyInjection\Exception\RuntimeException: "Cannot create service "xxx" from factory method without a factory service or factory class." at /<path>/<to>/vendor/symfony/dependency-injection/Symfony/Component/DependencyInjection/ContainerBuilder.php`

Fixed the problem, and updated the relevant test fixture.
