### PR TITLE
[Security] Uniform AccessDecisionManager decide behaviour

### DIFF
--- a/src/Symfony/Component/Security/Tests/Core/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authorization/AccessDecisionManagerTest.php
@@ -65,6 +65,48 @@ class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $manager->decide($token, array('ROLE_FOO')));
     }
 
+    /**
+     * @dataProvider getStrategiesWith2RolesTests
+     */
+    public function testStrategiesWith2Roles($token, $strategy, $voter, $expected)
+    {
+        $manager = new AccessDecisionManager(array($voter), $strategy);
+
+        $this->assertSame($expected, $manager->decide($token, array('ROLE_FOO', 'ROLE_BAR')));
+    }
+
+    public function getStrategiesWith2RolesTests()
+    {
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+
+        return array(
+            array($token, 'affirmative', $this->getVoter(VoterInterface::ACCESS_DENIED), false),
+            array($token, 'affirmative', $this->getVoter(VoterInterface::ACCESS_GRANTED), true),
+
+            array($token, 'consensus', $this->getVoter(VoterInterface::ACCESS_DENIED), false),
+            array($token, 'consensus', $this->getVoter(VoterInterface::ACCESS_GRANTED), true),
+ 
+            array($token, 'unanimous', $this->getVoterFor2Roles($token, VoterInterface::ACCESS_DENIED, VoterInterface::ACCESS_DENIED), false),
+            array($token, 'unanimous', $this->getVoterFor2Roles($token, VoterInterface::ACCESS_DENIED, VoterInterface::ACCESS_GRANTED), false),
+            array($token, 'unanimous', $this->getVoterFor2Roles($token, VoterInterface::ACCESS_GRANTED, VoterInterface::ACCESS_DENIED), false),
+            array($token, 'unanimous', $this->getVoterFor2Roles($token, VoterInterface::ACCESS_GRANTED, VoterInterface::ACCESS_GRANTED), true),
+        );
+    }
+
+    protected function getVoterFor2Roles($token, $vote1, $vote2)
+    {
+        $voter = $this->getMock('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface');
+        $voter->expects($this->exactly(2))
+              ->method('vote')
+              ->will($this->returnValueMap(array(
+                  array($token, null, array("ROLE_FOO"),$vote1),
+                  array($token, null, array("ROLE_BAR"),$vote2),
+              )))
+        ;
+
+        return $voter;
+    }
+
     public function getStrategyTests()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10170 |
| License | MIT |
| Doc PR | none |

This PR uniforms the way the 3 decision policies (affirmative, consensus, unanimous) are handled in the Security\Core\Authoritzation\AccessDecisionManager.php

See #10170
