### PR TITLE
Improve the exception message of UrlMatcher

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -93,7 +93,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
 
         throw 0 < count($this->allow)
             ? new MethodNotAllowedException(array_unique(array_map('strtoupper', $this->allow)))
-            : new ResourceNotFoundException();
+            : new ResourceNotFoundException(sprintf('No routes found for %s.', $pathinfo));
     }
 
     /**


### PR DESCRIPTION
The current exception message is not optimal, some more context always helps.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
