### PR TITLE
[DX][HttpFoundation] Allow to check multiple methods at once

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1404,12 +1404,22 @@ class Request
     /**
      * Checks if the request method is of specified type.
      *
-     * @param string $method Uppercase request method (GET, POST etc).
+     * @param string|string[] $method Uppercase request method (GET, POST etc).
      *
      * @return bool
      */
     public function isMethod($method)
     {
+        if (is_array($method)) {
+            foreach ($method as $m) {
+                if ($this->getMethod() === strtoupper($m)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         return $this->getMethod() === strtoupper($method);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1296,6 +1296,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($request->isMethod('get'));
         $this->assertFalse($request->isMethod('POST'));
         $this->assertFalse($request->isMethod('post'));
+
+        $request->setMethod('PATCH');
+        $this->assertTrue($request->isMethod(array('GET', 'post', 'PatCH')));
+        $this->assertTrue($request->isMethod(array('post', 'PATCH')));
+        $this->assertFalse($request->isMethod(array('GET', 'POST')));
+        $this->assertFalse($request->isMethod(array('GET')));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This code allows to replace calls like:

``` php
if (in_array($request->getMethod(), array('POST', 'PUT', 'PATCH'))) {
    // do something
}
```

With:

``` php
if ($request->isMethod(array('POST', 'PUT', 'PATCH'))) {
    // do something
}
```
