### PR TITLE
[Validator] deprecate member metadata accessors

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -15,8 +15,10 @@ use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
-use Symfony\Component\Validator\MetadataFactoryInterface;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
+use Symfony\Component\Validator\Mapping\GenericMetadata;
+use Symfony\Component\Validator\MetadataFactoryInterface;
 
 class ValidatorTypeGuesser implements FormTypeGuesserInterface
 {
@@ -264,10 +266,14 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
         $guesses = array();
         $classMetadata = $this->metadataFactory->getMetadataFor($class);
 
-        if ($classMetadata->hasMemberMetadatas($property)) {
-            $memberMetadatas = $classMetadata->getMemberMetadatas($property);
+        if ($classMetadata instanceof ClassMetadataInterface && $classMetadata->hasPropertyMetadata($property)) {
+            $memberMetadatas = $classMetadata->getPropertyMetadata($property);
 
             foreach ($memberMetadatas as $memberMetadata) {
+                if (!$memberMetadata instanceof GenericMetadata) {
+                    continue;
+                }
+
                 $constraints = $memberMetadata->getConstraints();
 
                 foreach ($constraints as $constraint) {

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -17,7 +17,6 @@ use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
-use Symfony\Component\Validator\Mapping\GenericMetadata;
 use Symfony\Component\Validator\MetadataFactoryInterface;
 
 class ValidatorTypeGuesser implements FormTypeGuesserInterface
@@ -270,10 +269,6 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             $memberMetadatas = $classMetadata->getPropertyMetadata($property);
 
             foreach ($memberMetadatas as $memberMetadata) {
-                if (!$memberMetadata instanceof GenericMetadata) {
-                    continue;
-                }
-
                 $constraints = $memberMetadata->getConstraints();
 
                 foreach ($constraints as $constraint) {

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -23,7 +23,7 @@
         "symfony/property-access": "~2.3"
     },
     "require-dev": {
-        "symfony/validator": "~2.2",
+        "symfony/validator": "~2.3",
         "symfony/http-foundation": "~2.2",
         "symfony/http-kernel": "~2.4",
         "symfony/security-csrf": "~2.4",

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * deprecated `ClassMetadata::hasMemberMetadatas()`
  * deprecated `ClassMetadata::getMemberMetadatas()`
  * deprecated `ClassMetadata::addMemberMetadata()`
+ * [BC BREAK] added `Mapping\MetadataInterface::getConstraints()`
 
 2.5.0
 -----

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
  * [BC BREAK] `UserPasswordValidator` source message change
  * [BC BREAK] added internal `ExecutionContextInterface::setConstraint()`
  * added `ConstraintViolation::getConstraint()`
+ * deprecated `ClassMetadata::hasMemberMetadatas()`
+ * deprecated `ClassMetadata::getMemberMetadatas()`
+ * deprecated `ClassMetadata::addMemberMetadata()`
 
 2.5.0
 -----

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -89,7 +89,7 @@ class ExecutionContext implements ExecutionContextInterface
     /**
      * The current validation metadata.
      *
-     * @var MetadataInterface
+     * @var MetadataInterface|null
      */
     private $metadata;
 

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -160,7 +160,7 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
             $pathPrefix = empty($propertyPath) ? '' : $propertyPath.'.';
 
             foreach ($this->getConstrainedProperties() as $property) {
-                foreach ($this->getMemberMetadatas($property) as $member) {
+                foreach ($this->getPropertyMetadata($property) as $member) {
                     $member->accept($visitor, $member->getPropertyValue($value), $group, $pathPrefix.$property, $propagatedGroup);
                 }
             }
@@ -268,7 +268,7 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
         if (!isset($this->properties[$property])) {
             $this->properties[$property] = new PropertyMetadata($this->getClassName(), $property);
 
-            $this->addMemberMetadata($this->properties[$property]);
+            $this->addPropertyMetadata($this->properties[$property]);
         }
 
         $constraint->addImplicitGroupName($this->getDefaultGroup());
@@ -294,7 +294,7 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
         if (!isset($this->getters[$property])) {
             $this->getters[$property] = new GetterMetadata($this->getClassName(), $property);
 
-            $this->addMemberMetadata($this->getters[$property]);
+            $this->addPropertyMetadata($this->getters[$property]);
         }
 
         $constraint->addImplicitGroupName($this->getDefaultGroup());
@@ -316,16 +316,18 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
         }
 
         foreach ($source->getConstrainedProperties() as $property) {
-            foreach ($source->getMemberMetadatas($property) as $member) {
+            foreach ($source->getPropertyMetadata($property) as $member) {
                 $member = clone $member;
 
-                foreach ($member->getConstraints() as $constraint) {
-                    $constraint->addImplicitGroupName($this->getDefaultGroup());
+                if ($member instanceof GenericMetadata) {
+                    foreach ($member->getConstraints() as $constraint) {
+                        $constraint->addImplicitGroupName($this->getDefaultGroup());
+                    }
                 }
 
-                $this->addMemberMetadata($member);
+                $this->addPropertyMetadata($member);
 
-                if (!$member->isPrivate($this->name)) {
+                if ($member instanceof MemberMetadata && !$member->isPrivate($this->name)) {
                     $property = $member->getPropertyName();
 
                     if ($member instanceof PropertyMetadata && !isset($this->properties[$property])) {
@@ -342,12 +344,12 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
      * Adds a member metadata.
      *
      * @param MemberMetadata $metadata
+     *
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     protected function addMemberMetadata(MemberMetadata $metadata)
     {
-        $property = $metadata->getPropertyName();
-
-        $this->members[$property][] = $metadata;
+        $this->addPropertyMetadata($metadata);
     }
 
     /**
@@ -356,10 +358,12 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
      * @param string $property The name of the property
      *
      * @return bool
+     *
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0. Use {@link hasPropertyMetadata} instead.
      */
     public function hasMemberMetadatas($property)
     {
-        return array_key_exists($property, $this->members);
+        return $this->hasPropertyMetadata($property);
     }
 
     /**
@@ -368,14 +372,12 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
      * @param string $property The name of the property
      *
      * @return MemberMetadata[] An array of MemberMetadata
+     *
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0. Use {@link getPropertyMetadata} instead.
      */
     public function getMemberMetadatas($property)
     {
-        if (!isset($this->members[$property])) {
-            return array();
-        }
-
-        return $this->members[$property];
+        return $this->getPropertyMetadata($property);
     }
 
     /**
@@ -504,5 +506,17 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
     public function getCascadingStrategy()
     {
         return CascadingStrategy::NONE;
+    }
+
+    /**
+     * Adds a property metadata.
+     *
+     * @param PropertyMetadataInterface $metadata
+     */
+    private function addPropertyMetadata(PropertyMetadataInterface $metadata)
+    {
+        $property = $metadata->getPropertyName();
+
+        $this->members[$property][] = $metadata;
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -319,10 +319,8 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
             foreach ($source->getPropertyMetadata($property) as $member) {
                 $member = clone $member;
 
-                if ($member instanceof GenericMetadata) {
-                    foreach ($member->getConstraints() as $constraint) {
-                        $constraint->addImplicitGroupName($this->getDefaultGroup());
-                    }
+                foreach ($member->getConstraints() as $constraint) {
+                    $constraint->addImplicitGroupName($this->getDefaultGroup());
                 }
 
                 $this->addPropertyMetadata($member);

--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -74,7 +74,7 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
     }
 
     /**
-     * Returns the metadata for the given class name or object.
+     * {@inheritdoc}
      *
      * If the method was called with the same class name (or an object of that
      * class) before, the same metadata instance is returned.
@@ -87,12 +87,6 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
      * configured with a loader, the metadata is passed to the
      * {@link LoaderInterface::loadClassMetadata()} method for further
      * configuration. At last, the new object is returned.
-     *
-     * @param string|object $value A class name or an object
-     *
-     * @return MetadataInterface The metadata for the value
-     *
-     * @throws NoSuchMetadataException If no metadata exists for the given value
      */
     public function getMetadataFor($value)
     {
@@ -141,12 +135,7 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
     }
 
     /**
-     * Returns whether the factory is able to return metadata for the given
-     * class name or object.
-     *
-     * @param string|object $value A class name or an object
-     *
-     * @return bool    Whether metadata can be returned for that class
+     * {@inheritdoc}
      */
     public function hasMetadataFor($value)
     {

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -180,9 +180,7 @@ class GenericMetadata implements MetadataInterface
     }
 
     /**
-     * Returns all constraints of this element.
-     *
-     * @return Constraint[] A list of Constraint instances
+     * {@inheritdoc}
      */
     public function getConstraints()
     {
@@ -200,12 +198,9 @@ class GenericMetadata implements MetadataInterface
     }
 
     /**
-     * Returns the constraints of the given group and global ones (* group).
+     * {@inheritdoc}
      *
-     * @param string $group The group name
-     *
-     * @return Constraint[] An list of all the Constraint instances belonging
-     *                      to the group
+     * Aware of the global group (* group).
      */
     public function findConstraints($group)
     {

--- a/src/Symfony/Component/Validator/Mapping/MetadataInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/MetadataInterface.php
@@ -48,4 +48,11 @@ interface MetadataInterface extends LegacyMetadataInterface
      * @see TraversalStrategy
      */
     public function getTraversalStrategy();
+
+    /**
+     * Returns all constraints of this element.
+     *
+     * @return Constraint[] A list of Constraint instances
+     */
+    public function getConstraints();
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FakeClassMetadata.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FakeClassMetadata.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class FakeClassMetadata extends ClassMetadata
 {
-    public function addPropertyMetadata($propertyName, $metadata)
+    public function addCustomPropertyMetadata($propertyName, $metadata)
     {
         if (!isset($this->members[$propertyName])) {
             $this->members[$propertyName] = array();

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -101,7 +101,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
             ))),
         );
 
-        $members = $this->metadata->getMemberMetadatas('firstName');
+        $members = $this->metadata->getPropertyMetadata('firstName');
 
         $this->assertCount(1, $members);
         $this->assertEquals(self::PARENTCLASS, $members[0]->getClassName());
@@ -112,8 +112,8 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $this->metadata->addPropertyConstraint('firstName', new ConstraintA());
 
-        $this->assertTrue($this->metadata->hasMemberMetadatas('firstName'));
-        $this->assertFalse($this->metadata->hasMemberMetadatas('non_existant_field'));
+        $this->assertTrue($this->metadata->hasPropertyMetadata('firstName'));
+        $this->assertFalse($this->metadata->hasPropertyMetadata('non_existant_field'));
     }
 
     public function testMergeConstraintsKeepsPrivateMembersSeparate()
@@ -138,7 +138,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
             ))),
         );
 
-        $members = $this->metadata->getMemberMetadatas('internal');
+        $members = $this->metadata->getPropertyMetadata('internal');
 
         $this->assertCount(2, $members);
         $this->assertEquals(self::PARENTCLASS, $members[0]->getClassName());

--- a/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
@@ -633,7 +633,7 @@ abstract class Abstract2Dot5ApiTest extends AbstractValidatorTest
         // Legacy interface
         $propertyMetadata = $this->getMock('Symfony\Component\Validator\MetadataInterface');
         $metadata = new FakeClassMetadata(get_class($entity));
-        $metadata->addPropertyMetadata('firstName', $propertyMetadata);
+        $metadata->addCustomPropertyMetadata('firstName', $propertyMetadata);
 
         $this->metadataFactory->addMetadata($metadata);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | sort of |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/11614/files#r16385109 |
| License | MIT |
| Doc PR |  |

deprecate member metadata accessors in favor of existing property metadata accessors
