### PR TITLE
[Validator] Add ClassMetadata plural methods for convinience

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -320,6 +320,21 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
     }
 
     /**
+     * @param string       $property
+     * @param Constraint[] $constraints
+     *
+     * @return ClassMetadata
+     */
+    public function addGetterConstraints($property, array $constraints)
+    {
+        foreach ($constraints as $constraint) {
+            $this->addGetterConstraint($property, $constraint);
+        }
+
+        return $this;
+    }
+
+    /**
      * Merges the constraints of the given metadata into this object.
      *
      * @param ClassMetadata $source The source metadata

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -279,6 +279,21 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
     }
 
     /**
+     * @param string       $property
+     * @param Constraint[] $constraints
+     *
+     * @return ClassMetadata
+     */
+    public function addPropertyConstraints($property, array $constraints)
+    {
+        foreach ($constraints as $constraint) {
+            $this->addPropertyConstraint($property, $constraint);
+        }
+
+        return $this;
+    }
+
+    /**
      * Adds a constraint to the getter of the given property.
      *
      * The name of the getter is assumed to be the name of the property with an

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -184,7 +184,7 @@ class ClassMetadata extends ElementMetadata implements LegacyMetadataInterface, 
             'members',
             'name',
             'properties',
-            'defaultGroup'
+            'defaultGroup',
         ));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -58,6 +58,22 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('firstName', 'lastName'), $this->metadata->getConstrainedProperties());
     }
 
+    public function testAddMultiplePropertyConstraints()
+    {
+        $this->metadata->addPropertyConstraints('lastName', array(new ConstraintA(), new ConstraintB()));
+
+        $constraints = array(
+            new ConstraintA(array('groups' => array('Default', 'Entity'))),
+            new ConstraintB(array('groups' => array('Default', 'Entity'))),
+        );
+
+        $properties = $this->metadata->getPropertyMetadata('lastName');
+
+        $this->assertCount(1, $properties);
+        $this->assertEquals('lastName', $properties[0]->getName());
+        $this->assertEquals($constraints, $properties[0]->getConstraints());
+    }
+
     public function testMergeConstraintsMergesClassConstraints()
     {
         $parent = new ClassMetadata(self::PARENTCLASS);

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -74,6 +74,39 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($constraints, $properties[0]->getConstraints());
     }
 
+    public function testAddGetterConstraints()
+    {
+        $this->metadata->addGetterConstraint('lastName', new ConstraintA());
+        $this->metadata->addGetterConstraint('lastName', new ConstraintB());
+
+        $constraints = array(
+            new ConstraintA(array('groups' => array('Default', 'Entity'))),
+            new ConstraintB(array('groups' => array('Default', 'Entity'))),
+        );
+
+        $properties = $this->metadata->getPropertyMetadata('lastName');
+
+        $this->assertCount(1, $properties);
+        $this->assertEquals('getLastName', $properties[0]->getName());
+        $this->assertEquals($constraints, $properties[0]->getConstraints());
+    }
+
+    public function testAddMultipleGetterConstraints()
+    {
+        $this->metadata->addGetterConstraints('lastName', array(new ConstraintA(), new ConstraintB()));
+
+        $constraints = array(
+            new ConstraintA(array('groups' => array('Default', 'Entity'))),
+            new ConstraintB(array('groups' => array('Default', 'Entity'))),
+        );
+
+        $properties = $this->metadata->getPropertyMetadata('lastName');
+
+        $this->assertCount(1, $properties);
+        $this->assertEquals('getLastName', $properties[0]->getName());
+        $this->assertEquals($constraints, $properties[0]->getConstraints());
+    }
+
     public function testMergeConstraintsMergesClassConstraints()
     {
         $parent = new ClassMetadata(self::PARENTCLASS);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #4143 |
| License | MIT |
| Doc PR | - |

I realised there's no specific place to document this methods, as the code examples always include all the formats. I think it's enough if IDE autocompletes these methods.
