### PR TITLE
[HttpFoundation] Request - URI - comment improvements

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1044,9 +1044,9 @@ class Request
     }
 
     /**
-     * Returns the requested URI.
+     * Returns the requested URI (URN).
      *
-     * @return string The raw URI (i.e. not urldecoded)
+     * @return string The raw URI (i.e. not URI decoded)
      *
      * @api
      */
@@ -1073,9 +1073,9 @@ class Request
     }
 
     /**
-     * Generates a normalized URI for the Request.
+     * Generates a normalized URI (URL) for the Request.
      *
-     * @return string A normalized URI for the Request
+     * @return string A normalized URI (URL) for the Request
      *
      * @see getQueryString()
      *

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1044,7 +1044,7 @@ class Request
     }
 
     /**
-     * Returns the requested URI (URN).
+     * Returns the requested URI (path and query).
      *
      * @return string The raw URI (i.e. not URI decoded)
      *


### PR DESCRIPTION
Hi all,

I was wondering why there is a difference between the URI's given by the `Request` object.

The method `getUri` will give a URL so  including scheme,http host and base URL, for example:
`http://dev.decorrespondent.nl/verleng?a=1`

While the method `getRequestUri` will give:
`/verleng?a=1`

While both correct it can get confusing, that is why I propose these copy changes in the comments.
