### PR TITLE
[HttpKernel] Escape SSI virtual in generated response

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -71,7 +71,7 @@ class Ssi implements SurrogateInterface
         $current = $request->headers->get('Surrogate-Capability');
         $new = 'symfony2="SSI/1.0"';
 
-        $request->headers->set('Surrogate-Capability', $current ? $current . ', ' . $new : $new);
+        $request->headers->set('Surrogate-Capability', $current ? $current.', '.$new : $new);
     }
 
     /**
@@ -188,7 +188,7 @@ class Ssi implements SurrogateInterface
             throw new \RuntimeException('Unable to process an SSI tag without a "virtual" attribute.');
         }
 
-        return sprintf('<?php echo $this->surrogate->handle($this, %s, \'\', false) ?>' . "\n",
+        return sprintf('<?php echo $this->surrogate->handle($this, %s, \'\', false) ?>'."\n",
             var_export($options['virtual'], true)
         );
     }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -188,10 +188,8 @@ class Ssi implements SurrogateInterface
             throw new \RuntimeException('Unable to process an SSI tag without a "virtual" attribute.');
         }
 
-        return sprintf('<?php echo $this->surrogate->handle($this, \'%s\', \'%s\', %s) ?>' . "\n",
-            $options['virtual'],
-            '',
-            'false'
+        return sprintf('<?php echo $this->surrogate->handle($this, %s, \'\', false) ?>' . "\n",
+            var_export($options['virtual'], true)
         );
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -101,6 +101,11 @@ class SsiTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo <?php echo $this->surrogate->handle($this, \'...\', \'\', false) ?>'."\n", $response->getContent());
         $this->assertEquals('SSI', $response->headers->get('x-body-eval'));
+
+        $response = new Response('foo <!--#include virtual="foo\'" -->');
+        $ssi->process($request, $response);
+
+        $this->assertEquals("foo <?php echo \$this->surrogate->handle(\$this, 'foo\\'', '', false) ?>"."\n", $response->getContent());
     }
 
     public function testProcessEscapesPhpTags()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | NA |

If a template with an `<!--#inlude -->` tag  is configured with an "virtual" containing a `'` ; the HttpCache will generate invalide php code.

See #11845 for the same issue on `<esi>` tags
