### PR TITLE
[DependencyInjection] Fixed factory service not within the ServiceReferenceGraph.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -69,7 +69,11 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
 
             $this->currentId = $id;
             $this->currentDefinition = $definition;
+
             $this->processArguments($definition->getArguments());
+            if ($definition->getFactoryService()) {
+                $this->processArguments(array(new Reference($definition->getFactoryService())));
+            }
 
             if (!$this->onlyConstructorArguments) {
                 $this->processArguments($definition->getMethodCalls());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
@@ -97,6 +97,26 @@ class AnalyzeServiceReferencesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $graph->getNode('a')->getInEdges());
     }
 
+    public function testProcessDetectsFactoryReferences()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('foo', 'stdClass')
+            ->setFactoryClass('stdClass')
+            ->setFactoryMethod('getInstance');
+
+        $container
+            ->register('bar', 'stdClass')
+            ->setFactoryService('foo')
+            ->setFactoryMethod('getInstance');
+
+        $graph = $this->process($container);
+
+        $this->assertTrue($graph->hasNode('foo'));
+        $this->assertCount(1, $graph->getNode('foo')->getInEdges());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new RepeatedPass(array(new AnalyzeServiceReferencesPass()));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveUnusedDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveUnusedDefinitionsPassTest.php
@@ -81,6 +81,33 @@ class RemoveUnusedDefinitionsPassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('bar'));
     }
 
+    public function testProcessWontRemovePrivateFactory()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('foo', 'stdClass')
+            ->setFactoryClass('stdClass')
+            ->setFactoryMethod('getInstance')
+            ->setPublic(false);
+
+        $container
+            ->register('bar', 'stdClass')
+            ->setFactoryService('foo')
+            ->setFactoryMethod('getInstance')
+            ->setPublic(false);
+
+        $container
+            ->register('foobar')
+            ->addArgument(new Reference('bar'));
+
+        $this->process($container);
+
+        $this->assertTrue($container->hasDefinition('foo'));
+        $this->assertTrue($container->hasDefinition('bar'));
+        $this->assertTrue($container->hasDefinition('foobar'));
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $repeatedPass = new RepeatedPass(array(new AnalyzeServiceReferencesPass(), new RemoveUnusedDefinitionsPass()));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Fixed a problem where Factory services are not added to the ServiceReferenceGraph.
