### PR TITLE
[Console] Added the CommandInterface and the CommandDecorator.

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -86,6 +86,34 @@ UPGRADE FROM 2.x to 3.0
    $table->render();
    ```
 
+ * `Application` requires a `CommandInterface` instead of a `Command`. ```Command``` implements this interface.
+
+   Before:
+
+   ```
+   public function add(Command $command)
+   ```
+
+   After:
+
+   ```
+   public function add(CommandInterface $command)
+   ```
+
+   This also applies for the `doRunCommand` method.
+
+   Before:
+
+   ```
+   protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
+   ```
+
+   After:
+
+   ```
+   protected function doRunCommand(CommandInterface $command, InputInterface $input, OutputInterface $output)
+   ```
+
 ### EventDispatcher
 
  * The interface `Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface`

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandInterface;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -392,13 +393,13 @@ class Application
      *
      * If a command with the same name already exists, it will be overridden.
      *
-     * @param Command $command A Command object
+     * @param CommandInterface $command A Command object
      *
-     * @return Command The registered command
+     * @return CommandInterface The registered command
      *
      * @api
      */
-    public function add(Command $command)
+    public function add(CommandInterface $command)
     {
         $command->setApplication($this);
 
@@ -426,7 +427,7 @@ class Application
      *
      * @param string $name The command name or alias
      *
-     * @return Command A Command object
+     * @return CommandInterface A Command
      *
      * @throws \InvalidArgumentException When command name given does not exist
      *
@@ -871,15 +872,15 @@ class Application
      * If an event dispatcher has been attached to the application,
      * events are also dispatched during the life-cycle of the command.
      *
-     * @param Command         $command A Command instance
-     * @param InputInterface  $input   An Input instance
-     * @param OutputInterface $output  An Output instance
+     * @param CommandInterface $command A Command instance
+     * @param InputInterface   $input   An Input instance
+     * @param OutputInterface  $output  An Output instance
      *
      * @return int 0 if everything went fine, or an error code
      *
      * @throws \Exception when the command being run threw an exception
      */
-    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
+    protected function doRunCommand(CommandInterface $command, InputInterface $input, OutputInterface $output)
     {
         foreach ($command->getHelperSet() as $helper) {
             if ($helper instanceof InputAwareInterface) {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -29,7 +29,7 @@ use Symfony\Component\Console\Helper\HelperSet;
  *
  * @api
  */
-class Command
+class Command implements CommandInterface
 {
     private $application;
     private $name;
@@ -80,11 +80,7 @@ class Command
     }
 
     /**
-     * Sets the application instance for this command.
-     *
-     * @param Application $application An Application instance
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function setApplication(Application $application = null)
     {
@@ -107,9 +103,7 @@ class Command
     }
 
     /**
-     * Gets the helper set.
-     *
-     * @return HelperSet A HelperSet instance
+     * {@inheritdoc}
      */
     public function getHelperSet()
     {
@@ -117,11 +111,7 @@ class Command
     }
 
     /**
-     * Gets the application instance for this command.
-     *
-     * @return Application An Application instance
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getApplication()
     {
@@ -129,12 +119,7 @@ class Command
     }
 
     /**
-     * Checks whether the command is enabled or not in the current environment
-     *
-     * Override this to check for x or y and return false if the command can not
-     * run properly under the current conditions.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isEnabled()
     {
@@ -193,23 +178,14 @@ class Command
     }
 
     /**
-     * Runs the command.
+     * {@inheritdoc}
      *
      * The code to execute is either defined directly with the
      * setCode() method or by overriding the execute() method
      * in a sub-class.
      *
-     * @param InputInterface  $input  An InputInterface instance
-     * @param OutputInterface $output An OutputInterface instance
-     *
-     * @return int     The command exit code
-     *
-     * @throws \Exception
-     *
      * @see setCode()
      * @see execute()
-     *
-     * @api
      */
     public function run(InputInterface $input, OutputInterface $output)
     {
@@ -283,11 +259,7 @@ class Command
     }
 
     /**
-     * Merges the application definition with the command definition.
-     *
-     * This method is not part of public API and should not be used directly.
-     *
-     * @param bool    $mergeArgs Whether to merge or not the Application definition arguments to Command definition arguments
+     * {@inheritdoc}
      */
     public function mergeApplicationDefinition($mergeArgs = true)
     {
@@ -332,11 +304,7 @@ class Command
     }
 
     /**
-     * Gets the InputDefinition attached to this Command.
-     *
-     * @return InputDefinition An InputDefinition instance
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getDefinition()
     {
@@ -344,14 +312,7 @@ class Command
     }
 
     /**
-     * Gets the InputDefinition to be used to create XML and Text representations of this Command.
-     *
-     * Can be overridden to provide the original command representation when it would otherwise
-     * be changed by merging with the application InputDefinition.
-     *
-     * This method is not part of public API and should not be used directly.
-     *
-     * @return InputDefinition An InputDefinition instance
+     * {@inheritdoc}
      */
     public function getNativeDefinition()
     {
@@ -442,11 +403,7 @@ class Command
     }
 
     /**
-     * Returns the command name.
-     *
-     * @return string The command name
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getName()
     {
@@ -470,11 +427,7 @@ class Command
     }
 
     /**
-     * Returns the description for the command.
-     *
-     * @return string The description for the command
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getDescription()
     {
@@ -498,11 +451,7 @@ class Command
     }
 
     /**
-     * Returns the help for the command.
-     *
-     * @return string The help for the command
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getHelp()
     {
@@ -510,10 +459,7 @@ class Command
     }
 
     /**
-     * Returns the processed help for the command replacing the %command.name% and
-     * %command.full_name% patterns with the real values dynamically.
-     *
-     * @return string  The processed help for the command
+     * {@inheritdoc}
      */
     public function getProcessedHelp()
     {
@@ -558,11 +504,7 @@ class Command
     }
 
     /**
-     * Returns the aliases for the command.
-     *
-     * @return array An array of aliases for the command
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getAliases()
     {
@@ -570,9 +512,7 @@ class Command
     }
 
     /**
-     * Returns the synopsis for the command.
-     *
-     * @return string The synopsis
+     * {@inheritdoc}
      */
     public function getSynopsis()
     {

--- a/src/Symfony/Component/Console/Command/CommandDecorator.php
+++ b/src/Symfony/Component/Console/Command/CommandDecorator.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Class to decorate a command.
+ * For example, add behaviour before or after executing.
+ *
+ * @author Nico Schoenmaker<nschoenmaker@hostnet.nl>
+ *
+ * @api
+ */
+class CommandDecorator implements CommandInterface
+{
+    private $command;
+
+    /**
+     * @param CommandInterface $command
+     */
+    public function __construct(CommandInterface $command)
+    {
+        $this->command = $command;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setApplication(Application $application = null)
+    {
+        return $this->command->setApplication($application);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHelperSet()
+    {
+        return $this->command->getHelperSet();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getApplication()
+    {
+        return $this->command->getApplication();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled()
+    {
+        return $this->command->isEnabled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(InputInterface $input, OutputInterface $output)
+    {
+        return $this->command->run($input, $output);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mergeApplicationDefinition($mergeArgs = true)
+    {
+        return $this->command->mergeApplicationDefinition($mergeArgs);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return $this->command->getDefinition();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNativeDefinition()
+    {
+        return $this->command->getNativeDefinition();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->command->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return $this->command->getDescription();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHelp()
+    {
+        return $this->command->getHelp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProcessedHelp()
+    {
+        return $this->command->getProcessedHelp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases()
+    {
+        return $this->command->getAliases();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSynopsis()
+    {
+        return $this->command->getSynopsis();
+    }
+}

--- a/src/Symfony/Component/Console/Command/CommandInterface.php
+++ b/src/Symfony/Component/Console/Command/CommandInterface.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Interface that needs to be implemented by every command.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Nico Schoenmaker <nschoenmaker@hostnet.nl>
+ *
+ * @api
+ */
+interface CommandInterface
+{
+    /**
+     * Sets the application instance for this command.
+     *
+     * @param Application $application An Application instance
+     *
+     * @api
+     */
+    public function setApplication(Application $application = null);
+
+    /**
+     * Gets the helper set.
+     *
+     * @return HelperSet A HelperSet instance
+     */
+    public function getHelperSet();
+
+    /**
+     * Gets the application instance for this command.
+     *
+     * @return Application An Application instance
+     *
+     * @api
+     */
+    public function getApplication();
+
+    /**
+     * Checks whether the command is enabled or not in the current environment
+     *
+     * Override this to check for x or y and return false if the command can not
+     * run properly under the current conditions.
+     *
+     * @return bool
+     */
+    public function isEnabled();
+
+    /**
+     * Runs the command.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     *
+     * @return int     The command exit code
+     *
+     * @throws \Exception
+     *
+     * @api
+     */
+    public function run(InputInterface $input, OutputInterface $output);
+
+    /**
+     * Merges the application definition with the command definition.
+     *
+     * This method is not part of public API and should not be used directly.
+     *
+     * @param bool    $mergeArgs Whether to merge or not the Application definition arguments to Command definition arguments
+     */
+    public function mergeApplicationDefinition($mergeArgs = true);
+
+    /**
+     * Gets the InputDefinition attached to this Command.
+     *
+     * @return InputDefinition An InputDefinition instance
+     *
+     * @api
+     */
+    public function getDefinition();
+
+    /**
+     * Gets the InputDefinition to be used to create XML and Text representations of this Command.
+     *
+     * Can be overridden to provide the original command representation when it would otherwise
+     * be changed by merging with the application InputDefinition.
+     *
+     * This method is not part of public API and should not be used directly.
+     *
+     * @return InputDefinition An InputDefinition instance
+     */
+    public function getNativeDefinition();
+
+    /**
+     * Returns the command name.
+     *
+     * @return string The command name
+     *
+     * @api
+     */
+    public function getName();
+
+    /**
+     * Returns the description for the command.
+     *
+     * @return string The description for the command
+     *
+     * @api
+     */
+    public function getDescription();
+
+    /**
+     * Returns the help for the command.
+     *
+     * @return string The help for the command
+     *
+     * @api
+     */
+    public function getHelp();
+
+    /**
+     * Returns the processed help for the command replacing the %command.name% and
+     * %command.full_name% patterns with the real values dynamically.
+     *
+     * @return string  The processed help for the command
+     */
+    public function getProcessedHelp();
+
+    /**
+     * Returns the aliases for the command.
+     *
+     * @return array An array of aliases for the command
+     *
+     * @api
+     */
+    public function getAliases();
+
+    /**
+     * Returns the synopsis for the command.
+     *
+     * @return string The synopsis
+     */
+    public function getSynopsis();
+}

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -60,9 +60,9 @@ EOF
     /**
      * Sets the command
      *
-     * @param Command $command The command to set
+     * @param CommandInterface $command The command to set
      */
-    public function setCommand(Command $command)
+    public function setCommand(CommandInterface $command)
     {
         $this->command = $command;
     }

--- a/src/Symfony/Component/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/Descriptor.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Console\Descriptor;
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -45,7 +45,7 @@ abstract class Descriptor implements DescriptorInterface
             case $object instanceof InputDefinition:
                 $this->describeInputDefinition($object, $options);
                 break;
-            case $object instanceof Command:
+            case $object instanceof CommandInterface:
                 $this->describeCommand($object, $options);
                 break;
             case $object instanceof Application:
@@ -100,12 +100,12 @@ abstract class Descriptor implements DescriptorInterface
     /**
      * Describes a Command instance.
      *
-     * @param Command $command
-     * @param array   $options
+     * @param CommandInterface $command
+     * @param array            $options
      *
      * @return string|mixed
      */
-    abstract protected function describeCommand(Command $command, array $options = array());
+    abstract protected function describeCommand(CommandInterface $command, array $options = array());
 
     /**
      * Describes an Application instance.

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Console\Descriptor;
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -51,7 +51,7 @@ class JsonDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeCommand(Command $command, array $options = array())
+    protected function describeCommand(CommandInterface $command, array $options = array())
     {
         $this->writeData($this->getCommandData($command), $options);
     }
@@ -144,11 +144,11 @@ class JsonDescriptor extends Descriptor
     }
 
     /**
-     * @param Command $command
+     * @param CommandInterface $command
      *
      * @return array
      */
-    private function getCommandData(Command $command)
+    private function getCommandData(CommandInterface $command)
     {
         $command->getSynopsis();
         $command->mergeApplicationDefinition(false);

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Console\Descriptor;
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -85,7 +85,7 @@ class MarkdownDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeCommand(Command $command, array $options = array())
+    protected function describeCommand(CommandInterface $command, array $options = array())
     {
         $command->getSynopsis();
         $command->mergeApplicationDefinition(false);

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Console\Descriptor;
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -111,7 +111,7 @@ class TextDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeCommand(Command $command, array $options = array())
+    protected function describeCommand(CommandInterface $command, array $options = array())
     {
         $command->getSynopsis();
         $command->mergeApplicationDefinition(false);

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Console\Descriptor;
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -48,11 +48,11 @@ class XmlDescriptor extends Descriptor
     }
 
     /**
-     * @param Command $command
+     * @param CommandInterface $command
      *
      * @return \DOMDocument
      */
-    public function getCommandDocument(Command $command)
+    public function getCommandDocument(CommandInterface $command)
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($commandXML = $dom->createElement('command'));
@@ -158,7 +158,7 @@ class XmlDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeCommand(Command $command, array $options = array())
+    protected function describeCommand(CommandInterface $command, array $options = array())
     {
         $this->writeDocument($this->getCommandDocument($command));
     }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -270,7 +272,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         return array(
             array('f', 'Command "f" is not defined.'),
             array('a', 'Command "a" is ambiguous (afoobar, afoobar1 and 1 more).'),
-            array('foo:b', 'Command "foo:b" is ambiguous (foo:bar, foo:bar1 and 1 more).')
+            array('foo:b', 'Command "foo:b" is ambiguous (foo:bar, foo:bar1 and 1 more).'),
         );
     }
 
@@ -317,7 +319,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('foo3:baR'),
-            array('foO3:bar')
+            array('foO3:bar'),
         );
     }
 
@@ -676,8 +678,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application = $this->getMock('Symfony\Component\Console\Application', array('doRun'));
         $application->setAutoExit(false);
         $application->expects($this->once())
-             ->method('doRun')
-             ->will($this->throwException($exception));
+            ->method('doRun')
+            ->will($this->throwException($exception));
 
         $exitCode = $application->run(new ArrayInput(array()), new NullOutput());
 
@@ -691,8 +693,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application = $this->getMock('Symfony\Component\Console\Application', array('doRun'));
         $application->setAutoExit(false);
         $application->expects($this->once())
-             ->method('doRun')
-             ->will($this->throwException($exception));
+            ->method('doRun')
+            ->will($this->throwException($exception));
 
         $exitCode = $application->run(new ArrayInput(array()), new NullOutput());
 
@@ -968,6 +970,32 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester->run(array());
 
         $this->assertEquals('interact called'.PHP_EOL.'called'.PHP_EOL, $tester->getDisplay(), 'Application runs the default set command if different from \'list\' command');
+    }
+
+    public function testRunWithCommandInterface()
+    {
+        $input = new StringInput('symfony:command-interface');
+        $output = new BufferedOutput();
+        $command = $this->getMock('Symfony\Component\Console\Command\CommandInterface');
+        $command->expects($this->any())->method('getName')->will($this->returnValue('symfony:command-interface'));
+        $command->expects($this->any())->method('isEnabled')->will($this->returnValue(true));
+        $command->expects($this->any())->method('getAliases')->will($this->returnValue(array()));
+        $command->expects($this->any())->method('getHelperSet')->will($this->returnValue(new HelperSet()));
+
+        $definition = new InputDefinition();
+        $command->expects($this->any())->method('getDefinition')->will($this->returnValue($definition));
+        $command->
+            expects($this->once())->
+            method('run')->
+            with($input, $output)->
+            will($this->returnCallback(function ($input, $output) { $output->write('meh'); } ));
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+        $application->run($input, $output);
+
+        $this->assertEquals('meh', $output->fetch());
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandDecoratorTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandDecoratorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\CommandDecorator;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CommandDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    private $commandDecorator;
+    private $decoratedCommand;
+
+    public function setUp()
+    {
+        $this->decoratedCommand = $this->getMock('Symfony\Component\Console\Command\CommandInterface');
+        $this->commandDecorator = new CommandDecorator($this->decoratedCommand);
+    }
+
+    public function testSetApplication()
+    {
+        $application = new Application();
+        $this->setDecorationExpectation('setApplication')->with($application);
+        $this->commandDecorator->setApplication($application);
+    }
+
+    public function testGetHelperSet()
+    {
+        $helperSet = new HelperSet();
+        $this->setDecorationExpectation('getHelperSet', $helperSet);
+        $this->assertEquals($helperSet, $this->commandDecorator->getHelperSet());
+    }
+
+    public function testGetApplication()
+    {
+        $application = new Application();
+        $this->setDecorationExpectation('getApplication', $application);
+        $this->assertEquals($application, $this->commandDecorator->getApplication());
+    }
+
+    public function testIsEnabled()
+    {
+        $this->setDecorationExpectation('isEnabled', true);
+        $this->assertTrue($this->commandDecorator->isEnabled());
+    }
+
+    public function testRun()
+    {
+        $input = new StringInput('asf');
+        $output = new NullOutput();
+        $this->setDecorationExpectation('run', 1)->with($input, $output);
+        $this->assertEquals(1, $this->commandDecorator->run($input, $output));
+    }
+
+    public function testMergeApplicationDefinition()
+    {
+        $this->setDecorationExpectation('mergeApplicationDefinition')->with(true);
+        $this->commandDecorator->mergeApplicationDefinition(true);
+    }
+
+    public function testGetDefinition()
+    {
+        $definition = new InputDefinition();
+        $this->setDecorationExpectation('getDefinition', $definition);
+        $this->assertEquals($definition, $this->commandDecorator->getDefinition());
+    }
+
+    public function testGetNativeDefinition()
+    {
+        $definition = new InputDefinition();
+        $this->setDecorationExpectation('getNativeDefinition', $definition);
+        $this->assertEquals($definition, $this->commandDecorator->getNativeDefinition());
+    }
+
+    public function testGetName()
+    {
+        $this->setDecorationExpectation('getName', 'foo:bar');
+        $this->assertEquals('foo:bar', $this->commandDecorator->getName());
+    }
+
+    public function testGetDescription()
+    {
+        $this->setDecorationExpectation('getDescription', 'description');
+        $this->assertEquals('description', $this->commandDecorator->getDescription());
+    }
+
+    public function testGetHelp()
+    {
+        $this->setDecorationExpectation('getHelp', 'how to');
+        $this->assertEquals('how to', $this->commandDecorator->getHelp());
+    }
+
+    public function testGetProcessedHelp()
+    {
+        $this->setDecorationExpectation('getProcessedHelp', 'how to');
+        $this->assertEquals('how to', $this->commandDecorator->getProcessedHelp());
+    }
+
+    public function testGetAliases()
+    {
+        $this->setDecorationExpectation('getAliases', array('foo:meh'));
+        $this->assertEquals(array('foo:meh'), $this->commandDecorator->getAliases());
+    }
+
+    public function testGetSynopsis()
+    {
+        $this->setDecorationExpectation('getSynopsis', 'synopsis');
+        $this->assertEquals('synopsis', $this->commandDecorator->getSynopsis());
+    }
+
+    private function setDecorationExpectation($method, $returnValue = null)
+    {
+        return $this->decoratedCommand->expects($this->once())->
+            method($method)->
+            will($this->returnValue($returnValue));
+    }
+}


### PR DESCRIPTION
For a project I needed to make sure multiple commands can run only once. There was some code duplication between the commands, which I didn't like. I though it was a nice idea to create a `@RunOnce` annotation. When I tried to implement this, I found that it's a bit hard to [decorate](http://symfony.com/doc/current/components/dependency_injection/advanced.html#decorating-services) a command that is created as a [service](http://symfony.com/doc/current/cookbook/console/console_command.html#register-commands-in-the-service-container).

This pull request makes this a lot easier. Should this be accepted I'd only have to subclass the `CommandDecorator` and override the `run` method with this behaviour.

Solution: Created a `CommandInterface` implemented by `Command` and `CommandDecorator`.

I could also imagine a decorator that logs when a command was started and ended. Or one that changes a duplicate name, or..

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | None yet |

BC break:
`Application->add` and `Application->doRunCommand` now require a `CommandInterface` instead of a `Command`. `Command` implements this interface, but it would break if you subclass `Application`. I do not see a way of doing this change without breaking the backwards compatibility (unless we override all 32 public/protected functions inside the decorator).
