### PR TITLE
[HttpKernel] Make sure HttpCache is a trusted proxy

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -462,6 +462,12 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         // is always called from the same process as the backend.
         $request->server->set('REMOTE_ADDR', '127.0.0.1');
 
+        // make sure HttpCache is a trusted proxy
+        if (!in_array('127.0.0.1', $trustedProxies = Request::getTrustedProxies())) {
+            $trustedProxies[] = '127.0.0.1';
+            Request::setTrustedProxies($trustedProxies);
+        }
+
         // always a "master" request (as the real master request can be in cache)
         $response = $this->kernel->handle($request, HttpKernelInterface::MASTER_REQUEST, $catch);
         // FIXME: we probably need to also catch exceptions if raw === true

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1156,6 +1156,28 @@ class HttpCacheTest extends HttpCacheTestCase
     }
 
     /**
+     * @dataProvider getTrustedProxyData
+     */
+    public function testHttpCacheIsSetAsATrustedProxy(array $existing, array $expected)
+    {
+        Request::setTrustedProxies($existing);
+
+        $this->setNextResponse();
+        $this->request('GET', '/', array('REMOTE_ADDR' => '10.0.0.1'));
+
+        $this->assertEquals($expected, Request::getTrustedProxies());
+    }
+
+    public function getTrustedProxyData()
+    {
+        return array(
+            array(array(), array('127.0.0.1')),
+            array(array('10.0.0.2'), array('10.0.0.2', '127.0.0.1')),
+            array(array('10.0.0.2', '127.0.0.1'), array('10.0.0.2', '127.0.0.1')),
+        );
+    }
+
+    /**
      * @dataProvider getXForwardedForData
      */
     public function testXForwarderForHeaderForForwardedRequests($xForwardedFor, $expected)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (of sorts) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9292 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/4239 |

Fixes #9292 by adding `127.0.0.1` as a trusted proxy when using `HttpCache` (assuming it hasn't been already).
