### PR TITLE
[Translator] Do not use cache if debug is on

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -302,7 +302,7 @@ class Translator implements TranslatorInterface
      */
     protected function loadCatalogue($locale)
     {
-        if (null === $this->cacheDir) {
+        if ($this->debug || null === $this->cacheDir) {
             $this->initializeCatalogue($locale);
         } else {
             $this->initializeCacheCatalogue($locale);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11530 |
| License | MIT |
| Doc PR | N/A |

As I can't find a way to know if a new translation file have been added to invalidate the cache in the method isFresh of ConfigCache I decided to go with the easy way and never use the cache if the debug is turned on. 

I'm pretty sure that trying to determine if we should use the cache or not is heavier that just not use it. 
