### PR TITLE
[YAML] fix handling of empty sequence items

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsBasicTests.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsBasicTests.yml
@@ -11,6 +11,30 @@ yaml: |
 php: |
     array('apple', 'banana', 'carrot')
 ---
+test: Sequence With Item Being Null In The Middle
+brief: |
+    You can specify a list in YAML by placing each
+    member of the list on a new line with an opening
+    dash. These lists are called sequences.
+yaml: |
+    - apple
+    -
+    - carrot
+php: |
+    array('apple', null, 'carrot')
+---
+test: Sequence With Last Item Being Null
+brief: |
+    You can specify a list in YAML by placing each
+    member of the list on a new line with an opening
+    dash. These lists are called sequences.
+yaml: |
+    - apple
+    - banana
+    -
+php: |
+    array('apple', 'banana', null)
+---
 test: Nested Sequences
 brief: |
     You can include a sequence within another


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11798 |
| License | MIT |
| Doc PR |  |

When a line contains only a dash it cannot safely be assumed that it contains a nested list or an embedded mapping. If the next line starts with a dash at the same indentation, the current line's item is to be treated as `null`.
