### PR TITLE
[FrameworkBundle] improve handling router script paths

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -101,6 +101,14 @@ EOF
             ->locateResource(sprintf('@FrameworkBundle/Resources/config/router_%s.php', $env))
         ;
 
+        if (!file_exists($router)) {
+            $output->writeln(sprintf('<error>The given router script "%s" does not exist</error>', $router));
+
+            return 1;
+        }
+
+        $router = realpath($router);
+
         $output->writeln(sprintf("Server running on <info>http://%s</info>\n", $input->getArgument('address')));
 
         $builder = new ProcessBuilder(array(PHP_BINARY, '-S', $input->getArgument('address'), $router));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `server:run` command switches the working directory before starting the built-in web server. Therefore, the path to a custom router script had to be specified based on the document root path and not based on the user's working directory.

Another option is to update the documentation (as started in symfony/symfony-docs#4194). Though I think the current behaviour is a bug. The intended behaviour can be derived from the command's help message:

> ```
> If you have custom docroot directory layout, you can specify your own
>  router script using --router option:
> 
>   ./app/console server:run --router=app/config/router.php
> ```

As you can see, the path is specified based on the current working directory.
