### PR TITLE
[Routing] refactored route-matching strategies into separate classes

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Strategy/CompositeStrategy.php
+++ b/src/Symfony/Component/Routing/Matcher/Strategy/CompositeStrategy.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Strategy;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+
+class CompositeStrategy implements MatcherStrategy
+{
+    /**
+     * @var array
+     */
+    private $strategies;
+
+    public function __construct(array $strategies)
+    {
+        $this->strategies = $strategies;
+    }
+
+    /**
+     * @param string $pathinfo
+     * @param Route $route
+     * @param RequestContext $context
+     * @return bool
+     */
+    public function matches($pathinfo, Route $route, RequestContext $context)
+    {
+        foreach ($this->strategies as $strategy) {
+            if (!$strategy->matches($pathinfo, $route, $context)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/Strategy/HostRegexStrategy.php
+++ b/src/Symfony/Component/Routing/Matcher/Strategy/HostRegexStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Strategy;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+
+class HostRegexStrategy implements MatcherStrategy
+{
+    /**
+     * @param string $pathinfo
+     * @param Route $route
+     * @param RequestContext $context
+     * @return bool
+     */
+    public function matches($pathinfo, Route $route, RequestContext $context)
+    {
+        $compiledRoute = $route->compile();
+        $host = $context->getHost();
+
+        return !$compiledRoute->getHostRegex() || preg_match($compiledRoute->getHostRegex(), $host);
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/Strategy/HttpMethodStrategy.php
+++ b/src/Symfony/Component/Routing/Matcher/Strategy/HttpMethodStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Strategy;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+
+class HttpMethodStrategy implements MatcherStrategy
+{
+    /**
+     * @param string $pathinfo
+     * @param Route $route
+     * @param RequestContext $context
+     * @return bool
+     */
+    public function matches($pathinfo, Route $route, RequestContext $context)
+    {
+        if ($req = $route->getRequirement('_method')) {
+            // HEAD and GET are equivalent as per RFC
+            $method = $context->getMethod();
+            if ('HEAD' === $method) {
+                $method = 'GET';
+            }
+
+            if (!in_array($method, $req = explode('|', strtoupper($req)))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/Strategy/MatcherStrategy.php
+++ b/src/Symfony/Component/Routing/Matcher/Strategy/MatcherStrategy.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Strategy;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+
+interface MatcherStrategy
+{
+    /**
+     * @param string $pathinfo
+     * @param Route $route
+     * @param RequestContext $context
+     * @return bool
+     */
+    public function matches($pathinfo, Route $route, RequestContext $context);
+}

--- a/src/Symfony/Component/Routing/Matcher/Strategy/RegexStrategy.php
+++ b/src/Symfony/Component/Routing/Matcher/Strategy/RegexStrategy.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Strategy;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+
+class RegexStrategy implements MatcherStrategy
+{
+    /**
+     * @param string $pathinfo
+     * @param Route $route
+     * @param RequestContext $context
+     * @return bool
+     */
+    public function matches($pathinfo, Route $route, RequestContext $context)
+    {
+        return preg_match($route->compile()->getRegex(), $pathinfo);
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/Strategy/StaticPrefixStrategy.php
+++ b/src/Symfony/Component/Routing/Matcher/Strategy/StaticPrefixStrategy.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Strategy;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+
+class StaticPrefixStrategy implements MatcherStrategy
+{
+    /**
+     * @param string $pathinfo
+     * @param Route $route
+     * @param RequestContext $context
+     * @return bool
+     */
+    public function matches($pathinfo, Route $route, RequestContext $context)
+    {
+        $compiledRoute = $route->compile();
+
+        return '' === $compiledRoute->getStaticPrefix() || 0 === strpos($pathinfo, $compiledRoute->getStaticPrefix());
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Matcher/Strategy/AlwaysMatchStrategy.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Strategy/AlwaysMatchStrategy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Matcher\Strategy;
+
+use Symfony\Component\Routing\Matcher\Strategy\MatcherStrategy;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+
+class AlwaysMatchStrategy implements MatcherStrategy
+{
+    /**
+     * @param string $pathinfo
+     * @param Route $route
+     * @param RequestContext $context
+     * @return bool
+     */
+    public function matches($pathinfo, Route $route, RequestContext $context)
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Tests\Matcher\Strategy\AlwaysMatchStrategy;
 
 class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 {
@@ -402,5 +403,15 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'example.com'));
         $matcher->match('/foo/bar');
+    }
+
+    public function testSetMatcherStrategy()
+    {
+        $coll = new RouteCollection();
+        $route = new Route('/foo');
+        $coll->add('foo', $route);
+        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher->setMatcherStrategy(new AlwaysMatchStrategy());
+        $matcher->match('/bar');
     }
 }


### PR DESCRIPTION
Extracts existing match-checks for routes into separate classes using the Strategy pattern. This will allow for runtime substitution of the default cascade of matching strategies. This is useful in cases where complex custom routing is desired, as an alternative to the expression-based [`condition` setting](http://symfony.com/doc/current/book/routing.html#completely-customized-route-matching-with-conditions).

This is a modified version of https://github.com/yitznewton/symfony/pull/1 (which includes feedback from @cordoval)

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no (refactoring to enable substitution of routing rules) |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
