### PR TITLE
[ExpressionLanguage] Added ability to evaluate callables

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -60,7 +60,19 @@ class ExpressionLanguage
      */
     public function evaluate($expression, $values = array())
     {
-        return $this->parse($expression, array_keys($values))->getNodes()->evaluate($this->functions, $values);
+        $functions = $this->functions;
+
+        foreach ($values as $name => $value) {
+            if (is_callable($value)) {
+                $functions[$name] = array('evaluator' => function () use ($value) {
+                    return call_user_func_array($value, array_slice(func_get_args(), 1));
+                });
+
+                unset($values[$name]);
+            }
+        }
+
+        return $this->parse($expression, array_keys($values))->getNodes()->evaluate($functions, $values);
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ExpressionLanguage\Node;
 
 use Symfony\Component\ExpressionLanguage\Compiler;
+use Symfony\Component\ExpressionLanguage\RuntimeError;
 
 class FunctionNode extends Node
 {
@@ -42,6 +43,12 @@ class FunctionNode extends Node
             $arguments[] = $node->evaluate($functions, $values);
         }
 
-        return call_user_func_array($functions[$this->attributes['name']]['evaluator'], $arguments);
+        $functionName = $this->attributes['name'];
+
+        if (!isset($functions[$functionName])) {
+            throw new RuntimeError(sprintf('The function "%s" does not exist', $functionName));
+        }
+
+        return call_user_func_array($functions[$functionName]['evaluator'], $arguments);
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -184,10 +184,6 @@ class Parser
 
                     default:
                         if ('(' === $this->stream->current->value) {
-                            if (false === isset($this->functions[$token->value])) {
-                                throw new SyntaxError(sprintf('The function "%s" does not exist', $token->value), $token->cursor);
-                            }
-
                             $node = new Node\FunctionNode($token->value, $this->parseArguments());
                         } else {
                             if (!in_array($token->value, $this->names, true)) {

--- a/src/Symfony/Component/ExpressionLanguage/RuntimeError.php
+++ b/src/Symfony/Component/ExpressionLanguage/RuntimeError.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage;
+
+class RuntimeError extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -96,4 +96,30 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
             array('true or foo', array('foo' => 'foo'), true),
         );
     }
+
+    public function testEvaluateCallable()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $this->assertEquals(
+            'Name: John Doe',
+            $expressionLanguage->evaluate("name() ~ concatenate(firstName, ' Doe')", array(
+                'firstName' => 'John',
+                'name' => function () {
+                    return 'Name: ';
+                },
+                'concatenate' => function ($left, $right) {
+                    return $left.$right;
+                },
+            ))
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\ExpressionLanguage\RuntimeError
+     */
+    public function testEvaluateFunctionNotRegistered()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $expressionLanguage->evaluate("not_registered()");
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/11938 |
| License | MIT |
| Doc PR |  |

This PR adds a way to pass callables when evaluating the expression. It also removes the first argument passed to the evaluator function, which makes it easier to directly pass PHP functions for example.
