### PR TITLE
[FrameworkBundle] Controller as a service

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -357,6 +357,10 @@ UPGRADE FROM 2.x to 3.0
 
  * The `RouterApacheDumperCommand` was removed.
 
+ * The `has` and `get` methods of the base `Controller` class have been deprecated
+   since Symfony 2.6 and must be therefore removed in 3.0. Developers should use
+   proper service injection and not rely on the whole service container.
+
 ### HttpKernel
 
  * The `Symfony\Component\HttpKernel\Log\LoggerInterface` has been removed in

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Controller is a simple implementation of a Controller.
@@ -265,7 +265,7 @@ class Controller extends ContainerAware
     /**
      * Shortcut to return the Doctrine Registry service.
      *
-     * @return RegistryInterface
+     * @return ManagerRegistry
      *
      * @throws \LogicException If DoctrineBundle is not available
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -338,4 +338,60 @@ class Controller extends ContainerAware
     {
         return $this->container->get($id);
     }
+
+    /**
+     * @param \Symfony\Bridge\Doctrine\RegistryInterface $doctrine
+     */
+    public function setDoctrine($doctrine)
+    {
+        $this->doctrine = $doctrine;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
+     */
+    public function setFormFactory($formFactory)
+    {
+        $this->formFactory = $formFactory;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\HttpKernelInterface $httpKernel
+     */
+    public function setHttpKernel($httpKernel)
+    {
+        $this->httpKernel = $httpKernel;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     */
+    public function setRequestStack($requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @param \Symfony\Component\Routing\RouterInterface $router
+     */
+    public function setRouter($router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @param \Symfony\Component\Security\Core\SecurityContextInterface $securityContext
+     */
+    public function setSecurityContext($securityContext)
+    {
+        $this->securityContext = $securityContext;
+    }
+
+    /**
+     * @param \Symfony\Bundle\FrameworkBundle\Templating\EngineInterface $templating
+     */
+    public function setTemplating($templating)
+    {
+        $this->templating = $templating;
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * Controller is a simple implementation of a Controller.
@@ -265,7 +266,7 @@ class Controller extends ContainerAware
     /**
      * Shortcut to return the Doctrine Registry service.
      *
-     * @return Registry
+     * @return RegistryInterface
      *
      * @throws \LogicException If DoctrineBundle is not available
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -88,7 +88,6 @@ class Controller extends ContainerAware
         $this->templating      = $this->container->get('templating',       ContainerInterface::NULL_ON_INVALID_REFERENCE);
     }
 
-
     /**
      * Generates a URL from the given parameters.
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,9 +35,10 @@ class ControllerTest extends TestCase
             return new Response($request->getRequestFormat().'--'.$request->getLocale());
         }));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container->expects($this->at(0))->method('get')->will($this->returnValue($requestStack));
-        $container->expects($this->at(1))->method('get')->will($this->returnValue($kernel));
+        $container = new Container(new ParameterBag([
+            "request_stack" => $requestStack,
+            "http_kernel"   => $kernel
+        ]));
 
         $controller = new Controller();
         $controller->setContainer($container);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Today, using controllers as a service is kind of a pain in the ass since the base Controller class (`Symfony\Bundle\FrameworkBundle\Controller\Controller`) is using services directly from the service container. When a controller is built as a service, the service container is not injected into the controller. This behavior of not injecting the whole service container into a service is a good thing : you don't want to depend on the whole service container. It would make your application quickly look like a spaghetti dish ! 
Nevertheless, in this case, since the service container is not injected, it will make the Controller class to fail on all of its functionnalities since `$this->get('anything')` will fail.

To avoid this, I've changed the way the Controller base class uses its dependencies : there are not retrieved from the service container at each usage but gathered once when the Controller is built and stores into public properties.
When the controller is used in the historical way (ie : not as a service), public properties are filled at Controller creation.
When the controller is used as a service (as it should be I think), public properties can be properly injected by the subclass (either using setter injection 'Symfony-style' or public properties injection 'JMSDiExtraBundle-style').

I've also marked `get` and `has` methods as deprecated since it is really a terrible idea to inject (and thus use) the service container inside a service. As of Symfony 3.0, it would be good I think to remove the `implements` on ContainerAware and to stop injecting the whole service container

I've also changed the dependency from `Doctrine\Bundle\DoctrineBundle\Registry` to `Symfony\Bridge\Doctrine\RegistryInterface` to avoid a soft dependency towards a non mandatory bundle (moreover, it is better to depend on the actual interface instead of one implementation).
