### PR TITLE
[HttpKernel] Escape ESI url in generated response

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -236,9 +236,9 @@ class Esi
             throw new \RuntimeException('Unable to process an ESI tag without a "src" attribute.');
         }
 
-        return sprintf('<?php echo $this->esi->handle($this, \'%s\', \'%s\', %s) ?>'."\n",
-            $options['src'],
-            isset($options['alt']) ? $options['alt'] : null,
+        return sprintf('<?php echo $this->esi->handle($this, %s, %s, %s) ?>'."\n",
+            var_export($options['src'], true),
+            var_export(isset($options['alt']) ? $options['alt'] : '', true),
             isset($options['onerror']) && 'continue' == $options['onerror'] ? 'true' : 'false'
         );
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -110,6 +110,11 @@ class EsiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo <?php echo $this->esi->handle($this, \'...\', \'alt\', true) ?>'."\n", $response->getContent());
         $this->assertEquals('ESI', $response->headers->get('x-body-eval'));
 
+        $response = new Response('foo <esi:comment text="some comment" /><esi:include src="foo\'" alt="bar\'" onerror="continue" />');
+        $esi->process($request, $response);
+
+        $this->assertEquals("foo <?php echo \$this->esi->handle(\$this, 'foo\\'', 'bar\\'', true) ?>"."\n", $response->getContent());
+
         $response = new Response('foo <esi:include src="..." />');
         $esi->process($request, $response);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | NA |

If a template with an `<esi>` tag  is configured with an URL containing a `'` (in  `src` or `alt`) ; the HttpCache will generate invalide php code.

It's not a security issue, given the template and the `<esi>` tag is written by the developper, but, as the character quote is allowed in URL (https://tools.ietf.org/html/rfc3986) it coud be a potential bug.
