### PR TITLE
[Bundle][FrameworkBundle] make the stopwatch service always available

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
@@ -23,9 +23,15 @@ class StopwatchExtension extends \Twig_Extension
 {
     private $stopwatch;
 
-    public function __construct(Stopwatch $stopwatch = null)
+    /**
+     * @var bool
+     */
+    private $enabled;
+
+    public function __construct(Stopwatch $stopwatch = null, $enabled = true)
     {
         $this->stopwatch = $stopwatch;
+        $this->enabled = $enabled;
     }
 
     public function getStopwatch()
@@ -41,7 +47,7 @@ class StopwatchExtension extends \Twig_Extension
              * Some stuff which will be recorded on the timeline
              * {% endstopwatch %}
              */
-            new StopwatchTokenParser($this->stopwatch !== null),
+            new StopwatchTokenParser($this->stopwatch !== null && $this->enabled),
         );
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -6,14 +6,11 @@
 
     <parameters>
         <parameter key="debug.event_dispatcher.class">Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher</parameter>
-        <parameter key="debug.stopwatch.class">Symfony\Component\Stopwatch\Stopwatch</parameter>
         <parameter key="debug.container.dump">%kernel.cache_dir%/%kernel.container_class%.xml</parameter>
         <parameter key="debug.controller_resolver.class">Symfony\Component\HttpKernel\Controller\TraceableControllerResolver</parameter>
     </parameters>
 
     <services>
-        <service id="debug.stopwatch" class="%debug.stopwatch.class%" />
-
         <service id="debug.event_dispatcher" class="%debug.event_dispatcher.class%">
             <tag name="monolog.logger" channel="event" />
             <argument type="service" id="debug.event_dispatcher.parent" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="debug.debug_handlers_listener.class">Symfony\Component\HttpKernel\EventListener\DebugHandlersListener</parameter>
+        <parameter key="debug.stopwatch.class">Symfony\Component\Stopwatch\Stopwatch</parameter>
     </parameters>
 
     <services>
@@ -17,5 +18,7 @@
             <argument /><!-- Log levels map for enabled error levels -->
             <argument>%kernel.debug%</argument>
         </service>
+
+        <service id="debug.stopwatch" class="%debug.stopwatch.class%" />
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/default_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/default_config.php
@@ -1,0 +1,3 @@
+<?php
+
+$container->loadFromExtension('framework', array());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/default_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/default_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config />
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/default_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/default_config.yml
@@ -1,0 +1,1 @@
+framework: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -402,6 +402,25 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('_custom_form', $container->getParameter('form.type_extension.csrf.field_name'));
     }
 
+    public function testStopwatchEnabledWithDebugModeEnabled()
+    {
+        $container = $this->createContainerFromFile('default_config', array(
+            'kernel.container_class' => 'foo',
+            'kernel.debug' => true,
+        ));
+
+        $this->assertTrue($container->has('debug.stopwatch'));
+    }
+
+    public function testStopwatchEnabledWithDebugModeDisabled()
+    {
+        $container = $this->createContainerFromFile('default_config', array(
+            'kernel.container_class' => 'foo',
+        ));
+
+        $this->assertTrue($container->has('debug.stopwatch'));
+    }
+
     protected function createContainer(array $data = array())
     {
         return new ContainerBuilder(new ParameterBag(array_merge(array(

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -92,6 +92,7 @@
         <service id="twig.extension.debug.stopwatch" class="%twig.extension.debug.stopwatch.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
+            <argument>%kernel.debug%</argument>
         </service>
 
         <service id="twig.extension.expression" class="%twig.extension.expression.class%" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11347 |
| License | MIT |
| Doc PR |  |

Previously, one had to be careful to check if the `debug.stopwatch` service was available before using it. Otherwise, the application would break in the prod environment.
