### PR TITLE
[Console] Added the ability to return the default answer in a question

### DIFF
--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -25,6 +25,7 @@ class Question
     private $autocompleterValues;
     private $validator;
     private $default;
+    private $showDefault = false;
     private $normalizer;
 
     /**
@@ -46,6 +47,10 @@ class Question
      */
     public function getQuestion()
     {
+        if ($this->showDefault) {
+            return sprintf('%s [%s]', $this->question, $this->default);
+        }
+
         return $this->question;
     }
 
@@ -57,6 +62,20 @@ class Question
     public function getDefault()
     {
         return $this->default;
+    }
+
+    /**
+     * Sets whether the default answer should be shown to the user in the question
+     *
+     * @param bool $showDefault
+     *
+     * @return Question The current instance
+     */
+    public function setShowDefault($showDefault)
+    {
+        $this->showDefault = (bool) $showDefault;
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -75,6 +75,24 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('Superman', 'Batman'), $questionHelper->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
     }
 
+    public function testAskWithShowDefaults()
+    {
+        $dialog = new QuestionHelper();
+
+        $dialog->setInputStream($this->getInputStream("\n8AM\n"));
+
+        $question = new Question('What time is it?', '2PM');
+        $question->setShowDefault(true);
+        $this->assertEquals('2PM', $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
+
+        $question = new Question('What time is it?', '2PM');
+        $question->setShowDefault(true);
+        $this->assertEquals('8AM', $dialog->ask($this->createInputInterfaceMock(), $output = $this->createOutputInterface(), $question));
+
+        rewind($output->getStream());
+        $this->assertEquals('What time is it? [2PM]', stream_get_contents($output->getStream()));
+    }
+
     public function testAsk()
     {
         $dialog = new QuestionHelper();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | symfony/symfony-docs#4254 |

This gives the option of showing the default answer along with the question. The documentation is a work in progress.
