### PR TITLE
[Security] Made optimization on constant-time algorithm removing modulus operator

### DIFF
--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -35,12 +35,11 @@ class StringUtils
      */
     public static function equals($knownString, $userInput)
     {
-        // Prevent issues if string length is 0
-        $knownString .= chr(0);
-        $userInput .= chr(0);
-
         $knownLen = strlen($knownString);
         $userLen = strlen($userInput);
+
+        // Extend know string to avoid uninitialized string offsets
+        $knownString .= $userInput;
 
         // Set the result to the difference between the lengths
         $result = $knownLen - $userLen;
@@ -48,10 +47,7 @@ class StringUtils
         // Note that we ALWAYS iterate over the user-supplied length
         // This is to prevent leaking length information
         for ($i = 0; $i < $userLen; $i++) {
-            // Using % here is a trick to prevent notices
-            // It's safe, since if the lengths are different
-            // $result is already non-0
-            $result |= (ord($knownString[$i % $knownLen]) ^ ord($userInput[$i]));
+            $result |= (ord($knownString[$i]) ^ ord($userInput[$i]));
         }
 
         // They are only identical strings if $result is exactly 0...


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This fix improves the constant-time algorithm used to compare strings, as it removes the `%` operator inside the loop. 
