### PR TITLE
New php library structure made easier

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -72,13 +72,12 @@ abstract class Bundle extends ContainerAware implements BundleInterface
     public function getContainerExtension()
     {
         if (null === $this->extension) {
-            $basename = preg_replace('/Bundle$/', '', $this->getName());
-
-            $class = $this->getNamespace().'\\DependencyInjection\\'.$basename.'Extension';
+            $class = $this->getContainerExtensionClass();
             if (class_exists($class)) {
                 $extension = new $class();
 
                 // check naming convention
+                $basename = preg_replace('/Bundle$/', '', $this->getName());
                 $expectedAlias = Container::underscore($basename);
                 if ($expectedAlias != $extension->getAlias()) {
                     throw new \LogicException(sprintf(
@@ -196,5 +195,17 @@ abstract class Bundle extends ContainerAware implements BundleInterface
                 $application->add($r->newInstance());
             }
         }
+    }
+
+    /**
+     * Returns the bundle's container extension class.
+     *
+     * @return string
+     */
+    protected function getContainerExtensionClass()
+    {
+        $basename = preg_replace('/Bundle$/', '', $this->getName());
+
+        return $this->getNamespace().'\\DependencyInjection\\'.$basename.'Extension';
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

[This article](https://medium.com/@christophewillemsen/stop-making-bundles-think-bundles-deadd27b88c0) from @ikwattro gives some good ideas on how to ease the creation of a PHP package:
- which is not a bundle usable only on a symfony full stack framework
- without requiring to maintain 2 repos (one for the lib and the other for the bundle)

The only drawback is that Symfony requires the DI extension to be on a given location. So I created a new method Bundle#getContainerExtensionClass than can be easily overwritten if you want to move the Extension class in another directory.
