### PR TITLE
[Console] added type hinting for array to setAliases method

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -521,11 +521,11 @@ class Command
 
         $placeholders = array(
             '%command.name%',
-            '%command.full_name%'
+            '%command.full_name%',
         );
         $replacements = array(
             $name,
-            $_SERVER['PHP_SELF'].' '.$name
+            $_SERVER['PHP_SELF'].' '.$name,
         );
 
         return str_replace($placeholders, $replacements, $this->getHelp());

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -542,7 +542,7 @@ class Command
      *
      * @api
      */
-    public function setAliases($aliases)
+    public function setAliases(array $aliases)
     {
         foreach ($aliases as $alias) {
             $this->validateName($alias);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This patch would improve feedback when passing an invalid alias to setAliases method:

e.g.

`Argument 1 passed to Symfony\Component\Console\Command\Command::setAliases() must be of the type array, string given,` [...]

instead of 

`Invalid argument supplied for foreach()`
