### PR TITLE
[HttpFoundation] MongoDbSessionHandler supports auto expiry via configurable expiry_field

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -41,7 +41,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             'data_field' => 'data',
             'time_field' => 'time',
             'database' => 'sf2-test',
-            'collection' => 'session-test'
+            'collection' => 'session-test',
         );
 
         $this->storage = new MongoDbSessionHandler($this->mongo, $this->options);
@@ -100,6 +100,45 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $that->assertInstanceOf('MongoDate', $data[$this->options['time_field']]);
     }
 
+    public function testWriteWhenUsingExpiresField()
+    {
+        $this->options = array(
+            'id_field'   => '_id',
+            'data_field' => 'data',
+            'time_field' => 'time',
+            'database' => 'sf2-test',
+            'collection' => 'session-test',
+            'expiry_field' => 'expiresAt'
+        );
+
+        $this->storage = new MongoDbSessionHandler($this->mongo, $this->options);
+
+        $collection = $this->createMongoCollectionMock();
+
+        $this->mongo->expects($this->once())
+            ->method('selectCollection')
+            ->with($this->options['database'], $this->options['collection'])
+            ->will($this->returnValue($collection));
+
+        $that = $this;
+        $data = array();
+
+        $collection->expects($this->once())
+            ->method('update')
+            ->will($this->returnCallback(function ($criteria, $updateData, $options) use ($that, &$data) {
+                $that->assertEquals(array($that->options['id_field'] => 'foo'), $criteria);
+                $that->assertEquals(array('upsert' => true, 'multiple' => false), $options);
+
+                $data = $updateData['$set'];
+            }));
+
+        $this->assertTrue($this->storage->write('foo', 'bar'));
+
+        $this->assertEquals('bar', $data[$this->options['data_field']]->bin);
+        $that->assertInstanceOf('MongoDate', $data[$this->options['time_field']]);
+        $that->assertInstanceOf('MongoDate', $data[$this->options['expiry_field']]);
+    }
+
     public function testReplaceSessionData()
     {
         $collection = $this->createMongoCollectionMock();
@@ -154,10 +193,36 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             ->method('remove')
             ->will($this->returnCallback(function ($criteria) use ($that) {
                 $that->assertInstanceOf('MongoDate', $criteria[$that->options['time_field']]['$lt']);
-                $that->assertGreaterThanOrEqual(time() - -1, $criteria[$that->options['time_field']]['$lt']->sec);
+                $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['time_field']]['$lt']->sec);
             }));
 
-        $this->assertTrue($this->storage->gc(-1));
+        $this->assertTrue($this->storage->gc(1));
+    }
+
+    public function testGcWhenUsingExpiresField()
+    {
+        $this->options = array(
+            'id_field'   => '_id',
+            'data_field' => 'data',
+            'time_field' => 'time',
+            'database' => 'sf2-test',
+            'collection' => 'session-test',
+            'expiry_field' => 'expiresAt'
+        );
+
+        $this->storage = new MongoDbSessionHandler($this->mongo, $this->options);
+
+        $collection = $this->createMongoCollectionMock();
+
+        $this->mongo->expects($this->never())
+            ->method('selectCollection');
+
+        $that = $this;
+
+        $collection->expects($this->never())
+            ->method('remove');
+
+        $this->assertTrue($this->storage->gc(1));
     }
 
     public function testGetConnection()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11508 |
| License | MIT |
| Doc PR | no |

This PR applies #11510 to master instead of 2.3

Should be merged on master:
- [x] after https://github.com/symfony/symfony/pull/11667 is merged to 2.3
- [x] and after 2.3 is merged back to master
