### PR TITLE
[Form] Changed "allow_html5" to "html5"

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 2.6.0
 -----
 
- * added "allow_html5" option to Date, Time and DateTimeFormType to be able to
+ * added "html5" option to Date, Time and DateTimeFormType to be able to
    enable/disable HTML5 input date when widget option is "single_text"
 
 2.5.0

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -117,7 +117,7 @@ class DateTimeType extends AbstractType
                 'empty_value',
                 'required',
                 'translation_domain',
-                'allow_html5',
+                'html5',
             )));
 
             $timeOptions = array_intersect_key($options, array_flip(array(
@@ -129,7 +129,7 @@ class DateTimeType extends AbstractType
                 'empty_value',
                 'required',
                 'translation_domain',
-                'allow_html5',
+                'html5',
             )));
 
             if (null !== $options['date_widget']) {
@@ -185,8 +185,8 @@ class DateTimeType extends AbstractType
         // Change the input to a HTML5 datetime input if
         //  * the widget is set to "single_text"
         //  * the format matches the one expected by HTML5
-        //  * the allow_html5 is set to true
-        if ($options['allow_html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
+        //  * the html5 is set to true
+        if ($options['html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
             $view->vars['type'] = 'datetime';
         }
     }
@@ -221,7 +221,7 @@ class DateTimeType extends AbstractType
             'time_widget'    => $timeWidget,
             'with_minutes'   => true,
             'with_seconds'   => false,
-            'allow_html5'    => true,
+            'html5'          => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
             'by_reference'   => false,

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -136,8 +136,8 @@ class DateType extends AbstractType
         // Change the input to a HTML5 date input if
         //  * the widget is set to "single_text"
         //  * the format matches the one expected by HTML5
-        //  * the allow_html5 is set to true
-        if ($options['allow_html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
+        //  * the html5 is set to true
+        if ($options['html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
             $view->vars['type'] = 'date';
         }
 
@@ -206,7 +206,7 @@ class DateType extends AbstractType
             'model_timezone' => null,
             'view_timezone'  => null,
             'empty_value'    => $emptyValue,
-            'allow_html5'   => true,
+            'html5'          => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
             'by_reference'   => false,

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -140,8 +140,8 @@ class TimeType extends AbstractType
 
         // Change the input to a HTML5 time input if
         //  * the widget is set to "single_text"
-        //  * the allow_html5 is set to true
-        if ($options['allow_html5'] && 'single_text' === $options['widget']) {
+        //  * the html5 is set to true
+        if ($options['html5'] && 'single_text' === $options['widget']) {
             $view->vars['type'] = 'time';
 
             // we need to force the browser to display the seconds by
@@ -195,7 +195,7 @@ class TimeType extends AbstractType
             'model_timezone' => null,
             'view_timezone'  => null,
             'empty_value'    => $emptyValue,
-            'allow_html5'   => true,
+            'html5'          => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
             'by_reference'   => false,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -409,7 +409,7 @@ class DateTimeTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('datetime', null, array(
             'widget' => 'single_text',
-            'allow_html5' => false,
+            'html5' => false,
         ));
 
         $view = $form->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -709,7 +709,7 @@ class DateTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('date', null, array(
             'widget' => 'single_text',
-            'allow_html5' => false,
+            'html5' => false,
         ));
 
         $view = $form->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -523,7 +523,7 @@ class TimeTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('time', null, array(
             'widget' => 'single_text',
-            'allow_html5' => false,
+            'html5' => false,
         ));
 
         $view = $form->createView();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is a follow-up to #8291, which I missed before it was merged. IMO "allow_html5" is a confusing name. We don't "allow" HTML5, but we use it - or we don't. I think "html5" conveys that meaning well and is shorter at the same time.
