### PR TITLE
[FrameworkBundle][DX] Add --expand option to show full parameters.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -51,6 +51,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
                 new InputOption('parameters', null, InputOption::VALUE_NONE, 'Displays parameters for an application'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'To output description in other formats', 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw description'),
+                new InputOption('expand', null, InputOption::VALUE_NONE, 'Display full parameter value'),
             ))
             ->setDescription('Displays current services for an application')
             ->setHelp(<<<EOF
@@ -118,6 +119,7 @@ EOF
         $helper = new DescriptorHelper();
         $options['format'] = $input->getOption('format');
         $options['raw_text'] = $input->getOption('raw');
+        $options['expand'] = $input->getOption('expand');
         $helper->describe($output, $object, $options);
     }
 
@@ -144,6 +146,10 @@ EOF
             throw new \InvalidArgumentException('The options tags, tag, parameters & parameter can not be combined with the service name argument.');
         } elseif ((null === $name) && $optionsCount > 1) {
             throw new \InvalidArgumentException('The options tags, tag, parameters & parameter can not be combined together.');
+        } elseif ($input->getOption('expand') && $input->getOption('parameter') === null) {
+            throw new \InvalidArgumentException('The expand option can only be used with the parameter option.');
+        } elseif ($input->getOption('expand') && $input->getOption('format') !== 'txt') {
+            throw new \InvalidArgumentException('The expand option is only available for dumping parameters in "txt" format.');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
@@ -281,6 +282,13 @@ class TextDescriptor extends Descriptor
      */
     protected function describeContainerParameter($parameter, array $options = array())
     {
+        if (!empty($options['expand']) && !is_scalar($parameter)) {
+
+            $this->writeText(Yaml::dump($parameter), $options);
+
+            return;
+        }
+
         $this->writeText($this->formatParameter($parameter), $options);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | NA |
| License | MIT |
| Doc PR | TODO |

Dumping non-scalar parameters most likely result to the output being a truncated JSON string. This PR simply adds an `--expand` flag which allows us to dump the full value of non-scalar parameters in YAML format (for maximum readability)

This only applies for the `txt` format. `xml`, `json`, and `md` will still have the truncated JSON representation.
