### PR TITLE
[Translation] [Config] Clear libxml errors after parsing xliff file

### DIFF
--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -58,6 +58,16 @@ class XmlUtilsTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate')));
+        $this->assertSame(array(), libxml_get_errors());
+    }
+
+    public function testLoadFileWithInternalErrorsEnabled()
+    {
+        libxml_use_internal_errors(true);
+
+        $this->assertSame(array(), libxml_get_errors());
+        $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile(__DIR__.'/../Fixtures/Util/invalid_schema.xml'));
+        $this->assertSame(array(), libxml_get_errors());
     }
 
     /**

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -31,7 +31,7 @@ class XmlUtils
     /**
      * Loads an XML file.
      *
-     * @param string $file                      An XML file path
+     * @param string          $file             An XML file path
      * @param string|callable $schemaOrCallable An XSD schema file path or callable
      *
      * @return \DOMDocument
@@ -95,9 +95,10 @@ class XmlUtils
                 }
                 throw new \InvalidArgumentException(implode("\n", $messages), 0, $e);
             }
-
-            libxml_use_internal_errors($internalErrors);
         }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($internalErrors);
 
         return $dom;
     }

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -116,6 +116,7 @@ class XliffFileLoader implements LoaderInterface
 
         $dom->normalizeDocument();
 
+        libxml_clear_errors();
         libxml_use_internal_errors($internalErrors);
 
         return array(simplexml_import_dom($dom), strtoupper($dom->encoding));
@@ -124,7 +125,7 @@ class XliffFileLoader implements LoaderInterface
     /**
      * Returns the XML errors of the internal XML parser
      *
-     * @param bool    $internalErrors
+     * @param bool $internalErrors
      *
      * @return array An array of errors
      */

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -31,6 +31,22 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
+        $this->assertSame(array(), libxml_get_errors());
+    }
+
+    public function testLoadWithInternalErrorsEnabled()
+    {
+        libxml_use_internal_errors(true);
+
+        $this->assertSame(array(), libxml_get_errors());
+
+        $loader = new XliffFileLoader();
+        $resource = __DIR__.'/../fixtures/resources.xlf';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals('en', $catalogue->getLocale());
+        $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
+        $this->assertSame(array(), libxml_get_errors());
     }
 
     public function testLoadWithResname()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

If libxml_use_internal_errors is set to `true` before parsing xliff file, the libxml errors are not cleared correctly. An error `Validation failed: no DTD found !` occurs in libxml errors after parsing and it's available outside the xliff parser (can break other functionality that use `libxml_get_errors` function).
