### PR TITLE
fixed DateComparator if file does not exist

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
@@ -44,6 +44,10 @@ class DateRangeFilterIterator extends FilterIterator
     {
         $fileinfo = $this->current();
 
+				if (!file_exists($fileinfo->getRealPath())) {
+					  return false;
+				}
+
         $filedate = $fileinfo->getMTime();
         foreach ($this->comparators as $compare) {
             if (!$compare->test($filedate)) {

--- a/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
@@ -44,9 +44,9 @@ class DateRangeFilterIterator extends FilterIterator
     {
         $fileinfo = $this->current();
 
-				if (!file_exists($fileinfo->getRealPath())) {
-					  return false;
-				}
+        if (!file_exists($fileinfo->getRealPath())) {
+            return false;
+        }
 
         $filedate = $fileinfo->getMTime();
         foreach ($this->comparators as $compare) {

--- a/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
@@ -20,10 +20,10 @@ class DateRangeFilterIteratorTest extends RealIteratorTestCase
      * @dataProvider getAcceptData
      */
     public function testAccept($size, $expected)
-   {
-				$files = self::$files;
-				$files[] = self::toAbsolute('doesnotexist');
-				$inner = new Iterator($files);
+    {
+        $files = self::$files;
+        $files[] = self::toAbsolute('doesnotexist');
+        $inner = new Iterator($files);
 
         $iterator = new DateRangeFilterIterator($inner, $size);
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
@@ -20,8 +20,10 @@ class DateRangeFilterIteratorTest extends RealIteratorTestCase
      * @dataProvider getAcceptData
      */
     public function testAccept($size, $expected)
-    {
-        $inner = new Iterator(self::$files);
+   {
+				$files = self::$files;
+				$files[] = self::toAbsolute('doesnotexist');
+				$inner = new Iterator($files);
 
         $iterator = new DateRangeFilterIterator($inner, $size);
 


### PR DESCRIPTION
Description:
When a file is deleted after the iterator is created, the accept function throws the following exception: SplFileInfo::getMTime(): stat failed.  This is because the function doesn't check first for the existence of the file.  In theory, a deletion between existence being checked and getMTime getting called would still result in this error, but the risk area for this race condition is much smaller than the current risk area.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11785 |
| License | MIT |
| Doc PR |  |
