### PR TITLE
Convert host to IDNA ASCII form

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -68,8 +68,14 @@ class EmailValidator extends ConstraintValidator
 
         if ($valid) {
             $host = substr($value, strpos($value, '@') + 1);
+            
+            // Convert host to IDNA ASCII form
+            // 'täst.de' is converted to 'xn--tst-qla.de'
+            if (function_exists(idn_to_ascii)) {
+                $host = idn_to_ascii($host);
+            }
+            
             // Check for host DNS resource records
-
             if ($valid && $constraint->checkMX) {
                 $valid = $this->checkMX($host);
             } elseif ($valid && $constraint->checkHost) {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -71,7 +71,7 @@ class EmailValidator extends ConstraintValidator
             
             // Convert host to IDNA ASCII form
             // 'täst.de' is converted to 'xn--tst-qla.de'
-            if (function_exists(idn_to_ascii)) {
+            if (function_exists('idn_to_ascii')) {
                 $host = idn_to_ascii($host);
             }
             


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | NA |

`checkdnsrr()` returns `false` if the host contains unusual characters.
Converting it using `idn_to_ascii()` prevents that.
