### PR TITLE
[Finder] Escape location for regex searches

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -216,7 +216,7 @@ abstract class AbstractFindAdapter extends AbstractAdapter
             // Fixes 'not search' regex problems.
             if ($expr->isRegex()) {
                 $regex = $expr->getRegex();
-                $regex->prepend($regex->hasStartFlag() ? $dir.DIRECTORY_SEPARATOR : '.*')->setEndJoker(!$regex->hasEndFlag());
+                $regex->prepend($regex->hasStartFlag() ? preg_quote($dir).DIRECTORY_SEPARATOR : '.*')->setEndJoker(!$regex->hasEndFlag());
             } else {
                 $expr->prepend('*')->append('*');
             }

--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -247,7 +247,7 @@ abstract class AbstractFindAdapter extends AbstractAdapter
                     $command->add('-size -'.($size->getTarget() + 1).'c');
                     break;
                 case '>=':
-                    $command->add('-size +'. ($size->getTarget() - 1).'c');
+                    $command->add('-size +'.($size->getTarget() - 1).'c');
                     break;
                 case '>':
                     $command->add('-size +'.$size->getTarget().'c');

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -569,6 +569,20 @@ class FinderTest extends Iterator\RealIteratorTestCase
         }
     }
 
+    /**
+     * @dataProvider getAdaptersTestData
+     */
+    public function testRegexSpecialCharsLocationWithPathRestrictionContainingStartFlag(Adapter\AdapterInterface $adapter)
+    {
+        $finder = $this->buildFinder($adapter);
+        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.g?e*x[c]a(r)s')
+            ->path('/^dir/');
+
+        $expected = array('r+e.g?e*x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir',
+                          'r+e.g?e*x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
+        $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
+    }
+
     public function testAdaptersOrdering()
     {
         $finder = Finder::create()

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -687,7 +687,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $tests = array(
             array('', '', array()),
             array('/^A\/B\/C/', '/C$/',
-                array('A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat')
+                array('A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat'),
             ),
             array('/^A\/B/', 'foobar',
                 array(
@@ -695,7 +695,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
                     'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C',
                     'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'ab.dat',
                     'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat',
-                )
+                ),
             ),
             array('A/B/C', 'foobar',
                 array(
@@ -703,7 +703,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
                     'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat',
                     'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C',
                     'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat.copy',
-                )
+                ),
             ),
             array('A/B', 'foobar',
                 array(
@@ -717,12 +717,12 @@ class FinderTest extends Iterator\RealIteratorTestCase
                     'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat',
                     'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'ab.dat.copy',
                     'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat.copy',
-                )
+                ),
             ),
             array('/^with space\//', 'foobar',
                 array(
                     'with space'.DIRECTORY_SEPARATOR.'foo.txt',
-                )
+                ),
             ),
         );
 
@@ -822,7 +822,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
             array(
                 new Adapter\BsdFindAdapter(),
                 new Adapter\GnuFindAdapter(),
-                new Adapter\PhpAdapter()
+                new Adapter\PhpAdapter(),
             ),
             function (Adapter\AdapterInterface $adapter) {
                 return $adapter->isSupported();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

If the location to start searching in contains a regex special char
like + or ? and the path restriction is a regular expresion with a start
limitation. No results will be found wtih at least GnuFindAdapter - e.g.:

```
use Symfony\Component\Finder\Finder;
use Symfony\Component\Finder\Adapter;

mkdir('/tmp/reg+ex/dir/subdir', 0777, true);

$finder = Finder::create()
    ->removeAdapters()
    ->addAdapter(new Adapter\GnuFindAdapter());
$finder->in('/tmp/reg+ex')->path('/^dir/');

print count($finder)."\n";
```

Expected result: 2
Actual result is: 0

This pull request consists of:
- a new test checking for this bug (0e81086a49425d0e12cff4f479fabeb97e9ed757)
- the actual fix (6595b6b2b71afc57ef08686b4584713c0e4e48ed)
- changes to comply with the coding standard (7f199c5b53b3c1f38b36dcc286d3b20ae877425b)
## How to reproduce
### Fastest way
1. Move or copy your local symfony clone into a location containing special regex chars:
   - `mv symfony symfony+regex`
2. Run tests in there
   - `cd symfony+regex && phpunit`

> Result: Some tests in the finder component will fail.
### Alternative: A new clone
1. Clone symfony in a directory containing at least one regex special char
   - `git clone https://github.com/symfony/symfony.git /tmp/symfony+regexchar`
2. As usual get composer, install dependencies and get phpunit
   - You might simply want to follow [this guide](http://symfony.com/doc/current/contributing/code/tests.html)
3. Run tests in there
   - `cd /tmp/symfony+regexchar && phpunit`

> Result: Some tests in the finder component will fail.
### Alternative: Apply the new test
1. Apply commit a29d1207ced2949c918357cf271200523960caef to your symfony clone
2. Run tests

> Result: The new test will fail.
