### PR TITLE
[Security] Add more tests for StringUtils::equals

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Util/StringUtilsTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Util/StringUtilsTest.php
@@ -13,11 +13,49 @@ namespace Symfony\Component\Security\Core\Tests\Util;
 
 use Symfony\Component\Security\Core\Util\StringUtils;
 
+/**
+ * Data from PHP.net's hash_equals tests
+ */
 class StringUtilsTest extends \PHPUnit_Framework_TestCase
 {
-    public function testEquals()
+    public function dataProviderTrue()
     {
-        $this->assertTrue(StringUtils::equals('password', 'password'));
-        $this->assertFalse(StringUtils::equals('password', 'foo'));
+        return array(
+            array('same', 'same'),
+            array('', ''),
+            array(123, 123),
+            array(null, ''),
+            array(null, null),
+        );
+    }
+
+    public function dataProviderFalse()
+    {
+        return array(
+            array('not1same', 'not2same'),
+            array('short', 'longer'),
+            array('longer', 'short'),
+            array('', 'notempty'),
+            array('notempty', ''),
+            array(123, 'NaN'),
+            array('NaN', 123),
+            array(null, 123),
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderTrue
+     */
+    public function testEqualsTrue($known, $user)
+    {
+        $this->assertTrue(StringUtils::equals($known, $user));
+    }
+
+    /**
+     * @dataProvider dataProviderFalse
+     */
+    public function testEqualsFalse($known, $user)
+    {
+        $this->assertFalse(StringUtils::equals($known, $user));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

More tests for `StringUtils::equals`.
