### PR TITLE
[SwiftmailerBridge] Bump allowed versions of swiftmailer

### DIFF
--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "swiftmailer/swiftmailer": ">=4.2.0,<5.1-dev"
+        "swiftmailer/swiftmailer": ">=4.2.0,<6.0-dev"
     },
     "suggest": {
         "symfony/http-kernel": ""


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (but SwiftmailerBridge itself does not contain any tests) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Current version of Swiftmailer is 5.2.1, while (previously to this commit)
the version installed by composer was 5.0.3.

This is rather important, since 5.2.1 closes a security issue that 5.0.3 is
vulnarable to (https://github.com/swiftmailer/swiftmailer/issues/494).
