### PR TITLE
[Filesystem] Check number of bytes copied.

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -60,13 +60,17 @@ class Filesystem
                 throw new IOException(sprintf('Failed to copy "%s" to "%s" because target file could not be opened for writing.', $originFile, $targetFile), 0, null, $originFile);
             }
 
-            stream_copy_to_stream($source, $target);
+            $bytesCopied = stream_copy_to_stream($source, $target);
             fclose($source);
             fclose($target);
             unset($source, $target);
 
             if (!is_file($targetFile)) {
                 throw new IOException(sprintf('Failed to copy "%s" to "%s".', $originFile, $targetFile), 0, null, $originFile);
+            }
+
+            if (stream_is_local($originFile) && $bytesCopied !== filesize($originFile)) {
+                throw new IOException(sprintf('Failed to copy the whole content of "%s" to "%s %g bytes copied".', $originFile, $targetFile, $bytesCopied), 0, null, $originFile);
             }
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10838 |
| License | MIT |
| Doc PR | n/a |

This only test local files (because of `filesize`), wonder if we should include the remote files using `get_headers` in order to get the Content-length for example. However, it will perform an additional request...

Here's a little benchmark for 500 copy from a remote origin file :
- Standard without check -> Time: 47.34 seconds, Memory: 3.75Mb
- Check with `get_headers` ->Time: 1.32 minutes, Memory: 3.75Mb
