### PR TITLE
[Security] [Firewall] Bug fixed in SimplePreAuthenticationListener when createToken() not return TokenInterface object

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -21,7 +21,6 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * SimplePreAuthenticationListener implements simple proxying to an authenticator.
@@ -76,13 +75,15 @@ class SimplePreAuthenticationListener implements ListenerInterface
         }
 
         try {
-            $this->securityContext->setToken(null);
             $token = $this->simpleAuthenticator->createToken($request, $this->providerKey);
 
-            if ($token instanceof TokenInterface) {
-                $token = $this->authenticationManager->authenticate($token);
-                $this->securityContext->setToken($token);
+            // allow null to be returned to skip authentication
+            if (null === $token) {
+                return;
             }
+
+            $token = $this->authenticationManager->authenticate($token);
+            $this->securityContext->setToken($token);
         } catch (AuthenticationException $e) {
             $this->securityContext->setToken(null);
 

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * SimplePreAuthenticationListener implements simple proxying to an authenticator.
@@ -75,9 +76,13 @@ class SimplePreAuthenticationListener implements ListenerInterface
         }
 
         try {
+            $this->securityContext->setToken(null);
             $token = $this->simpleAuthenticator->createToken($request, $this->providerKey);
-            $token = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($token);
+
+            if ($token instanceof TokenInterface) {
+                $token = $this->authenticationManager->authenticate($token);
+                $this->securityContext->setToken($token);
+            }
         } catch (AuthenticationException $e) {
             $this->securityContext->setToken(null);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #11490, #11414 |
| License | MIT |
| Doc PR |  |

This is a follow-up for #11414 on the right branch.
