### PR TITLE
[Routing] NamePrefix option for Route annotation

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -30,6 +30,7 @@ class Route
     private $methods = array();
     private $schemes = array();
     private $condition;
+    private $namePrefix;
 
     /**
      * Constructor.
@@ -158,5 +159,15 @@ class Route
     public function getCondition()
     {
         return $this->condition;
+    }
+
+    public function setNamePrefix($namePrefix)
+    {
+        $this->namePrefix = $namePrefix;
+    }
+
+    public function getNamePrefix()
+    {
+        return $this->namePrefix;
     }
 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -122,6 +122,9 @@ abstract class AnnotationClassLoader implements LoaderInterface
             $this->defaultRouteIndex = 0;
             foreach ($this->reader->getMethodAnnotations($method) as $annot) {
                 if ($annot instanceof $this->routeAnnotationClass) {
+                    if (null !== $annot->getNamePrefix()) {
+                        throw new \InvalidArgumentException(sprintf('Annotation for method %s in class %s may not contain "namePrefix" option.', $method, $class));
+                    }
                     $this->addRoute($collection, $annot, $globals, $class, $method);
                 }
             }
@@ -136,6 +139,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         if (null === $name) {
             $name = $this->getDefaultRouteName($class, $method);
         }
+        $name = $globals['namePrefix'].$name;
 
         $defaults = array_replace($globals['defaults'], $annot->getDefaults());
         foreach ($method->getParameters() as $param) {
@@ -217,6 +221,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
             'methods'      => array(),
             'host'         => '',
             'condition'    => '',
+            'namePrefix'   => '',
         );
 
         if ($annot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass)) {
@@ -253,6 +258,10 @@ abstract class AnnotationClassLoader implements LoaderInterface
 
             if (null !== $annot->getCondition()) {
                 $globals['condition'] = $annot->getCondition();
+            }
+
+            if (null !== $annot->getNamePrefix()) {
+                $globals['namePrefix'] = $annot->getNamePrefix();
             }
         }
 

--- a/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
@@ -45,6 +45,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
             array('methods', array('GET', 'POST'), 'getMethods'),
             array('host', array('{locale}.example.com'), 'getHost'),
             array('condition', array('context.getMethod() == "GET"'), 'getCondition'),
+            array('namePrefix', array('sf2_'), 'getNamePrefix'),
         );
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/NamePrefixInMethodClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/NamePrefixInMethodClass.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class NamePrefixInMethodClass
+{
+    /**
+     * @Route("/", namePrefix="sf2_")
+     */
+    public function testAction()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -42,6 +42,28 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadWithNamePrefixOptionInMethod()
+    {
+        $this->reader
+            ->expects($this->once())
+            ->method('getClassAnnotation')
+            ->will($this->returnValue(array()))
+        ;
+
+        $this->reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue(array($this->getAnnotatedRoute(array(
+                'namePrefix' => 'sf2_',
+            )))))
+        ;
+
+        $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\NamePrefixInMethodClass');
+    }
+
+    /**
      * @dataProvider provideTestSupportsChecksResource
      */
     public function testSupportsChecksResource($resource, $expectedSupports)
@@ -108,6 +130,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
             'schemes'      => array(),
             'methods'      => array(),
             'condition'    => null,
+            'namePrefix'   => null,
         ), $routeDatas);
 
         $this->reader

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -29,7 +29,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 
     public function testLoad()
     {
-        $this->reader->expects($this->exactly(2))->method('getClassAnnotation');
+        $this->reader->expects($this->exactly(3))->method('getClassAnnotation');
 
         $this->reader
             ->expects($this->any())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Added ability to set name prefix to routes through annotations. Example:

``` php
/**
 * @Route("/", namePrefix="sf2_")
 */
class SomeController
{
    /**
     * @Route("/", name="test")
     * Name will be sf2_test
     */
    public function someAction()
    {
    }
}
```

This option must be used only in annotations for class!
