### PR TITLE
[Routing] fix handling of nullable XML attributes

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -215,7 +215,7 @@ class XmlFileLoader extends FileLoader
         foreach ($node->getElementsByTagNameNS(self::NAMESPACE_URI, '*') as $n) {
             switch ($n->localName) {
                 case 'default':
-                    if ($n->hasAttribute('xsi:nil') && 'true' == $n->getAttribute('xsi:nil')) {
+                    if ($this->isElementValueNull($n)) {
                         $defaults[$n->getAttribute('key')] = null;
                     } else {
                         $defaults[$n->getAttribute('key')] = trim($n->textContent);
@@ -234,5 +234,16 @@ class XmlFileLoader extends FileLoader
         }
 
         return array($defaults, $requirements, $options);
+    }
+
+    private function isElementValueNull(\DOMElement $element)
+    {
+        $namespaceUri = 'http://www.w3.org/2001/XMLSchema-instance';
+
+        if (!$element->hasAttributeNS($namespaceUri, 'nil')) {
+            return false;
+        }
+
+        return 'true' === $element->getAttributeNS($namespaceUri, 'nil') || '1' === $element->getAttributeNS($namespaceUri, 'nil');
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/null_values.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/null_values.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="blog_show" path="/blog/{slug}">
+        <default key="foo" xsi:nil="true" />
+        <default key="bar" xsi:nil="1" />
+        <default key="foobar" xsi:nil="false">foo</default>
+        <default key="baz" xsi:nil="0">bar</default>
+    </route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -124,4 +124,18 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
         $loader->load('withdoctype.xml');
     }
+
+    public function testNullValues()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $routeCollection = $loader->load('null_values.xml');
+        $route = $routeCollection->get('blog_show');
+
+        $this->assertTrue($route->hasDefault('foo'));
+        $this->assertNull($route->getDefault('foo'));
+        $this->assertTrue($route->hasDefault('bar'));
+        $this->assertNull($route->getDefault('bar'));
+        $this->assertEquals('foo', $route->getDefault('foobar'));
+        $this->assertEquals('bar', $route->getDefault('baz'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

As @Tobion pointed out in #11394, `true` and `1` are valid values in boolean XML attributes. The XmlFileLoader didn't handle `1` values properly.
