### PR TITLE
Trans fixes

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf
@@ -11,7 +11,7 @@
                 <target>Igotako fitxategia handiegia da. Mesedez saiatu fitxategi txikiago bat igotzen.</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF tokena ez da egokia.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf
@@ -3,7 +3,7 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields.</source>
+                <source>This form should not contain extra fields.</source>
                 <target>Tämä kenttäryhmä ei voi sisältää ylimääräisiä kenttiä.</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Component/Form/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.he.xlf
@@ -11,7 +11,7 @@
                 <target>הקובץ שהועלה גדול מדי. נסה להעלות קובץ קטן יותר.</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>אסימון CSRF אינו חוקי.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
@@ -11,7 +11,7 @@
                 <target>アップロードされたファイルが大きすぎます。小さなファイルで再度アップロードしてください。</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRFトークンが無効です。</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
@@ -11,7 +11,7 @@
                 <target>Den opplastede file var for stor. Vennligst last opp en mindre fil.</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF nøkkelen er ugyldig.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
@@ -11,7 +11,7 @@
                 <target>Den uppladdade filen var för stor. Försök ladda upp en mindre fil.</target>
             </trans-unit>
             <trans-unit id="30">
-                <source>The CSRF token is invalid.</source>
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF-symbolen är inte giltig.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -27,8 +27,8 @@ class Collection extends Composite
     public $fields = array();
     public $allowExtraFields = false;
     public $allowMissingFields = false;
-    public $extraFieldsMessage = 'This field was not expected.';
-    public $missingFieldsMessage = 'This field is missing.';
+    public $extraFieldsMessage = 'The fields {{ fields }} were not expected.';
+    public $missingFieldsMessage = 'The fields {{ fields }} are missing.';
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
@@ -179,7 +179,7 @@
                 <target>Väärtus peaks olema kasutaja kehtiv salasõna.</target>
             </trans-unit>
             <trans-unit id="48">
-                <source>This value should have exactly {{ limit }} characters.</source>
+                <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
                 <target>Väärtus peaks olema täpselt {{ limit }} tähemärk pikk.|Väärtus peaks olema täpselt {{ limit }} tähemärki pikk.</target>
             </trans-unit>
             <trans-unit id="49">
@@ -203,15 +203,15 @@
                 <target>PHP laiendi tõttu ebaõnnestus faili üleslaadimine.</target>
             </trans-unit>
             <trans-unit id="54">
-                <source>This collection should contain {{ limit }} elements or more.</source>
+                <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
                 <target>Kogumikus peaks olema vähemalt {{ limit }} element.|Kogumikus peaks olema vähemalt {{ limit }} elementi.</target>
             </trans-unit>
             <trans-unit id="55">
-                <source>This collection should contain {{ limit }} elements or less.</source>
+                <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
                 <target>Kogumikus peaks olema ülimalt {{ limit }} element.|Kogumikus peaks olema ülimalt {{ limit }} elementi.</target>
             </trans-unit>
             <trans-unit id="56">
-                <source>This collection should contain exactly {{ limit }} elements.</source>
+                <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
                 <target>Kogumikus peaks olema täpselt {{ limit }} element.|Kogumikus peaks olema täpselt {{ limit }}|elementi.</target>
             </trans-unit>
             <trans-unit id="57">

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -131,24 +131,24 @@
                 <target>Արժեքը պետք է լինի թիվ.</target>
             </trans-unit>
             <trans-unit id="36">
-                <source>This value is not a valid country.</source>
-                <target>Արժեքը պետք է լինի երկիր.</target>
-            </trans-unit>
-            <trans-unit id="37">
                 <source>This file is not a valid image.</source>
                 <target>Ֆայլը նկարի թույլատրելի ֆորմատ չէ.</target>
             </trans-unit>
-            <trans-unit id="38">
+            <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
                 <target>Արժեքը թույլատրելի IP հասցե չէ.</target>
             </trans-unit>
-            <trans-unit id="39">
+			<trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>Արժեքը թույլատրելի լեզու չէ.</target>
             </trans-unit>
-            <trans-unit id="40">
+            <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
                 <target>Արժեքը չի հանդիսանում թույլատրելի տեղայնացում.</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country.</source>
+                <target>Արժեքը պետք է լինի երկիր.</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -138,7 +138,7 @@
                 <source>This is not a valid IP address.</source>
                 <target>Արժեքը թույլատրելի IP հասցե չէ.</target>
             </trans-unit>
-			<trans-unit id="38">
+            <trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>Արժեքը թույլատրելի լեզու չէ.</target>
             </trans-unit>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -175,7 +175,7 @@
                 <target>画像の高さが小さすぎます({{ height }}ピクセル)。{{ min_height }}ピクセル以上にしてください。</target>
             </trans-unit>
             <trans-unit id="47">
-                <source>This value should be the user current password.</source>
+                <source>This value should be the user's current password.</source>
                 <target>ユーザーの現在のパスワードでなければなりません。</target>
             </trans-unit>
             <trans-unit id="48">

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -131,24 +131,24 @@
                 <target>Ši reikšmė turi būti skaičius.</target>
             </trans-unit>
             <trans-unit id="36">
-                <source>This value is not a valid country.</source>
-                <target>Ši reikšmė nėra tinkama šalis.</target>
-            </trans-unit>
-            <trans-unit id="37">
                 <source>This file is not a valid image.</source>
                 <target>Byla nėra paveikslėlis.</target>
             </trans-unit>
-            <trans-unit id="38">
+            <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
                 <target>Ši reikšmė nėra tinkamas IP adresas.</target>
             </trans-unit>
-            <trans-unit id="39">
+            <trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>Ši reikšmė nėra tinkama kalba.</target>
             </trans-unit>
-            <trans-unit id="40">
+            <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
                 <target>Ši reikšmė nėra tinkama lokalė.</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country.</source>
+                <target>Ši reikšmė nėra tinkama šalis.</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
@@ -35,8 +35,8 @@
                 <target>Өгөгдсөн нэг эсвэл нэгээс олон утга буруу байна.</target>
             </trans-unit>
             <trans-unit id="9">
-                <source>Талбарууд {{ fields }} зөвшөөрөгдөөгүй байна.</source>
-                <target>{{ fields }}.</target>
+            	<source>The fields {{ fields }} were not expected.</source>
+                <target>Талбарууд {{ fields }} зөвшөөрөгдөөгүй байна.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>The fields {{ fields }} are missing.</source>
@@ -131,20 +131,20 @@
                 <target>Энэ утга зөвхөн тоо байна.</target>
             </trans-unit>
             <trans-unit id="36">
-                <source>This value is not a valid country.</source>
-                <target>Энэ утга үнэн бодит улс биш байна.</target>
-            </trans-unit>
-            <trans-unit id="37">
                 <source>This file is not a valid image.</source>
                 <target>Файл зураг биш байна.</target>
             </trans-unit>
-            <trans-unit id="38">
+            <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
                 <target>IP хаяг зөв биш байна.</target>
             </trans-unit>
-            <trans-unit id="39">
+            <trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>Энэ утга үнэн зөв хэл биш байна .</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country.</source>
+                <target>Энэ утга үнэн бодит улс биш байна.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
@@ -35,7 +35,7 @@
                 <target>Өгөгдсөн нэг эсвэл нэгээс олон утга буруу байна.</target>
             </trans-unit>
             <trans-unit id="9">
-            	<source>The fields {{ fields }} were not expected.</source>
+                <source>The fields {{ fields }} were not expected.</source>
                 <target>Талбарууд {{ fields }} зөвшөөрөгдөөгүй байна.</target>
             </trans-unit>
             <trans-unit id="10">

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -259,7 +259,7 @@
                 <target>Deze waarde moet groter dan of gelijk aan {{ compared_value }} zijn.</target>
             </trans-unit>
             <trans-unit id="68">
-                <source>This value should be identical  to {{ compared_value_type }} {{ compared_value }}.</source>
+                <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
                 <target>Deze waarde moet identiek zijn aan {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="69">
@@ -275,8 +275,8 @@
                 <target>Deze waarde mag niet gelijk zijn aan {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="72">
-                <source>This value should not be identical to {{ compared_value }}.</source>
-                <target>Deze waarde mag niet identiek zijn aan {{ compared_value }}.</target>
+                <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
+                <target>Deze waarde mag niet identiek zijn aan {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="73">
                 <source>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -131,24 +131,24 @@
                 <target>Значение должно быть числом.</target>
             </trans-unit>
             <trans-unit id="36">
-                <source>This value is not a valid country.</source>
-                <target>Значение не является допустимой страной.</target>
-            </trans-unit>
-            <trans-unit id="37">
                 <source>This file is not a valid image.</source>
                 <target>Файл не является допустимым форматом изображения.</target>
             </trans-unit>
-            <trans-unit id="38">
+            <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
                 <target>Значение не является допустимым IP адресом.</target>
             </trans-unit>
-            <trans-unit id="39">
+            <trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>Значение не является допустимым языком.</target>
             </trans-unit>
-            <trans-unit id="40">
+            <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
                 <target>Значение не является допустимой локалью.</target>
+            </trans-unit>            
+            <trans-unit id="40">
+                <source>This value is not a valid country.</source>
+                <target>Значение не является допустимой страной.</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
@@ -175,7 +175,7 @@
                 <target>ความสูงของภาพไม่ได้ขนาด ({{ height }}px) อนุญาตให้สูงอย่างน้อยที่สุด {{ min_height }}px</target>
             </trans-unit>
             <trans-unit id="47">
-                <source>This value should be the user current password.</source>
+                <source>This value should be the user's current password.</source>
                 <target>ค่านี้ควรจะเป็นรหัสผ่านปัจจุบันของผู้ใช้</target>
             </trans-unit>
             <trans-unit id="48">

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -131,24 +131,24 @@
                 <target>该值应该为有效的数字。</target>
             </trans-unit>
             <trans-unit id="36">
-                <source>This value is not a valid country.</source>
-                <target>该值不是有效的国家名。</target>
-            </trans-unit>
-            <trans-unit id="37">
                 <source>This file is not a valid image.</source>
                 <target>该文件不是有效的图片。</target>
             </trans-unit>
-            <trans-unit id="38">
+            <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
                 <target>该值不是有效的IP地址。</target>
             </trans-unit>
-            <trans-unit id="39">
+            <trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>该值不是有效的语言名。</target>
             </trans-unit>
-            <trans-unit id="40">
+            <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
                 <target>该值不是有效的区域值（locale）。</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country.</source>
+                <target>该值不是有效的国家名。</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -131,24 +131,24 @@
                 <target>該值應該為有效的數字。</target>
             </trans-unit>
             <trans-unit id="36">
-                <source>This value is not a valid country.</source>
-                <target>該值不是有效的國家名。</target>
-            </trans-unit>
-            <trans-unit id="37">
                 <source>This file is not a valid image.</source>
                 <target>該檔案不是有效的圖片。</target>
             </trans-unit>
-            <trans-unit id="38">
+            <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
                 <target>該值不是有效的IP地址。</target>
             </trans-unit>
-            <trans-unit id="39">
+            <trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>該值不是有效的語言名。</target>
             </trans-unit>
-            <trans-unit id="40">
+            <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
                 <target>該值不是有效的區域值（locale）。</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country.</source>
+                <target>該值不是有效的國家名。</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11630 |
| License | MIT |
### Version: master. At: 2293556
#### Directory:

https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Form/Resources/translations
##### File name root: validators
###### Source diffs between English and locale

| Locale | Message ids |
| --- | --- |
| [eu](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf) | 30 |
| [fi](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf) | 28 |
| [he](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Form/Resources/translations/validators.he.xlf) | 30 |
| [ja](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf) | 30 |
| [nb](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf) | 30 |
| [sv](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf) | 30 |
#### Directory:

https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations
##### File name root: validators
###### Source diffs between English and locale

| Locale | Message ids |
| --- | --- |
| [et](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf) | 48 54 55 56 |
| [hy](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf) | 36 37 38 39 40 |
| [ja](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf) | 47 |
| [lt](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf) | 36 37 38 39 40 |
| [mn](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf) | 9  36 37 38 39 |
| [nl](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf) | 68 72 |
| [ru](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf) | 36 37 38 39 40 |
| [th](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf) | 47 |
| [zh_CN](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf) | 36 37 38 39 40 |
| [zh_TW](https://github.com/symfony/symfony/tree/master/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf) | 36 37 38 39 40 |

Message used by constraints but not found in translation file

| Class | Message |
| --- | --- |
| Collection | This field was not expected. |
| Collection | This field is missing. |
