### PR TITLE
[HttpFoundation] Remove CSRF warning from enableHttpMethodParameterOverride documentation

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -667,9 +667,6 @@ class Request
     /**
      * Enables support for the _method request parameter to determine the intended HTTP method.
      *
-     * Be warned that enabling this feature might lead to CSRF issues in your code.
-     * Check that you are using CSRF tokens when required.
-     *
      * The HTTP method can only be overridden when the real HTTP method is POST.
      */
     public static function enableHttpMethodParameterOverride()


### PR DESCRIPTION
Unless there's a good reason to keep it (nothing was forthcoming when [I asked on the user list](https://groups.google.com/forum/#!topic/Symfony2/88nn3y_Wi3w)), this documentation is misleading. 

As far as I can tell, the `_method` parameter can only turn a `POST` request into `PUT` or `DELETE` request, which shouldn't have an effect on CSRF token validation.

If there is actually a security issue when `httpMethodParameterOverride` is enabled, that should be documented so that users know how to avoid it.
