### PR TITLE
[Security] Use hash_equals when available for constant-time string comparison

### DIFF
--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -35,6 +35,11 @@ class StringUtils
      */
     public static function equals($knownString, $userInput)
     {
+        // Use hash_equals if available (since PHP 5.6)
+        if (function_exists('hash_equals')) {
+            return hash_equals($knownString, $userInput);
+        }
+
         // Prevent issues if string length is 0
         $knownString .= chr(0);
         $userInput .= chr(0);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Use the `hash_equals` function (introduced in PHP 5.6) for timing attack safe string comparison when available.
