### PR TITLE
[Security] Change private properties and methods into protected to make ...

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -37,15 +37,15 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class SwitchUserListener implements ListenerInterface
 {
-    private $securityContext;
-    private $provider;
-    private $userChecker;
-    private $providerKey;
-    private $accessDecisionManager;
-    private $usernameParameter;
-    private $role;
-    private $logger;
-    private $dispatcher;
+    protected $securityContext;
+    protected $provider;
+    protected $userChecker;
+    protected $providerKey;
+    protected $accessDecisionManager;
+    protected $usernameParameter;
+    protected $role;
+    protected $logger;
+    protected $dispatcher;
 
     /**
      * Constructor.
@@ -108,7 +108,7 @@ class SwitchUserListener implements ListenerInterface
      * @throws \LogicException
      * @throws AccessDeniedException
      */
-    private function attemptSwitchUser(Request $request)
+    protected function attemptSwitchUser(Request $request)
     {
         $token = $this->securityContext->getToken();
         $originalToken = $this->getOriginalToken($token);
@@ -156,7 +156,7 @@ class SwitchUserListener implements ListenerInterface
      *
      * @throws AuthenticationCredentialsNotFoundException
      */
-    private function attemptExitUser(Request $request)
+    protected function attemptExitUser(Request $request)
     {
         if (false === $original = $this->getOriginalToken($this->securityContext->getToken())) {
             throw new AuthenticationCredentialsNotFoundException('Could not find original Token object.');
@@ -177,7 +177,7 @@ class SwitchUserListener implements ListenerInterface
      *
      * @return TokenInterface|false The original TokenInterface instance, false if the current TokenInterface is not switched
      */
-    private function getOriginalToken(TokenInterface $token)
+    protected function getOriginalToken(TokenInterface $token)
     {
         foreach ($token->getRoles() as $role) {
             if ($role instanceof SwitchUserRole) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Loosening the properties and method visibility to `protected` allows to quickly create a new SwitchUserListener class, which extends the core class, and hook your custom changes anywhere.

Before this patch, I had to copy the whole class, just to add 1 line of code...
