### PR TITLE
[Validator] DateRange class validator.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DateRange.php
+++ b/src/Symfony/Component/Validator/Constraints/DateRange.php
@@ -33,17 +33,19 @@ class DateRange extends Constraint
      */
     public $end;
 
-    public $startMessage = 'Start date should be less than or equal to {{ limit }}';
+    public $startMessage = 'Start date should be earlier than or equal to {{ limit }}';
 
-    public $endMessage = 'End date should be greater than or equal to {{ limit }}';
+    public $endMessage = 'End date should be later than or equal to {{ limit }}';
 
-    public $emptyStartMessage = 'Start date cannot be empty';
-
-    public $emptyEndMessage = 'End date cannot be empty';
+    public $invalidIntervalMessage = 'Dates must be {{ interval }} apart';
 
     public $invalidMessage = 'Invalid date range';
 
     public $limitFormat = 'Y-m-d';
+
+    public $min = null;
+
+    public $max = null;
 
     /**
      * @var string The property to attach the error message on.

--- a/src/Symfony/Component/Validator/Constraints/DateRange.php
+++ b/src/Symfony/Component/Validator/Constraints/DateRange.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class DateRange
+ *
+ * @Annotation
+ * @Target({"CLASS"})
+ *
+ * @author Bez Hermoso <bezalelhermoso@gmail.com>
+ */
+class DateRange extends Constraint
+{
+    /**
+     * @var string The property which contains the start date.
+     */
+    public $start;
+
+    /**
+     * @var string The property which contains the end date.
+     */
+    public $end;
+
+    public $startMessage = 'Start date should be less than or equal to {{ limit }}';
+
+    public $endMessage = 'End date should be greater than or equal to {{ limit }}';
+
+    public $emptyStartMessage = 'Start date cannot be empty';
+
+    public $emptyEndMessage = 'End date cannot be empty';
+
+    public $invalidMessage = 'Invalid date range';
+
+    public $limitFormat = 'Y-m-d';
+
+    /**
+     * @var string The property to attach the error message on.
+     */
+    public $errorPath = false;
+
+    public function getRequiredOptions()
+    {
+        return array(
+            'start',
+            'end',
+        );
+    }
+
+    public function getTargets()
+    {
+        return static::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/DateRangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateRangeValidator.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Class DateRange
+ *
+ * @Annotation
+ * @Target({"CLASS"})
+ *
+ * @author Bez Hermoso <bezalelhermoso@gmail.com>
+ */
+class DateRangeValidator extends ConstraintValidator
+{
+
+    /**
+     * Checks if the passed value is valid.
+     *
+     * @param mixed      $value      The value that should be validated
+     * @param Constraint $constraint The constraint for the validation
+     *
+     * @throws \Symfony\Component\Validator\Exception\UnexpectedTypeException
+     * @throws \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @api
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof DateRange) {
+            throw new UnexpectedTypeException($value, __NAMESPACE__ . '\\DateRange');
+        }
+
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        try {
+            $start = $accessor->getValue($value, $constraint->start);
+        } catch (NoSuchIndexException $e) {
+            throw new ConstraintDefinitionException(
+                sprintf(
+                    'The object "%s" does not have a "%s" property.',
+                    get_class($value),
+                    $constraint->start
+                )
+            );
+        }
+
+        try {
+            $end = $accessor->getValue($value, $constraint->end);
+        } catch (NoSuchIndexException $e) {
+            throw new ConstraintDefinitionException(
+                sprintf(
+                    'The object "%s" does not have a "%s" property.',
+                    get_class($value),
+                    $constraint->end
+                )
+            );
+        }
+
+        $validPropertyPaths = array($constraint->start, $constraint->end);
+
+        if ($constraint->errorPath && !in_array($constraint->errorPath, $validPropertyPaths)) {
+            throw new ConstraintDefinitionException(
+                sprintf(
+                    'Cannot set error message on "%s". Choose from: %s',
+                    $constraint->errorPath,
+                    json_encode($validPropertyPaths)
+                )
+            );
+        }
+
+        if (empty($start) || empty($end)) {
+            return;
+        }
+
+        $diff = $start->diff($end);
+
+        if ($diff->invert === 0) {
+            return;
+        }
+
+        if ($constraint->errorPath) {
+            $message =
+                $constraint->errorPath === $constraint->end ? $constraint->endMessage : $constraint->startMessage;
+            $limit =
+                $constraint->errorPath === $constraint->end ?
+                    $start->format($constraint->limitFormat) : $end->format($constraint->limitFormat);
+            $this
+                ->context
+                ->addViolationAt(
+                $constraint->errorPath,
+                    $message,
+                    array(
+                        '{{ limit }}' => $limit,
+                    ),
+                    null
+                );
+        } else {
+            $this->context
+                ->addViolation(
+                $constraint->invalidMessage,
+                    array(
+                        '{{ start }}' => $start->format($constraint->limitFormat),
+                        '{{ end }}' => $end->format($constraint->limitFormat),
+                    )
+                );
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Validation;
 
-abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
+abstract class  CollectionValidatorTest extends AbstractConstraintValidatorTest
 {
     protected function getApiVersion()
     {

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateRangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateRangeValidatorTest.php
@@ -129,7 +129,7 @@ class DateRangeValidatorTest extends AbstractConstraintValidatorTest
         $value = new TestEvent(new \DateTime(), new \DateTime('-1 day'));
         $this->validator->validate($value, $constraint);
         $this->assertViolation(
-             'Start date should be less than or equal to {{ limit }}',
+             'Start date should be earlier than or equal to {{ limit }}',
              array(
                  '{{ limit }}' => $value->getEndDate()->format('Y-m-d'),
              ),
@@ -148,12 +148,174 @@ class DateRangeValidatorTest extends AbstractConstraintValidatorTest
         $value = new TestEvent(new \DateTime(), new \DateTime('-1 day'));
         $this->validator->validate($value, $constraint);
         $this->assertViolation(
-             'End date should be greater than or equal to {{ limit }}',
+             'End date should be later than or equal to {{ limit }}',
              array(
                  '{{ limit }}' => $value->getStartDate()->format('Y-m-d'),
              ),
              'property.path.endDate',
              $value
+        );
+    }
+
+    /**
+     * @param $value
+     * @param $interval
+     *
+     * @dataProvider dateMinIntervalViolations
+     */
+    public function testMinIntervalViolations($value, $interval)
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+            'min' => $interval
+        ));
+        $this->validator->validate($value, $constraint);
+        $this->assertViolation(
+             'Dates must be {{ interval }} apart',
+             array(
+                 '{{ interval }}' => $interval,
+             ),
+             'property.path',
+             $value
+        );
+    }
+
+    public function dateMinIntervalViolations()
+    {
+        return array(
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+1 hour')),
+                '1 day',
+            ),
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+1 week')),
+                '1 month',
+            ),
+            array(
+                new TestEvent(new \DateTime('2014-02-01'), new \DateTime('2014-02-27')),
+                '1 month',
+            ),
+            array(
+                new TestEvent(new \DateTime('-30 seconds'), new \DateTime()),
+                '1 minute',
+            ),
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+1 month 2 days')),
+                '1 month + 10 days',
+            ),
+        );
+    }
+
+    /**
+     * @param $value
+     * @param $interval
+     *
+     * @dataProvider dateMinIntervalValid
+     */
+    public function testMinIntervalsValid($value, $interval)
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+            'min' => $interval
+        ));
+        $this->validator->validate($value, $constraint);
+        $this->assertNoViolation();
+    }
+
+    public function dateMinIntervalValid()
+    {
+        return array(
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+1 day')),
+                '1 day',
+            ),
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+1 week')),
+                '5 days',
+            ),
+            array(
+                new TestEvent(new \DateTime('2014-02-01'), new \DateTime('2014-03-01')),
+                '1 month',
+            ),
+        );
+    }
+
+    /**
+     * @param $value
+     * @param $interval
+     *
+     * @dataProvider dateMaxIntervalViolations
+     */
+    public function testMaxIntervalViolations($value, $interval)
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+            'max' => $interval
+        ));
+        $this->validator->validate($value, $constraint);
+        $this->assertViolation(
+             'Dates must be {{ interval }} apart',
+                 array(
+                     '{{ interval }}' => $interval,
+                 ),
+                 'property.path',
+                 $value
+        );
+    }
+
+    public function dateMaxIntervalViolations()
+    {
+        return array(
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+1 day 1 seconds')),
+                '1 day',
+            ),
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+1 year')),
+                '1 month',
+            ),
+            array(
+                new TestEvent(new \DateTime('2014-12-01'), new \DateTime('2015-01-02')),
+                '1 month',
+            ),
+        );
+    }
+
+    /**
+     * @param $value
+     * @param $interval
+     *
+     * @dataProvider dateMaxIntervalValid
+     */
+    public function testMaxIntervalsValid($value, $interval)
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+            'max' => $interval
+        ));
+        $this->validator->validate($value, $constraint);
+        $this->assertNoViolation();
+    }
+
+    public function dateMaxIntervalValid()
+    {
+        return array(
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+1 day')),
+                '1 day',
+            ),
+            array(
+                new TestEvent(new \DateTime(), new \DateTime('+3 days')),
+                '5 days',
+            ),
+            array(
+                new TestEvent(new \DateTime('2014-02-01'), new \DateTime('2014-03-01')),
+                '1 month',
+            ),
         );
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateRangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateRangeValidatorTest.php
@@ -12,7 +12,7 @@ class DateRangeValidatorTest extends AbstractConstraintValidatorTest
 
     protected function getApiVersion()
     {
-        return Validation::API_VERSION_2_4;
+        return Validation::API_VERSION_2_5;
     }
 
     protected function createValidator()
@@ -101,7 +101,9 @@ class DateRangeValidatorTest extends AbstractConstraintValidatorTest
              array(
                  '{{ start }}' => $value->getStartDate()->format('Y-m-d'),
                  '{{ end }}' => $value->getEndDate()->format('Y-m-d'),
-             )
+             ),
+             'property.path',
+             $value
         );
     }
 
@@ -132,7 +134,7 @@ class DateRangeValidatorTest extends AbstractConstraintValidatorTest
                  '{{ limit }}' => $value->getEndDate()->format('Y-m-d'),
              ),
              'property.path.startDate',
-             null
+             $value
         );
     }
 
@@ -151,7 +153,7 @@ class DateRangeValidatorTest extends AbstractConstraintValidatorTest
                  '{{ limit }}' => $value->getStartDate()->format('Y-m-d'),
              ),
              'property.path.endDate',
-             null
+             $value
         );
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateRangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateRangeValidatorTest.php
@@ -1,0 +1,181 @@
+<?php
+
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\DateRange;
+use Symfony\Component\Validator\Constraints\DateRangeValidator;
+use Symfony\Component\Validator\Validation;
+
+class DateRangeValidatorTest extends AbstractConstraintValidatorTest
+{
+
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_4;
+    }
+
+    protected function createValidator()
+    {
+        return new DateRangeValidator();
+    }
+
+    public function testBothBlank()
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+        ));
+        $this->validator->validate(new TestEvent(null, null), $constraint);
+        $this->assertNoViolation();
+    }
+
+    public function testStartBlank()
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+        ));
+        $this->validator->validate(new TestEvent(null, new \DateTime()), $constraint);
+        $this->assertNoViolation();
+    }
+
+    public function testEndBlank()
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+        ));
+        $this->validator->validate(new TestEvent(new \DateTime(), null), $constraint);
+        $this->assertNoViolation();
+    }
+
+    public function testEqual()
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+        ));
+        $this->validator->validate(new TestEvent(new \DateTime(), new \DateTime()), $constraint);
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider dataTestValid
+     */
+    public function testValid($value)
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+        ));
+        $this->validator->validate($value, $constraint);
+        $this->assertNoViolation();
+    }
+
+    public function dataTestValid()
+    {
+        return array(
+            array(
+                new TestEvent(new \DateTime('2014-01-01'), new \DateTime('2014-01-02')),
+            ),
+            array(
+                new TestEvent(new \DateTime('2014-01-01 00:00:00'), new \DateTime('2014-01-01 00:30:00')),
+            )
+        );
+    }
+
+    /**
+     * @param TestEvent $value
+     * @dataProvider dataTestInvalid
+     */
+    public function testInvalid($value)
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+        ));
+        $this->validator->validate($value, $constraint);
+        $this->assertViolation(
+             'Invalid date range',
+             array(
+                 '{{ start }}' => $value->getStartDate()->format('Y-m-d'),
+                 '{{ end }}' => $value->getEndDate()->format('Y-m-d'),
+             )
+        );
+    }
+
+    public function dataTestInvalid()
+    {
+        return array(
+            array(
+                new TestEvent(new \DateTime('2014-01-01'), new \DateTime('2013-12-31')),
+            ),
+            array(
+                new TestEvent(new \DateTime('2014-01-01 00:30:00'), new \DateTime('2014-01-01 00:00:00')),
+            )
+        );
+    }
+
+    public function testErrorPathOnStart()
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+            'errorPath' => 'startDate',
+        ));
+        $value = new TestEvent(new \DateTime(), new \DateTime('-1 day'));
+        $this->validator->validate($value, $constraint);
+        $this->assertViolation(
+             'Start date should be less than or equal to {{ limit }}',
+             array(
+                 '{{ limit }}' => $value->getEndDate()->format('Y-m-d'),
+             ),
+             'property.path.startDate',
+             null
+        );
+    }
+
+    public function testErrorPathOnEnd()
+    {
+        $constraint = new DateRange(array(
+            'start' => 'startDate',
+            'end' => 'endDate',
+            'errorPath' => 'endDate',
+        ));
+        $value = new TestEvent(new \DateTime(), new \DateTime('-1 day'));
+        $this->validator->validate($value, $constraint);
+        $this->assertViolation(
+             'End date should be greater than or equal to {{ limit }}',
+             array(
+                 '{{ limit }}' => $value->getStartDate()->format('Y-m-d'),
+             ),
+             'property.path.endDate',
+             null
+        );
+    }
+
+}
+
+class TestEvent
+{
+    protected $startDate;
+
+    protected $endDate;
+
+    public function __construct($startDate, $endDate)
+    {
+        $this->startDate = $startDate;
+        $this->endDate = $endDate;
+    }
+
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | _NA_ |
| License | MIT |
| Doc PR | (https://github.com/symfony/symfony-docs/pull/4123) |

A validator that checks two `DateTime` values in a class and validates that its a valid range (start date is lesser than/equal to end date)
- [x] 2.3 API
- [x] 2.5 API
- [x] Add `min` and `max` interval constraints
### Use-case

``` php

/**
 * @Assert\DateRange(start="startDate", end="endDate")
 */
class Event
{
      /**
       * @var DateTime
       */
      private $startDate;

      /**
       * @var DateTime
       */
      private $endDate;
}
```

This validator asserts that `startDate` and `endDate` must constitute to a valid date-range. This validator ignores if one of them is `null` (add `NotBlank`to the related fields if required)

**Enforce that dates are at least 1 month apart**:

``` php
/**
 * @Assert\DateRange(start="startDate", end="endDate", min="1 month")
 */
```

**Enforce that dates can only be 1 week apart or less**:

``` php
/**
 * @Assert\DateRange(start="startDate", end="endDate", max="1 week")
 */
```
