### PR TITLE
[YAML] properly mask escape sequences in quoted strings

### DIFF
--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -26,13 +26,13 @@ class Escaper
     // first to ensure proper escaping because str_replace operates iteratively
     // on the input arrays. This ordering of the characters avoids the use of strtr,
     // which performs more slowly.
-    private static $escapees = array('\\\\', '\\"', '"',
+    private static $escapees = array('\\', '\\\\', '\\"', '"',
                                      "\x00",  "\x01",  "\x02",  "\x03",  "\x04",  "\x05",  "\x06",  "\x07",
                                      "\x08",  "\x09",  "\x0a",  "\x0b",  "\x0c",  "\x0d",  "\x0e",  "\x0f",
                                      "\x10",  "\x11",  "\x12",  "\x13",  "\x14",  "\x15",  "\x16",  "\x17",
                                      "\x18",  "\x19",  "\x1a",  "\x1b",  "\x1c",  "\x1d",  "\x1e",  "\x1f",
                                      "\xc2\x85", "\xc2\xa0", "\xe2\x80\xa8", "\xe2\x80\xa9");
-    private static $escaped  = array('\\"', '\\\\', '\\"',
+    private static $escaped  = array('\\\\', '\\"', '\\\\', '\\"',
                                      "\\0",   "\\x01", "\\x02", "\\x03", "\\x04", "\\x05", "\\x06", "\\a",
                                      "\\b",   "\\t",   "\\n",   "\\v",   "\\f",   "\\r",   "\\x0e", "\\x0f",
                                      "\\x10", "\\x11", "\\x12", "\\x13", "\\x14", "\\x15", "\\x16", "\\x17",

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -199,6 +199,37 @@ EOF;
     {
         $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, true, false);
     }
+
+    /**
+     * @dataProvider getEscapeSequences
+     */
+    public function testEscapedEscapeSequencesInQuotedScalar($input, $expected)
+    {
+        $this->assertEquals($expected, $this->dumper->dump($input));
+    }
+
+    public function getEscapeSequences()
+    {
+        return array(
+            'null' => array("\t\\0", '"\t\\\\0"'),
+            'bell' => array("\t\\a", '"\t\\\\a"'),
+            'backspace' => array("\t\\b", '"\t\\\\b"'),
+            'horizontal-tab' => array("\t\\t", '"\t\\\\t"'),
+            'line-feed' => array("\t\\n", '"\t\\\\n"'),
+            'vertical-tab' => array("\t\\v", '"\t\\\\v"'),
+            'form-feed' => array("\t\\f", '"\t\\\\f"'),
+            'carriage-return' => array("\t\\r", '"\t\\\\r"'),
+            'escape' => array("\t\\e", '"\t\\\\e"'),
+            'space' => array("\t\\ ", '"\t\\\\ "'),
+            'double-quote' => array("\t\\\"", '"\t\\\\\\""'),
+            'slash' => array("\t\\/", '"\t\\\\/"'),
+            'backslash' => array("\t\\\\", '"\t\\\\\\\\"'),
+            'next-line' => array("\t\\N", '"\t\\\\N"'),
+            'non-breaking-space' => array("\t\\�", '"\t\\\\�"'),
+            'line-separator' => array("\t\\L", '"\t\\\\L"'),
+            'paragraph-separator' => array("\t\\P", '"\t\\\\P"'),
+        );
+    }
 }
 
 class A


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11789 |
| License | MIT |
| Doc PR |  |
