### PR TITLE
[FrameworkBundle] composer.json fix for validator component

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -29,14 +29,14 @@
         "symfony/stopwatch": "~2.3",
         "symfony/templating": "~2.1",
         "symfony/translation": "~2.3",
+        "symfony/validator": "~2.1",
         "doctrine/annotations": "~1.0"
     },
     "require-dev": {
         "symfony/finder": "~2.0",
         "symfony/security": "~2.4",
         "symfony/form": "~2.3",
-        "symfony/class-loader": "~2.1",
-        "symfony/validator": "~2.1"
+        "symfony/class-loader": "~2.1"
     },
     "suggest": {
         "symfony/console": "For using the console commands",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

`Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension` depends on constants in `Symfony\Component\Validator\Validation` but the validator component was listed as a dev dependency so if a project requires the framework bundle it will get a class not found exception. 

The `symfony/validator` has been moved from require-dev to require.
