### PR TITLE
[Security] Split of the SecurityContext

### DIFF
--- a/UPGRADE-2.6.md
+++ b/UPGRADE-2.6.md
@@ -77,3 +77,27 @@ Validator
    ```
    value == null or (YOUR_EXPRESSION)
    ```
+
+Security
+--------
+
+ * The `SecurityContextInterface` is marked as deprecated in favor of the 
+   `Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface` and 
+   `Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface`.
+   ```
+   isGranted  => AuthorizationCheckerInterface
+   getToken   => TokenStorageInterface
+   setToken   => TokenStorageInterface
+   ```
+   The Implementations have moved too, The `SecurityContext` is marked as 
+   deprecated and has been split to use the `AuthorizationCheckerInterface` 
+   and `TokenStorage`. This change is 100% Backwards Compatible as the SecurityContext 
+   delegates the methods.
+
+ * The service `security.context` is deprecated along with the above change. Recommended 
+   to use instead:
+   ```
+   @security.authorization_checker => isGranted()
+   @security.token_storage         => getToken()
+   @security.token_storage         => setToken()
+   ```

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Added `Controller::addFlash` helper
  * Added `Controller::isGranted` helper
  * Added `Controller::denyAccessUnlessGranted` helper
+ * Deprecated `app.security` in twig as `app.user` and `is_granted()` are already available
 
 2.5.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bundle\FrameworkBundle\Templating;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\Security\Core\SecurityContext;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\SecurityContext;
 
 /**
  * GlobalVariables is the entry point for Symfony global variables in Twig templates.
@@ -37,6 +37,7 @@ class GlobalVariables
     /**
      * Returns the security context service.
      *
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      * @return SecurityContext|null The security context
      */
     public function getSecurity()
@@ -55,11 +56,11 @@ class GlobalVariables
      */
     public function getUser()
     {
-        if (!$security = $this->getSecurity()) {
+        if (!$tokenStorage = $this->container->get('security.token_storage')) {
             return;
         }
 
-        if (!$token = $security->getToken()) {
+        if (!$token = $tokenStorage->getToken()) {
             return;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
+
+use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+class GlobalVariablesTest extends TestCase
+{
+    private $container;
+    private $globals;
+
+    public function setUp()
+    {
+        $this->container = new Container();
+        $this->globals = new GlobalVariables($this->container);
+    }
+
+    public function testGetSecurity()
+    {
+        $securityContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+
+        $this->assertNull($this->globals->getSecurity());
+        $this->container->set('security.context', $securityContext);
+        $this->assertSame($securityContext, $this->globals->getSecurity());
+    }
+
+    public function testGetUser()
+    {
+        // missing test cases to return null, only happy flow tested
+        $securityContext = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+
+        $this->container->set('security.token_storage', $securityContext);
+
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->will($this->returnValue($user));
+
+        $securityContext
+            ->expects($this->once())
+            ->method('getToken')
+            ->will($this->returnValue($token));
+
+        $this->assertSame($user, $this->globals->getUser());
+    }
+
+    public function testGetRequest()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testGetSession()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testGetEnvironment()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testGetDubug()
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * Deprecated the `security.context` service for the `security.token_storage` and 
+   `security.authorization_checker` services.
+
 2.4.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -6,6 +6,8 @@
 
     <parameters>
         <parameter key="security.context.class">Symfony\Component\Security\Core\SecurityContext</parameter>
+        <parameter key="security.authorization_checker.class">Symfony\Component\Security\Core\Authorization\AuthorizationChecker</parameter>
+        <parameter key="security.token_storage.class">Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage</parameter>
 
         <parameter key="security.user_checker.class">Symfony\Component\Security\Core\User\UserChecker</parameter>
 
@@ -54,10 +56,18 @@
 
     <services>
         <service id="security.context" class="%security.context.class%">
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.authorization_checker" />
+        </service>
+
+        <service id="security.authorization_checker" class="%security.authorization_checker.class%">
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="security.access.decision_manager" />
             <argument>%security.access.always_authenticate_before_granting%</argument>
         </service>
+
+        <service id="security.token_storage" class="%security.token_storage.class%" />
 
         <!-- Authentication related services -->
         <service id="security.authentication.manager" class="%security.authentication.manager.class%" public="false">

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added Symfony\Component\Security\Http\Authentication\AuthenticationUtils
+ * Deprecated the `SecurityContext` class in favor of the `AuthorizationChecker` and `TokenStorage` classes
 
 2.4.0
 -----

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token\Storage;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * TokenStorage contains a TokenInterface
+ *
+ * It gives access to the token representing the current user authentication.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class TokenStorage implements TokenStorageInterface
+{
+    private $token;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setToken(TokenInterface $token = null)
+    {
+        $this->token = $token;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorageInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorageInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token\Storage;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * The TokenStorageInterface.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface TokenStorageInterface
+{
+    /**
+     * Returns the current security token.
+     *
+     * @return TokenInterface|null A TokenInterface instance or null if no authentication information is available
+     */
+    public function getToken();
+
+    /**
+     * Sets the authentication token.
+     *
+     * @param TokenInterface $token A TokenInterface token, or null if no further authentication information should be stored
+     */
+    public function setToken(TokenInterface $token = null);
+}

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+
+/**
+ * AuthorizationChecker is the main authorization point of the Security component.
+ *
+ * It gives access to the token representing the current user authentication.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class AuthorizationChecker implements AuthorizationCheckerInterface
+{
+    private $tokenStorage;
+    private $accessDecisionManager;
+    private $authenticationManager;
+    private $alwaysAuthenticate;
+
+    /**
+     * Constructor.
+     *
+     * @param TokenStorageInterface          $tokenStorage
+     * @param AuthenticationManagerInterface $authenticationManager An AuthenticationManager instance
+     * @param AccessDecisionManagerInterface $accessDecisionManager An AccessDecisionManager instance
+     * @param bool                           $alwaysAuthenticate
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager, $alwaysAuthenticate = false)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->authenticationManager = $authenticationManager;
+        $this->accessDecisionManager = $accessDecisionManager;
+        $this->alwaysAuthenticate = $alwaysAuthenticate;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws AuthenticationCredentialsNotFoundException when the token storage has no authentication token.
+     */
+    final public function isGranted($attributes, $object = null)
+    {
+        if (null === ($token = $this->tokenStorage->getToken())) {
+            throw new AuthenticationCredentialsNotFoundException('The token storage contains no authentication token. One possible reason may be that there is no firewall configured for this URL.');
+        }
+
+        if ($this->alwaysAuthenticate || !$token->isAuthenticated()) {
+            $this->tokenStorage->setToken($token = $this->authenticationManager->authenticate($token));
+        }
+
+        if (!is_array($attributes)) {
+            $attributes = array($attributes);
+        }
+
+        return $this->accessDecisionManager->decide($token, $attributes, $object);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+/**
+ * The AuthorizationCheckerInterface.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface AuthorizationCheckerInterface
+{
+    /**
+     * Checks if the attributes are granted against the current authentication token and optionally supplied object.
+     *
+     * @param mixed $attributes
+     * @param mixed $object
+     *
+     * @return bool
+     */
+    public function isGranted($attributes, $object = null);
+}

--- a/src/Symfony/Component/Security/Core/SecurityContextInterface.php
+++ b/src/Symfony/Component/Security/Core/SecurityContextInterface.php
@@ -11,40 +11,15 @@
 
 namespace Symfony\Component\Security\Core;
 
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * The SecurityContextInterface.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @deprecated Deprecated since version 2.6, to be removed in 3.0.
  */
-interface SecurityContextInterface
+interface SecurityContextInterface extends TokenStorageInterface, AuthorizationCheckerInterface, SecuritySessionStorageInterface
 {
-    const ACCESS_DENIED_ERROR  = '_security.403_error';
-    const AUTHENTICATION_ERROR = '_security.last_error';
-    const LAST_USERNAME        = '_security.last_username';
-
-    /**
-     * Returns the current security token.
-     *
-     * @return TokenInterface|null A TokenInterface instance or null if no authentication information is available
-     */
-    public function getToken();
-
-    /**
-     * Sets the authentication token.
-     *
-     * @param TokenInterface $token A TokenInterface token, or null if no further authentication information should be stored
-     */
-    public function setToken(TokenInterface $token = null);
-
-    /**
-     * Checks if the attributes are granted against the current authentication token and optionally supplied object.
-     *
-     * @param mixed $attributes
-     * @param mixed $object
-     *
-     * @return bool
-     */
-    public function isGranted($attributes, $object = null);
 }

--- a/src/Symfony/Component/Security/Core/SecuritySessionStorageInterface.php
+++ b/src/Symfony/Component/Security/Core/SecuritySessionStorageInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core;
+
+/**
+ * The SecuritySessionStorageInterface.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface SecuritySessionStorageInterface
+{
+    const ACCESS_DENIED_ERROR  = '_security.403_error';
+    const AUTHENTICATION_ERROR = '_security.last_error';
+    const LAST_USERNAME        = '_security.last_username';
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/TokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/TokenStorageTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authentication\Token\Storage;
+
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+
+class TokenStorageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSetToken()
+    {
+        $tokenStorage = new TokenStorage();
+        $this->assertNull($tokenStorage->getToken());
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $tokenStorage->setToken($token);
+        $this->assertSame($token, $tokenStorage->getToken());
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authorization;
+
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
+
+class AuthorizationCheckerTest extends \PHPUnit_Framework_TestCase
+{
+    private $authenticationManager;
+    private $accessDecisionManager;
+    private $authorizationChecker;
+    private $tokenStorage;
+
+    public function setUp()
+    {
+        $this->authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
+        $this->accessDecisionManager = $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface');
+        $this->tokenStorage = new TokenStorage();
+
+        $this->authorizationChecker = new AuthorizationChecker(
+            $this->tokenStorage,
+            $this->authenticationManager,
+            $this->accessDecisionManager
+        );
+    }
+
+    public function testVoteAuthenticatesTokenIfNecessary()
+    {
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $this->tokenStorage->setToken($token);
+
+        $newToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+
+        $this->authenticationManager
+            ->expects($this->once())
+            ->method('authenticate')
+            ->with($this->equalTo($token))
+            ->will($this->returnValue($newToken));
+
+        // default with() isn't a strict check
+        $tokenComparison = function ($value) use ($newToken) {
+            // make sure that the new token is used in "decide()" and not the old one
+            return $value === $newToken;
+        };
+
+        $this->accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($this->callback($tokenComparison))
+            ->will($this->returnValue(true));
+
+        // first run the token has not been re-authenticated yet, after isGranted is called, it should be equal
+        $this->assertFalse($newToken === $this->tokenStorage->getToken());
+        $this->assertTrue($this->authorizationChecker->isGranted('foo'));
+        $this->assertTrue($newToken === $this->tokenStorage->getToken());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
+     */
+    public function testVoteWithoutAuthenticationToken()
+    {
+        $this->authorizationChecker->isGranted('ROLE_FOO');
+    }
+
+    /**
+     * @dataProvider isGrantedProvider
+     */
+    public function testIsGranted($decide)
+    {
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token
+            ->expects($this->once())
+            ->method('isAuthenticated')
+            ->will($this->returnValue(true));
+
+        $this->accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->will($this->returnValue($decide));
+        $this->tokenStorage->setToken($token);
+        $this->assertTrue($decide === $this->authorizationChecker->isGranted('ROLE_FOO'));
+    }
+
+    public function isGrantedProvider()
+    {
+        return array(array(true), array(false));
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
@@ -27,8 +28,8 @@ class ContextListenerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->securityContext = new SecurityContext(
-            $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface'),
-            $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')
+            new TokenStorage(),
+            $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')
         );
     }
 


### PR DESCRIPTION
~~_As a reminder, this PR is not ready to be merged. It's merely a proof of concept in which I'm trying to fix a circular dependency with the SecurityContext and the entity manager for Symfony 2.6 and/or 3.0_~~
# PR Info

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/4188 |
# TODO List
- [x] Split tests for SecurityContext/AuthorizationChecker/TokenStorage
- [x] Fix tests for security usages (only the component has been successfully tested at this point)
- [x] Submit changes to the documentation
- [x] Document the BC breaks
# Main Problem for my use case

I've build a bunch of event listeners on `doctrine.event_manager`. They include a Blamable, Revision and Mutation annotation on entities. It works by creating a custom event listener on preFlush which then throws an entityChanged event (also a doctrine hooked up event).

To make it configurable and flexible, we have written a provider for Blamable to provide the username/user-id and a date time (updated-by, updated-at). In order to get that information, we need to look into the SecurityContext to get the current user and ask the user id (custom user implementation). 

However, injecting the SecurityContext - or services depending on the SecurityContext - creates a circular reference and causes the container to blurt out an Exception. This is because the SecurityContext uses a UserProvider (indirectly) which has a dependency on doctrine (em, connection). Because it needs doctrine, it's impossible for my listener to inject the SecurityContext as it becomes this:
- SecurityContext requires AuthenticationProvider
- (Simple)AuthenticationProvider requires UserProvider
- UserProvider requires EntityManager
- EntityManager requires _insert connection name here_ 
- My custom Listener calls addEvent (or something similar) in doctrine which causes a dependency from the EM/Connection to my Listener
- My Listener requires SecurityContext... which finishes the circle.

I've googled for this problem and it wasn't hard to find similar issues, it seems to be a quite common issue regarding the SecurityContext and the EntityManager
- http://stackoverflow.com/questions/7561013/injecting-securitycontext-into-a-listener-prepersist-or-preupdate-in-symfony2-to
- http://stackoverflow.com/questions/8708822/circular-reference-when-injecting-security-context-into-entity-listener-class
- http://stackoverflow.com/questions/17020733/how-to-get-userid-from-eventlistener-which-are-called-from-ajax
- You can find more simply by googling.

The main solution seems to be to lazy load using an additional bundle or as recommended in the above topics, inject the container. Neither of them is really a solution I'm happy with. I don't want my code to know about the Container(Interface), nor do I want to use a another bundle just to get around an issue that a lot of people seem to have with the SecurityContext and EntityManager.
# Possible Solutions

I've been thinking about several solutions:
- I could write a service that listens to `kernel.request` and when possible injects the username/user-id into my provider which then can provide it to my listener
- I could use the Container directly
- I can use a lazy service with `symfony/proxy-manager-bridge` 
- I can store the user-id in my request

However, those solutions are just not it for me. Depending on an event like `kernel.request` is a bad practice in my opinion, I shouldn't depend on what listeners might be registered. Using the container directly inverses the dependency which is also wrong in my opinion. Using a lazy service will only work around the problem and storing the user-id in my request means I might not always have it (say commands).

Long story short, not what I'm looking for.
# Splitting the SecurityContext

So, I ended up at the SecurityContext. Digging back to the real problem, I started asking myself the following questions: why do I have that dependency? Why do I need to have the EntityManager when the only thing I want, is the currently logged in User object? (which is not related to a database). I came to the conclusion that the SecurityContext gives me too many dependencies in order to retrieve a simple Token/User object, which is not really what I want. Most of the times I need the SecurityContext to get the token/user and not for isGranted. Personally I use `@Security` and `access_control` for that.

I came to the conclusion that storing the Token within the SecurityContext wasn't what I found useful due to the dependencies of the SecurityContext. I figured I'd want a storage class with a dependency on the SessionInterface which could autonomously retrieve and store the TokenInterface (`@session` in this case). It would also be handling the storage within the session using get/setToken.

I have proposed this change and had a small discussion with @WouterJ on IRC about my proposal to take out the Token (can be read here http://pastebin.com/8kSvVZtj). Based on his feedback, I have split the isGranted to the AuthorizationChecker(Interface), which now has those dependencies. I have also moved the set/getToken to a TokenStorage.

tldr; 
- The getToken en setToken are moved to the TokenStorage(Interface). 
- ~~If this idea is feasible, I will also try to get the SecurityContext to actually store and retrieve it from the session instead of `ContextListener::onKernelResponse`. This will just do `$context->setToken($token);` which will handle this storage itself.~~ I still chase this idea but I will create a new PR for this in the future if I find time.
- isGranted is moved to AuthorizationChecker(Interface) so that you don't have a bunch of dependencies you don't need when retrieving the Token/User.
# Draft

~~This PR is just a draft. I'm looking for feedback if this proposal is A) desired and B) in-line with the developer's ideas regarding the SecurityContext.~~
# Changed Components/bundles

[FrameworkBundle] Updated GlobalVariables, added test for GlobalVariables
[SecurityBundle] Updated service definitions
[Security Component] Deprecated SecurityContext(Interface), added AuthorizationChecker(Interface) and TokenStorage(Interface)
