### PR TITLE
[YAML] Added fixture to test parsing of hash keys ending with a space and #

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
@@ -63,3 +63,11 @@ brief: >
 yaml: 'foo#bar: baz'
 php: |
     array('foo#bar' => 'baz')
+---
+test: 'Hash key ending with a space and a #'
+brief: >
+    'Hash key ending with a space and a #'
+yaml: |
+    'foo #': baz
+php: |
+    array('foo #' => 'baz')


### PR DESCRIPTION
I encountered a bug in the YAML parser when the following YAML is used:

``` yaml
'ticket #': 'ticket nummer'
```

If I read the specs correctly, using the number sign inside a string is fully acceptable.

This PR adds a fixture that detects this anomaly, no fix however.
