### PR TITLE
[Console] [DialogHelper] Make DialogHelper::ask() accept anon function for dynamic option lists.

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -93,13 +93,13 @@ class DialogHelper extends InputAwareHelper
      * @param OutputInterface $output       An Output instance
      * @param string|array    $question     The question to ask
      * @param string          $default      The default answer if none is given by the user
-     * @param array           $autocomplete List of values to autocomplete
+     * @param array|callable  $autocomplete List of values to autocomplete
      *
      * @return string The user answer
      *
      * @throws \RuntimeException If there is no data to read in the input stream
      */
-    public function ask(OutputInterface $output, $question, $default = null, array $autocomplete = null)
+    public function ask(OutputInterface $output, $question, $default = null, $autocomplete = null)
     {
         if ($this->input && !$this->input->isInteractive()) {
             return $default;
@@ -145,7 +145,7 @@ class DialogHelper extends InputAwareHelper
 
                     if ($i === 0) {
                         $ofs = -1;
-                        $matches = $autocomplete;
+                        $matches = is_callable($autocomplete) ? (array) $autocomplete($ret) : $autocomplete;
                         $numMatches = count($matches);
                     } else {
                         $numMatches = 0;
@@ -195,10 +195,11 @@ class DialogHelper extends InputAwareHelper
 
                     $numMatches = 0;
                     $ofs = 0;
+                    $matches = is_callable($autocomplete) ? (array) $autocomplete($ret) : $autocomplete;
 
-                    foreach ($autocomplete as $value) {
+                    foreach ($matches as $value) {
                         // If typed characters match the beginning chunk of value (e.g. [AcmeDe]moBundle)
-                        if (0 === strpos($value, $ret) && $i !== strlen($value)) {
+                        if (0 === strpos(strtolower($value), $ret) && $i !== strlen($value)) {
                             $matches[$numMatches++] = $value;
                         }
                     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

DialogHelper::ask() currently only accepts a static array for autocomplete. In my use case, I needed a dynamic list based off of the results of an API call. This patch allows the caller to pass in an anonymous function as well as an array for $autocomplete.
- [ ] needs tests
