### PR TITLE
[EventDispatcher] Add an interface for the ContainerAwareEventDispatcher

### DIFF
--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Jordan Alliot <jordan.alliot@gmail.com>
  */
-class ContainerAwareEventDispatcher extends EventDispatcher
+class ContainerAwareEventDispatcher extends EventDispatcher implements ContainerAwareEventDispatcherInterface
 {
     /**
      * The container from where services are loaded
@@ -52,16 +52,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     }
 
     /**
-     * Adds a service as event listener
-     *
-     * @param string $eventName Event for which the listener is added
-     * @param array  $callback  The service ID of the listener service & the method
-     *                            name that has to be called
-     * @param int     $priority The higher this value, the earlier an event listener
-     *                            will be triggered in the chain.
-     *                            Defaults to 0.
-     *
-     * @throws \InvalidArgumentException
+     * {@inheritdoc}
      */
     public function addListenerService($eventName, $callback, $priority = 0)
     {
@@ -132,10 +123,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     }
 
     /**
-     * Adds a service as event subscriber
-     *
-     * @param string $serviceId The service ID of the subscriber service
-     * @param string $class     The service's class name (which must implement EventSubscriberInterface)
+     * {@inheritdoc}
      */
     public function addSubscriberService($serviceId, $class)
     {

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcherInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ * A ContainerAwareEventDispatcher is able to load the listeners
+ * and subscribers from the dependency injection container.
+ *
+ * @author Tristan Darricau <tristan@darricau.eu>
+ */
+interface ContainerAwareEventDispatcherInterface extends EventDispatcherInterface
+{
+    /**
+     * Adds a service as event listener
+     *
+     * @param string $eventName Event for which the listener is added
+     * @param array  $callback  The service ID of the listener service & the method
+     *                          name that has to be called
+     * @param int    $priority  The higher this value, the earlier an event listener
+     *                          will be triggered in the chain.
+     *                          Defaults to 0.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function addListenerService($eventName, $callback, $priority = 0);
+
+    /**
+     * Adds a service as event subscriber
+     *
+     * @param string $serviceId The service ID of the subscriber service
+     * @param string $class     The service's class name (which must implement EventSubscriberInterface)
+     */
+    public function addSubscriberService($serviceId, $class);
+}

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableContainerAwareEventDispatcher.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Debug;
+
+use Symfony\Component\Stopwatch\Stopwatch;
+use Psr\Log\LoggerInterface;
+
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcherInterface;
+
+/**
+ * Collects some data about event listeners.
+ *
+ * This event dispatcher delegates the dispatching to another one.
+ *
+ * @author Tristan Darricau <tristan@darricau.eu>
+ */
+class TraceableContainerAwareEventDispatcher extends TraceableEventDispatcher implements ContainerAwareEventDispatcherInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param ContainerAwareEventDispatcherInterface $dispatcher An EventDispatcherInterface instance
+     * @param Stopwatch                              $stopwatch  A Stopwatch instance
+     * @param LoggerInterface                        $logger     A LoggerInterface instance
+     */
+    public function __construct(ContainerAwareEventDispatcherInterface $dispatcher, Stopwatch $stopwatch, LoggerInterface $logger = null)
+    {
+        parent::__construct($dispatcher, $stopwatch, $logger);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addListenerService($eventName, $callback, $priority = 0)
+    {
+        $this->dispatcher->addListenerService($eventName, $callback, $priority);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSubscriberService($serviceId, $class)
+    {
+        $this->dispatcher->addSubscriberService($serviceId, $class);
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -28,9 +28,9 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
 {
     protected $logger;
     protected $stopwatch;
+    protected $dispatcher;
 
     private $called;
-    private $dispatcher;
 
     /**
      * Constructor.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently if a class depends on the ContainerAwareEventDispatcher it's not possible to replace it by the TraceableEventDispatcher without rewriting the class.
