### PR TITLE
[Form] Fix PHPDoc for builder setData methods

### DIFF
--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -425,7 +425,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param array $data
+     * @param mixed $data
      *
      * @throws BadMethodCallException
      */

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -212,7 +212,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets the initial data of the form.
      *
-     * @param array $data The data of the form in application format.
+     * @param mixed $data The data of the form in application format.
      *
      * @return self The configuration object.
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #11933 |
| License | MIT |

The underlying data variable is typed as mixed whereas the methods paramers where typed as array.
The method is also described to accept objects, etc. in the documentation.
