### PR TITLE
[Validator] Convert objects to string in comparison validators

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -32,8 +32,8 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
 
         if (!$this->compareValues($value, $constraint->value)) {
             $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value, true),
-                '{{ compared_value }}' => $this->formatValue($constraint->value, true),
+                '{{ value }}' => $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE),
+                '{{ compared_value }}' => $this->formatValue($constraint->value, self::OBJECT_TO_STRING | self::PRETTY_DATE),
                 '{{ compared_value_type }}' => $this->formatTypeOf($constraint->value)
             ));
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -15,6 +15,21 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\AbstractComparisonValidator;
 
+class ComparisonTest_Class
+{
+    protected $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->value;
+    }
+}
+
 /**
  * @author Daniel Holmes <daniel@danielholmes.org>
  */

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -39,6 +39,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(3, '3'),
             array('a', 'a'),
             array(new \DateTime('2000-01-01'), new \DateTime('2000-01-01')),
+            array(new ComparisonTest_Class(5), new ComparisonTest_Class(5)),
             array(null, 1),
         );
     }
@@ -51,7 +52,8 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
         return array(
             array(1, '1', 2, '2', 'integer'),
             array('22', '"22"', '333', '"333"', 'string'),
-            array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime')
+            array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -37,6 +37,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
         return array(
             array(2, 1),
             array(new \DateTime('2005/01/01'), new \DateTime('2001/01/01')),
+            array(new ComparisonTest_Class(5), new ComparisonTest_Class(4)),
             array('333', '22'),
             array(null, 1),
         );
@@ -52,6 +53,8 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             array(2, '2', 2, '2', 'integer'),
             array(new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2005/01/01'), 'Jan 1, 2005, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
             array('22', '"22"', '333', '"333"', 'string'),
             array('22', '"22"', '22', '"22"', 'string')
         );

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -35,11 +35,13 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     public function provideValidComparisons()
     {
         $date = new \DateTime('2000-01-01');
+        $object = new ComparisonTest_Class(2);
 
         return array(
             array(3, 3),
             array('a', 'a'),
             array($date, $date),
+            array($object, $object),
             array(null, 1),
         );
     }
@@ -54,7 +56,8 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             array(2, '2', '2', '"2"', 'string'),
             array('22', '"22"', '333', '"333"', 'string'),
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', 'DateTime'),
-            array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('1999-01-01'), 'Jan 1, 1999, 12:00 AM', 'DateTime')
+            array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('1999-01-01'), 'Jan 1, 1999, 12:00 AM', 'DateTime'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -39,6 +39,8 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
             array(1, 1),
             array(new \DateTime('2000-01-01'), new \DateTime('2000-01-01')),
             array(new \DateTime('2000-01-01'), new \DateTime('2020-01-01')),
+            array(new ComparisonTest_Class(4), new ComparisonTest_Class(5)),
+            array(new ComparisonTest_Class(5), new ComparisonTest_Class(5)),
             array('a', 'a'),
             array('a', 'z'),
             array(null, 1),
@@ -53,6 +55,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
         return array(
             array(2, '2', 1, '1', 'integer'),
             array(new \DateTime('2010-01-01'), 'Jan 1, 2010, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', __NAMESPACE__.'\ComparisonTest_Class'),
             array('c', '"c"', 'b', '"b"', 'string')
         );
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -37,6 +37,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
         return array(
             array(1, 2),
             array(new \DateTime('2000-01-01'), new \DateTime('2010-01-01')),
+            array(new ComparisonTest_Class(4), new ComparisonTest_Class(5)),
             array('22', '333'),
             array(null, 1),
         );
@@ -52,6 +53,8 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
             array(2, '2', 2, '2', 'integer'),
             array(new \DateTime('2010-01-01'), 'Jan 1, 2010, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
             array('333', '"333"', '22', '"22"', 'string'),
         );
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -38,6 +38,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(1, 2),
             array('22', '333'),
             array(new \DateTime('2001-01-01'), new \DateTime('2000-01-01')),
+            array(new ComparisonTest_Class(6), new ComparisonTest_Class(5)),
             array(null, 1),
         );
     }
@@ -51,7 +52,8 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(3, '3', 3, '3', 'integer'),
             array('2', '"2"', 2, '2', 'integer'),
             array('a', '"a"', 'a', '"a"', 'string'),
-            array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime')
+            array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -50,11 +50,13 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     public function provideInvalidComparisons()
     {
         $date = new \DateTime('2000-01-01');
+        $object = new ComparisonTest_Class(2);
 
         return array(
             array(3, '3', 3, '3', 'integer'),
             array('a', '"a"', 'a', '"a"', 'string'),
-            array($date, 'Jan 1, 2000, 12:00 AM', $date, 'Jan 1, 2000, 12:00 AM', 'DateTime')
+            array($date, 'Jan 1, 2000, 12:00 AM', $date, 'Jan 1, 2000, 12:00 AM', 'DateTime'),
+            array($object, '2', $object, '2', __NAMESPACE__.'\ComparisonTest_Class'),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In the [latest merge from 2.3 into 2.4](/symfony/symfony/commit/3bed1b7988e94a897a64c6a2ad3bf70bde9005c1), the changes from 6cf5e0812e6f20d60acbc0324abf96475e89b6ef in 2.4 got lost. This PR brings back these changes and backports them to 2.3.

The change is BC, because the former value `true` of the `$prettyDateTime` will be cast to `1`, which corresponds to the `PRETTY_DATE` format constant.
