### PR TITLE
[Validator] Backported constraint validator tests from 2.5

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -51,6 +51,7 @@ class ExpressionValidator extends ConstraintValidator
         $variables = array();
 
         if (null === $this->context->getPropertyName()) {
+            $variables['value'] = $value;
             $variables['this'] = $value;
         } else {
             // Extract the object that the property belongs to from the object


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR backports the constraint validator tests from 2.5 to 2.4 to facilitate maintenance. When we adapt a test in 2.4, we can now easily merge the change forward to 2.5.
