### PR TITLE
[Finder] Fix broken windows install

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -575,11 +575,11 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testRegexSpecialCharsLocationWithPathRestrictionContainingStartFlag(Adapter\AdapterInterface $adapter)
     {
         $finder = $this->buildFinder($adapter);
-        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.g?e*x[c]a(r)s')
+        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.g-e$x[c]a(r)s')
             ->path('/^dir/');
 
-        $expected = array('r+e.g?e*x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir',
-                          'r+e.g?e*x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
+        $expected = array('r+e.g-e$x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir',
+                          'r+e.g-e$x[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
         $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11984 |
| License | MIT |
| Doc PR | - |

The commit b63926b24666798e8e20030b7c4f9b29ae7b7f09 from PR #11970
introduces a directory containing invalid chars for directory
names under windows.
