### PR TITLE
[Intl] Removed non-working $fallback argument from ArrayAccessibleResourceBundle

### DIFF
--- a/src/Symfony/Component/Intl/ResourceBundle/Util/ArrayAccessibleResourceBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/Util/ArrayAccessibleResourceBundle.php
@@ -32,16 +32,16 @@ class ArrayAccessibleResourceBundle implements \ArrayAccess, \IteratorAggregate,
         $this->bundleImpl = $bundleImpl;
     }
 
-    public function get($offset, $fallback = null)
+    public function get($offset)
     {
-        $value = $this->bundleImpl->get($offset, $fallback);
+        $value = $this->bundleImpl->get($offset);
 
         return $value instanceof \ResourceBundle ? new static($value) : $value;
     }
 
     public function offsetExists($offset)
     {
-        return null !== $this->bundleImpl[$offset];
+        return null !== $this->bundleImpl->get($offset);
     }
 
     public function offsetGet($offset)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The code in question didn't actually work. This was extracted from #9206.
