### PR TITLE
Extend AbstractFactory for easy extending

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -176,7 +176,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
 
         $successHandlerId = $this->getSuccessHandlerId($id);
 
-        $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator('security.authentication.success_handler'));
+        $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator($this->getDefaultAuthenticationSuccessHandlerServiceId()));
         $successHandler->replaceArgument(1, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
         $successHandler->addMethodCall('setProviderKey', array($id));
 
@@ -189,12 +189,22 @@ abstract class AbstractFactory implements SecurityFactoryInterface
             return $config['failure_handler'];
         }
 
-        $id = $this->getFailureHandlerId($id);
+        $failureHandlerId = $this->getFailureHandlerId($id);
 
-        $failureHandler = $container->setDefinition($id, new DefinitionDecorator('security.authentication.failure_handler'));
+        $failureHandler = $container->setDefinition($failureHandlerId, new DefinitionDecorator($this->getDefaultAuthenticationFailureHandlerServiceId()));
         $failureHandler->replaceArgument(2, array_intersect_key($config, $this->defaultFailureHandlerOptions));
 
-        return $id;
+        return $failureHandlerId;
+    }
+    
+    protected function getDefaultAuthenticationFailureHandlerServiceId()
+    {
+        return 'security.authentication.failure_handler';   
+    }
+    
+    protected function getDefaultAuthenticationSuccessHandlerServiceId()
+    {
+        return 'security.authentication.success_handler';   
     }
 
     protected function getSuccessHandlerId($id)


### PR DESCRIPTION
by this way, it is possible to use the hole abstract class and just override the 4 last getter functions. it will this class more reuseable!
