### PR TITLE
[Finder] Shell escape and windows support

### DIFF
--- a/src/Symfony/Component/Finder/Shell/Shell.php
+++ b/src/Symfony/Component/Finder/Shell/Shell.php
@@ -55,14 +55,14 @@ class Shell
         }
 
         // todo: find a better way (command could not be available)
-        $testCommand = 'command -v ';
+        $testCommand = 'which ';
         if (self::TYPE_WINDOWS === $this->type) {
             $testCommand = 'where ';
         }
 
         $command = escapeshellcmd($command);
 
-        exec($testCommand . $command, $output, $code);
+        exec($testCommand.$command, $output, $code);
 
         return 0 === $code && count($output) > 0;
     }

--- a/src/Symfony/Component/Finder/Shell/Shell.php
+++ b/src/Symfony/Component/Finder/Shell/Shell.php
@@ -59,6 +59,8 @@ class Shell
             return false;
         }
 
+        $command = escapeshellcmd($command);
+
         // todo: find a better way (command could not be available)
         exec('command -v '.$command, $output, $code);
 

--- a/src/Symfony/Component/Finder/Shell/Shell.php
+++ b/src/Symfony/Component/Finder/Shell/Shell.php
@@ -50,19 +50,19 @@ class Shell
      */
     public function testCommand($command)
     {
-        if (self::TYPE_WINDOWS === $this->type) {
-            // todo: find a way to test if Windows command exists
-            return false;
-        }
-
         if (!function_exists('exec')) {
             return false;
         }
 
+        // todo: find a better way (command could not be available)
+        $testCommand = 'command -v ';
+        if (self::TYPE_WINDOWS === $this->type) {
+            $testCommand = 'where ';
+        }
+
         $command = escapeshellcmd($command);
 
-        // todo: find a better way (command could not be available)
-        exec('command -v '.$command, $output, $code);
+        exec($testCommand . $command, $output, $code);
 
         return 0 === $code && count($output) > 0;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Add escaping of command passed to Shell::testCommand().
Fix todo add support for windows.
