### PR TITLE
[Routing] Export route definitions in yml, xml or php format

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterExportCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterExportCommand.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Routing\Exporter\RouteExporter;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * A console command to convert route definitions to another format.
+ *
+ * @author David Tengeri <dtengeri@gmail.com>
+ */
+class RouterExportCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled()
+    {
+        if (!$this->getContainer()->has('router')) {
+            return false;
+        }
+        $router = $this->getContainer()->get('router');
+        if (!$router instanceof RouterInterface) {
+            return false;
+        }
+
+        return parent::isEnabled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('router:export')
+            ->setDefinition(array(
+                new InputOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Target format (yaml, xml, php) of route definitions.', 'yaml'),
+                new InputOption('output', 'o', InputOption::VALUE_REQUIRED, 'The output folder.'),
+                new InputOption('system', null, InputOption::VALUE_NONE, 'Include system paths.'),
+            ))
+            ->setDescription('Exports the route definitions in the given format (yaml, xml, php). ')
+            ->setHelp(<<<EOF
+The <info>%command.name%</info> exports the route definitions in the given format:
+
+  <info>php %command.full_name%</info>
+
+Available formats are:
+ - yaml
+ - xml
+ - php
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException When unknown format is given
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $routes = $this->getContainer()->get('router')->getRouteCollection();
+        foreach ($routes->all() as $name => $route) {
+            if (!$input->getOption('system') && substr($name, 0, 1) === '_') {
+                // Skip paths defined by the framework.
+                $routes->remove($name);
+                continue;
+            }
+            $this->convertController($route);
+        }
+
+        $destination = $input->getOption('output');
+        $format = $input->getOption('format');
+
+        RouteExporter::getExporter($destination, $format)->export($routes);
+    }
+
+    private function convertController(Route $route)
+    {
+        $nameParser = $this->getContainer()->get('controller_name_converter');
+        if ($route->hasDefault('_controller')) {
+            try {
+                $route->setDefault('_controller', $nameParser->build($route->getDefault('_controller')));
+            } catch (\InvalidArgumentException $e) {
+            }
+        }
+    }
+} 

--- a/src/Symfony/Component/Routing/Exporter/Driver/AbstractExporter.php
+++ b/src/Symfony/Component/Routing/Exporter/Driver/AbstractExporter.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Exporter\Driver;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Base abstract class to convert route definitions.
+ *
+ * @author David Tengeri <dtengeri@gmail.com>
+ */
+abstract class AbstractExporter
+{
+
+    protected $outputDir;
+
+    /**
+     * Creates a new exporter and sets its output directory to $destination.
+     *
+     * @param string $destination The path to the output directory.
+     */
+    public function __construct($destination)
+    {
+        $this->outputDir = $destination;
+    }
+
+    /**
+     * Saves the defined routes into a routing file in the desired format.
+     *
+     * @param RouteCollection $routes
+     */
+    public abstract function exportRoutes(RouteCollection $routes);
+
+    /**
+     * Saves the given routes in a routing file.
+     * Creates the output directory if it is not exists.
+     *
+     * @param RouteCollection $routes The routes to save.
+     *
+     * @throws \InvalidArgumentException If the output directory is not writable.
+     */
+    public function export(RouteCollection $routes)
+    {
+        // Create the output directory.
+        if (!is_dir($this->outputDir)) {
+            mkdir($this->outputDir, 0777, true);
+        }
+
+        // Check if it is writable.
+        if (!is_writable($this->outputDir)) {
+            throw new \InvalidArgumentException(sprintf('The output directory "%s" is not writable.', $this->outputDir));
+        }
+
+        $this->exportRoutes($routes);
+    }
+} 

--- a/src/Symfony/Component/Routing/Exporter/Driver/PhpExporter.php
+++ b/src/Symfony/Component/Routing/Exporter/Driver/PhpExporter.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Exporter\Driver;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Converts route definitions to PHP.
+ *
+ * @author David Tengeri <dtengeri@gmail.com>
+ */
+class PhpExporter extends AbstractExporter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function exportRoutes(RouteCollection $routes)
+    {
+        // The routing php content.
+        $routesPhp = <<<'EOF'
+<?php
+
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Route;
+
+$collection = new RouteCollection();
+
+EOF;
+        // Add the route definitions.
+        foreach ($routes->all() as $name => $route) {
+            $routesPhp .= <<<EOF
+\$collection->add('$name', new Route(
+    {$this->generateArgument($route->getPath())}, // path
+    {$this->generateArgument($route->getDefaults())}, // defaults
+    {$this->generateArgument($route->getRequirements())}, // requirements
+    {$this->generateArgument($route->getOptions())}, // options
+    {$this->generateArgument($route->getHost())}, // host
+    {$this->generateArgument($route->getSchemes())}, // schemes
+    {$this->generateArgument($route->getMethods())}, // methods
+    {$this->generateArgument($route->getCondition())} // condition
+));
+
+EOF;
+        }
+        $routesPhp .= 'return $collection;';
+
+        // Save the file.
+        file_put_contents($this->outputDir . DIRECTORY_SEPARATOR . 'routing.php', $routesPhp);
+    }
+
+    /**
+     * Generates function argument in string format.
+     *
+     * @param object $argument The argument to convert to its source code string.
+     *
+     * @return string The PHP code representation of $argument.
+     */
+    private function generateArgument($argument)
+    {
+        return str_replace("\n", '', var_export($argument, true));
+    }
+} 

--- a/src/Symfony/Component/Routing/Exporter/Driver/XmlExporter.php
+++ b/src/Symfony/Component/Routing/Exporter/Driver/XmlExporter.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Exporter\Driver;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Converts route definitions to XML.
+ *
+ * @author David Tengeri <dtengeri@gmail.com>
+ */
+class XmlExporter extends AbstractExporter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function exportRoutes(RouteCollection $routes)
+    {
+        // Create the root element.
+        $routesXml = new \SimpleXMLElement(
+            '<?xml version="1.0" encoding="UTF-8" ?>' .
+            '<routes xmlns="http://symfony.com/schema/routing"' .
+                'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' .
+                'xsi:schemaLocation="http://symfony.com/schema/routing ' .
+                'http://symfony.com/schema/routing/routing-1.0.xsd" />');
+
+        foreach ($routes->all() as $name => $route) {
+            $routeXml = $routesXml->addChild('route');
+
+            $routeXml->addAttribute('id', $name);
+            $routeXml->addAttribute('path', $route->getPath());
+
+            foreach ($route->getDefaults() as $key => $value) {
+                $defaultXml = $routeXml->addChild('default', $value);
+                $defaultXml->addAttribute('key', $key);
+            }
+
+            if (count($route->getRequirements())) {
+                foreach ($route->getRequirements() as $key => $value) {
+                    $requirementXml = $routeXml->addChild('requirement', $value);
+                    $requirementXml->addAttribute('key', $key);
+                }
+            }
+
+            if (count($route->getOptions())) {
+                foreach ($route->getOptions() as $key => $value) {
+                    $optionXml = $routeXml->addChild('option', $value);
+                    $optionXml->addAttribute('key', $key);
+                }
+            }
+
+            if ($route->getHost()) {
+                $routeXml->addAttribute('host', $route->getHost());
+            }
+
+            if (count($route->getSchemes())) {
+                $routeXml->addAttribute('schemes', implode(', ', $route->getSchemes()));
+            }
+
+            if (count($route->getMethods())) {
+                $routeXml->addAttribute('methods', implode(', ', $route->getMethods()));
+            }
+
+            if ($route->getCondition()) {
+                $routeXml->addChild('condition', $route->getCondition());
+            }
+        }
+
+        // Save the route definitions as XML.
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML($routesXml->asXML());
+        $dom->formatOutput = true;
+
+        file_put_contents($this->outputDir . DIRECTORY_SEPARATOR . 'routing.xml', $dom->saveXML());
+    }
+} 

--- a/src/Symfony/Component/Routing/Exporter/Driver/YamlExporter.php
+++ b/src/Symfony/Component/Routing/Exporter/Driver/YamlExporter.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Exporter\Driver;
+
+
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Converts route definitions to YAML.
+ *
+ * @author David Tengeri <dtengeri@gmail.com>
+ */
+class YamlExporter extends AbstractExporter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function exportRoutes(RouteCollection $routes)
+    {
+        // The route definitions.
+        $definitions = array();
+        foreach ($routes->all() as $name => $route) {
+            $definitions[$name] = array(
+                'path' => $route->getPath(),
+                'defaults' => $route->getDefaults(),
+            );
+
+            if (count($route->getRequirements())) {
+                $definitions[$name]['requirements'] = $route->getRequirements();
+            }
+
+            if (count($route->getOptions())) {
+                $definitions[$name]['options'] = $route->getOptions();
+            }
+
+            if ($route->getHost()) {
+                $definitions[$name]['host'] = $route->getHost();
+            }
+
+            if (count($route->getSchemes())) {
+                $definitions[$name]['schemes'] = $route->getSchemes();
+            }
+
+            if (count($route->getMethods())) {
+                $definitions[$name]['methods'] = $route->getMethods();
+            }
+
+            if ($route->getCondition()) {
+                $definitions[$name]['condition'] = $route->getCondition();
+            }
+
+        }
+
+        // Save the definitions as yml.
+        file_put_contents($this->outputDir . DIRECTORY_SEPARATOR . 'routing.yml', Yaml::dump($definitions));
+    }
+
+} 

--- a/src/Symfony/Component/Routing/Exporter/RouteExporter.php
+++ b/src/Symfony/Component/Routing/Exporter/RouteExporter.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Exporter;
+use Symfony\Component\Routing\Exporter\Driver\AbstractExporter;
+
+/**
+ * Factory class to create an exporter for the given format.
+ * @author David Tengeri <dtengeri@gmail.com>
+ */
+class RouteExporter
+{
+    /**
+     * @var array The available exporters.
+     */
+    private static $exportedDrivers = array(
+        'yaml' => 'Symfony\\Component\\Routing\\Exporter\\Driver\\YamlExporter',
+        'xml' => 'Symfony\\Component\\Routing\\Exporter\\Driver\\XmlExporter',
+        'php' => 'Symfony\\Component\\Routing\\Exporter\\Driver\\PhpExporter',
+    );
+
+    /**
+     * @param string $destination The output dir where the generated routing file will be saved.
+     * @param string $format      The desired format. Available options: yaml (default), xml, php.
+     *
+     * @return AbstractExporter
+     *
+     * @throws \InvalidArgumentException If unknown format is given.
+     */
+    public static function getExporter($destination, $format)
+    {
+        // Check if the format is registered.
+        if (!isset(self::$exportedDrivers[$format])) {
+            throw new \InvalidArgumentException(sprintf('The export format "%s" does not exist. Available formats are: yaml, xml or php.', $format));
+        }
+
+        return new self::$exportedDrivers[$format]($destination);
+    }
+} 

--- a/src/Symfony/Component/Routing/Tests/Exporter/Driver/PhpExporterTest.php
+++ b/src/Symfony/Component/Routing/Tests/Exporter/Driver/PhpExporterTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Exporter\Driver;
+
+
+use Symfony\Component\Routing\Exporter\Driver\PhpExporter;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class PhpExporterTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $fixtureDirPath;
+
+    /**
+     * @var RouteCollection
+     */
+    private $routeCollection;
+
+    /**
+     * @var string
+     */
+    private $testTmpDirPath;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->routeCollection = $this->getRouteCollection();
+        $this->fixtureDirPath = realpath(__DIR__.'/../../Fixtures/exporter');
+        $this->testTmpDirPath = sys_get_temp_dir();
+        @unlink($this->testTmpDirPath . '/routing.php');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        @unlink($this->testTmpDirPath . '/routing.php');
+
+        $this->routeCollection = null;
+        $this->fixtureDirPath = null;
+        $this->testTmpDirpath = null;
+    }
+
+    public function testExport()
+    {
+        $exporter = new PhpExporter($this->testTmpDirPath);
+        $exporter->export($this->routeCollection);
+        $this->assertFileEquals($this->testTmpDirPath . '/routing.php', $this->fixtureDirPath . '/routing.php');
+    }
+
+    private function getRouteCollection()
+    {
+        $collection = new RouteCollection();
+
+        // defaults and requirements
+        $collection->add('foo', new Route(
+            '/foo/{bar}',
+            array('def' => 'test'),
+            array('bar' => 'baz|symfony')
+        ));
+        // defaults parameters in pattern
+        $collection->add('foobar', new Route(
+            '/foo/{bar}',
+            array('bar' => 'toto')
+        ));
+        // method requirement
+        $collection->add('bar', new Route(
+            '/bar/{foo}',
+            array(),
+            array('_method' => 'GET|head')
+        ));
+        // method requirement (again)
+        $collection->add('baragain', new Route(
+            '/baragain/{foo}',
+            array(),
+            array('_method' => 'get|post')
+        ));
+        // simple
+        $collection->add('baz', new Route(
+            '/test/baz'
+        ));
+        // simple with extension
+        $collection->add('baz2', new Route(
+            '/test/baz.html'
+        ));
+        // trailing slash
+        $collection->add('baz3', new Route(
+            '/test/baz3/'
+        ));
+        // trailing slash with variable
+        $collection->add('baz4', new Route(
+            '/test/{foo}/'
+        ));
+        // trailing slash and safe method
+        $collection->add('baz5', new Route(
+            '/test/{foo}/',
+            array(),
+            array('_method' => 'get')
+        ));
+        // trailing slash and unsafe method
+        $collection->add('baz5unsafe', new Route(
+            '/testunsafe/{foo}/',
+            array(),
+            array('_method' => 'post')
+        ));
+        // complex
+        $collection->add('baz6', new Route(
+            '/test/baz',
+            array('foo' => 'bar baz')
+        ));
+        // space in path
+        $collection->add('baz7', new Route(
+            '/te st/baz'
+        ));
+        // space preceded with \ in path
+        $collection->add('baz8', new Route(
+            '/te\\ st/baz'
+        ));
+        // space preceded with \ in requirement
+        $collection->add('baz9', new Route(
+            '/test/{baz}',
+            array(),
+            array(
+                'baz' => 'te\\\\ st',
+            )
+        ));
+
+        $collection1 = new RouteCollection();
+
+        $route1 = new Route('/route1', array(), array(), array(), 'a.example.com');
+        $collection1->add('route1', $route1);
+
+        $collection2 = new RouteCollection();
+
+        $route2 = new Route('/route2', array(), array(), array(), 'a.example.com');
+        $collection2->add('route2', $route2);
+
+        $route3 = new Route('/route3', array(), array(), array(), 'b.example.com');
+        $collection2->add('route3', $route3);
+
+        $collection2->addPrefix('/c2');
+        $collection1->addCollection($collection2);
+
+        $route4 = new Route('/route4', array(), array(), array(), 'a.example.com');
+        $collection1->add('route4', $route4);
+
+        $route5 = new Route('/route5', array(), array(), array(), 'c.example.com');
+        $collection1->add('route5', $route5);
+
+        $route6 = new Route('/route6', array(), array(), array(), null);
+        $collection1->add('route6', $route6);
+
+        $collection->addCollection($collection1);
+
+        // host and variables
+
+        $collection1 = new RouteCollection();
+
+        $route11 = new Route('/route11', array(), array(), array(), '{var1}.example.com');
+        $collection1->add('route11', $route11);
+
+        $route12 = new Route('/route12', array('var1' => 'val'), array(), array(), '{var1}.example.com');
+        $collection1->add('route12', $route12);
+
+        $route13 = new Route('/route13/{name}', array(), array(), array(), '{var1}.example.com');
+        $collection1->add('route13', $route13);
+
+        $route14 = new Route('/route14/{name}', array('var1' => 'val'), array(), array(), '{var1}.example.com');
+        $collection1->add('route14', $route14);
+
+        $route15 = new Route('/route15/{name}', array(), array(), array(), 'c.example.com');
+        $collection1->add('route15', $route15);
+
+        $route16 = new Route('/route16/{name}', array('var1' => 'val'), array(), array(), null);
+        $collection1->add('route16', $route16);
+
+        $route17 = new Route('/route17', array(), array(), array(), null);
+        $collection1->add('route17', $route17);
+
+        $collection->addCollection($collection1);
+
+        return $collection;
+    }
+
+
+} 

--- a/src/Symfony/Component/Routing/Tests/Exporter/Driver/XmlExporterTest.php
+++ b/src/Symfony/Component/Routing/Tests/Exporter/Driver/XmlExporterTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Exporter\Driver;
+
+
+use Symfony\Component\Routing\Exporter\Driver\XmlExporter;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class XmlExporterTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $fixtureDirPath;
+
+    /**
+     * @var RouteCollection
+     */
+    private $routeCollection;
+
+    /**
+     * @var string
+     */
+    private $testTmpDirPath;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->routeCollection = $this->getRouteCollection();
+        $this->fixtureDirPath = realpath(__DIR__.'/../../Fixtures/exporter');
+        $this->testTmpDirPath = sys_get_temp_dir();
+        @unlink($this->testTmpDirPath . '/routing.xml');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        @unlink($this->testTmpDirPath . '/routing.xml');
+
+        $this->routeCollection = null;
+        $this->fixtureDirPath = null;
+        $this->testTmpDirpath = null;
+    }
+
+    public function testExport()
+    {
+        $exporter = new XmlExporter($this->testTmpDirPath);
+        $exporter->export($this->routeCollection);
+        $this->assertFileEquals($this->testTmpDirPath . '/routing.xml', $this->fixtureDirPath . '/routing.xml');
+    }
+
+    private function getRouteCollection()
+    {
+        $collection = new RouteCollection();
+
+        // defaults and requirements
+        $collection->add('foo', new Route(
+            '/foo/{bar}',
+            array('def' => 'test'),
+            array('bar' => 'baz|symfony')
+        ));
+        // defaults parameters in pattern
+        $collection->add('foobar', new Route(
+            '/foo/{bar}',
+            array('bar' => 'toto')
+        ));
+        // method requirement
+        $collection->add('bar', new Route(
+            '/bar/{foo}',
+            array(),
+            array('_method' => 'GET|head')
+        ));
+        // method requirement (again)
+        $collection->add('baragain', new Route(
+            '/baragain/{foo}',
+            array(),
+            array('_method' => 'get|post')
+        ));
+        // simple
+        $collection->add('baz', new Route(
+            '/test/baz'
+        ));
+        // simple with extension
+        $collection->add('baz2', new Route(
+            '/test/baz.html'
+        ));
+        // trailing slash
+        $collection->add('baz3', new Route(
+            '/test/baz3/'
+        ));
+        // trailing slash with variable
+        $collection->add('baz4', new Route(
+            '/test/{foo}/'
+        ));
+        // trailing slash and safe method
+        $collection->add('baz5', new Route(
+            '/test/{foo}/',
+            array(),
+            array('_method' => 'get')
+        ));
+        // trailing slash and unsafe method
+        $collection->add('baz5unsafe', new Route(
+            '/testunsafe/{foo}/',
+            array(),
+            array('_method' => 'post')
+        ));
+        // complex
+        $collection->add('baz6', new Route(
+            '/test/baz',
+            array('foo' => 'bar baz')
+        ));
+        // space in path
+        $collection->add('baz7', new Route(
+            '/te st/baz'
+        ));
+        // space preceded with \ in path
+        $collection->add('baz8', new Route(
+            '/te\\ st/baz'
+        ));
+        // space preceded with \ in requirement
+        $collection->add('baz9', new Route(
+            '/test/{baz}',
+            array(),
+            array(
+                'baz' => 'te\\\\ st',
+            )
+        ));
+
+        $collection1 = new RouteCollection();
+
+        $route1 = new Route('/route1', array(), array(), array(), 'a.example.com');
+        $collection1->add('route1', $route1);
+
+        $collection2 = new RouteCollection();
+
+        $route2 = new Route('/route2', array(), array(), array(), 'a.example.com');
+        $collection2->add('route2', $route2);
+
+        $route3 = new Route('/route3', array(), array(), array(), 'b.example.com');
+        $collection2->add('route3', $route3);
+
+        $collection2->addPrefix('/c2');
+        $collection1->addCollection($collection2);
+
+        $route4 = new Route('/route4', array(), array(), array(), 'a.example.com');
+        $collection1->add('route4', $route4);
+
+        $route5 = new Route('/route5', array(), array(), array(), 'c.example.com');
+        $collection1->add('route5', $route5);
+
+        $route6 = new Route('/route6', array(), array(), array(), null);
+        $collection1->add('route6', $route6);
+
+        $collection->addCollection($collection1);
+
+        // host and variables
+
+        $collection1 = new RouteCollection();
+
+        $route11 = new Route('/route11', array(), array(), array(), '{var1}.example.com');
+        $collection1->add('route11', $route11);
+
+        $route12 = new Route('/route12', array('var1' => 'val'), array(), array(), '{var1}.example.com');
+        $collection1->add('route12', $route12);
+
+        $route13 = new Route('/route13/{name}', array(), array(), array(), '{var1}.example.com');
+        $collection1->add('route13', $route13);
+
+        $route14 = new Route('/route14/{name}', array('var1' => 'val'), array(), array(), '{var1}.example.com');
+        $collection1->add('route14', $route14);
+
+        $route15 = new Route('/route15/{name}', array(), array(), array(), 'c.example.com');
+        $collection1->add('route15', $route15);
+
+        $route16 = new Route('/route16/{name}', array('var1' => 'val'), array(), array(), null);
+        $collection1->add('route16', $route16);
+
+        $route17 = new Route('/route17', array(), array(), array(), null);
+        $collection1->add('route17', $route17);
+
+        $collection->addCollection($collection1);
+
+        return $collection;
+    }
+
+
+} 

--- a/src/Symfony/Component/Routing/Tests/Exporter/Driver/YamlExporterTest.php
+++ b/src/Symfony/Component/Routing/Tests/Exporter/Driver/YamlExporterTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Exporter\Driver;
+
+
+use Symfony\Component\Routing\Exporter\Driver\YamlExporter;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class YamlExporterTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $fixtureDirPath;
+
+    /**
+     * @var RouteCollection
+     */
+    private $routeCollection;
+
+    /**
+     * @var string
+     */
+    private $testTmpDirPath;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->routeCollection = $this->getRouteCollection();
+        $this->fixtureDirPath = realpath(__DIR__.'/../../Fixtures/exporter');
+        $this->testTmpDirPath = sys_get_temp_dir();
+        @unlink($this->testTmpDirPath . '/routing.yml');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        @unlink($this->testTmpDirPath . '/routing.yml');
+
+        $this->routeCollection = null;
+        $this->fixtureDirPath = null;
+        $this->testTmpDirpath = null;
+    }
+
+    public function testExport()
+    {
+        $exporter = new YamlExporter($this->testTmpDirPath);
+        $exporter->export($this->routeCollection);
+        $this->assertFileEquals($this->testTmpDirPath . '/routing.yml', $this->fixtureDirPath . '/routing.yml');
+    }
+
+    private function getRouteCollection()
+    {
+        $collection = new RouteCollection();
+
+        // defaults and requirements
+        $collection->add('foo', new Route(
+            '/foo/{bar}',
+            array('def' => 'test'),
+            array('bar' => 'baz|symfony')
+        ));
+        // defaults parameters in pattern
+        $collection->add('foobar', new Route(
+            '/foo/{bar}',
+            array('bar' => 'toto')
+        ));
+        // method requirement
+        $collection->add('bar', new Route(
+            '/bar/{foo}',
+            array(),
+            array('_method' => 'GET|head')
+        ));
+        // method requirement (again)
+        $collection->add('baragain', new Route(
+            '/baragain/{foo}',
+            array(),
+            array('_method' => 'get|post')
+        ));
+        // simple
+        $collection->add('baz', new Route(
+            '/test/baz'
+        ));
+        // simple with extension
+        $collection->add('baz2', new Route(
+            '/test/baz.html'
+        ));
+        // trailing slash
+        $collection->add('baz3', new Route(
+            '/test/baz3/'
+        ));
+        // trailing slash with variable
+        $collection->add('baz4', new Route(
+            '/test/{foo}/'
+        ));
+        // trailing slash and safe method
+        $collection->add('baz5', new Route(
+            '/test/{foo}/',
+            array(),
+            array('_method' => 'get')
+        ));
+        // trailing slash and unsafe method
+        $collection->add('baz5unsafe', new Route(
+            '/testunsafe/{foo}/',
+            array(),
+            array('_method' => 'post')
+        ));
+        // complex
+        $collection->add('baz6', new Route(
+            '/test/baz',
+            array('foo' => 'bar baz')
+        ));
+        // space in path
+        $collection->add('baz7', new Route(
+            '/te st/baz'
+        ));
+        // space preceded with \ in path
+        $collection->add('baz8', new Route(
+            '/te\\ st/baz'
+        ));
+        // space preceded with \ in requirement
+        $collection->add('baz9', new Route(
+            '/test/{baz}',
+            array(),
+            array(
+                'baz' => 'te\\\\ st',
+            )
+        ));
+
+        $collection1 = new RouteCollection();
+
+        $route1 = new Route('/route1', array(), array(), array(), 'a.example.com');
+        $collection1->add('route1', $route1);
+
+        $collection2 = new RouteCollection();
+
+        $route2 = new Route('/route2', array(), array(), array(), 'a.example.com');
+        $collection2->add('route2', $route2);
+
+        $route3 = new Route('/route3', array(), array(), array(), 'b.example.com');
+        $collection2->add('route3', $route3);
+
+        $collection2->addPrefix('/c2');
+        $collection1->addCollection($collection2);
+
+        $route4 = new Route('/route4', array(), array(), array(), 'a.example.com');
+        $collection1->add('route4', $route4);
+
+        $route5 = new Route('/route5', array(), array(), array(), 'c.example.com');
+        $collection1->add('route5', $route5);
+
+        $route6 = new Route('/route6', array(), array(), array(), null);
+        $collection1->add('route6', $route6);
+
+        $collection->addCollection($collection1);
+
+        // host and variables
+
+        $collection1 = new RouteCollection();
+
+        $route11 = new Route('/route11', array(), array(), array(), '{var1}.example.com');
+        $collection1->add('route11', $route11);
+
+        $route12 = new Route('/route12', array('var1' => 'val'), array(), array(), '{var1}.example.com');
+        $collection1->add('route12', $route12);
+
+        $route13 = new Route('/route13/{name}', array(), array(), array(), '{var1}.example.com');
+        $collection1->add('route13', $route13);
+
+        $route14 = new Route('/route14/{name}', array('var1' => 'val'), array(), array(), '{var1}.example.com');
+        $collection1->add('route14', $route14);
+
+        $route15 = new Route('/route15/{name}', array(), array(), array(), 'c.example.com');
+        $collection1->add('route15', $route15);
+
+        $route16 = new Route('/route16/{name}', array('var1' => 'val'), array(), array(), null);
+        $collection1->add('route16', $route16);
+
+        $route17 = new Route('/route17', array(), array(), array(), null);
+        $collection1->add('route17', $route17);
+
+        $collection->addCollection($collection1);
+
+        return $collection;
+    }
+
+
+} 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/exporter/routing.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/exporter/routing.php
@@ -1,0 +1,277 @@
+<?php
+
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Route;
+
+$collection = new RouteCollection();
+$collection->add('foo', new Route(
+    '/foo/{bar}', // path
+    array (  'def' => 'test',), // defaults
+    array (  'bar' => 'baz|symfony',), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('foobar', new Route(
+    '/foo/{bar}', // path
+    array (  'bar' => 'toto',), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('bar', new Route(
+    '/bar/{foo}', // path
+    array (), // defaults
+    array (  '_method' => 'GET|head',), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (  0 => 'GET',  1 => 'HEAD',), // methods
+    '' // condition
+));
+$collection->add('baragain', new Route(
+    '/baragain/{foo}', // path
+    array (), // defaults
+    array (  '_method' => 'get|post',), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (  0 => 'GET',  1 => 'POST',), // methods
+    '' // condition
+));
+$collection->add('baz', new Route(
+    '/test/baz', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('baz2', new Route(
+    '/test/baz.html', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('baz3', new Route(
+    '/test/baz3/', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('baz4', new Route(
+    '/test/{foo}/', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('baz5', new Route(
+    '/test/{foo}/', // path
+    array (), // defaults
+    array (  '_method' => 'get',), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (  0 => 'GET',), // methods
+    '' // condition
+));
+$collection->add('baz5unsafe', new Route(
+    '/testunsafe/{foo}/', // path
+    array (), // defaults
+    array (  '_method' => 'post',), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (  0 => 'POST',), // methods
+    '' // condition
+));
+$collection->add('baz6', new Route(
+    '/test/baz', // path
+    array (  'foo' => 'bar baz',), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('baz7', new Route(
+    '/te st/baz', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('baz8', new Route(
+    '/te\\ st/baz', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('baz9', new Route(
+    '/test/{baz}', // path
+    array (), // defaults
+    array (  'baz' => 'te\\\\ st',), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route1', new Route(
+    '/route1', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    'a.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route2', new Route(
+    '/c2/route2', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    'a.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route3', new Route(
+    '/c2/route3', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    'b.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route4', new Route(
+    '/route4', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    'a.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route5', new Route(
+    '/route5', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    'c.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route6', new Route(
+    '/route6', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route11', new Route(
+    '/route11', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '{var1}.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route12', new Route(
+    '/route12', // path
+    array (  'var1' => 'val',), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '{var1}.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route13', new Route(
+    '/route13/{name}', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '{var1}.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route14', new Route(
+    '/route14/{name}', // path
+    array (  'var1' => 'val',), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '{var1}.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route15', new Route(
+    '/route15/{name}', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    'c.example.com', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route16', new Route(
+    '/route16/{name}', // path
+    array (  'var1' => 'val',), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+$collection->add('route17', new Route(
+    '/route17', // path
+    array (), // defaults
+    array (), // requirements
+    array (  'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler',), // options
+    '', // host
+    array (), // schemes
+    array (), // methods
+    '' // condition
+));
+return $collection;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/exporter/routing.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/exporter/routing.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+  <route id="foo" path="/foo/{bar}">
+    <default key="def">test</default>
+    <requirement key="bar">baz|symfony</requirement>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="foobar" path="/foo/{bar}">
+    <default key="bar">toto</default>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="bar" path="/bar/{foo}" methods="GET, HEAD">
+    <requirement key="_method">GET|head</requirement>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baragain" path="/baragain/{foo}" methods="GET, POST">
+    <requirement key="_method">get|post</requirement>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz" path="/test/baz">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz2" path="/test/baz.html">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz3" path="/test/baz3/">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz4" path="/test/{foo}/">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz5" path="/test/{foo}/" methods="GET">
+    <requirement key="_method">get</requirement>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz5unsafe" path="/testunsafe/{foo}/" methods="POST">
+    <requirement key="_method">post</requirement>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz6" path="/test/baz">
+    <default key="foo">bar baz</default>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz7" path="/te st/baz">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz8" path="/te\ st/baz">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="baz9" path="/test/{baz}">
+    <requirement key="baz">te\\ st</requirement>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route1" path="/route1" host="a.example.com">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route2" path="/c2/route2" host="a.example.com">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route3" path="/c2/route3" host="b.example.com">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route4" path="/route4" host="a.example.com">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route5" path="/route5" host="c.example.com">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route6" path="/route6">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route11" path="/route11" host="{var1}.example.com">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route12" path="/route12" host="{var1}.example.com">
+    <default key="var1">val</default>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route13" path="/route13/{name}" host="{var1}.example.com">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route14" path="/route14/{name}" host="{var1}.example.com">
+    <default key="var1">val</default>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route15" path="/route15/{name}" host="c.example.com">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route16" path="/route16/{name}">
+    <default key="var1">val</default>
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+  <route id="route17" path="/route17">
+    <option key="compiler_class">Symfony\Component\Routing\RouteCompiler</option>
+  </route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/exporter/routing.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/exporter/routing.yml
@@ -1,0 +1,128 @@
+foo:
+    path: '/foo/{bar}'
+    defaults: { def: test }
+    requirements: { bar: baz|symfony }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+foobar:
+    path: '/foo/{bar}'
+    defaults: { bar: toto }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+bar:
+    path: '/bar/{foo}'
+    defaults: {  }
+    requirements: { _method: GET|head }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    methods: [GET, HEAD]
+baragain:
+    path: '/baragain/{foo}'
+    defaults: {  }
+    requirements: { _method: get|post }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    methods: [GET, POST]
+baz:
+    path: /test/baz
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+baz2:
+    path: /test/baz.html
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+baz3:
+    path: /test/baz3/
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+baz4:
+    path: '/test/{foo}/'
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+baz5:
+    path: '/test/{foo}/'
+    defaults: {  }
+    requirements: { _method: get }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    methods: [GET]
+baz5unsafe:
+    path: '/testunsafe/{foo}/'
+    defaults: {  }
+    requirements: { _method: post }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    methods: [POST]
+baz6:
+    path: /test/baz
+    defaults: { foo: 'bar baz' }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+baz7:
+    path: '/te st/baz'
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+baz8:
+    path: '/te\ st/baz'
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+baz9:
+    path: '/test/{baz}'
+    defaults: {  }
+    requirements: { baz: 'te\\ st' }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+route1:
+    path: /route1
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: a.example.com
+route2:
+    path: /c2/route2
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: a.example.com
+route3:
+    path: /c2/route3
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: b.example.com
+route4:
+    path: /route4
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: a.example.com
+route5:
+    path: /route5
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: c.example.com
+route6:
+    path: /route6
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+route11:
+    path: /route11
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: '{var1}.example.com'
+route12:
+    path: /route12
+    defaults: { var1: val }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: '{var1}.example.com'
+route13:
+    path: '/route13/{name}'
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: '{var1}.example.com'
+route14:
+    path: '/route14/{name}'
+    defaults: { var1: val }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: '{var1}.example.com'
+route15:
+    path: '/route15/{name}'
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+    host: c.example.com
+route16:
+    path: '/route16/{name}'
+    defaults: { var1: val }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }
+route17:
+    path: /route17
+    defaults: {  }
+    options: { compiler_class: Symfony\Component\Routing\RouteCompiler }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8334 |
| License | MIT |
| Doc PR | - |

[Routing] Added classes to export route definitions. Added three export drivers: yml, xml and php.
[FrameworkBundle] Added command to export route definitions.

Annotations are great way to define your routes, but the usage of annotations when using for example Ioncube Php encoder is not supported. The command can export the route definitions in yml, xml or php formats to be able to use the encoder.
