### PR TITLE
[Finder][urgent] Remove asterisk and question mark from folder name in test to prevent windows file system issues.

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -586,11 +586,11 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testRegexSpecialCharsLocationWithPathRestrictionContainingStartFlag(Adapter\AdapterInterface $adapter)
     {
         $finder = $this->buildFinder($adapter);
-        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.g?e*x[c]a(r)s')
+        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.gex[c]a(r)s')
             ->path('/^dir/');
 
-        $expected = array('r+e.g?e*x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir',
-                          'r+e.g?e*x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
+        $expected = array('r+e.gex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir',
+                          'r+e.gex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
         $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
     }
 


### PR DESCRIPTION
Bugfix: Yes
Fixed tickets: #11984 , #11985 
Related tickets: #11970 

Commit #11970 prevented Symphony from being checked out via windows due to invalid characters in a folder name within the tests.

The issue was reported in #11984  and was attempted to be fixed in #11985 but wasn't due to still including the question mark.

Please accept this ASAP as it entirely breaks any composer that relies on it.
