### PR TITLE
[FrameworkBundle] resolve parameters before the configs are processed in the config:debug command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -75,10 +75,10 @@ EOF
 
         $this->validateConfiguration($extension, $configuration);
 
+        $configs = $container->getParameterBag()->resolveValue($configs);
+
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);
-
-        $config = $container->getParameterBag()->resolveValue($config);
 
         if ($name === $extension->getAlias()) {
             $output->writeln(sprintf('# Current configuration for extension with alias: "%s"', $name));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11622 |
| License | MIT |
| Doc PR |  |

If the raw values are passed to the processor, config values don't necessarily have the expected data type. For example, the value of the kernel.debug parameter is a boolean type. But when passed as the raw parameter name, it is a string.

@lyrixx Do you have any objections?
