### PR TITLE
[Yaml] improve error message when detecting unquoted asterisks

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -392,7 +392,7 @@ class Inline
      *
      * @return string A YAML string
      *
-     * @throws ParseException when object parsing support was disabled and the parser detected a PHP object
+     * @throws ParseException when object parsing support was disabled and the parser detected a PHP object or when a reference could not be resolved
      */
     private static function evaluateScalar($scalar, $references = array())
     {
@@ -404,6 +404,11 @@ class Inline
                 $value = substr($scalar, 1, $pos - 2);
             } else {
                 $value = substr($scalar, 1);
+            }
+
+            // an unquoted *
+            if (false === $value || '' === $value) {
+                throw new ParseException('A reference must contain at least one character.');
             }
 
             if (!array_key_exists($value, $references)) {

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -147,6 +147,24 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array($foo), Inline::parse('[*foo]', false, false, array('foo' => $foo)));
     }
 
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage A reference must contain at least one character.
+     */
+    public function testParseUnquotedAsterisk()
+    {
+        Inline::parse('{ foo: * }');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage A reference must contain at least one character.
+     */
+    public function testParseUnquotedAsteriskFollowedByAComment()
+    {
+        Inline::parse('{ foo: * #foo }');
+    }
+
     protected function getTestsForParse()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11835 |
| License | MIT |
| Doc PR |  |

Asterisks in unquoted strings are used in YAML to reference variables. Before Symfony 2.3.19, Symfony 2.4.9 and Symfony 2.5.4, unquoted asterisks in inlined YAML code were treated as regular strings. This was fixed for the inline parser in #11677. However, an unquoted \* character now led to an error message like this:

```
PHP Warning:  array_key_exists(): The first argument should be either a string or an integer in vendor/symfony/symfony/src/Symfony/Component/Yaml/Inline.php on line 409

  [Symfony\Component\Yaml\Exception\ParseException]
  Reference "" does not exist at line 171 (near "- { foo: * }").
```
