### PR TITLE
[Console] Added three state long option

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -249,7 +249,7 @@ class ArgvInput extends Input
 
         if ($option->isArray()) {
             $this->options[$name][] = $value;
-        } elseif ($option->isValueOptionull() && true === $value) {
+        } elseif ($option->isValueTernary() && true === $value) {
             $this->options[$name] = $option->getSetDefault();
         } else {
             $this->options[$name] = $value;

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -169,7 +169,7 @@ class ArgvInput extends Input
         // if input is expecting another argument, add it
         if ($this->definition->hasArgument($c)) {
             $arg = $this->definition->getArgument($c);
-            $this->arguments[$arg->getName()] = $arg->isArray()? array($token) : $token;
+            $this->arguments[$arg->getName()] = $arg->isArray() ? array($token) : $token;
 
         // if last argument isArray(), append token to last argument
         } elseif ($this->definition->hasArgument($c - 1) && $this->definition->getArgument($c - 1)->isArray()) {
@@ -249,7 +249,7 @@ class ArgvInput extends Input
 
         if ($option->isArray()) {
             $this->options[$name][] = $value;
-        } else if ($option->isValueOptionull() && true === $value) {
+        } elseif ($option->isValueOptionull() && true === $value) {
             $this->options[$name] = $option->getSetDefault();
         } else {
             $this->options[$name] = $value;
@@ -338,7 +338,7 @@ class ArgvInput extends Input
         $self = $this;
         $tokens = array_map(function ($token) use ($self) {
             if (preg_match('{^(-[^=]+=)(.+)}', $token, $match)) {
-                return $match[1] . $self->escapeToken($match[2]);
+                return $match[1].$self->escapeToken($match[2]);
             }
 
             if ($token && $token[0] !== '-') {

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -249,6 +249,8 @@ class ArgvInput extends Input
 
         if ($option->isArray()) {
             $this->options[$name][] = $value;
+        } else if ($option->isValueOptionull() && true === $value) {
+            $this->options[$name] = $option->getSetDefault();
         } else {
             $this->options[$name] = $value;
         }

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -250,7 +250,7 @@ class ArgvInput extends Input
         if ($option->isArray()) {
             $this->options[$name][] = $value;
         } elseif ($option->isValueTernary() && true === $value) {
-            $this->options[$name] = $option->getSetDefault();
+            $this->options[$name] = $option->getFlagValue();
         } else {
             $this->options[$name] = $value;
         }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -24,11 +24,13 @@ class InputOption
     const VALUE_REQUIRED = 2;
     const VALUE_OPTIONAL = 4;
     const VALUE_IS_ARRAY = 8;
+    const VALUE_OPTIONULL = 16;
 
     private $name;
     private $shortcut;
     private $mode;
     private $default;
+    private $set_default;
     private $description;
 
     /**
@@ -73,7 +75,7 @@ class InputOption
 
         if (null === $mode) {
             $mode = self::VALUE_NONE;
-        } elseif (!is_int($mode) || $mode > 15 || $mode < 1) {
+        } elseif (!is_int($mode) || $mode > 31 || $mode < 1) {
             throw new \InvalidArgumentException(sprintf('Option mode "%s" is not valid.', $mode));
         }
 
@@ -116,7 +118,7 @@ class InputOption
      */
     public function acceptValue()
     {
-        return $this->isValueRequired() || $this->isValueOptional();
+        return $this->isValueRequired() || $this->isValueOptional() || $this->isValueOptionull();
     }
 
     /**
@@ -150,6 +152,16 @@ class InputOption
     }
 
     /**
+     * Returns true if the option takes an optional value with null as default.
+     *
+     * @return bool    true if mode is self::VALUE_OPTIONULL, false otherwise
+     */
+    public function isValueOptionull()
+    {
+        return self::VALUE_OPTIONULL === (self::VALUE_OPTIONULL & $this->mode);
+    }
+
+    /**
      * Sets the default value.
      *
      * @param mixed $default The default value
@@ -170,6 +182,14 @@ class InputOption
             }
         }
 
+        $set_default = false;
+
+        if ($this->isValueOptionull()) {
+            $set_default = $default;
+            $default = false;
+        }
+
+        $this->set_default = $set_default;
         $this->default = $this->acceptValue() ? $default : false;
     }
 
@@ -182,6 +202,17 @@ class InputOption
     {
         return $this->default;
     }
+
+    /**
+     * Returns the default value.
+     *
+     * @return mixed The default value
+     */
+    public function getSetDefault()
+    {
+        return $this->set_default;
+    }
+
 
     /**
      * Returns the description text.
@@ -207,6 +238,7 @@ class InputOption
             && $option->isArray() === $this->isArray()
             && $option->isValueRequired() === $this->isValueRequired()
             && $option->isValueOptional() === $this->isValueOptional()
+            && $option->isValueOptionull() === $this->isValueOptionull()
         ;
     }
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -118,7 +118,7 @@ class InputOption
      */
     public function acceptValue()
     {
-        return $this->isValueRequired() || $this->isValueOptional() || $this->isValueOptionull();
+        return $this->isValueRequired() || $this->isValueOptional() || $this->isValueTernary();
     }
 
     /**
@@ -152,17 +152,20 @@ class InputOption
     }
 
     /**
-     * Returns true if the option takes an optional value with null as default.
+     * Returns true if the option takes an optional value with false as default and setDefault as default
      *
      * @return bool    true if mode is self::VALUE_TERNARY, false otherwise
      */
-    public function isValueOptionull()
+    public function isValueTernary()
     {
         return self::VALUE_TERNARY === (self::VALUE_TERNARY & $this->mode);
     }
 
     /**
      * Sets the default value.
+     *
+     * For VALUE_TERNARY the $default will always be set to false (for when the longoption is not used)
+     * and $setDefault will be used to store the default (for when the longoption is used without a value)
      *
      * @param mixed $default The default value
      *
@@ -184,7 +187,7 @@ class InputOption
 
         $setDefault = false;
 
-        if ($this->isValueOptionull()) {
+        if ($this->isValueTernary()) {
             $setDefault = $default;
             $default = false;
         }
@@ -204,7 +207,7 @@ class InputOption
     }
 
     /**
-     * Returns the default value.
+     * Returns the default value for a longoption without a value
      *
      * @return mixed The default value
      */
@@ -237,7 +240,7 @@ class InputOption
             && $option->isArray() === $this->isArray()
             && $option->isValueRequired() === $this->isValueRequired()
             && $option->isValueOptional() === $this->isValueOptional()
-            && $option->isValueOptionull() === $this->isValueOptionull()
+            && $option->isValueTernary() === $this->isValueTernary()
         ;
     }
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -24,13 +24,13 @@ class InputOption
     const VALUE_REQUIRED = 2;
     const VALUE_OPTIONAL = 4;
     const VALUE_IS_ARRAY = 8;
-    const VALUE_OPTIONULL = 16;
+    const VALUE_TERNARY = 16;
 
     private $name;
     private $shortcut;
     private $mode;
     private $default;
-    private $set_default;
+    private $setDefault;
     private $description;
 
     /**
@@ -154,11 +154,11 @@ class InputOption
     /**
      * Returns true if the option takes an optional value with null as default.
      *
-     * @return bool    true if mode is self::VALUE_OPTIONULL, false otherwise
+     * @return bool    true if mode is self::VALUE_TERNARY, false otherwise
      */
     public function isValueOptionull()
     {
-        return self::VALUE_OPTIONULL === (self::VALUE_OPTIONULL & $this->mode);
+        return self::VALUE_TERNARY === (self::VALUE_TERNARY & $this->mode);
     }
 
     /**
@@ -182,14 +182,14 @@ class InputOption
             }
         }
 
-        $set_default = false;
+        $setDefault = false;
 
         if ($this->isValueOptionull()) {
-            $set_default = $default;
+            $setDefault = $default;
             $default = false;
         }
 
-        $this->set_default = $set_default;
+        $this->setDefault = $setDefault;
         $this->default = $this->acceptValue() ? $default : false;
     }
 
@@ -210,7 +210,7 @@ class InputOption
      */
     public function getSetDefault()
     {
-        return $this->set_default;
+        return $this->setDefault;
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -164,8 +164,8 @@ class InputOption
     /**
      * Sets the default value.
      *
-     * For VALUE_TERNARY the $default will always be set to false (for when the longoption is not used)
-     * and $setDefault will be used to store the default (for when the longoption is used without a value)
+     * For VALUE_TERNARY the $default will always be set to false (for when the long option is not used)
+     * and $setDefault will be used to store the default (for when the long option is used without a value)
      *
      * @param mixed $default The default value
      *

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -30,7 +30,7 @@ class InputOption
     private $shortcut;
     private $mode;
     private $default;
-    private $setDefault;
+    private $flagValue;
     private $description;
 
     /**
@@ -152,7 +152,7 @@ class InputOption
     }
 
     /**
-     * Returns true if the option takes an optional value with false as default and setDefault as default
+     * Returns true if the option takes an optional value with false as default and flagValue as default
      *
      * @return bool    true if mode is self::VALUE_TERNARY, false otherwise
      */
@@ -165,7 +165,7 @@ class InputOption
      * Sets the default value.
      *
      * For VALUE_TERNARY the $default will always be set to false (for when the long option is not used)
-     * and $setDefault will be used to store the default (for when the long option is used without a value)
+     * and $flagValue will be used to store the default (for when the long option is used without a value)
      *
      * @param mixed $default The default value
      *
@@ -185,14 +185,14 @@ class InputOption
             }
         }
 
-        $setDefault = false;
+        $flagValue = false;
 
         if ($this->isValueTernary()) {
-            $setDefault = $default;
+            $flagValue = $default;
             $default = false;
         }
 
-        $this->setDefault = $setDefault;
+        $this->flagValue = $flagValue;
         $this->default = $this->acceptValue() ? $default : false;
     }
 
@@ -211,9 +211,9 @@ class InputOption
      *
      * @return mixed The default value
      */
-    public function getSetDefault()
+    public function getFlagValue()
     {
-        return $this->setDefault;
+        return $this->flagValue;
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -213,7 +213,6 @@ class InputOption
         return $this->set_default;
     }
 
-
     /**
      * Returns the description text.
      *

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -57,110 +57,110 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
                 array('cli.php', '--foo'),
                 array(new InputOption('foo')),
                 array('foo' => true),
-                '->parse() parses long options without a value'
+                '->parse() parses long options without a value',
             ),
             array(
                 array('cli.php', '--foo=bar'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_REQUIRED)),
                 array('foo' => 'bar'),
-                '->parse() parses long options with a required value (with a = separator)'
+                '->parse() parses long options with a required value (with a = separator)',
             ),
             array(
                 array('cli.php', '--foo', 'bar'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_REQUIRED)),
                 array('foo' => 'bar'),
-                '->parse() parses long options with a required value (with a space separator)'
+                '->parse() parses long options with a required value (with a space separator)',
             ),
             array(
                 array('cli.php', '-f'),
                 array(new InputOption('foo', 'f')),
                 array('foo' => true),
-                '->parse() parses short options without a value'
+                '->parse() parses short options without a value',
             ),
             array(
                 array('cli.php', '-fbar'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_REQUIRED)),
                 array('foo' => 'bar'),
-                '->parse() parses short options with a required value (with no separator)'
+                '->parse() parses short options with a required value (with no separator)',
             ),
             array(
                 array('cli.php', '-f', 'bar'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_REQUIRED)),
                 array('foo' => 'bar'),
-                '->parse() parses short options with a required value (with a space separator)'
+                '->parse() parses short options with a required value (with a space separator)',
             ),
             array(
                 array('cli.php', '-f', ''),
                 array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL)),
                 array('foo' => ''),
-                '->parse() parses short options with an optional empty value'
+                '->parse() parses short options with an optional empty value',
             ),
             array(
                 array('cli.php', '-f', '', 'foo'),
                 array(new InputArgument('name'), new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL)),
                 array('foo' => ''),
-                '->parse() parses short options with an optional empty value followed by an argument'
+                '->parse() parses short options with an optional empty value followed by an argument',
             ),
             array(
                 array('cli.php', '-f', '', '-b'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputOption('bar', 'b')),
                 array('foo' => '', 'bar' => true),
-                '->parse() parses short options with an optional empty value followed by an option'
+                '->parse() parses short options with an optional empty value followed by an option',
             ),
             array(
                 array('cli.php', '-f', '-b', 'foo'),
                 array(new InputArgument('name'), new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputOption('bar', 'b')),
                 array('foo' => null, 'bar' => true),
-                '->parse() parses short options with an optional value which is not present'
+                '->parse() parses short options with an optional value which is not present',
             ),
             array(
                 array('cli.php', '-fb'),
                 array(new InputOption('foo', 'f'), new InputOption('bar', 'b')),
                 array('foo' => true, 'bar' => true),
-                '->parse() parses short options when they are aggregated as a single one'
+                '->parse() parses short options when they are aggregated as a single one',
             ),
             array(
                 array('cli.php', '-fb', 'bar'),
                 array(new InputOption('foo', 'f'), new InputOption('bar', 'b', InputOption::VALUE_REQUIRED)),
                 array('foo' => true, 'bar' => 'bar'),
-                '->parse() parses short options when they are aggregated as a single one and the last one has a required value'
+                '->parse() parses short options when they are aggregated as a single one and the last one has a required value',
             ),
             array(
                 array('cli.php', '-fb', 'bar'),
                 array(new InputOption('foo', 'f'), new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL)),
                 array('foo' => true, 'bar' => 'bar'),
-                '->parse() parses short options when they are aggregated as a single one and the last one has an optional value'
+                '->parse() parses short options when they are aggregated as a single one and the last one has an optional value',
             ),
             array(
                 array('cli.php', '-fbbar'),
                 array(new InputOption('foo', 'f'), new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL)),
                 array('foo' => true, 'bar' => 'bar'),
-                '->parse() parses short options when they are aggregated as a single one and the last one has an optional value with no separator'
+                '->parse() parses short options when they are aggregated as a single one and the last one has an optional value with no separator',
             ),
             array(
                 array('cli.php', '-fbbar'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL)),
                 array('foo' => 'bbar', 'bar' => null),
-                '->parse() parses short options when they are aggregated as a single one and one of them takes a value'
+                '->parse() parses short options when they are aggregated as a single one and one of them takes a value',
             ),
             array(
                 array('cli.php'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_TERNARY)),
                 array('foo' => false),
-                '->parse() parses undefined ternary long option'
+                '->parse() parses undefined ternary long option',
             ),
             array(
                 array('cli.php', '--foo'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_TERNARY)),
                 array('foo' => null),
-                '->parse() parses ternary long option without a value'
+                '->parse() parses ternary long option without a value',
             ),
             array(
                 array('cli.php', '--foo=test'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_TERNARY)),
                 array('foo' => 'test'),
-                '->parse() parses ternary long option with a value'
-            )
+                '->parse() parses ternary long option with a value',
+            ),
         );
     }
 
@@ -181,43 +181,43 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
             array(
                 array('cli.php', '--foo'),
                 new InputDefinition(array(new InputOption('foo', 'f', InputOption::VALUE_REQUIRED))),
-                'The "--foo" option requires a value.'
+                'The "--foo" option requires a value.',
             ),
             array(
                 array('cli.php', '-f'),
                 new InputDefinition(array(new InputOption('foo', 'f', InputOption::VALUE_REQUIRED))),
-                'The "--foo" option requires a value.'
+                'The "--foo" option requires a value.',
             ),
             array(
                 array('cli.php', '-ffoo'),
                 new InputDefinition(array(new InputOption('foo', 'f', InputOption::VALUE_NONE))),
-                'The "-o" option does not exist.'
+                'The "-o" option does not exist.',
             ),
             array(
                 array('cli.php', '--foo=bar'),
                 new InputDefinition(array(new InputOption('foo', 'f', InputOption::VALUE_NONE))),
-                'The "--foo" option does not accept a value.'
+                'The "--foo" option does not accept a value.',
             ),
             array(
                 array('cli.php', 'foo', 'bar'),
                 new InputDefinition(),
-                'Too many arguments.'
+                'Too many arguments.',
             ),
             array(
                 array('cli.php', '--foo'),
                 new InputDefinition(),
-                'The "--foo" option does not exist.'
+                'The "--foo" option does not exist.',
             ),
             array(
                 array('cli.php', '-f'),
                 new InputDefinition(),
-                'The "-f" option does not exist.'
+                'The "-f" option does not exist.',
             ),
             array(
                 array('cli.php', '-1'),
                 new InputDefinition(array(new InputArgument('number'))),
-                'The "-1" option does not exist.'
-            )
+                'The "-1" option does not exist.',
+            ),
         );
     }
 

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -142,6 +142,24 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
                 array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL)),
                 array('foo' => 'bbar', 'bar' => null),
                 '->parse() parses short options when they are aggregated as a single one and one of them takes a value'
+            ),
+            array(
+                array('cli.php'),
+                array(new InputOption('foo', 'f', InputOption::VALUE_TERNARY)),
+                array('foo' => false),
+                '->parse() parses undefined ternary long option'
+            ),
+            array(
+                array('cli.php', '--foo'),
+                array(new InputOption('foo', 'f', InputOption::VALUE_TERNARY)),
+                array('foo' => null),
+                '->parse() parses ternary long option without a value'
+            ),
+            array(
+                array('cli.php', '--foo=test'),
+                array(new InputOption('foo', 'f', InputOption::VALUE_TERNARY)),
+                array('foo' => 'test'),
+                '->parse() parses ternary long option with a value'
             )
         );
     }

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -91,7 +91,7 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('ANOTHER_ONE'),
-            array(-1)
+            array(-1),
         );
     }
 
@@ -159,7 +159,6 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
         $option = new InputOption('foo', null, InputOption::VALUE_TERNARY, '', 'default');
         $this->assertFalse($option->getDefault(), '->getDefault() returns false');
     }
-
 
     public function testGetFlagValue()
     {

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -161,16 +161,16 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
     }
 
 
-    public function testGetSetDefault()
+    public function testGetFlagValue()
     {
         $option = new InputOption('foo');
-        $this->assertEquals(false, $option->getSetDefault(), '->getDefault() returns false');
+        $this->assertEquals(false, $option->getFlagValue(), '->getDefault() returns false');
 
         $option = new InputOption('foo', null, InputOption::VALUE_TERNARY);
-        $this->assertEquals(null, $option->getSetDefault(), '->getDefault() returns null if the option does not have a value');
+        $this->assertEquals(null, $option->getFlagValue(), '->getDefault() returns null if the option does not have a value');
 
         $option = new InputOption('foo', null, InputOption::VALUE_TERNARY, '', 'default');
-        $this->assertEquals('default', $option->getSetDefault(), '->getDefault() returns the default value');
+        $this->assertEquals('default', $option->getFlagValue(), '->getDefault() returns the default value');
     }
 
     public function testSetDefault()

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -154,20 +154,20 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($option->getDefault(), '->getDefault() returns false if the option does not take a value');
 
         $option = new InputOption('foo', null, InputOption::VALUE_TERNARY);
-        $this->assertEquals(false, $option->getDefault(), '->getDefault() returns false');
+        $this->assertFalse($option->getDefault(), '->getDefault() returns false');
 
         $option = new InputOption('foo', null, InputOption::VALUE_TERNARY, '', 'default');
-        $this->assertEquals(false, $option->getDefault(), '->getDefault() returns false');
+        $this->assertFalse($option->getDefault(), '->getDefault() returns false');
     }
 
 
     public function testGetFlagValue()
     {
         $option = new InputOption('foo');
-        $this->assertEquals(false, $option->getFlagValue(), '->getDefault() returns false');
+        $this->assertFalse($option->getFlagValue(), '->getDefault() returns false');
 
         $option = new InputOption('foo', null, InputOption::VALUE_TERNARY);
-        $this->assertEquals(null, $option->getFlagValue(), '->getDefault() returns null if the option does not have a value');
+        $this->assertNull($option->getFlagValue(), '->getDefault() returns null if the option does not have a value');
 
         $option = new InputOption('foo', null, InputOption::VALUE_TERNARY, '', 'default');
         $this->assertEquals('default', $option->getFlagValue(), '->getDefault() returns the default value');

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -70,6 +70,11 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($option->acceptValue(), '__construct() can take "InputOption::VALUE_OPTIONAL" as its mode');
         $this->assertFalse($option->isValueRequired(), '__construct() can take "InputOption::VALUE_OPTIONAL" as its mode');
         $this->assertTrue($option->isValueOptional(), '__construct() can take "InputOption::VALUE_OPTIONAL" as its mode');
+
+        $option = new InputOption('foo', 'f', InputOption::VALUE_TERNARY);
+        $this->assertTrue($option->acceptValue(), '__construct() can take "InputOption::VALUE_TERNARY" as its mode');
+        $this->assertFalse($option->isValueRequired(), '__construct() can take "InputOption::VALUE_TERNARY" as its mode');
+        $this->assertTrue($option->isValueTernary(), '__construct() can take "InputOption::VALUE_TERNARY" as its mode');
     }
 
     /**
@@ -144,6 +149,28 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
 
         $option = new InputOption('foo', null, InputOption::VALUE_NONE);
         $this->assertFalse($option->getDefault(), '->getDefault() returns false if the option does not take a value');
+
+        $option = new InputOption('foo', null, InputOption::VALUE_TERNARY);
+        $this->assertFalse($option->getDefault(), '->getDefault() returns false if the option does not take a value');
+
+        $option = new InputOption('foo', null, InputOption::VALUE_TERNARY);
+        $this->assertEquals(false, $option->getDefault(), '->getDefault() returns false');
+
+        $option = new InputOption('foo', null, InputOption::VALUE_TERNARY, '', 'default');
+        $this->assertEquals(false, $option->getDefault(), '->getDefault() returns false');
+    }
+
+
+    public function testGetSetDefault()
+    {
+        $option = new InputOption('foo');
+        $this->assertEquals(false, $option->getSetDefault(), '->getDefault() returns false');
+
+        $option = new InputOption('foo', null, InputOption::VALUE_TERNARY);
+        $this->assertEquals(null, $option->getSetDefault(), '->getDefault() returns null if the option does not have a value');
+
+        $option = new InputOption('foo', null, InputOption::VALUE_TERNARY, '', 'default');
+        $this->assertEquals('default', $option->getSetDefault(), '->getDefault() returns the default value');
     }
 
     public function testSetDefault()


### PR DESCRIPTION
[Console] Added three state long option

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11572 |
| License | MIT |
| Doc PR |  |

A three state long option, instead of the current 2 state version:
- Not setting the longoption will make the default set to false, just like a standard longoption.
- Setting the longoption without a value will set it to it's default
- Setting the longoption with a value will set it to that value.

Let's say --dev

```
php tool.php
array(1) {
  'dev' =>
  bool(false)
}
php tool.php --dev
array(1) {
  'dev' =>
  'the default value'
}
php tool.php --dev=test
array(1) {
  'dev' =>
  'test'
}
```

A couple of notes:
- I assume you guys agree that it's not a good idea to break current functionality. Therefor VALUE_OPTIONAL will stay how it is and I added a new constant: VALUE_OPTIONULL.
- All the tests still work!
- We need to come up with a better name.
- I'll need to write new test for the new config option (VALUE_OPTIONULL).
