### PR TITLE
[HttpFoundation] add with*Request() convenience methods

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RequestStack.php
+++ b/src/Symfony/Component/HttpFoundation/RequestStack.php
@@ -100,4 +100,48 @@ class RequestStack
 
         return $this->requests[$pos];
     }
+
+    /**
+     * Executes callback if there is a current request available
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function withCurrentRequest($callback)
+    {
+        return $this->invokeCallbackIfRequestPresent($callback, $this->getCurrentRequest());
+    }
+
+    /**
+     * Executes callback if there is a master request available
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function withMasterRequest($callback)
+    {
+        return $this->invokeCallbackIfRequestPresent($callback, $this->getMasterRequest());
+    }
+
+    /**
+     * Executes callback if there is a parent request available
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function withParentRequest($callback)
+    {
+        return $this->invokeCallbackIfRequestPresent($callback, $this->getParentRequest());
+    }
+
+    private static function invokeCallbackIfRequestPresent($callback, Request $request = null)
+    {
+        if (!is_callable($callback)) {
+            throw new \InvalidArgumentException('Invalid callback given');
+        }
+
+        if ($request) {
+            return $callback($request);
+        }
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [n.A. |
| License | MIT |
| Doc PR | - |

When using request stack you end up with a lot of code that looks like this:

``` php
$request = $this->requestStack->getCurrentRequest();

if ($request === null) {
    return;
}

$this->doSomethingWithRequest($request);
```

This is such a common pattern, especially in listeners, that I want that to be more convenient. Replace above code with:

``` php
$request = $this->requestStack->withCurrentRequest(
    function (Request $request) {
         $this->doSomethingWithRequest($request);
    }
);
```
