### PR TITLE
[ExpressionLanguage] Added closures support

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -81,7 +81,7 @@ class Lexer
                 // punctuation
                 $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);
                 ++$cursor;
-            } elseif (preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A', $expression, $match, null, $cursor)) {
+            } elseif (preg_match('/\$?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A', $expression, $match, null, $cursor)) {
                 // names
                 $tokens[] = new Token(Token::NAME_TYPE, $match[0], $cursor + 1);
                 $cursor += strlen($match[0]);

--- a/src/Symfony/Component/ExpressionLanguage/Node/ClosureNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ClosureNode.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Node;
+
+use Symfony\Component\ExpressionLanguage\Compiler;
+
+class ClosureNode extends FunctionNode
+{
+    public function compile(Compiler $compiler)
+    {
+        $arguments = array();
+        foreach ($this->nodes['arguments']->nodes as $node) {
+            $arguments[] = $compiler->subcompile($node);
+        }
+
+        $compiler->raw(sprintf('$%s(%s)', $this->attributes['name'], implode(', ', $arguments)));
+    }
+
+    public function evaluate($functions, $values)
+    {
+        $arguments = array();
+        foreach ($this->nodes['arguments']->nodes as $node) {
+            $arguments[] = $node->evaluate($functions, $values);
+        }
+
+        return call_user_func_array($values[$this->attributes['name']], $arguments);
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -184,11 +184,18 @@ class Parser
 
                     default:
                         if ('(' === $this->stream->current->value) {
-                            if (false === isset($this->functions[$token->value])) {
+                            if (0 === strpos($token->value, '$')) {
+                                $tokenValue = substr($token->value, 1);
+                                if (!in_array($tokenValue, $this->names, true)) {
+                                    throw new SyntaxError(sprintf('The closure "%s" does not exist', $tokenValue), $token->cursor);
+                                }
+
+                                $node = new Node\ClosureNode($tokenValue, $this->parseArguments());
+                            } elseif (isset($this->functions[$token->value])) {
+                                $node = new Node\FunctionNode($token->value, $this->parseArguments());
+                            } else {
                                 throw new SyntaxError(sprintf('The function "%s" does not exist', $token->value), $token->cursor);
                             }
-
-                            $node = new Node\FunctionNode($token->value, $this->parseArguments());
                         } else {
                             if (!in_array($token->value, $this->names, true)) {
                                 throw new SyntaxError(sprintf('Variable "%s" is not valid', $token->value), $token->cursor);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -86,6 +86,17 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 array(new Token('string', '#foo', 1)),
                 '"#foo"',
             ),
+            array(
+                array(
+                    new Token('name', '$foo', 1),
+                    new Token('punctuation', '(', 5),
+                    new Token('number', '4', 6),
+                    new Token('punctuation', ',', 7),
+                    new Token('string', 'bar', 9),
+                    new Token('punctuation', ')', 14),
+                ),
+                '$foo(4, "bar")',
+            ),
         );
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/ClosureNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/ClosureNodeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Tests\Node;
+
+use Symfony\Component\ExpressionLanguage\Node\ClosureNode;
+use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
+use Symfony\Component\ExpressionLanguage\Node\Node;
+
+class ClosureNodeTest extends AbstractNodeTest
+{
+    public function getEvaluateData()
+    {
+        $foo = function ($a, $b) {
+            return $a + $b;
+        };
+
+        return array(
+            array(2, new ClosureNode('foo', new Node(array(new ConstantNode(1), new ConstantNode(1)))), array('foo' => $foo)),
+            array(3, new ClosureNode('foo', new Node(array(new ClosureNode('foo', new Node(array(new ConstantNode(1), new ConstantNode(1)))), new ConstantNode(1)))), array('foo' => $foo)),
+        );
+    }
+
+    public function getCompileData()
+    {
+        return array(
+            array('$foo()', new ClosureNode('foo', new Node(array()))),
+            array('$foo(1, 1)', new ClosureNode('foo', new Node(array(new ConstantNode(1), new ConstantNode(1))))),
+            array('$foo($bar())', new ClosureNode('foo', new Node(array(new ClosureNode('bar', new Node(array())))))),
+        );
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -148,6 +148,11 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'foo.bar().foo().baz[3]',
                 array('foo'),
             ),
+            array(
+                new Node\ClosureNode('foo', new Node\Node(array(new Node\ConstantNode(3)))),
+                '$foo(3)',
+                array('foo'),
+            ),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/11938 |
| License | MIT |
| Doc PR |  |

This PR adds closures support to the `ExpressionLanguage` for both compiled and evaluated modes.

As @stof suggested in https://github.com/symfony/symfony/issues/11938, I added a new syntax to differentiate them from functions. The simplest syntax I could come up with is to prepend a `$` to a function name.
## Evaluation mode

In evaluation mode, you can pass the closure as a variable when evaluating the expression.

``` php
// => '3'
echo $language->evaluate('$add(1, 2)', array(
    'add' => function ($a, $b) {
        return $a + $b;
    }
));
```
## Compilation mode

When compiled, the closure expression is unchanged because it uses the same syntax than php .

``` php
$hello = function () {
    return 'hello';
};

$world = function () {
    return 'world';
};

$language = new ExpressionLanguage();

// => hello world
eval(sprintf('echo %s;', $language->compile('$hello() ~ " " ~ $world()', array('hello', 'world'))));
```
