### PR TITLE
[Console] Add methods for check verbosity of the output

### DIFF
--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -75,7 +75,6 @@ interface OutputInterface
      */
     public function getVerbosity();
 
-
     /**
      * The current verbosity of the output is quiet
      *

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -75,6 +75,43 @@ interface OutputInterface
      */
     public function getVerbosity();
 
+
+    /**
+     * The current verbosity of the output is quiet
+     *
+     * @return bool
+     *
+     * @api
+     */
+    public function isQuiet();
+
+    /**
+     * The current verbosity of the output is verbose
+     *
+     * @return bool
+     *
+     * @api
+     */
+    public function isVerbose();
+
+    /**
+     * The current verbosity of the output is very verbose
+     *
+     * @return bool
+     *
+     * @api
+     */
+    public function isVeryVerbose();
+
+    /**
+     * The current verbosity of the output is debug
+     *
+     * @return bool
+     *
+     * @api
+     */
+    public function isDebug();
+
     /**
      * Sets the decorated flag.
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| New feature? | yes |
| License | MIT |

Added to interface of the output, methods that are all implementations of the output classes ([1](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Output/Output.php#L101), [2](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Output/NullOutput.php#L78)) and [expected in other implementations](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L99).

In my project, created a proxy class that implements the interface to output, but found that is not enough.
