### PR TITLE
[Debug] Restoring error handler before assertions

### DIFF
--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -206,13 +206,13 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $m->setAccessible(true);
         $m->invoke($handler, array($exceptionHandler, 'handle'), $error);
 
+        restore_error_handler();
         $this->assertInstanceof($class, $exceptionHandler->e);
         // class names are case insensitive and PHP/HHVM do not return the same
         $this->assertSame(strtolower($translatedMessage), strtolower($exceptionHandler->e->getMessage()));
         $this->assertSame($error['type'], $exceptionHandler->e->getSeverity());
         $this->assertSame($error['file'], $exceptionHandler->e->getFile());
         $this->assertSame($error['line'], $exceptionHandler->e->getLine());
-        restore_error_handler();
     }
 
     public function provideFatalErrorHandlersData()


### PR DESCRIPTION
[Debug] Improving unit test

As a follow up of @stof's comment on #11952 the reset of error handlers been moved up before the assertions to clean up even in case of a failure.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
