### PR TITLE
[FrameworkBundle] [TwigBundle] Move debug commands to debug namespace

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -30,7 +30,10 @@ class ConfigDebugCommand extends AbstractConfigCommand
     protected function configure()
     {
         $this
-            ->setName('config:debug')
+            ->setName('debug:config')
+            ->setAliases(array(
+                'config:debug',
+            ))
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'The Bundle name or the extension alias'),
             ))

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -38,7 +38,10 @@ class ContainerDebugCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('container:debug')
+            ->setName('debug:container')
+            ->setAliases(array(
+                'container:debug',
+            ))
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'A service name (foo)'),
                 new InputOption('show-private', null, InputOption::VALUE_NONE, 'Used to show public *and* private services'),

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -49,7 +49,10 @@ class RouterDebugCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('router:debug')
+            ->setName('debug:router')
+            ->setAliases(array(
+                'router:debug',
+            ))
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'A route name'),
                 new InputOption('show-controllers', null,  InputOption::VALUE_NONE, 'Show assigned controllers in overview'),

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -38,7 +38,10 @@ class TranslationDebugCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('translation:debug')
+            ->setName('debug:translation')
+            ->setAliases(array(
+                'translation:debug',
+            ))
             ->setDefinition(array(
                 new InputArgument('locale', InputArgument::REQUIRED, 'The locale'),
                 new InputArgument('bundle', InputArgument::REQUIRED, 'The bundle name'),

--- a/src/Symfony/Bundle/TwigBundle/Command/DebugCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/DebugCommand.php
@@ -27,7 +27,10 @@ class DebugCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('twig:debug')
+            ->setName('debug:twig')
+            ->setAliases(array(
+                'twig:debug',
+            ))
             ->setDefinition(array(
                 new InputArgument('filter', InputArgument::OPTIONAL, 'Show details for all entries matching this filter'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'Output format: text or json', 'text'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

Instead of having several namespaces with only one debug command (container:debug, event-dispatcher:debug), move all these debug commands to a new **debug** namespace.

Related to https://github.com/symfony/symfony/pull/10388#issuecomment-49007419

I don't how to tag these aliases as deprecated as there are only here for backward compatibility.
The renaming should also be done in the Swiftmailer Bundle. 
