### PR TITLE
[Console] Fixed QuestionHelper validation write error

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -354,7 +354,7 @@ class QuestionHelper extends Helper
         $attempts = $question->getMaxAttempts();
         while (null === $attempts || $attempts--) {
             if (null !== $error) {
-                $output->writeln($this->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+                $output->writeln($output->getFormatter()->format('<error>' . $error->getMessage() . '</error>'));
             }
 
             try {


### PR DESCRIPTION
<table>
<thead><tr>
<th>Q</th>
<th>A</th>
</tr></thead>
<tbody>
<tr>
<td>Bug fix?</td>
<td>yes</td>
</tr>
<tr>
<td>New feature?</td>
<td>no</td>
</tr>
<tr>
<td>BC breaks?</td>
<td>no</td>
</tr>
<tr>
<td>Deprecations?</td>
<td>no</td>
</tr>
<tr>
<td>Tests pass?</td>
<td>yes</td>
</tr>
<tr>
<td>Fixed tickets</td>
<td>None</td>
</tr>
<tr>
<td>License</td>
<td>MIT</td>
</tr>
<tr>
<td>Doc PR</td>
<td>None</td>
</tr>
</tbody>
</table>


<p>Function getHelperSet() don't exist.</p>


<p>Todo:</p>

<ul>
<li>add unit tests</li>
</ul>
