### PR TITLE
[DependencyInjection] remove `service` parameter type from XSD

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -156,7 +156,6 @@
   <xsd:simpleType name="parameter_type">
     <xsd:restriction base="xsd:string">
       <xsd:enumeration value="collection" />
-      <xsd:enumeration value="service" />
       <xsd:enumeration value="string" />
       <xsd:enumeration value="constant" />
     </xsd:restriction>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services2.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services2.xml
@@ -23,7 +23,6 @@
         <parameter>bar</parameter>
       </parameter>
     </parameter>
-    <parameter key="foo_bar" type="service" id="foo_bar" />
     <parameter key="MixedCase" type="collection"> <!-- Should be lower cased -->
       <parameter key="MixedCaseKey">value</parameter> <!-- Should stay mixed case -->
     </parameter>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -99,7 +99,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services2.xml');
 
         $actual = $container->getParameterBag()->all();
-        $expected = array('a string', 'foo' => 'bar', 'values' => array(0, 'integer' => 4, 100 => null, 'true', true, false, 'on', 'off', 'float' => 1.3, 1000.3, 'a string', array('foo', 'bar')), 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'));
+        $expected = array('a string', 'foo' => 'bar', 'values' => array(0, 'integer' => 4, 100 => null, 'true', true, false, 'on', 'off', 'float' => 1.3, 1000.3, 'a string', array('foo', 'bar')), 'mixedcase' => array('MixedCaseKey' => 'value'));
 
         $this->assertEquals($expected, $actual, '->load() converts XML values to PHP ones');
     }
@@ -120,7 +120,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services4.xml');
 
         $actual = $container->getParameterBag()->all();
-        $expected = array('a string', 'foo' => 'bar', 'values' => array(true, false), 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'), 'bar' => '%foo%', 'imported_from_ini' => true, 'imported_from_yaml' => true);
+        $expected = array('a string', 'foo' => 'bar', 'values' => array(true, false), 'mixedcase' => array('MixedCaseKey' => 'value'), 'bar' => '%foo%', 'imported_from_ini' => true, 'imported_from_yaml' => true);
 
         $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | symfony/symfony-docs#4222 |

Referencing a service in a parameter doesn't work and will lead to an error when the configuration is loaded (see symfony/symfony-docs#4211).
