### PR TITLE
[Session] Changed session.flash_bag service to publicly available

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -22,7 +22,7 @@
         <service id="session" class="%session.class%">
             <argument type="service" id="session.storage" />
             <argument type="service" id="session.attribute_bag" />
-            <argument type="service" id="session.flash_bag" />
+            <argument type="service" id="session.default_flash_bag" />
         </service>
 
         <service id="session.storage.metadata_bag" class="%session.storage.metadata_bag.class%" public="false">
@@ -41,7 +41,9 @@
             <argument type="service" id="session.storage.metadata_bag" />
         </service>
 
-        <service id="session.flash_bag" class="%session.flashbag.class%" public="false" />
+        <service id="session.flash_bag" class="Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface" factory-class="session" factory-method="getFlashBag" />
+        
+        <service id="session.default_flash_bag" class="%session.flashbag.class%" public="false" />
 
         <service id="session.attribute_bag" class="%session.attribute_bag.class%" public="false" />
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11279 |
| License | MIT |
| Doc PR | - |

Main issue is described in my ticket. The problem is that in order to get the flash bag, you have to either ignore the `SessionInterface` on `Request` or type hint `Session` instead of `SessionInterface` during injection. Neither solutions work nicely with custom implementations of the session.

By defining `session.flash_bag` as public service, you can just inject this as it's created by `session.getFlashBag`. This makes sure that you always have the right bag, even if you decide to inject a custom flash bag in the session service.

For the default implementation, the old variant is used as injection. I have left this as it is so that people can still choose to omit it when constructing or putting in their own flash bag, with their own key if desired. This PR should be 100% BC.
