### PR TITLE
[Form] renamed option "always_empty" to "reset_on_submit"

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class PasswordType extends AbstractType
@@ -23,7 +24,7 @@ class PasswordType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if ($options['always_empty'] || !$form->isSubmitted()) {
+        if ($options['reset_on_submit'] || !$form->isSubmitted()) {
             $view->vars['value'] = '';
         }
     }
@@ -33,9 +34,21 @@ class PasswordType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        // BC with old "always_empty" option
+        $resetOnSubmit = function (Options $options) {
+            if (null !== $options['always_empty']) {
+                // Uncomment this as soon as the deprecation note should be shown
+                // trigger_error('The form option "always_empty" is deprecated since version 2.3 and will be removed in 3.0. Use "reset_on_submit" instead.', E_USER_DEPRECATED);
+                return $options['always_empty'];
+            }
+
+            return true;
+        };
+
         $resolver->setDefaults(array(
-            'always_empty' => true,
-            'trim'         => false,
+            'reset_on_submit' => $resetOnSubmit,
+            'always_empty'    => null,
+            'trim'            => false,
         ));
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1400,10 +1400,10 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testPasswordSubmittedWithNotAlwaysEmpty()
+    public function testPasswordSubmittedWithNotResetOnSubmit()
     {
         $form = $this->factory->createNamed('name', 'password', null, array(
-            'always_empty' => false,
+            'reset_on_submit' => false,
         ));
         $form->submit('foo&bar');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -40,6 +40,15 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('pAs5w0rd', $view->vars['value']);
     }
 
+    public function testNotEmptyIfSubmittedAndNotResetOnSubmit()
+    {
+        $form = $this->factory->create('password', null, array('reset_on_submit' => false));
+        $form->submit('pAs5w0rd');
+        $view = $form->createView();
+
+        $this->assertSame('pAs5w0rd', $view->vars['value']);
+    }
+
     public function testNotTrimmed()
     {
         $form = $this->factory->create('password', null);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #6325 |
| License | MIT |
| Doc PR | symfony/symfony-docs#3781 |

This PR renames the option "always_empty" to "reset_on_submit" for more clarity (the old option is deprecated and usable until 2.3).

The documentation PR is based on 2.6. It would be better to put it on 2.3.
