### PR TITLE
Fix/11785 splfileinfo finder issue

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
@@ -44,6 +44,10 @@ class DateRangeFilterIterator extends FilterIterator
     {
         $fileinfo = $this->current();
 
+				if (!file_exists($fileinfo->getRealPath())) {
+					  return false;
+				}
+
         $filedate = $fileinfo->getMTime();
         foreach ($this->comparators as $compare) {
             if (!$compare->test($filedate)) {

--- a/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
@@ -44,9 +44,9 @@ class DateRangeFilterIterator extends FilterIterator
     {
         $fileinfo = $this->current();
 
-				if (!file_exists($fileinfo->getRealPath())) {
-					  return false;
-				}
+        if (!file_exists($fileinfo->getRealPath())) {
+            return false;
+        }
 
         $filedate = $fileinfo->getMTime();
         foreach ($this->comparators as $compare) {

--- a/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
@@ -20,10 +20,10 @@ class DateRangeFilterIteratorTest extends RealIteratorTestCase
      * @dataProvider getAcceptData
      */
     public function testAccept($size, $expected)
-   {
-				$files = self::$files;
-				$files[] = self::toAbsolute('doesnotexist');
-				$inner = new Iterator($files);
+    {
+        $files = self::$files;
+        $files[] = self::toAbsolute('doesnotexist');
+        $inner = new Iterator($files);
 
         $iterator = new DateRangeFilterIterator($inner, $size);
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
@@ -20,8 +20,10 @@ class DateRangeFilterIteratorTest extends RealIteratorTestCase
      * @dataProvider getAcceptData
      */
     public function testAccept($size, $expected)
-    {
-        $inner = new Iterator(self::$files);
+   {
+				$files = self::$files;
+				$files[] = self::toAbsolute('doesnotexist');
+				$inner = new Iterator($files);
 
         $iterator = new DateRangeFilterIterator($inner, $size);
 


### PR DESCRIPTION
Description:
When you search some files with date constraints, all folders are given, even if they are not in the date scope.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11785 |
| License | MIT |
| Doc PR |  |
