### PR TITLE
[Validator] Allow basic auth in url when using UrlValidator.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -24,6 +24,7 @@ class UrlValidator extends ConstraintValidator
 {
     const PATTERN = '~^
             (%s)://                                 # protocol
+            (([\pL\pN-]+:)?([\pL\pN-]+)@)?          # basic auth
             (
                 ([\pL\pN\pS-\.])+(\.?([\pL]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
                     |                                              # or

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -108,6 +108,8 @@ class UrlValidatorTest extends AbstractConstraintValidatorTest
             array('http://xn--espaa-rta.xn--ca-ol-fsay5a/'),
             array('http://xn--d1abbgf6aiiy.xn--p1ai/'),
             array('http://☎.com/'),
+            array('http://username:password@symfony.com'),
+            array('http://user-name@symfony.com'),
         );
     }
 
@@ -145,6 +147,10 @@ class UrlValidatorTest extends AbstractConstraintValidatorTest
             array('ftp://[::1]/'),
             array('http://[::1'),
             array('http://hello.☎/'),
+            array('http://:password@symfony.com'),
+            array('http://:password@@symfony.com'),
+            array('http://username:passwordsymfony.com'),
+            array('http://usern@me:password@symfony.com'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Now an url with basic auth like `http://username:password@symfony.com` can be valid.
