### PR TITLE
[Dom crawler] Issue with domcrawler + js template

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -801,6 +801,33 @@ HTML;
         }
     }
 
+    public function testFormTextarea()
+    {
+        $html = <<<EOL
+            <html>
+                <script id="comment-form-template" type="text/template">
+                    <form method="post" action="#">
+                        <textarea id="violation_comment_comment" name="violation_comment[comment]" required="required"></textarea>
+                        <button type="submit" name="action" value="comment">Comment</button>
+                    </form>
+                </script>
+            </html>
+EOL;
+
+        $crawler1 = new Crawler(null, 'http://localhost/');
+        $crawler1->addContent($html);
+
+        $expected = <<<EOL
+
+                    <form method="post" action="#">
+                        <textarea id="violation_comment_comment" name="violation_comment[comment]" required="required"></textarea>
+                        <button type="submit" name="action" value="comment">Comment</button>
+                    </form>
+EOL;
+        $this->assertSame($expected, $crawler1->filter('#comment-form-template')->text());
+    }
+
+
     public function testLast()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');


### PR DESCRIPTION
in SF 2.4.1 our tests suite passed, but not in sf 2.4.2+. And now, I'm trying again to update symfony to 2.5.3 and I got this error again. So I reproduced our issue as a SF unit test.

```
1) Symfony\Component\DomCrawler\Tests\CrawlerTest::testFormTextarea
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@

                     <form method="post" action="#">
-                        <textarea id="violation_comment_comment" name="violation_comment[comment]" required="required"></textarea>
-                        <button type="submit" name="action" value="comment">Comment</button>
-                    </form>
+                        <textarea id="violation_comment_comment" name="violation_comment[comment]" required="required">
+                        <button type="submit" name="action" value="comment">Comment
+                    
+

```
