### PR TITLE
[DependencyInjection] Cache resolved parameter values in ParameterBag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -190,7 +190,7 @@ class ParameterBag implements ParameterBagInterface
     {
         if ($this->resolved) {
             return $this->get($name);
-        } else if (isset($this->resolvedParameters[$name])) {
+        } elseif (isset($this->resolvedParameters[$name])) {
             return $this->resolvedParameters[$name];
         } else {
             return $this->resolvedParameters[$name] = $this->resolveValue($this->get($name), $resolving);
@@ -252,6 +252,7 @@ class ParameterBag implements ParameterBagInterface
             }
 
             $resolving[$key] = true;
+
             return $this->resolveParameter($key, $resolving);
 
         }
@@ -276,6 +277,7 @@ class ParameterBag implements ParameterBagInterface
             }
 
             $resolving[$key] = true;
+
             return (string) $self->resolveParameter($key, $resolving);
 
         }, $value);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR |  |

Problem:
The ParameterBag's method 'resolveValue()' recursively resolves parameters referenced inside other parameters' values every time. However, if a parameter is referenced (i.e. %name%) two or more times inside other parameters' values, it's recursively resolved every time.

Solution:
Added a simple $resolvedParameters private field in ParameterBag to cache resolved parameters while resolving the ParameterBag.
Did some refactoring, and created a new public method 'resolveParameter($name)', that caches (and looks up) resolved parameter values before returning them.

NOTES:
- Based on 2.5 since this is not a bug fix.
- No change in behavior, and thus no new tests were created.
