### PR TITLE
[Yaml] Ability to supress file content parsing.

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/YamlTest.php
+++ b/src/Symfony/Component/Yaml/Tests/YamlTest.php
@@ -28,4 +28,11 @@ class YamlTest extends \PHPUnit_Framework_TestCase
         $parsedByContents = Yaml::parse($contents);
         $this->assertEquals($parsedByFilename, $parsedByContents);
     }
+
+    public function testSupressedFileCheck()
+    {
+        $filename = __DIR__ . '/Fixtures/index.yml';
+        $parsed = Yaml::parse($filename, false, false, false);
+        $this->assertEquals($filename, $parsed);
+    }
 }

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -38,9 +38,10 @@ class Yaml
      * you must validate the input before calling this method. Passing a file
      * as an input is a deprecated feature and will be removed in 3.0.
      *
-     * @param string  $input                  Path to a YAML file or a string containing YAML
-     * @param bool    $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
-     * @param bool    $objectSupport          True if object support is enabled, false otherwise
+     * @param string $input                  Path to a YAML file or a string containing YAML
+     * @param bool   $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
+     * @param bool   $objectSupport          True if object support is enabled, false otherwise
+     * @param bool   $checkFile              False to force the first parameter to be always interpreted as a string even if it's as a file.
      *
      * @return array The YAML converted to a PHP array
      *
@@ -48,11 +49,11 @@ class Yaml
      *
      * @api
      */
-    public static function parse($input, $exceptionOnInvalidType = false, $objectSupport = false)
+    public static function parse($input, $exceptionOnInvalidType = false, $objectSupport = false, $checkFile = true)
     {
         // if input is a file, process it
         $file = '';
-        if (strpos($input, "\n") === false && is_file($input)) {
+        if ($checkFile === true && strpos($input, "\n") === false && is_file($input)) {
             if (false === is_readable($input)) {
                 throw new ParseException(sprintf('Unable to parse "%s" as the file is not readable.', $input));
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | I don't think so |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | _TODO_ |

This is in relation to a question I posted here: https://github.com/symfony/symfony/issues/11720

I'll just repeat it here, I guess:

Currently `Yaml#parse` would check if the first parameter is a file and would parse the contents if it is readable.

I understand that this behavior is deprecated and for a good reason, and will actually be removed in `3.0`.

My question is: would it be acceptable to add a fourth parameter to the current API (maybe as far back as `2.3`) to suppress this behavior?

``` php
public static function parse($input, $exceptionOnInvalidType = false, $objectSupport = false, $checkFile = true)
{
```

Would this pose a BC problem? My belief is that it won't introduce any, but I have no extensive experience in maintaining open-source code-base and there might be areas that I could've thought considering thus I could be wrong. I just might have missed something really obvious, which happens. FWIW, all test-cases pass.
