### PR TITLE
[WIP][Routing] Add support for 'priority' option for annotated Routes

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -73,6 +73,11 @@ abstract class AnnotationClassLoader implements LoaderInterface
     protected $defaultRouteIndex = 0;
 
     /**
+     * @var bool
+     */
+    protected $routeWithPriority = false;
+
+    /**
      * Constructor.
      *
      * @param Reader $reader
@@ -93,6 +98,16 @@ abstract class AnnotationClassLoader implements LoaderInterface
     }
 
     /**
+     * Tells if one of the annotationed route has priority info
+     *
+     * @return bool
+     */
+    public function hasRouteWithPriority()
+    {
+        return $this->routeWithPriority;
+    }
+
+    /**
      * Loads from annotations from a class.
      *
      * @param string      $class A class name
@@ -104,6 +119,8 @@ abstract class AnnotationClassLoader implements LoaderInterface
      */
     public function load($class, $type = null)
     {
+        $hasPriority = false;
+
         if (!class_exists($class)) {
             throw new \InvalidArgumentException(sprintf('Class "%s" does not exist.', $class));
         }
@@ -123,6 +140,9 @@ abstract class AnnotationClassLoader implements LoaderInterface
             foreach ($this->reader->getMethodAnnotations($method) as $annot) {
                 if ($annot instanceof $this->routeAnnotationClass) {
                     $this->addRoute($collection, $annot, $globals, $class, $method);
+                    if (array_key_exists('priority',$annot->getOptions())) {
+                        $this->routeWithPriority = true;
+                    }
                 }
             }
         }

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -60,7 +60,7 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
         }
 
         if ($this->loader->hasRouteWithPriority()) {
-            $collection->getIterator()->uasort(function(Route $a, Route $b){
+            $collection->getIterator()->uasort(function(Route $a, Route $b) {
                 if ($a->getOption('priority') == $b->getOption('priority')) {
                     return 0;
                 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Loader;
 
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Config\Resource\DirectoryResource;
 
@@ -56,6 +57,15 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
 
                 $collection->addCollection($this->loader->load($class, $type));
             }
+        }
+
+        if ($this->loader->hasRouteWithPriority()) {
+            $collection->getIterator()->uasort(function(Route $a, Route $b){
+                if ($a->getOption('priority') == $b->getOption('priority')) {
+                    return 0;
+                }
+                return $a->getOption('priority') > $b->getOption('priority') ? 1 : -1;
+            });
         }
 
         return $collection;

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -91,6 +91,11 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
                 array('name' => 'route1', 'defaults' => array('arg2' => 'foo'), 'condition' => 'context.getMethod() == "GET"'),
                 array('arg2' => 'defaultValue2', 'arg3' =>'defaultValue3')
             ),
+            array(
+                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
+                array('name' => 'route_priority', 'options' => array('priority' => '10')),
+                array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3')
+            ),
         );
     }
 
@@ -120,9 +125,10 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 
         $this->assertSame($routeDatas['path'], $route->getPath(), '->load preserves path annotation');
         $this->assertSame($routeDatas['requirements'],$route->getRequirements(), '->load preserves requirements annotation');
-        $this->assertCount(0, array_intersect($route->getOptions(), $routeDatas['options']), '->load preserves options annotation');
+        $this->assertSame(count($routeDatas['options']), count(array_intersect($route->getOptions(), $routeDatas['options'])), '->load preserves options annotation');
         $this->assertSame(array_replace($methodArgs, $routeDatas['defaults']), $route->getDefaults(), '->load preserves defaults annotation');
         $this->assertEquals($routeDatas['condition'], $route->getCondition(), '->load preserves condition annotation');
+        $this->assertSame(isset($routeDatas['options']['priority']), $this->loader->hasRouteWithPriority());
     }
 
     public function testClassRouteLoad()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [sensiolabs/SensioFrameworkExtraBundle#320] |
| License | MIT |

If the given route option parameter has a priority key, it will be sorted. The use case is described in the linked ticket.

If the changes are acceptable, then I will create the changes also for the Doc
