### PR TITLE
[TwigBundle] Remove hard dependency of RequestContext in AssetsExtension

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
@@ -24,7 +24,7 @@ class AssetsExtension extends \Twig_Extension
     private $container;
     private $context;
 
-    public function __construct(ContainerInterface $container, RequestContext $requestContext)
+    public function __construct(ContainerInterface $container, RequestContext $requestContext = null)
     {
         $this->container = $container;
         $this->context = $requestContext;
@@ -94,11 +94,16 @@ class AssetsExtension extends \Twig_Extension
      * @param string $url The URL that has to be absolute
      *
      * @return string The absolute URL
+     * @throws \RuntimeException
      */
     private function ensureUrlIsAbsolute($url)
     {
         if (false !== strpos($url, '://') || 0 === strpos($url, '//')) {
             return $url;
+        }
+
+        if (!$this->context) {
+            throw new \RuntimeException('To generate an absolute URL for an asset, the Symfony Routing component is required.');
         }
 
         if ('' === $host = $this->context->getHost()) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -66,7 +66,7 @@
         <service id="twig.extension.assets" class="%twig.extension.assets.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="service_container" />
-            <argument type="service" id="router.request_context" />
+            <argument type="service" id="router.request_context" on-invalid="null" />
         </service>
 
         <service id="twig.extension.actions" class="%twig.extension.actions.class%" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11466 |
| License | MIT |
| Doc PR | - |

symfony/symfony#10451 introduced the requirement of RequestContext in AssetsExtension. This is only needed when generating absolute URLs for assets. When sending emails with Twig from the CLI, the router may not be present and most times is not required. 

This PR attempts to remove the hard dependency and set RequestContext if the router is present according to issue #11466.
