### PR TITLE
[DX] Removed strict alias name check

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -82,9 +82,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
                 $expectedAlias = Container::underscore($basename);
                 if ($expectedAlias != $extension->getAlias()) {
                     throw new \LogicException(sprintf(
-                        'The extension alias for the default extension of a '.
-                        'bundle must be the underscored version of the '.
-                        'bundle name ("%s" instead of "%s")',
+                        'Users will expect the alias of the default extension of a bundle to be the underscored version of the bundle name ("%s"). You can override "Bundle::getContainerExtension()" if you want to use "%s" or another alias.',
                         $expectedAlias, $extension->getAlias()
                     ));
                 }


### PR DESCRIPTION
Symfony allows to change the DI alias by overriding `Extension#getAlias()`, but it does throw an exception when it is anything else than the default. That doesn't sound nice and it makes it harder to change the alias. This can result in problems when the bundle is called WouterJEloquentBundle for instance (which has a default alias of `wouter_j_eloquent_bundle`, where I want it to be `wouterj_eloquent_bundle`).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
