### PR TITLE
[Security] Use hash_equals when available for constant-time string comparison

### DIFF
--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Security\Core\Util;
  * String utility functions.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  */
 class StringUtils
 {
@@ -35,6 +36,11 @@ class StringUtils
      */
     public static function equals($knownString, $userInput)
     {
+        // Use hash_equals if applicable
+        if (function_exists('hash_equals') && strlen($knownString) === strlen($userInput)) {
+            return hash_equals($knownString, $userInput);
+        }
+
         // Prevent issues if string length is 0
         $knownString .= chr(0);
         $userInput .= chr(0);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Use the `hash_equals` function (introduced in PHP 5.6) for timing attack safe string comparison when available.

(https://github.com/symfony/symfony/pull/11795 reopened against the 2.3 branch.) 
