### PR TITLE
[Validators] Fixed failing tests requiring ICU 52.1 which are skipped otherwise

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -82,7 +82,7 @@ class CountryValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($country, $constraint);
 
         $this->assertViolation('myMessage', array(
-            '{{ value }}' => $country,
+            '{{ value }}' => '"'.$country.'"',
         ));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -96,7 +96,7 @@ class CurrencyValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($currency, $constraint);
 
         $this->assertViolation('myMessage', array(
-            '{{ value }}' => $currency,
+            '{{ value }}' => '"'.$currency.'"',
         ));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Language;
 use Symfony\Component\Validator\Constraints\LanguageValidator;
-use Symfony\Component\Validator\Validation;
 
 class LanguageValidatorTest extends AbstractConstraintValidatorTest
 {
@@ -83,7 +82,7 @@ class LanguageValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($language, $constraint);
 
         $this->assertViolation('myMessage', array(
-            '{{ value }}' => $language,
+            '{{ value }}' => '"'.$language.'"',
         ));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Locale;
 use Symfony\Component\Validator\Constraints\LocaleValidator;
-use Symfony\Component\Validator\Validation;
 
 class LocaleValidatorTest extends AbstractConstraintValidatorTest
 {
@@ -85,7 +84,7 @@ class LocaleValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($locale, $constraint);
 
         $this->assertViolation('myMessage', array(
-            '{{ value }}' => $locale,
+            '{{ value }}' => '"'.$locale.'"',
         ));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I just ran the tests with ICU 52.1 installed and noticed that a few of them failed. This PR fixes these tests.
