### PR TITLE
[FileSystem] Fix Throw Exception on copying from an unreadable file

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -56,7 +56,7 @@ class Filesystem
             }
 
             // Stream context created to allow files overwrite when using FTP stream wrapper - disabled by default
-            if (false === $target = fopen($targetFile, 'w', null, stream_context_create(array('ftp' => array('overwrite' => true))))) {
+            if (false === $target = @fopen($targetFile, 'w', null, stream_context_create(array('ftp' => array('overwrite' => true))))) {
                 throw new IOException(sprintf('Failed to copy "%s" to "%s" because target file could not be opened for writing.', $originFile, $targetFile), 0, null, $originFile);
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | NA |

Two commits on `Filesystem::copy`  was merged on diffrentes branches c056a9c426af43920e543eaedc66fe919f0ae838 and cd5da9b3c879eac2665722cd5a4f7a2c726392e1 but on the merge operation a `@fopen` was transformed to `fopen` . Thas why, actualy, travis is down on master branch (https://travis-ci.org/symfony/symfony/jobs/34427199#L434)
