### PR TITLE
[Monolog] added NotFoundActivationStrategy from MonologBundle

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/NotFoundActivationStrategy.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/NotFoundActivationStrategy.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Handler\FingersCrossed;
+
+use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Activation strategy that ignores 404s for certain URLs.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class NotFoundActivationStrategy extends ErrorLevelActivationStrategy
+{
+    private $blacklist;
+    private $request;
+
+    public function __construct(array $excludedUrls, $actionLevel)
+    {
+        parent::__construct($actionLevel);
+        $this->blacklist = '{('.implode('|', $excludedUrls).')}i';
+    }
+
+    public function isHandlerActivated(array $record)
+    {
+        $isActivated = parent::isHandlerActivated($record);
+        if (
+            $isActivated
+            && $this->request
+            && isset($record['context']['exception'])
+            && $record['context']['exception'] instanceof HttpException
+            && $record['context']['exception']->getStatusCode() == 404
+        ) {
+            return !preg_match($this->blacklist, $this->request->getPathInfo());
+        }
+
+        return $isActivated;
+    }
+
+    public function setRequest(Request $req = null)
+    {
+        $this->request = $req;
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Handler\FingersCrossed;
+
+use Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Monolog\Logger;
+
+class NotFoundActivationStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider isActivatedProvider
+     */
+    public function testIsActivated($url, $record, $expected)
+    {
+        $strategy = new NotFoundActivationStrategy(array('^/foo', 'bar'), Logger::WARNING);
+        $strategy->setRequest(Request::create($url));
+
+        $this->assertEquals($expected, $strategy->isHandlerActivated($record));
+    }
+
+    public function isActivatedProvider()
+    {
+        return array(
+            array('/test',      array('level' => Logger::DEBUG), false),
+            array('/foo',       array('level' => Logger::DEBUG, 'context' => $this->getContextException(404)), false),
+            array('/baz/bar',   array('level' => Logger::ERROR, 'context' => $this->getContextException(404)), false),
+            array('/foo',       array('level' => Logger::ERROR, 'context' => $this->getContextException(404)), false),
+            array('/foo',       array('level' => Logger::ERROR, 'context' => $this->getContextException(500)), true),
+
+            array('/test',      array('level' => Logger::ERROR), true),
+            array('/baz',       array('level' => Logger::ERROR, 'context' => $this->getContextException(404)), true),
+            array('/baz',       array('level' => Logger::ERROR, 'context' => $this->getContextException(500)), true),
+        );
+    }
+
+    protected function getContextException($code)
+    {
+        return array('exception' => new HttpException($code));
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Monolog\Tests\Handler\FingersCrossed;
 
 use Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Monolog\Logger;
 
@@ -23,8 +24,10 @@ class NotFoundActivationStrategyTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsActivated($url, $record, $expected)
     {
-        $strategy = new NotFoundActivationStrategy(array('^/foo', 'bar'), Logger::WARNING);
-        $strategy->setRequest(Request::create($url));
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create($url));
+
+        $strategy = new NotFoundActivationStrategy($requestStack, array('^/foo', 'bar'), Logger::WARNING);
 
         $this->assertEquals($expected, $strategy->isHandlerActivated($record));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The NotFoundActivationStrategy class from MonologBundle is totally independent of the framework and should be part of the bridge instead. That would allow people to use it easily with Silex for instance.

ping @Seldaek
