### PR TITLE
[Form] allowed CallbackTransformer to use callable

### DIFF
--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -18,24 +18,33 @@ class CallbackTransformer implements DataTransformerInterface
 {
     /**
      * The callback used for forward transform
-     * @var \Closure
+     * @var callable
      */
     private $transform;
 
     /**
      * The callback used for reverse transform
-     * @var \Closure
+     * @var callable
      */
     private $reverseTransform;
 
     /**
      * Constructor.
      *
-     * @param \Closure $transform        The forward transform callback
-     * @param \Closure $reverseTransform The reverse transform callback
+     * @param callable $transform        The forward transform callback
+     * @param callable $reverseTransform The reverse transform callback
+     *
+     * @throws \InvalidArgumentException when the given callbacks is invalid
      */
-    public function __construct(\Closure $transform, \Closure $reverseTransform)
+    public function __construct($transform, $reverseTransform)
     {
+        if (!is_callable($transform)) {
+            throw new \InvalidArgumentException('Argument 1 should be a callable');
+        }
+        if (!is_callable($reverseTransform)) {
+            throw new \InvalidArgumentException('Argument 2 should be a callable');
+        }
+
         $this->transform = $transform;
         $this->reverseTransform = $reverseTransform;
     }
@@ -47,7 +56,7 @@ class CallbackTransformer implements DataTransformerInterface
      *
      * @return mixed The value in the transformed representation
      *
-     * @throws UnexpectedTypeException       when the argument is not a string
+     * @throws UnexpectedTypeException       when the argument is not of the expected type
      * @throws TransformationFailedException when the transformation fails
      */
     public function transform($data)

--- a/src/Symfony/Component/Form/Tests/CallbackTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/CallbackTransformerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symfony\Component\Form\Tests;
+
+use Symfony\Component\Form\CallbackTransformer;
+
+class CallbackTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTransform()
+    {
+        $transformer = new CallbackTransformer(
+            function($value) { return $value.' has been transformed'; },
+            function($value) { return $value.' has reversely been transformed'; }
+        );
+
+        $this->assertEquals('foo has been transformed', $transformer->transform('foo'));
+        $this->assertEquals('bar has reversely been transformed', $transformer->reverseTransform('bar'));
+    }
+
+    /**
+     * @dataProvider invalidCallbacksProvider
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructorWithInvalidCallbacks($transformCallback, $reverseTransformCallback)
+    {
+        new CallbackTransformer($transformCallback, $reverseTransformCallback);
+    }
+
+    public function invalidCallbacksProvider()
+    {
+        return array(
+            array( null, function(){} ),
+            array( function(){}, null ),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

I want to use the callable(i.e. inner class methods) in CallbackTransformer, but its current constructor is defined argument type hinting for \Closure so i can't.
