### PR TITLE
added ability to set anchors/ref in parser or  to get it

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -29,6 +29,30 @@ class Parser
     private $refs           = array();
 
     /**
+     * Getter for anchors
+     *
+     * @return array Parsed anchors
+     */
+    public function getRefs()
+    {
+        return $this->refs;
+    }
+
+    /**
+     * Setter for anchors
+     *
+     * @param $refs
+     *
+     * @return self
+     */
+    public function setRefs($refs)
+    {
+        $this->refs = $refs;
+
+        return $this;
+    }
+
+    /**
      * Constructor
      *
      * @param int     $offset The offset of YAML document (used for line numbers in error messages)


### PR DESCRIPTION
This PR was submitted on the symfony/Yaml read-only repository and moved automatically to the main Symfony repository (closes symfony/Yaml#10).

It is very needed when someone has custom yaml file loader with imports.
Now there is no way that parser has known mappings or scalars from imported files.
