### PR TITLE
[Form] fix whitespace in Twig form template

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -299,7 +299,7 @@
 
 {% block widget_attributes -%}
     id="{{ id }}" name="{{ full_name }}"{% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
-    {% for attrname, attrvalue in attr %}{% if attrname in ['placeholder', 'title'] %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}" {% else %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}
+    {%- for attrname, attrvalue in attr %} {% if attrname in ['placeholder', 'title'] %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}"{% else %}{{ attrname }}="{{ attrvalue }}"{% endif %}{% endfor %}
 {%- endblock widget_attributes %}
 
 {% block widget_container_attributes -%}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kind of (after updating from 2.3.17 to 2.3.18, some of my tests were broken because of this) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | they should, let's see what Travis has to say... |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | -- |

This fixes some whitespace rendering.

after merging #11386:

``` html
<input type="text" id="myfield" name="myfield"     value="blah" />
```

before merging #11386 and with this PR again:

``` html
<input type="text" id="myfield" name="myfield" value="blah" />
```
