### PR TITLE
Disabled the PHPUnit self-update on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
     - sudo locale-gen fr_FR.UTF-8 && sudo update-locale
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "5.3.3" ]; then phpunit --self-update; fi;'
+#    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "5.3.3" ]; then phpunit --self-update; fi;'
 
 script:
     - ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark {};'


### PR DESCRIPTION
The 4.2.2 release available on Travis currently ships with a broken self-update command. Given that it is new enough to contain the fixes for the other bugs affecting the build, it is fine to keep using the available phar without updating it.

This avoids making all builds except 5.3.3 fail before running tests.

FYI, the bug itself is already fixed in PHPUnit so 4.2.3 will have a working command.
