### PR TITLE
[Routing] Make RedirectableUrlMatcher preserve schema when no slash given and matching routes with slash

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RedirectableUrlMatcherTest.php
@@ -29,7 +29,7 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
                 '_controller' => 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction',
                 'path'        => '/foo/',
                 'permanent'   => true,
-                'scheme'      => null,
+                'scheme'      => 'http',
                 'httpPort'    => $context->getHttpPort(),
                 'httpsPort'   => $context->getHttpsPort(),
                 '_route'      => null,

--- a/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
@@ -36,7 +36,7 @@ abstract class RedirectableUrlMatcher extends UrlMatcher implements Redirectable
             try {
                 parent::match($pathinfo.'/');
 
-                return $this->redirect($pathinfo.'/', null);
+                return $this->redirect($pathinfo.'/', null, $this->getContext()->getScheme());
             } catch (ResourceNotFoundException $e2) {
                 throw $e;
             }

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -27,6 +27,20 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher->match('/foo');
     }
 
+    public function testRedirectWhenNoSlashPreservesSchema()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo/'));
+
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext('', 'GET', 'localhost', 'https')));
+        $matcher
+            ->expects($this->once())
+            ->method('redirect')
+            ->with('/foo/', null, 'https')
+        ;
+        $matcher->match('/foo');
+    }
+
     /**
      * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When redirecting a route i.e. /foo/ called as /foo preserve schema. Current behaviour is to always use http if both http and https is allowed for the route.

This can lead to unexpected behaviour if https is enforced by different means than through Symfony i.e. by Apache mod_rewrite. 

We had a hard to debug situation where a page included by in an iframe was blocked by Google Chrome because of the non-secure redirect. As the redirect is not shown in developer tools in Chrome, this took some time to track down. 
