### PR TITLE
[Yaml] Ensure whole number floats have their data type is persisted.

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -134,7 +134,7 @@ class Inline
                         $repr = str_ireplace('INF', '.Inf', $repr);
                     } elseif (floor($value) == $value && $repr == $value) {
                         // Preserve float data type since storing a whole number will result in integer value.
-                        $repr = '!float '.$repr;
+                        $repr = '!!float '.$repr;
                     }
                 } else {
                     $repr = is_string($value) ? "'$value'" : strval($value);
@@ -479,8 +479,8 @@ class Inline
                         }
 
                         return;
-                    case 0 === strpos($scalar, '!float '):
-                        return (float) substr($scalar, 7);
+                    case 0 === strpos($scalar, '!!float '):
+                        return (float) substr($scalar, 8);
                     case ctype_digit($scalar):
                         $raw = $scalar;
                         $cast = intval($scalar);

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -134,7 +134,7 @@ class Inline
                         $repr = str_ireplace('INF', '.Inf', $repr);
                     } elseif (floor($value) == $value && $repr == $value) {
                         // Preserve float data type since storing a whole number will result in integer value.
-                        $repr = '!!float ' . $repr;
+                        $repr = '!!float '.$repr;
                     }
                 } else {
                     $repr = is_string($value) ? "'$value'" : strval($value);

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -128,8 +128,19 @@ class Inline
                 if (false !== $locale) {
                     setlocale(LC_NUMERIC, 'C');
                 }
-                $repr = is_string($value) ? "'$value'" : (is_infinite($value) ? str_ireplace('INF', '.Inf', strval($value)) : strval($value));
-
+                if (is_float($value)) {
+                    $repr = strval($value);
+                    if (is_infinite($value)) {
+                        $repr = str_ireplace('INF', '.Inf', $repr);
+                    }
+                    elseif (floor($value) == $value && $repr == $value) {
+                        // Preserve float data type since storing a whole number will result in integer value.
+                        $repr = '!!float ' . $repr;
+                    }
+                }
+                else {
+                    $repr = is_string($value) ? "'$value'" : strval($value);
+                }
                 if (false !== $locale) {
                     setlocale(LC_NUMERIC, $locale);
                 }
@@ -470,6 +481,8 @@ class Inline
                         }
 
                         return;
+                    case 0 === strpos($scalar, '!!float '):
+                        return (float) substr($scalar, 8);
                     case ctype_digit($scalar):
                         $raw = $scalar;
                         $cast = intval($scalar);

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -134,7 +134,7 @@ class Inline
                         $repr = str_ireplace('INF', '.Inf', $repr);
                     } elseif (floor($value) == $value && $repr == $value) {
                         // Preserve float data type since storing a whole number will result in integer value.
-                        $repr = '!!float '.$repr;
+                        $repr = '!float '.$repr;
                     }
                 } else {
                     $repr = is_string($value) ? "'$value'" : strval($value);
@@ -479,8 +479,8 @@ class Inline
                         }
 
                         return;
-                    case 0 === strpos($scalar, '!!float '):
-                        return (float) substr($scalar, 8);
+                    case 0 === strpos($scalar, '!float '):
+                        return (float) substr($scalar, 7);
                     case ctype_digit($scalar):
                         $raw = $scalar;
                         $cast = intval($scalar);

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -132,13 +132,11 @@ class Inline
                     $repr = strval($value);
                     if (is_infinite($value)) {
                         $repr = str_ireplace('INF', '.Inf', $repr);
-                    }
-                    elseif (floor($value) == $value && $repr == $value) {
+                    } elseif (floor($value) == $value && $repr == $value) {
                         // Preserve float data type since storing a whole number will result in integer value.
                         $repr = '!!float ' . $repr;
                     }
-                }
-                else {
+                } else {
                     $repr = is_string($value) ? "'$value'" : strval($value);
                 }
                 if (false !== $locale) {

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -96,8 +96,7 @@ EOF;
                     // TODO
                 } else {
                     eval('$expected = '.trim($test['php']).';');
-
-                    $this->assertEquals($expected, $this->parser->parse($this->dumper->dump($expected, 10)), $test['test']);
+                    $this->assertSame($expected, $this->parser->parse($this->dumper->dump($expected, 10)), $test['test']);
                 }
             }
         }

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -529,6 +529,7 @@ yaml: |
   fixed: 1,230.15
   negative infinity: -.inf
   not a number: .NaN
+  float as whole number: !!float 1
 php: |
   array(
     'canonical' => 1230.15,
@@ -536,6 +537,7 @@ php: |
     'fixed' => 1230.15,
     'negative infinity' => log(0),
     'not a number' => -log(0),
+    'float as whole number' => (float) 1
   )
 ---
 test: Miscellaneous

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -529,7 +529,7 @@ yaml: |
   fixed: 1,230.15
   negative infinity: -.inf
   not a number: .NaN
-  float as whole number: !float 1
+  float as whole number: !!float 1
 php: |
   array(
     'canonical' => 1230.15,

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -529,7 +529,7 @@ yaml: |
   fixed: 1,230.15
   negative infinity: -.inf
   not a number: .NaN
-  float as whole number: !!float 1
+  float as whole number: !float 1
 php: |
   array(
     'canonical' => 1230.15,

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -323,7 +323,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             array('true', true),
             array('12', 12),
             array("'quoted string'", 'quoted string'),
-            array('!float 1230', 12.30e+02),
+            array('!!float 1230', 12.30e+02),
             array('1234', 0x4D2),
             array('1243', 02333),
             array('.Inf', -log(0)),

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -40,7 +40,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($yaml, Inline::dump($value), sprintf('::dump() converts a PHP structure to an inline YAML (%s)', $yaml));
 
-        $this->assertEquals($value, Inline::parse(Inline::dump($value)), 'check consistency');
+        $this->assertSame($value, Inline::parse(Inline::dump($value)), 'check consistency');
     }
 
     public function testDumpNumericValueWithLocale()
@@ -323,7 +323,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             array('true', true),
             array('12', 12),
             array("'quoted string'", 'quoted string'),
-            array('12.30e+02', 12.30e+02),
+            array('!!float 1230', 12.30e+02),
             array('1234', 0x4D2),
             array('1243', 02333),
             array('.Inf', -log(0)),

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -323,7 +323,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             array('true', true),
             array('12', 12),
             array("'quoted string'", 'quoted string'),
-            array('!!float 1230', 12.30e+02),
+            array('!float 1230', 12.30e+02),
             array('1234', 0x4D2),
             array('1243', 02333),
             array('.Inf', -log(0)),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | Yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | no |

See http://yaml.org/spec/1.1/#id858936 specifically the spec about specific data types.

Sample code that exposes the issue:

``` php
$yaml = new \Symfony\Component\Yaml\Yaml();

$expected = array('float' => (float) 1);
$test = $yaml->parse($yaml->dump($expected));

if ($expected === $test) {
  print "match!\n";
}
else {
  var_dump($test);
}
```

This will output

```
array(1) {
  'float' =>
  int(1)
}
```
