### PR TITLE
Remove routes for removed WebProfiler actions

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -24,14 +24,6 @@
         <default key="_controller">web_profiler.controller.profiler:infoAction</default>
     </route>
 
-    <route id="_profiler_import" pattern="/import">
-        <default key="_controller">web_profiler.controller.profiler:importAction</default>
-    </route>
-
-    <route id="_profiler_export" pattern="/export/{token}.txt">
-        <default key="_controller">web_profiler.controller.profiler:exportAction</default>
-    </route>
-
     <route id="_profiler_phpinfo" pattern="/phpinfo">
         <default key="_controller">web_profiler.controller.profiler:phpinfoAction</default>
     </route>


### PR DESCRIPTION
The import/export functionality was moved to commands in f38536ab79058f6a934426c41170256ba9623a02, but the routes were not removed.
