### PR TITLE
[Validator] return empty metadata collection if none do exist

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -298,6 +298,10 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
      */
     public function getMemberMetadatas($property)
     {
+        if (!isset($this->members[$property])) {
+            return array();
+        }
+
         return $this->members[$property];
     }
 
@@ -314,6 +318,10 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
      */
     public function getPropertyMetadata($property)
     {
+        if (!isset($this->members[$property])) {
+            return array();
+        }
+
         return $this->members[$property];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -222,4 +222,20 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $metadata->setGroupSequenceProvider(true);
         $this->assertTrue($metadata->isGroupSequenceProvider());
     }
+
+    /**
+     * https://github.com/symfony/symfony/issues/11604
+     */
+    public function testGetMemberMetadatasReturnsEmptyArrayWithoutConfiguredMetadata()
+    {
+        $this->assertCount(0, $this->metadata->getMemberMetadatas('foo'), '->getMemberMetadatas() returns an empty collection if no metadata is configured for the given property');
+    }
+
+    /**
+     * https://github.com/symfony/symfony/issues/11604
+     */
+    public function testGetPropertyMetadataReturnsEmptyArrayWithoutConfiguredMetadata()
+    {
+        $this->assertCount(0, $this->metadata->getPropertyMetadata('foo'), '->getPropertyMetadata() returns an empty collection if no metadata is configured for the given property');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Backport of #11614 for Symfony 2.3 and 2.4.
