### PR TITLE
added useful reminder about form.vars.errors into UPGRADE-2.5 notes

### DIFF
--- a/UPGRADE-2.5.md
+++ b/UPGRADE-2.5.md
@@ -45,6 +45,18 @@ Form
    {
    ```
 
+   Before:
+
+   ```
+   {% if form.vars.errors %}
+   ```
+
+   After:
+
+   ```
+   {% if form.vars.errors|length %}
+   ```
+
 PropertyAccess
 --------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

PR is just about upgrading UPGRADE-2.5 notes.
We've been upgrading from 2.4 to 2.5.3 and missing this part (upgrading templates)
