### PR TITLE
[Intl] Added "internal" tag to all classes under Symfony\Component\Intl\ResourceBundle

### DIFF
--- a/src/Symfony/Component/Intl/ResourceBundle/AbstractBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/AbstractBundle.php
@@ -17,6 +17,8 @@ use Symfony\Component\Intl\ResourceBundle\Reader\StructuredBundleReaderInterface
  * Base class for {@link ResourceBundleInterface} implementations.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 abstract class AbstractBundle implements ResourceBundleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Compiler/BundleCompiler.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Compiler/BundleCompiler.php
@@ -17,6 +17,8 @@ use Symfony\Component\Intl\Exception\RuntimeException;
  * Compiles .txt resource bundles to binary .res files.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class BundleCompiler implements BundleCompilerInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Compiler/BundleCompilerInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Compiler/BundleCompilerInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Compiler;
  * Compiles a resource bundle.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 interface BundleCompilerInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundle.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle;
  * Default implementation of {@link CurrencyBundleInterface}.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class CurrencyBundle extends AbstractBundle implements CurrencyBundleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle;
  * Default implementation of {@link LanguageBundleInterface}.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class LanguageBundle extends AbstractBundle implements LanguageBundleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/LocaleBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LocaleBundle.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle;
  * Default implementation of {@link LocaleBundleInterface}.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class LocaleBundle extends AbstractBundle implements LocaleBundleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/AbstractBundleReader.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/AbstractBundleReader.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Reader;
  * Base class for {@link BundleReaderInterface} implementations.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 abstract class AbstractBundleReader implements BundleReaderInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/BinaryBundleReader.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/BinaryBundleReader.php
@@ -18,6 +18,8 @@ use Symfony\Component\Intl\ResourceBundle\Util\ArrayAccessibleResourceBundle;
  * Reads binary .res resource bundles.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class BinaryBundleReader extends AbstractBundleReader implements BundleReaderInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/BufferedBundleReader.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/BufferedBundleReader.php
@@ -15,6 +15,8 @@ use Symfony\Component\Intl\ResourceBundle\Util\RingBuffer;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class BufferedBundleReader implements BundleReaderInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/BundleReaderInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/BundleReaderInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Reader;
  * Reads resource bundle files.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 interface BundleReaderInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/PhpBundleReader.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/PhpBundleReader.php
@@ -18,6 +18,8 @@ use Symfony\Component\Intl\Exception\RuntimeException;
  * Reads .php resource bundles.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class PhpBundleReader extends AbstractBundleReader implements BundleReaderInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/StructuredBundleReader.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/StructuredBundleReader.php
@@ -19,6 +19,8 @@ use Symfony\Component\Intl\ResourceBundle\Util\RecursiveArrayAccess;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see StructuredResourceBundleBundleReaderInterface
+ *
+ * @internal
  */
 class StructuredBundleReader implements StructuredBundleReaderInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Reader/StructuredBundleReaderInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Reader/StructuredBundleReaderInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Reader;
  * Reads individual entries of a resource file.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 interface StructuredBundleReaderInterface extends BundleReaderInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/RegionBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/RegionBundle.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle;
  * Default implementation of {@link RegionBundleInterface}.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class RegionBundle extends AbstractBundle implements RegionBundleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/BundleTransformer.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/BundleTransformer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Intl\ResourceBundle\Writer\PhpBundleWriter;
  * Compiles a number of resource bundles based on predefined compilation rules.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class BundleTransformer
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/CompilationContext.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/CompilationContext.php
@@ -18,6 +18,8 @@ use Symfony\Component\Intl\ResourceBundle\Compiler\BundleCompilerInterface;
  * Default implementation of {@link CompilationContextInterface}.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class CompilationContext implements CompilationContextInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/CompilationContextInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/CompilationContextInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Transformer;
  * Stores contextual information for resource bundle compilation.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 interface CompilationContextInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/CurrencyBundleTransformationRule.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/CurrencyBundleTransformationRule.php
@@ -21,6 +21,8 @@ use Symfony\Component\Intl\Util\IcuVersion;
  * The rule for compiling the currency bundle.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class CurrencyBundleTransformationRule implements TransformationRuleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/LanguageBundleTransformationRule.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/LanguageBundleTransformationRule.php
@@ -20,6 +20,8 @@ use Symfony\Component\Intl\Util\IcuVersion;
  * The rule for compiling the language bundle.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class LanguageBundleTransformationRule implements TransformationRuleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/LocaleBundleTransformationRule.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/LocaleBundleTransformationRule.php
@@ -21,6 +21,8 @@ use Symfony\Component\Intl\ResourceBundle\Writer\TextBundleWriter;
  * The rule for compiling the locale bundle.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class LocaleBundleTransformationRule implements TransformationRuleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/RegionBundleTransformationRule.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/RegionBundleTransformationRule.php
@@ -20,6 +20,8 @@ use Symfony\Component\Intl\Util\IcuVersion;
  * The rule for compiling the region bundle.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class RegionBundleTransformationRule implements TransformationRuleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/TransformationRuleInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/Rule/TransformationRuleInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\Intl\ResourceBundle\Transformer\StubbingContextInterface;
  * Contains instruction for compiling a resource bundle.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 interface TransformationRuleInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/StubbingContext.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/StubbingContext.php
@@ -15,6 +15,8 @@ use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class StubbingContext implements StubbingContextInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Transformer/StubbingContextInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Transformer/StubbingContextInterface.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Transformer;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 interface StubbingContextInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Util/ArrayAccessibleResourceBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Util/ArrayAccessibleResourceBundle.php
@@ -20,6 +20,8 @@ use Symfony\Component\Intl\Exception\BadMethodCallException;
  * This class can be removed once that bug is fixed.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class ArrayAccessibleResourceBundle implements \ArrayAccess, \IteratorAggregate, \Countable
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Util/RecursiveArrayAccess.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Util/RecursiveArrayAccess.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Util;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class RecursiveArrayAccess
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Util/RingBuffer.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Util/RingBuffer.php
@@ -21,6 +21,8 @@ use Symfony\Component\Intl\Exception\OutOfBoundsException;
  * then the second and so on.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class RingBuffer implements \ArrayAccess
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Writer/BundleWriterInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Writer/BundleWriterInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Writer;
  * Writes resource bundle files.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 interface BundleWriterInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Writer/PhpBundleWriter.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Writer/PhpBundleWriter.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Writer;
  * Writes .php resource bundles.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
 class PhpBundleWriter implements BundleWriterInterface
 {

--- a/src/Symfony/Component/Intl/ResourceBundle/Writer/TextBundleWriter.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Writer/TextBundleWriter.php
@@ -20,6 +20,8 @@ namespace Symfony\Component\Intl\ResourceBundle\Writer;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
+ *
+ * @internal
  */
 class TextBundleWriter implements BundleWriterInterface
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes? |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

We didn't have this tag yet when this component was first written. The code in that
namespace is only used for resource bundle generation and was never meant for public
use.

We need to include in the update notes that users should check for usage of these classes.
