### PR TITLE
[Filesystem] Add FTP stream wrapper context option to enable overwrite

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -54,7 +54,8 @@ class Filesystem
             if (false === $source = @fopen($originFile, 'r')) {
                 throw new IOException(sprintf('Failed to copy "%s" to "%s" because source file could not be opened for reading.', $originFile, $targetFile), 0, null, $originFile);
             }
-            if (false === $target = @fopen($targetFile, 'w')) {
+            // Stream context created to allow files overwrite when using FTP stream wrapper - disabled by default
+            if (false === $target = @fopen($targetFile, 'w', null, stream_context_create(array('ftp' => array('overwrite' => true))))) {
                 throw new IOException(sprintf('Failed to copy "%s" to "%s" because target file could not be opened for writing.', $originFile, $targetFile), 0, null, $originFile);
             }
             stream_copy_to_stream($source, $target);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Without this change it's not possible to override a file on FTP by calling Filesystem::copy($originFile, $targetFile, true) as PHP/FTP server responds with error like:

fopen(ftp://...@ftp/file.txt): failed to open stream: Remote file already exists and overwrite context option not specified FTP server reports 213 166440 []

TODO: Write an integration tests? How? Use some real FTP server?
