### PR TITLE
fix dependencies on HttpFoundation component

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/twig-bridge": "~2.5",
+        "symfony/http-foundation": "~2.5",
         "symfony/http-kernel": "~2.1"
     },
     "require-dev": {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.5",
-        "symfony/http-foundation": "~2.4",
+        "symfony/http-foundation": "~2.5",
         "symfony/debug": "~2.5",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11636 |
| License | MIT |
| Doc PR |  |

The `closeOutputBuffers()` method was added to the `Response` class of the HttpFoundation in Symfony 2.5. Therefore, parts that are calling this method must depend on `symfony/http-foundation` 2.5 or higher.
