### PR TITLE
[Finder] Avoid asterisk in the file path to prevent windows filesystems problems

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -575,11 +575,11 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testRegexSpecialCharsLocationWithPathRestrictionContainingStartFlag(Adapter\AdapterInterface $adapter)
     {
         $finder = $this->buildFinder($adapter);
-        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.g?e*x[c]a(r)s')
+        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.g?ex[c]a(r)s')
             ->path('/^dir/');
 
-        $expected = array('r+e.g?e*x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir',
-                          'r+e.g?e*x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
+        $expected = array('r+e.g?ex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir',
+                          'r+e.g?ex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
         $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11984 |
| License | MIT |
| Doc PR | - |

`*` in directory name causes problems on windows. The other regexp characters in the directory name are sufficient to verify the name is escaped.
