### PR TITLE
[BrowserKit] Fixed regression with redirects and port number

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -598,7 +598,7 @@ abstract class Client
 
     private function updateServerFromUri($server, $uri)
     {
-        $server['HTTP_HOST'] = parse_url($uri, PHP_URL_HOST);
+        $server['HTTP_HOST'] = $this->extractHost($uri);
         $scheme = parse_url($uri, PHP_URL_SCHEME);
         $server['HTTPS'] = null === $scheme ? $server['HTTPS'] : 'https' == $scheme;
         unset($server['HTTP_IF_NONE_MATCH'], $server['HTTP_IF_MODIFIED_SINCE']);

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -349,6 +349,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.example.com/redirected', $client->getRequest()->getUri(), '->followRedirect() automatically follows redirects if followRedirects is true');
 
         $client = new TestClient();
+        $client->setNextResponse(new Response('', 302, array('Location' => 'http://www.example.com:8080/redirected')));
+        $client->request('GET', 'http://www.example.com/foo/foobar');
+
+        $this->assertEquals('http://www.example.com:8080/redirected', $client->getRequest()->getUri(), '->followRedirect() does not forget the port of the redirect URL');
+
+        $client = new TestClient();
         $client->setNextResponse(new Response('', 201, array('Location' => 'http://www.example.com/redirected')));
         $client->request('GET', 'http://www.example.com/foo/foobar');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11621 |
| License | MIT |
| Doc PR | - |

`updateServerFromUri()` did not consider the PORT as part of the Host but `request()` does this since https://github.com/symfony/BrowserKit/commit/650db4cc53461846f919d49199e50b85b56360b3 .

Changed the method to use `extractHost()` to be consistent with other behavior.

fixes #11621
