### PR TITLE
[Console] fixed output escaping when using the process helper

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -48,7 +48,7 @@ class ProcessHelper extends Helper
         }
 
         if ($verbosity <= $output->getVerbosity()) {
-            $output->write($formatter->start(spl_object_hash($process), $process->getCommandLine()));
+            $output->write($formatter->start(spl_object_hash($process), $this->escapeString($process->getCommandLine())));
         }
 
         if ($output->isDebug()) {
@@ -63,7 +63,7 @@ class ProcessHelper extends Helper
         }
 
         if (!$process->isSuccessful() && null !== $error) {
-            $output->writeln(sprintf('<error>%s</error>', $error));
+            $output->writeln(sprintf('<error>%s</error>', $this->escapeString($error)));
         }
 
         return $process;
@@ -111,13 +111,24 @@ class ProcessHelper extends Helper
     {
         $formatter = $this->getHelperSet()->get('debug_formatter');
 
-        return function ($type, $buffer) use ($output, $process, $callback, $formatter) {
-            $output->write($formatter->progress(spl_object_hash($process), $buffer, Process::ERR === $type));
+        $that = $this;
+        return function ($type, $buffer) use ($output, $process, $callback, $formatter, $that) {
+            $output->write($formatter->progress(spl_object_hash($process), $that->escapeString($buffer), Process::ERR === $type));
 
             if (null !== $callback) {
                 call_user_func($callback, $type, $buffer);
             }
         };
+    }
+
+    /**
+     * This method is public for PHP 5.3 compatibility, it should be private.
+     *
+     * @internal
+     */
+    public function escapeString($str)
+    {
+        return str_replace('<', '\\<', $str);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProcessHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProcessHelperTest.php
@@ -58,6 +58,12 @@ EOT;
   RES  Command ran successfully
 
 EOT;
+        $successOutputDebugWithTags = <<<EOT
+  RUN  php -r "echo \"<info>42</info>\";"
+  OUT  <info>42</info>
+  RES  Command ran successfully
+
+EOT;
         $successOutputProcessDebug = <<<EOT
   RUN  'php' '-r' 'echo 42;'
   OUT  42
@@ -86,6 +92,7 @@ EOT;
             array('', 'php -r "echo 42;"', StreamOutput::VERBOSITY_VERBOSE, null),
             array($successOutputVerbose, 'php -r "echo 42;"', StreamOutput::VERBOSITY_VERY_VERBOSE, null),
             array($successOutputDebug, 'php -r "echo 42;"', StreamOutput::VERBOSITY_DEBUG, null),
+            array($successOutputDebugWithTags, 'php -r "echo \"<info>42</info>\";"', StreamOutput::VERBOSITY_DEBUG, null),
             array('', 'php -r "syntax error"', StreamOutput::VERBOSITY_VERBOSE, null),
             array($syntaxErrorOutputVerbose, 'php -r "fwrite(STDERR, \'error message\');usleep(50000);fwrite(STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_VERY_VERBOSE, null),
             array($syntaxErrorOutputDebug, 'php -r "fwrite(STDERR, \'error message\');usleep(50000);fwrite(STDOUT, \'out message\');exit(252);"', StreamOutput::VERBOSITY_DEBUG, null),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When displaying the output of a process run, we must escape the `<` to avoid any formatting.
