### PR TITLE
[DependencyInjection] Cache resolved parameter values in ParameterBag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -26,6 +26,7 @@ class ParameterBag implements ParameterBagInterface
 {
     protected $parameters = array();
     protected $resolved = false;
+    private $resolvedParameters = array();
 
     /**
      * Constructor.
@@ -47,6 +48,7 @@ class ParameterBag implements ParameterBagInterface
     public function clear()
     {
         $this->parameters = array();
+        $this->resolvedParameters = array();
     }
 
     /**
@@ -61,6 +63,8 @@ class ParameterBag implements ParameterBagInterface
         foreach ($parameters as $key => $value) {
             $this->parameters[strtolower($key)] = $value;
         }
+
+        $this->resolvedParameters = array();
     }
 
     /**
@@ -120,6 +124,7 @@ class ParameterBag implements ParameterBagInterface
     public function set($name, $value)
     {
         $this->parameters[strtolower($name)] = $value;
+        $this->resolvedParameters = array();
     }
 
     /**
@@ -146,6 +151,7 @@ class ParameterBag implements ParameterBagInterface
     public function remove($name)
     {
         unset($this->parameters[strtolower($name)]);
+        $this->resolvedParameters = array();
     }
 
     /**
@@ -160,7 +166,7 @@ class ParameterBag implements ParameterBagInterface
         $parameters = array();
         foreach ($this->parameters as $key => $value) {
             try {
-                $value = $this->resolveValue($value);
+                $value = $this->resolveParameter($key);
                 $parameters[$key] = $this->unescapeValue($value);
             } catch (ParameterNotFoundException $e) {
                 $e->setSourceKey($key);
@@ -171,6 +177,34 @@ class ParameterBag implements ParameterBagInterface
 
         $this->parameters = $parameters;
         $this->resolved = true;
+        $this->resolvedParameters = array();
+    }
+
+    /**
+     * Replaces parameter placeholders (%name%) by their values, inside a parameter's value.
+     *
+     * @param string $name The parameter name whose value we want to resolve
+     * @param array $resolving An array of keys that are being resolved (used internally to detect circular references)
+     *
+     * @return mixed  The resolved parameter value
+     *
+     * @throws ParameterNotFoundException if a placeholder references a parameter that does not exist
+     * @throws ParameterCircularReferenceException if a circular reference if detected
+     * @throws RuntimeException when a given parameter has a type problem.
+     *
+     * @internal this method is public because it's called internally by a callback (calling private methods requires PHP 5.4+), do not use it explicitly in your code
+     */
+    public function resolveParameter($name, array $resolving = array())
+    {
+        if ($this->resolved) {
+            return $this->get($name);
+        }
+
+        if (isset($this->resolvedParameters[$name])) {
+            return $this->resolvedParameters[$name];
+        }
+
+        return $this->resolvedParameters[$name] = $this->resolveValue($this->get($name), $resolving);
     }
 
     /**
@@ -221,15 +255,15 @@ class ParameterBag implements ParameterBagInterface
         // as the preg_replace_callback throw an exception when trying
         // a non-string in a parameter value
         if (preg_match('/^%([^%\s]+)%$/', $value, $match)) {
-            $key = strtolower($match[1]);
 
+            $key = strtolower($match[1]);
             if (isset($resolving[$key])) {
                 throw new ParameterCircularReferenceException(array_keys($resolving));
             }
 
             $resolving[$key] = true;
 
-            return $this->resolved ? $this->get($key) : $this->resolveValue($this->get($key), $resolving);
+            return $this->resolveParameter($key, $resolving);
         }
 
         $self = $this;
@@ -245,16 +279,15 @@ class ParameterBag implements ParameterBagInterface
                 throw new ParameterCircularReferenceException(array_keys($resolving));
             }
 
-            $resolved = $self->get($key);
+            $paramValue = $self->get($key);
 
-            if (!is_string($resolved) && !is_numeric($resolved)) {
-                throw new RuntimeException(sprintf('A string value must be composed of strings and/or numbers, but found parameter "%s" of type %s inside string value "%s".', $key, gettype($resolved), $value));
+            if (!is_string($paramValue) && !is_numeric($paramValue)) {
+                throw new RuntimeException(sprintf('A string value must be composed of strings and/or numbers, but found parameter "%s" of type %s inside string value "%s".', $key, gettype($paramValue), $value));
             }
 
-            $resolved = (string) $resolved;
             $resolving[$key] = true;
 
-            return $self->isResolved() ? $resolved : $self->resolveString($resolved, $resolving);
+            return (string) $self->resolveParameter($key, $resolving);
         }, $value);
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -225,7 +225,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         } catch (ParameterNotFoundException $e) {
             $this->assertEquals('You have requested a non-existent parameter "foo".', $e->getMessage(), '->resolveValue() throws a ParameterNotFoundException if a placeholder references a parameter in a cleared bag');
         }
-
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -198,6 +198,36 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo.bar:1337', $bag->resolveValue('%host%:%port%'));
     }
 
+    public function testResolveAfterSettingAddingRemovingClearingParameters()
+    {
+        $bag = new ParameterBag(array('foo' => 'foo', 'bar' => 'bar', 'baz' => '%foo% %bar%', 'qux' => '%baz%'));
+        $bag->resolveValue('%qux%');
+
+        $bag->set('baz', '%bar% %foo%');
+        $this->assertEquals('bar foo', $bag->resolveValue('%qux%'), '->resolveValue() resolves placeholders after changing a referenced parameter via ->set()');
+
+        $bag->add(array('baz' => '%foo% %bar%'));
+        $this->assertEquals('foo bar', $bag->resolveValue('%qux%'), '->resolveValue() resolves placeholders after changing a referenced parameter via ->add');
+
+        $bag->remove('qux');
+        try {
+            $bag->resolveValue('%qux%');
+            $this->fail('->resolveValue() throws a ParameterNotFoundException if a placeholder references a removed parameter');
+        } catch (ParameterNotFoundException $e) {
+            $this->assertEquals('You have requested a non-existent parameter "qux".', $e->getMessage(), '->resolveValue() throws a ParameterNotFoundException if a placeholder references a removed parameter');
+        }
+
+        $bag->resolveValue('%baz%');
+        $bag->clear();
+        try {
+            $bag->resolveValue('%foo%');
+            $this->fail('->resolveValue() throws a ParameterNotFoundException if a placeholder references a parameter in a cleared bag');
+        } catch (ParameterNotFoundException $e) {
+            $this->assertEquals('You have requested a non-existent parameter "foo".', $e->getMessage(), '->resolveValue() throws a ParameterNotFoundException if a placeholder references a parameter in a cleared bag');
+        }
+
+    }
+
     /**
      * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolve
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

**Problem:**
The ParameterBag's method 'resolveValue()' recursively resolves parameters referenced inside other parameters' values every time.
However, if a parameter is referenced (i.e. %name%) two or more times inside other parameters' values, it's recursively resolved every time.

**Solution:**
Added a `resolvedParameters` private array field in ParameterBag to cache resolved parameters while resolving the ParameterBag (via `resolve()`), or while resolving any string or parameter (via `resolveValue()` or `resolveString()`).
Did some refactoring, and created a new public method 'resolveParameter()', that caches (and looks up) resolved parameter values before returning them.
The caching array is reset every time parameters are modified via either `set`, `add`, `remove`, `clear`.

**Tests:**
Added a `testResolveAfterSettingAddingRemovingClearingParameters()` test, to make sure that parameter values are refreshed after being resolved then modified.

**NOTES:**
- Based on master since this is not a bug fix.
