### PR TITLE
[Console] Add a concept of 'tail' arguments

### DIFF
--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -23,6 +23,7 @@ class InputArgument
     const REQUIRED = 1;
     const OPTIONAL = 2;
     const IS_ARRAY = 4;
+    const IS_TAIL  = 8;
 
     private $name;
     private $mode;
@@ -45,8 +46,10 @@ class InputArgument
     {
         if (null === $mode) {
             $mode = self::OPTIONAL;
-        } elseif (!is_int($mode) || $mode > 7 || $mode < 1) {
+        } elseif (!is_int($mode) || $mode > 15 || $mode < 1) {
             throw new \InvalidArgumentException(sprintf('Argument mode "%s" is not valid.', $mode));
+        } elseif ($mode & self::IS_TAIL && !($mode & self::IS_ARRAY)) {
+            throw new \InvalidArgumentException('InputArgument::IS_TAIL requires InputArgument::IS_ARRAY');
         }
 
         $this->name        = $name;
@@ -84,6 +87,16 @@ class InputArgument
     public function isArray()
     {
         return self::IS_ARRAY === (self::IS_ARRAY & $this->mode);
+    }
+
+    /**
+     * Returns true if the argument absorbs all the values at the tail.
+     *
+     * @return bool    true if mode is self::IS_TAIL, false otherwise
+     */
+    public function isTail()
+    {
+        return self::IS_TAIL === (self::IS_TAIL & $this->mode);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -50,7 +50,8 @@ class InputArgumentTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('ANOTHER_ONE'),
-            array(-1)
+            array(-1),
+            array(16),
         );
     }
 
@@ -62,6 +63,23 @@ class InputArgumentTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($argument->isArray(), '->isArray() returns true if the argument can be an array');
         $argument = new InputArgument('foo', InputArgument::OPTIONAL);
         $this->assertFalse($argument->isArray(), '->isArray() returns false if the argument can not be an array');
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage InputArgument::IS_TAIL requires InputArgument::IS_ARRAY
+     */
+    public function testInvalidTailMode()
+    {
+        new InputArgument('foo', InputArgument::IS_TAIL);
+    }
+
+    public function testIsTail()
+    {
+        $argument = new InputArgument('foo', InputArgument::IS_ARRAY | InputArgument::IS_TAIL);
+        $this->assertTrue($argument->isTail(), '->isTail() returns true if the argument is a tail');
+        $argument = new InputArgument('foo', InputArgument::OPTIONAL);
+        $this->assertFalse($argument->isTail(), '->isTail() returns false if the argument is not a tail');
     }
 
     public function testGetDescription()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR introduces the concept of a "tail argument". It is essentially an extension of the concept of `InputArgument::IS_ARRAY` that allows the last argument in the command line to unconditionally capture all the remaining arguments, whether they look like options or not.

The use case targeted here is the one of command lines that chains or wrap other command lines. It makes possible to implement those without forcing the user to use the `--` separator to explicitly separate the options of the wrapper with the options of the wrapped command (at least when they are non-overlapping).
