### PR TITLE
[Security] Fix usage of unexistent method in DoctrineAclCache.

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/DoctrineAclCache.php
+++ b/src/Symfony/Component/Security/Acl/Domain/DoctrineAclCache.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
 use Symfony\Component\Security\Acl\Model\AclCacheInterface;
 use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
@@ -55,7 +56,9 @@ class DoctrineAclCache implements AclCacheInterface
      */
     public function clearCache()
     {
-        $this->cache->deleteByPrefix($this->prefix);
+        if ($this->cache instanceof CacheProvider) {
+            $this->cache->deleteAll();
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10328 |
| License | MIT |
| Doc PR |  |

The method `deleteByPrefix` does not exist. I replaced it by `deleteAll`: as @guilhermeblanco said, this method is not available in the interface `Cache` but it is present in the abstract class `CacheProvider`.
