### PR TITLE
[Form] Fix #11694 - Enforce options value type check in some form types

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
@@ -24,6 +24,10 @@ class BirthdayType extends AbstractType
         $resolver->setDefaults(array(
             'years' => range(date('Y') - 120, date('Y')),
         ));
+
+        $resolver->setAllowedTypes(array(
+            'years' => 'array',
+        ));
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -237,6 +237,9 @@ class DateType extends AbstractType
 
         $resolver->setAllowedTypes(array(
             'format' => array('int', 'string'),
+            'years'  => 'array',
+            'months' => 'array',
+            'days'   => 'array',
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -55,6 +55,12 @@ class RepeatedType extends AbstractType
             'second_name'    => 'second',
             'error_bubbling' => false,
         ));
+
+        $resolver->setAllowedTypes(array(
+            'options'        => 'array',
+            'first_options'  => 'array',
+            'second_options' => 'array',
+        ));
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -221,6 +221,12 @@ class TimeType extends AbstractType
                 'choice',
             ),
         ));
+
+        $resolver->setAllowedTypes(array(
+            'hours'   => 'array',
+            'minutes' => 'array',
+            'seconds' => 'array',
+        ));
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -34,6 +34,10 @@ class UrlType extends AbstractType
         $resolver->setDefaults(array(
             'default_protocol' => 'http',
         ));
+
+        $resolver->setAllowedTypes(array(
+            'default_protocol' => array('null', 'string'),
+        ));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+/**
+ * @author Stepan Anchugov <kixxx1@gmail.com>
+ */
+class BirthdayTypeTest extends BaseTypeTest
+{
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidYearsOption()
+    {
+        $this->factory->create('birthday', null, array(
+            'years' => 'bad value',
+        ));
+    }
+
+    protected function getTestedType()
+    {
+        return 'birthday';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -340,6 +340,36 @@ class DateTypeTest extends TypeTestCase
         ));
     }
 
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testThrowExceptionIfYearsIsInvalid()
+    {
+        $this->factory->create('date', null, array(
+            'years' => 'bad value',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testThrowExceptionIfMonthsIsInvalid()
+    {
+        $this->factory->create('date', null, array(
+            'months' => 'bad value',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testThrowExceptionIfDaysIsInvalid()
+    {
+        $this->factory->create('date', null, array(
+            'days' => 'bad value',
+        ));
+    }
+
     public function testSetDataWithDifferentTimezones()
     {
         $form = $this->factory->create('date', null, array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -72,6 +72,39 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertFalse($form['second']->isRequired());
     }
 
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidOptions()
+    {
+        $this->factory->create('repeated', null, array(
+            'type'    => 'text',
+            'options' => 'bad value',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidFirstOptions()
+    {
+        $this->factory->create('repeated', null, array(
+            'type'          => 'text',
+            'first_options' => 'bad value',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidSecondOptions()
+    {
+        $this->factory->create('repeated', null, array(
+            'type'           => 'text',
+            'second_options' => 'bad value',
+        ));
+    }
+
     public function testSetErrorBubblingToTrue()
     {
         $form = $this->factory->create('repeated', null, array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -673,4 +673,34 @@ class TimeTypeTest extends TypeTestCase
             'with_seconds' => true,
         ));
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testThrowExceptionIfHoursIsInvalid()
+    {
+        $this->factory->create('time', null, array(
+            'hours' => 'bad value',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testThrowExceptionIfMinutesIsInvalid()
+    {
+        $this->factory->create('time', null, array(
+            'minutes' => 'bad value',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testThrowExceptionIfSecondsIsInvalid()
+    {
+        $this->factory->create('time', null, array(
+            'seconds' => 'bad value',
+        ));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -70,4 +70,14 @@ class UrlTypeTest extends TypeTestCase
         $this->assertSame('www.domain.com', $form->getData());
         $this->assertSame('www.domain.com', $form->getViewData());
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testThrowExceptionIfDefaultProtocolIsInvalid()
+    {
+        $this->factory->create('url', null, array(
+            'default_protocol' => array(),
+        ));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11694 |
| License | MIT |
| Doc PR | none |

`Symfony\Component\Form\Extension\Core\Type\RepeatedType` allowed passing strings as options, which caused problems as in #11694. 
