### PR TITLE
[CssSelector] Fix URL to SimonSapin/cssselect repo in README

### DIFF
--- a/src/Symfony/Component/CssSelector/README.md
+++ b/src/Symfony/Component/CssSelector/README.md
@@ -35,7 +35,7 @@ Resources
 This component is a port of the Python lxml library, which is copyright Infrae
 and distributed under the BSD license.
 
-Current code is a port of https://github.com/SimonSapin/cssselect@v0.7.1
+Current code is a port of https://github.com/SimonSapin/cssselect/releases/tag/v0.7.1
 
 You can run the unit tests with the following command:
 


### PR DESCRIPTION
This fixes a broken link in the CssSelector README spotted by @philsturgeon in https://github.com/symfony/CssSelector/pull/2.

| Q | A |
| --- | --- |
| Fixed tickets | none |
| License | MIT |
