### PR TITLE
[DIC] Fixed: anonymous services are always private

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -279,8 +279,10 @@ class XmlFileLoader extends FileLoader
         krsort($definitions);
         foreach ($definitions as $id => $def) {
             list($domElement, $file, $wild) = $def;
+
             // anonymous services are always private
-            $domElement->setAttribute('public', false);
+            // we could not use the constant false here, because of XML parsing
+            $domElement->setAttribute('public', 'false');
 
             $this->parseDefinition($id, $domElement, $file);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -278,18 +278,18 @@ class XmlFileLoader extends FileLoader
         // resolve definitions
         krsort($definitions);
         foreach ($definitions as $id => $def) {
+            list($domElement, $file, $wild) = $def;
             // anonymous services are always private
-            $def[0]->setAttribute('public', false);
+            $domElement->setAttribute('public', false);
 
-            $this->parseDefinition($id, $def[0], $def[1]);
+            $this->parseDefinition($id, $domElement, $file);
 
-            $oNode = $def[0];
-            if (true === $def[2]) {
-                $nNode = new \DOMElement('_services', null, self::NS);
-                $oNode->parentNode->replaceChild($nNode, $oNode);
-                $nNode->setAttribute('id', $id);
+            if (true === $wild) {
+                $tmpDomElement = new \DOMElement('_services', null, self::NS);
+                $domElement->parentNode->replaceChild($tmpDomElement, $domElement);
+                $tmpDomElement->setAttribute('id', $id);
             } else {
-                $oNode->parentNode->removeChild($oNode);
+                $domElement->parentNode->removeChild($domElement);
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -184,6 +184,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($services[(string) $args[0]]), '->load() makes a reference to the created ones');
         $inner = $services[(string) $args[0]];
         $this->assertEquals('BazClass', $inner->getClass(), '->load() uses the same configuration as for the anonymous ones');
+        $this->assertFalse($inner->isPublic());
 
         // anonymous service as a property
         $properties = $services['foo']->getProperties();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR |  |

This PR fix a regression introduce by https://github.com/symfony/symfony/commit/33c91f9be8e48fb085ab28019716eddc924c5904#diff-c68f5120ea7d664e07e96cc40bdf6295L268
- First commit is just about CS
- Second commit really fix the regression (see only this diff to easily understand)

ping @sandermarechal @romainneutron
