### PR TITLE
[DependencyInjection] Fixed missing 'factory-class' attribute in XmlDumper output

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -119,6 +119,9 @@ class XmlDumper extends Dumper
         if ($definition->getFactoryMethod()) {
             $service->setAttribute('factory-method', $definition->getFactoryMethod());
         }
+        if ($definition->getFactoryClass()) {
+            $service->setAttribute('factory-class', $definition->getFactoryClass());
+        }
         if ($definition->getFactoryService()) {
             $service->setAttribute('factory-service', $definition->getFactoryService());
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -6,7 +6,7 @@
     <parameter key="foo">bar</parameter>
   </parameters>
   <services>
-    <service id="foo" class="FooClass" factory-method="getInstance">
+    <service id="foo" class="FooClass" factory-method="getInstance" factory-class="FooClass">
       <tag name="foo" foo="foo"/>
       <tag name="foo" bar="bar"/>
       <argument>foo</argument>
@@ -35,7 +35,7 @@
       <argument>%foo_bar%</argument>
       <configurator service="foo.baz" method="configure"/>
     </service>
-    <service id="foo.baz" class="%baz_class%" factory-method="getInstance">
+    <service id="foo.baz" class="%baz_class%" factory-method="getInstance" factory-class="%baz_class%">
       <configurator class="%baz_class%" method="configureStatic1"/>
     </service>
     <service id="foo_bar" class="%foo_class%" scope="prototype"/>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Problem: XmlDumper doesn't write 'factory-class' XML attribute for definitions on which setFactoryClass() was called.

Impact: Container[Builder] to throws an exception when the relevant service is being requested/initiated after loading the dumped XML.
`Uncaught Exception Symfony\Component\DependencyInjection\Exception\RuntimeException: "Cannot create service "xxx" from factory method without a factory service or factory class." at /<path>/<to>//DependencyInjection/ContainerBuilder.php`

Solution: Made XmlDumper write the 'factory-class' attribute, and updated the relevant test fixture.

Another related problem, is that XMLFileLoader doesn't complain if the 'factory-class' attribute is missing for a 'service' elements that include 'factory-method' attribute, resulting in an ill-configured Definition object in the ContainerBuilder. I'll post an issue/ticket, and probably send another PR for that.
