### PR TITLE
[Routing] Add support for 'priority' option for annotated Routes

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -120,6 +120,11 @@ class Route
         return $this->options;
     }
 
+    public function getOption($name)
+    {
+        return isset($this->options[$name]) ? $this->options[$name] : null;
+    }
+
     public function setDefaults($defaults)
     {
         $this->defaults = $defaults;

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -133,8 +133,10 @@ abstract class AnnotationClassLoader implements LoaderInterface
             foreach ($this->reader->getMethodAnnotations($method) as $annot) {
                 if ($annot instanceof $this->routeAnnotationClass) {
                     if ($annot->getOption('priority')) {
+                        //These routes will be added to the collection later in File or Directory Loader
                         $this->routesWithPriority[$annot->getOption('priority')][]
                             = array($annot, $globals, $class, $method);
+                        continue;
                     }
                     $this->addRoute($collection, $annot, $globals, $class, $method);
                 }
@@ -144,7 +146,16 @@ abstract class AnnotationClassLoader implements LoaderInterface
         return $collection;
     }
 
-    public function addPriorityRoutes()
+    /**
+     * Create a new collection of routes with priority
+     * These routes will be already sorted by priority
+     * and after that append all the other routes which
+     * don't have any priority
+     *
+     * @param $originalCollection
+     * @return RouteCollection
+     */
+    public function addPriorityRoutes($originalCollection)
     {
         krsort($this->routesWithPriority);
         $collection = new RouteCollection();
@@ -154,6 +165,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
                 $this->addRoute($collection, $route[0], $route[1], $route[2], $route[3]);
             }
         }
+        $collection->addCollection($originalCollection);
 
         return $collection;
     }

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -144,7 +144,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         return $collection;
     }
 
-    public function adddPriorityRoutes()
+    public function addPriorityRoutes()
     {
         krsort($this->routesWithPriority);
         $collection = new RouteCollection();

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -58,6 +58,10 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
             }
         }
 
+        if ($this->loader->hasRoutesWithPriority()) {
+            $collection->addCollection($this->loader->adddPriorityRoutes());
+        }
+
         return $collection;
     }
 

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -59,7 +59,7 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
         }
 
         if ($this->loader->hasRoutesWithPriority()) {
-            $collection->addCollection($this->loader->adddPriorityRoutes());
+            $collection->addCollection($this->loader->addPriorityRoutes());
         }
 
         return $collection;

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -58,9 +58,7 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
             }
         }
 
-        if ($this->loader->hasRoutesWithPriority()) {
-            $collection = $this->loader->addPriorityRoutes($collection);
-        }
+        $collection = $this->loader->addPriorityRoutes($collection);
 
         return $collection;
     }

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -59,7 +59,7 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
         }
 
         if ($this->loader->hasRoutesWithPriority()) {
-            $collection->addCollection($this->loader->addPriorityRoutes());
+            $collection = $this->loader->addPriorityRoutes($collection);
         }
 
         return $collection;

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -66,7 +66,7 @@ class AnnotationFileLoader extends FileLoader
         }
 
         if ($this->loader->hasRoutesWithPriority()) {
-            $collection->addCollection($this->loader->addPriorityRoutes());
+            $collection = $this->loader->addPriorityRoutes($collection);
         }
 
         return $collection;

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -66,7 +66,7 @@ class AnnotationFileLoader extends FileLoader
         }
 
         if ($this->loader->hasRoutesWithPriority()) {
-            $collection->addCollection($this->loader->adddPriorityRoutes());
+            $collection->addCollection($this->loader->addPriorityRoutes());
         }
 
         return $collection;

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -65,6 +65,10 @@ class AnnotationFileLoader extends FileLoader
             $collection->addCollection($this->loader->load($class, $type));
         }
 
+        if ($this->loader->hasRoutesWithPriority()) {
+            $collection->addCollection($this->loader->adddPriorityRoutes());
+        }
+
         return $collection;
     }
 

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -65,9 +65,7 @@ class AnnotationFileLoader extends FileLoader
             $collection->addCollection($this->loader->load($class, $type));
         }
 
-        if ($this->loader->hasRoutesWithPriority()) {
-            $collection = $this->loader->addPriorityRoutes($collection);
-        }
+        $collection = $this->loader->addPriorityRoutes($collection);
 
         return $collection;
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -91,6 +91,11 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
                 array('name' => 'route1', 'defaults' => array('arg2' => 'foo'), 'condition' => 'context.getMethod() == "GET"'),
                 array('arg2' => 'defaultValue2', 'arg3' =>'defaultValue3')
             ),
+            array(
+                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
+                array('name' => 'route_priority', 'options' => array('priority' => 10)),
+                array('arg2' => 'defaultValue2', 'arg3' =>'defaultValue3'),
+            ),
         );
     }
 
@@ -120,7 +125,8 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 
         $this->assertSame($routeDatas['path'], $route->getPath(), '->load preserves path annotation');
         $this->assertSame($routeDatas['requirements'],$route->getRequirements(), '->load preserves requirements annotation');
-        $this->assertCount(0, array_intersect($route->getOptions(), $routeDatas['options']), '->load preserves options annotation');
+        $this->assertSame(count($routeDatas['options']), count(array_intersect($route->getOptions(), $routeDatas['options'])), '->load preserves options annotation');
+        $this->assertEquals(array_key_exists('priority', $routeDatas['options']), $this->loader->hasRoutesWithPriority());
         $this->assertSame(array_replace($methodArgs, $routeDatas['defaults']), $route->getDefaults(), '->load preserves defaults annotation');
         $this->assertEquals($routeDatas['condition'], $route->getCondition(), '->load preserves condition annotation');
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -91,6 +91,11 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
                 array('name' => 'route1', 'defaults' => array('arg2' => 'foo'), 'condition' => 'context.getMethod() == "GET"'),
                 array('arg2' => 'defaultValue2', 'arg3' =>'defaultValue3')
             ),
+            array(
+                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
+                array('name' => 'route1', 'options' => array('priority' => 10)),
+                array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
+            ),
         );
     }
 
@@ -121,7 +126,6 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->assertSame($routeDatas['path'], $route->getPath(), '->load preserves path annotation');
         $this->assertSame($routeDatas['requirements'],$route->getRequirements(), '->load preserves requirements annotation');
         $this->assertSame(count($routeDatas['options']), count(array_intersect($route->getOptions(), $routeDatas['options'])), '->load preserves options annotation');
-        $this->assertEquals(array_key_exists('priority', $routeDatas['options']), $this->loader->hasRoutesWithPriority());
         $this->assertSame(array_replace($methodArgs, $routeDatas['defaults']), $route->getDefaults(), '->load preserves defaults annotation');
         $this->assertEquals($routeDatas['condition'], $route->getCondition(), '->load preserves condition annotation');
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -91,11 +91,6 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
                 array('name' => 'route1', 'defaults' => array('arg2' => 'foo'), 'condition' => 'context.getMethod() == "GET"'),
                 array('arg2' => 'defaultValue2', 'arg3' =>'defaultValue3')
             ),
-            array(
-                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('name' => 'route_priority', 'options' => array('priority' => 10)),
-                array('arg2' => 'defaultValue2', 'arg3' =>'defaultValue3'),
-            ),
         );
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -56,6 +56,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
     {
         $routeDatas = array(
             'foo' => new Route(array('name' => 'foo', 'path' => '/foo')),
+            'unimportant' => new Route(array('name' => 'unimportant', 'path' => '/unimportant', 'options' => array('priority' => -10))),
             'bar' => new Route(array('name' => 'bar', 'path' => '/bar')),
             'static_id' => new Route(array('name' => 'static_id', 'path' => '/static/{id}', 'options' => array('priority' => 1))),
             'home' => new Route(array('name' => 'home', 'path' => '/home')),
@@ -70,7 +71,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
             ->will($this->returnValue($routeDatas));
 
         $routeCollection = $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
-        $expectedOrder = array( 'static_contact', 'static_location', 'static_id', 'foo', 'bar', 'home', 'login');
+        $expectedOrder = array( 'static_contact', 'static_location', 'static_id', 'foo', 'bar', 'home', 'login', 'unimportant');
         $this->assertEquals($expectedOrder, array_keys($routeCollection->all()));
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Annotation\Route;
+
 
 class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 {
@@ -49,5 +51,27 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 
         $this->assertTrue($this->loader->supports($fixturesDir, 'annotation'), '->supports() checks the resource type if specified');
         $this->assertFalse($this->loader->supports($fixturesDir, 'foo'), '->supports() checks the resource type if specified');
+    }
+
+    public function testRoutesWithPriority()
+    {
+        $routeDatas = array(
+            'foo' => new Route(array('name' => 'foo', 'path' => '/foo')),
+            'bar' => new Route(array('name' => 'bar', 'path' => '/bar')),
+            'static_id' => new Route(array('name' => 'static_id', 'path' => '/static/{id}', 'options' => array('priority' => 1))),
+            'home' => new Route(array('name' => 'home', 'path' => '/home')),
+            'static_contact' => new Route(array('name' => 'static_contact', 'path' => '/static/contact', 'options' => array('priority' => 5))),
+            'login' => new Route(array('name' => 'login', 'path' => '/login')),
+            'static_location' => new Route(array('name' => 'static_location', 'path' => '/static/location', 'options' => array('priority' => 5))),
+        );
+
+        $this->reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue($routeDatas));
+
+        $routeCollection = $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
+        $expectedOrder = array('foo', 'bar', 'home', 'login', 'static_contact', 'static_location', 'static_id');
+        $this->assertEquals($expectedOrder, array_keys($routeCollection->all()));
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -15,7 +15,6 @@ use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Annotation\Route;
 
-
 class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 {
     protected $loader;

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -70,7 +70,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
             ->will($this->returnValue($routeDatas));
 
         $routeCollection = $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
-        $expectedOrder = array('foo', 'bar', 'home', 'login', 'static_contact', 'static_location', 'static_id');
+        $expectedOrder = array( 'static_contact', 'static_location', 'static_id', 'foo', 'bar', 'home', 'login');
         $this->assertEquals($expectedOrder, array_keys($routeCollection->all()));
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -64,7 +64,7 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
             ->will($this->returnValue($routeDatas));
 
         $routeCollection = $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/BarClass.php');
-        $expectedOrder = array('foo', 'bar', 'home', 'login', 'static_contact', 'static_location', 'static_id');
+        $expectedOrder = array( 'static_contact', 'static_location', 'static_id', 'foo', 'bar', 'home', 'login');
         $this->assertEquals($expectedOrder, array_keys($routeCollection->all()));
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Tests\Loader;
 
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Loader\AnnotationFileLoader;
 use Symfony\Component\Config\FileLocator;
 
@@ -43,5 +44,27 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
 
         $this->assertTrue($this->loader->supports($fixture, 'annotation'), '->supports() checks the resource type if specified');
         $this->assertFalse($this->loader->supports($fixture, 'foo'), '->supports() checks the resource type if specified');
+    }
+
+    public function testRoutesWithPriority()
+    {
+        $routeDatas = array(
+            'foo' => new Route(array('name' => 'foo', 'path' => '/foo')),
+            'bar' => new Route(array('name' => 'bar', 'path' => '/bar')),
+            'static_id' => new Route(array('name' => 'static_id', 'path' => '/static/{id}', 'options' => array('priority' => 1))),
+            'home' => new Route(array('name' => 'home', 'path' => '/home')),
+            'static_contact' => new Route(array('name' => 'static_contact', 'path' => '/static/contact', 'options' => array('priority' => 5))),
+            'login' => new Route(array('name' => 'login', 'path' => '/login')),
+            'static_location' => new Route(array('name' => 'static_location', 'path' => '/static/location', 'options' => array('priority' => 5))),
+        );
+
+        $this->reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue($routeDatas));
+
+        $routeCollection = $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/BarClass.php');
+        $expectedOrder = array('foo', 'bar', 'home', 'login', 'static_contact', 'static_location', 'static_id');
+        $this->assertEquals($expectedOrder, array_keys($routeCollection->all()));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [sensiolabs/SensioFrameworkExtraBundle#320] |
| License | MIT |

If the given route option parameter has a priority key, it will be sorted. The use case is described in the linked ticket. This is a new implementation, previous one (#11747) was proven bad.

If the changes are acceptable, then I will create the changes also for the Doc
