### PR TITLE
TimeType: possibility to modify time part of datetime

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -47,6 +47,17 @@ class TimeType extends AbstractType
             $parts[] = 'second';
         }
 
+        if (!$options['unspecified_to_origin']) {
+            $parts = [
+                'year',
+                'month',
+                'day',
+                'hour',
+                'minute',
+                'second',
+            ];
+        }
+
         if ('single_text' === $options['widget']) {
             $builder->addViewTransformer(new DateTimeToStringTransformer($options['model_timezone'], $options['view_timezone'], $format));
         } else {
@@ -202,6 +213,7 @@ class TimeType extends AbstractType
             // this option.
             'data_class'     => null,
             'compound'       => $compound,
+            'unspecified_to_origin' => true,
         ));
 
         $resolver->setNormalizers(array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -45,6 +45,24 @@ class TimeTypeTest extends TypeTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
+    public function testSubmitDateTimeWithUnspecifiedToOriginSetToFalse()
+    {
+        $form = $this->factory->create('time', new \DateTime('2000-01-01 20:00:20'), [
+            'unspecified_to_origin' => false,
+        ]);
+
+        $input = array(
+            'hour' => '3',
+            'minute' => '4'
+        );
+
+        $form->submit($input);
+
+        $dateTime = new \DateTime('2000-01-01 03:04:20');
+
+        $this->assertEquals($dateTime, $form->getData());
+    }
+
     public function testSubmitString()
     {
         $form = $this->factory->create('time', null, array(


### PR DESCRIPTION
Hi. I think it would be nice to allow users to modify just time part of datetime. (I recently needed this feature but couldn't find the way to do that with current types and their options).

This feature should break nothing.
