### PR TITLE
[DomCrawler] check for the correct field type

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DomCrawler;
 
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
 use Symfony\Component\DomCrawler\Field\FormField;
 
 /**
@@ -444,7 +445,9 @@ class Form extends Link implements \ArrayAccess
         if ('select' == $nodeName || 'input' == $nodeName && 'checkbox' == strtolower($node->getAttribute('type'))) {
             $this->set(new Field\ChoiceFormField($node));
         } elseif ('input' == $nodeName && 'radio' == strtolower($node->getAttribute('type'))) {
-            if ($this->has($node->getAttribute('name'))) {
+            // there may be other fields with the same name that are no choice
+            // fields already registered (see https://github.com/symfony/symfony/issues/11689)
+            if ($this->has($node->getAttribute('name')) && $this->get($node->getAttribute('name')) instanceof ChoiceFormField) {
                 $this->get($node->getAttribute('name'))->addChoice($node);
             } else {
                 $this->set(new Field\ChoiceFormField($node));

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -782,6 +782,28 @@ class FormTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testDifferentFieldTypesWithSameName()
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML('
+            <html>
+                <body>
+                    <form action="/">
+                        <input type="hidden" name="option" value="default">
+                        <input type="radio" name="option" value="A">
+                        <input type="radio" name="option" value="B">
+                        <input type="hidden" name="settings[1]" value="0">
+                        <input type="checkbox" name="settings[1]" value="1" id="setting-1">
+                        <button>klickme</button>
+                    </form>
+                </body>
+            </html>
+        ');
+        $form = new Form($dom->getElementsByTagName('form')->item(0), 'http://example.com');
+
+        $this->assertInstanceOf('Symfony\Component\DomCrawler\Field\ChoiceFormField', $form->get('option'));
+    }
+
     protected function getFormFieldMock($name, $value = null)
     {
         $field = $this


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11689 |
| License | MIT |
| Doc PR |  |

HTML allow to define different form fields with the same name. Imagine the following form:

``` html
    <html>
        <body>
            <form action="/">
                <input type="hidden" name="option" value="default">
                <input type="radio" name="option" value="A">
                <input type="radio" name="option" value="B">
                <input type="hidden" name="settings[1]" value="0">
                <input type="checkbox" name="settings[1]" value="1" id="setting-1">
                <button>klickme</button>
            </form>
        </body>
    </html>
```

Since the `FormFieldRegistry` can only handle one field per name, the hidden field option is registered first before the radio field with the same name is evaluated. Thus, the `FormFieldRegistry` returns an `InputFormField` instance on which the `addChoices()` method can not be called.
