### PR TITLE
[Console] add overwrite flag to ProgressBar helper to allow non-decorated output

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -312,12 +312,62 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
     public function testNonDecoratedOutput()
     {
+        $bar = new ProgressBar($output = $this->getOutputStream(false), 200);
+        $bar->start();
+
+        for ($i = 0; $i < 200; $i++) {
+            $bar->advance();
+        }
+
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            "   0/200 [>---------------------------]   0%\n".
+            "  20/200 [==>-------------------------]  10%\n".
+            "  40/200 [=====>----------------------]  20%\n".
+            "  60/200 [========>-------------------]  30%\n".
+            "  80/200 [===========>----------------]  40%\n".
+            " 100/200 [==============>-------------]  50%\n".
+            " 120/200 [================>-----------]  60%\n".
+            " 140/200 [===================>--------]  70%\n".
+            " 160/200 [======================>-----]  80%\n".
+            " 180/200 [=========================>--]  90%\n".
+            " 200/200 [============================] 100%",
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testNonDecoratedOutputWithClear()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(false), 50);
+        $bar->start();
+        $bar->setProgress(25);
+        $bar->clear();
+        $bar->setProgress(50);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            "  0/50 [>---------------------------]   0%\n".
+            " 25/50 [==============>-------------]  50%\n".
+            " 50/50 [============================] 100%",
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testNonDecoratedOutputWithoutMax()
+    {
         $bar = new ProgressBar($output = $this->getOutputStream(false));
         $bar->start();
         $bar->advance();
 
         rewind($output->getStream());
-        $this->assertEquals('', stream_get_contents($output->getStream()));
+        $this->assertEquals(
+            "    0 [>---------------------------]\n".
+            "    1 [->--------------------------]",
+            stream_get_contents($output->getStream())
+        );
     }
 
     public function testParallelBars()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes, but not critical |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11542, #10011 |
| License | MIT |
| Doc PR | symfony/symfony-docs#4206 |

By default, the `ProgressBar` helper overwrites the output to give the nice progress bar look.  To prevent the output from blowing up in non-decorated environments, the output was hidden in these environments (see #9846).  

This PR enables using the `ProgressBar` in non-decorated environments by adding an `overwrite` flag.  When `false`, instead of overwriting the bar, it is rendered on a new line.  To prevent flooding the output, you can adjust the `redrawFrequency`.  

By default, when using the `ProgressBar` in a non-decorated environment, the `overwrite` flag is set to false.  If a `max` is set, the `redrawFrequency` is set to a sensible default (10% of the max).  If a `max` isn't set, the bar is output for every advance so to prevent flooding, a sensible `redrawFrequency` should be manually set.

The only BC break is that output will now display where it didn't before.
