### PR TITLE
[Validator] Pass strict argument into the strict email validator

### DIFF
--- a/UPGRADE-2.5.md
+++ b/UPGRADE-2.5.md
@@ -114,7 +114,7 @@ Validator
    Also you have to add to your composer.json:
 
    ```
-   "egulias/email-validator": "1.1.*"
+   "egulias/email-validator": "~1.2"
    ```
 
  * `ClassMetadata::getGroupSequence()` now returns `GroupSequence` instances

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "propel/propel1": "1.6.*",
         "ircmaxell/password-compat": "1.0.*",
         "ocramius/proxy-manager": ">=0.3.1,<0.6-dev",
-        "egulias/email-validator": "1.1.0"
+        "egulias/email-validator": "~1.2"
     },
     "autoload": {
         "psr-0": { "Symfony\\": "src/" },

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -59,7 +59,7 @@ class EmailValidator extends ConstraintValidator
 
         if ($constraint->strict && class_exists('\Egulias\EmailValidator\EmailValidator')) {
             $strictValidator = new StrictEmailValidator();
-            $valid = $strictValidator->isValid($value, false);
+            $valid = $strictValidator->isValid($value, false, true);
         } elseif ($constraint->strict === true) {
             throw new \RuntimeException('Strict email validation requires egulias/email-validator');
         } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11722, #11719 |
| License | MIT |
| Doc PR | none |

When strict = true is set in the Email constraint, it loads up the third
party library to do strict validation, but it doesn't pass strict into
the library. Unless strict is passed into the library, only major e-mail
errors will be validated and e-mails like user@gmail ,com or
user@gmail,com will pass validation because they are registered as
warnings by the library and not errors.

/cc @egulias @stof
