### PR TITLE
[Validator] Test that validateProperty() works if no constraint is defined

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
@@ -851,6 +851,17 @@ abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validateProperty('VALUE', 'someProperty');
     }
 
+    /**
+     * https://github.com/symfony/symfony/issues/11604
+     */
+    public function testValidatePropertyWithoutConstraints()
+    {
+        $entity = new Entity();
+        $violations = $this->validateProperty($entity, 'lastName');
+
+        $this->assertCount(0, $violations, '->validateProperty() returns no violations if no constraints have been configured for the property being validated');
+    }
+
     public function testValidatePropertyValue()
     {
         $test = $this;
@@ -968,6 +979,17 @@ abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
         $this->metadataFactory->addMetadataForValue('VALUE', $metadata);
 
         $this->validatePropertyValue('VALUE', 'someProperty', 'someValue');
+    }
+
+    /**
+     * https://github.com/symfony/symfony/issues/11604
+     */
+    public function testValidatePropertyValueWithoutConstraints()
+    {
+        $entity = new Entity();
+        $violations = $this->validatePropertyValue($entity, 'lastName', 'foo');
+
+        $this->assertCount(0, $violations, '->validatePropertyValue() returns no violations if no constraints have been configured for the property being validated');
     }
 
     public function testValidateObjectOnlyOncePerGroup()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (2.3 has to be merged into 2.5 first) |
| Fixed tickets | #11604, #11614 |
| License | MIT |
| Doc PR |  |

Adds a test case for #11604 to avoid regressions. The actual issue has been fixed in Symfony 2.3 with the merge of #11615.
