### PR TITLE
Use getPathname() instead of string casting to get BinaryFileReponse file path

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -35,13 +35,13 @@ class BinaryFileResponse extends Response
     /**
      * Constructor.
      *
-     * @param \SplFileInfo|string $file               The file to stream
-     * @param int                 $status             The response status code
-     * @param array               $headers            An array of response headers
-     * @param bool                $public             Files are public by default
-     * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
-     * @param bool                $autoEtag           Whether the ETag header should be automatically set
-     * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
+     * @param File|string $file               The file to stream
+     * @param int         $status             The response status code
+     * @param array       $headers            An array of response headers
+     * @param bool        $public             Files are public by default
+     * @param null|string $contentDisposition The type of Content-Disposition to set automatically with the filename
+     * @param bool        $autoEtag           Whether the ETag header should be automatically set
+     * @param bool        $autoLastModified   Whether the Last-Modified header should be automatically set
      */
     public function __construct($file, $status = 200, $headers = array(), $public = true, $contentDisposition = null, $autoEtag = false, $autoLastModified = true)
     {
@@ -55,13 +55,13 @@ class BinaryFileResponse extends Response
     }
 
     /**
-     * @param \SplFileInfo|string $file               The file to stream
-     * @param int                 $status             The response status code
-     * @param array               $headers            An array of response headers
-     * @param bool                $public             Files are public by default
-     * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
-     * @param bool                $autoEtag           Whether the ETag header should be automatically set
-     * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
+     * @param File|string $file               The file to stream
+     * @param int         $status             The response status code
+     * @param array       $headers            An array of response headers
+     * @param bool        $public             Files are public by default
+     * @param null|string $contentDisposition The type of Content-Disposition to set automatically with the filename
+     * @param bool        $autoEtag           Whether the ETag header should be automatically set
+     * @param bool        $autoLastModified   Whether the Last-Modified header should be automatically set
      *
      * @return BinaryResponse The created response
      */
@@ -73,10 +73,10 @@ class BinaryFileResponse extends Response
     /**
      * Sets the file to stream.
      *
-     * @param \SplFileInfo|string $file The file to stream
-     * @param string              $contentDisposition
-     * @param bool                $autoEtag
-     * @param bool                $autoLastModified
+     * @param File|string $file The file to stream
+     * @param string      $contentDisposition
+     * @param bool        $autoEtag
+     * @param bool        $autoLastModified
      *
      * @return BinaryFileResponse
      *

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -35,13 +35,13 @@ class BinaryFileResponse extends Response
     /**
      * Constructor.
      *
-     * @param File|string $file               The file to stream
-     * @param int         $status             The response status code
-     * @param array       $headers            An array of response headers
-     * @param bool        $public             Files are public by default
-     * @param null|string $contentDisposition The type of Content-Disposition to set automatically with the filename
-     * @param bool        $autoEtag           Whether the ETag header should be automatically set
-     * @param bool        $autoLastModified   Whether the Last-Modified header should be automatically set
+     * @param \SplFileInfo|string $file               The file to stream
+     * @param int                 $status             The response status code
+     * @param array               $headers            An array of response headers
+     * @param bool                $public             Files are public by default
+     * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
+     * @param bool                $autoEtag           Whether the ETag header should be automatically set
+     * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
      */
     public function __construct($file, $status = 200, $headers = array(), $public = true, $contentDisposition = null, $autoEtag = false, $autoLastModified = true)
     {
@@ -55,13 +55,13 @@ class BinaryFileResponse extends Response
     }
 
     /**
-     * @param File|string $file               The file to stream
-     * @param int         $status             The response status code
-     * @param array       $headers            An array of response headers
-     * @param bool        $public             Files are public by default
-     * @param null|string $contentDisposition The type of Content-Disposition to set automatically with the filename
-     * @param bool        $autoEtag           Whether the ETag header should be automatically set
-     * @param bool        $autoLastModified   Whether the Last-Modified header should be automatically set
+     * @param \SplFileInfo|string $file               The file to stream
+     * @param int                 $status             The response status code
+     * @param array               $headers            An array of response headers
+     * @param bool                $public             Files are public by default
+     * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
+     * @param bool                $autoEtag           Whether the ETag header should be automatically set
+     * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
      *
      * @return BinaryResponse The created response
      */
@@ -73,10 +73,10 @@ class BinaryFileResponse extends Response
     /**
      * Sets the file to stream.
      *
-     * @param File|string $file The file to stream
-     * @param string      $contentDisposition
-     * @param bool        $autoEtag
-     * @param bool        $autoLastModified
+     * @param \SplFileInfo|string $file The file to stream
+     * @param string              $contentDisposition
+     * @param bool                $autoEtag
+     * @param bool                $autoLastModified
      *
      * @return BinaryFileResponse
      *

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -85,7 +85,11 @@ class BinaryFileResponse extends Response
     public function setFile($file, $contentDisposition = null, $autoEtag = false, $autoLastModified = true)
     {
         if (!$file instanceof File) {
-            $file = new File((string) $file);
+            if ($file instanceof \SplFileInfo) {
+                $file = new File($file->getPathname());
+            } else {
+                $file = new File((string) $file);
+            }
         }
 
         if (!$file->isReadable()) {

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -211,6 +211,16 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertFileNotExists($path);
     }
 
+    public function testSplFileObject()
+    {
+        $filePath = __DIR__.'/File/Fixtures/test';
+        $file = new \SplFileObject($filePath);
+
+        $response = new BinaryFileResponse($file);
+
+        $this->assertEquals($response->getfile()->getPathname(), $filePath);
+    }
+
     public function getSampleXAccelMappings()
     {
         return array(

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -218,7 +218,7 @@ class BinaryFileResponseTest extends ResponseTestCase
 
         $response = new BinaryFileResponse($file);
 
-        $this->assertEquals($response->getfile()->getPathname(), $filePath);
+        $this->assertEquals($response->getFile()->getPathname(), $filePath);
     }
 
     public function getSampleXAccelMappings()

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -218,7 +218,7 @@ class BinaryFileResponseTest extends ResponseTestCase
 
         $response = new BinaryFileResponse($file);
 
-        $this->assertEquals($response->getFile()->getPathname(), $filePath);
+        $this->assertEquals(realpath($response->getFile()->getPathname()), realpath($filePath));
     }
 
     public function getSampleXAccelMappings()


### PR DESCRIPTION
According to the code, should be "File" instead of "\SplFileInfo"
