### PR TITLE
[Form] Renamed the option "empty_value" to "placeholder"

### DIFF
--- a/UPGRADE-2.6.md
+++ b/UPGRADE-2.6.md
@@ -1,6 +1,55 @@
 ﻿UPGRADE FROM 2.5 to 2.6
 =======================
 
+Form
+----
+
+ * The "empty_value" option in the types "choice", "date", "datetime" and "time"
+   was deprecated and replaced by a new option "placeholder". You should use
+   the option "placeholder" together with the view variables "placeholder" and
+   "placeholder_in_choices" now.
+
+   The option "empty_value" and the view variables "empty_value" and
+   "empty_value_in_choices" will be removed in Symfony 3.0.
+
+   Before:
+
+   ```php
+   $form->add('category', 'choice', array(
+       'choices' => array('politics', 'media'),
+       'empty_value' => 'Select a category...',
+   ));
+   ```
+
+   After:
+
+   ```php
+   $form->add('category', 'choice', array(
+       'choices' => array('politics', 'media'),
+       'placeholder' => 'Select a category...',
+   ));
+   ```
+
+   Before:
+
+   ```
+   {{ form.vars.empty_value }}
+
+   {% if form.vars.empty_value_in_choices %}
+       ...
+   {% endif %}
+   ```
+
+   After:
+
+   ```
+   {{ form.vars.placeholder }}
+
+   {% if form.vars.placeholder_in_choices %}
+       ...
+   {% endif %}
+   ```
+
 Validator
 ---------
 

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -52,12 +52,12 @@
 {% endblock choice_widget_expanded %}
 
 {% block choice_widget_collapsed -%}
-    {% if required and empty_value is none and not empty_value_in_choices and not multiple -%}
+    {% if required and placeholder is none and not placeholder_in_choices and not multiple -%}
         {% set required = false %}
     {%- endif -%}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
-        {% if empty_value is not none -%}
-            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
+        {% if placeholder is not none -%}
+            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder|trans({}, translation_domain) }}</option>
         {%- endif %}
         {%- if preferred_choices|length > 0 -%}
             {% set options = preferred_choices %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_collapsed.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_collapsed.html.php
@@ -1,5 +1,5 @@
 <select
-    <?php if ($required && null === $empty_value && $empty_value_in_choices === false && $multiple === false):
+    <?php if ($required && null === $placeholder && $placeholder_in_choices === false && $multiple === false):
         $required = false;
     endif; ?>
     <?php echo $view['form']->block($form, 'widget_attributes', array(
@@ -7,7 +7,7 @@
     )) ?>
     <?php if ($multiple): ?> multiple="multiple"<?php endif ?>
 >
-    <?php if (null !== $empty_value): ?><option value=""<?php if ($required and empty($value) && "0" !== $value): ?> selected="selected"<?php endif?>><?php echo $view->escape($view['translator']->trans($empty_value, array(), $translation_domain)) ?></option><?php endif; ?>
+    <?php if (null !== $placeholder): ?><option value=""<?php if ($required and empty($value) && "0" !== $value): ?> selected="selected"<?php endif?>><?php echo $view->escape($view['translator']->trans($placeholder, array(), $translation_domain)) ?></option><?php endif; ?>
     <?php if (count($preferred_choices) > 0): ?>
         <?php echo $view['form']->block($form, 'choice_widget_options', array('choices' => $preferred_choices)) ?>
         <?php if (count($choices) > 0 && null !== $separator): ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -57,8 +57,8 @@ class ChoiceType extends AbstractType
 
             // Check if the choices already contain the empty value
             // Only add the empty value option if this is not the case
-            if (null !== $options['empty_value'] && 0 === count($options['choice_list']->getChoicesForValues(array('')))) {
-                $placeholderView = new ChoiceView(null, '', $options['empty_value']);
+            if (null !== $options['placeholder'] && 0 === count($options['choice_list']->getChoicesForValues(array('')))) {
+                $placeholderView = new ChoiceView(null, '', $options['placeholder']);
 
                 // "placeholder" is a reserved index
                 // see also ChoiceListInterface::getIndicesForChoices()
@@ -101,7 +101,7 @@ class ChoiceType extends AbstractType
             'preferred_choices' => $options['choice_list']->getPreferredViews(),
             'choices'           => $options['choice_list']->getRemainingViews(),
             'separator'         => '-------------------',
-            'empty_value'       => null,
+            'placeholder'       => null,
         ));
 
         // The decision, whether a choice is selected, is potentially done
@@ -119,12 +119,16 @@ class ChoiceType extends AbstractType
         }
 
         // Check if the choices already contain the empty value
-        $view->vars['empty_value_in_choices'] = 0 !== count($options['choice_list']->getChoicesForValues(array('')));
+        $view->vars['placeholder_in_choices'] = 0 !== count($options['choice_list']->getChoicesForValues(array('')));
 
         // Only add the empty value option if this is not the case
-        if (null !== $options['empty_value'] && !$view->vars['empty_value_in_choices']) {
-            $view->vars['empty_value'] = $options['empty_value'];
+        if (null !== $options['placeholder'] && !$view->vars['placeholder_in_choices']) {
+            $view->vars['placeholder'] = $options['placeholder'];
         }
+
+        // BC
+        $view->vars['empty_value'] = $view->vars['placeholder'];
+        $view->vars['empty_value_in_choices'] = $view->vars['placeholder_in_choices'];
 
         if ($options['multiple'] && !$options['expanded']) {
             // Add "[]" to the name in case a select tag with multiple options is
@@ -187,20 +191,25 @@ class ChoiceType extends AbstractType
             return $options['required'] ? null : '';
         };
 
-        $emptyValueNormalizer = function (Options $options, $emptyValue) {
+        // for BC with the "empty_value" option
+        $placeholder = function (Options $options) {
+            return $options['empty_value'];
+        };
+
+        $placeholderNormalizer = function (Options $options, $placeholder) {
             if ($options['multiple']) {
                 // never use an empty value for this case
                 return;
-            } elseif (false === $emptyValue) {
+            } elseif (false === $placeholder) {
                 // an empty value should be added but the user decided otherwise
                 return;
-            } elseif ($options['expanded'] && '' === $emptyValue) {
+            } elseif ($options['expanded'] && '' === $placeholder) {
                 // never use an empty label for radio buttons
                 return 'None';
             }
 
             // empty value has been set explicitly
-            return $emptyValue;
+            return $placeholder;
         };
 
         $compound = function (Options $options) {
@@ -214,7 +223,8 @@ class ChoiceType extends AbstractType
             'choices'           => array(),
             'preferred_choices' => array(),
             'empty_data'        => $emptyData,
-            'empty_value'       => $emptyValue,
+            'empty_value'       => $emptyValue, // deprecated
+            'placeholder'       => $placeholder,
             'error_bubbling'    => false,
             'compound'          => $compound,
             // The view data is always a string, even if the "data" option
@@ -224,7 +234,8 @@ class ChoiceType extends AbstractType
         ));
 
         $resolver->setNormalizers(array(
-            'empty_value' => $emptyValueNormalizer,
+            'empty_value' => $placeholderNormalizer,
+            'placeholder' => $placeholderNormalizer,
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -115,6 +115,7 @@ class DateTimeType extends AbstractType
                 'months',
                 'days',
                 'empty_value',
+                'placeholder',
                 'required',
                 'translation_domain',
                 'html5',
@@ -127,6 +128,7 @@ class DateTimeType extends AbstractType
                 'with_minutes',
                 'with_seconds',
                 'empty_value',
+                'placeholder',
                 'required',
                 'translation_domain',
                 'html5',
@@ -237,7 +239,8 @@ class DateTimeType extends AbstractType
         // Don't add some defaults in order to preserve the defaults
         // set in DateType and TimeType
         $resolver->setOptional(array(
-            'empty_value',
+            'empty_value', // deprecated
+            'placeholder',
             'years',
             'months',
             'days',

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -88,11 +88,11 @@ class DateType extends AbstractType
             if ('choice' === $options['widget']) {
                 // Only pass a subset of the options to children
                 $yearOptions['choices'] = $this->formatTimestamps($formatter, '/y+/', $this->listYears($options['years']));
-                $yearOptions['empty_value'] = $options['empty_value']['year'];
+                $yearOptions['placeholder'] = $options['placeholder']['year'];
                 $monthOptions['choices'] = $this->formatTimestamps($formatter, '/[M|L]+/', $this->listMonths($options['months']));
-                $monthOptions['empty_value'] = $options['empty_value']['month'];
+                $monthOptions['placeholder'] = $options['placeholder']['month'];
                 $dayOptions['choices'] = $this->formatTimestamps($formatter, '/d+/', $this->listDays($options['days']));
-                $dayOptions['empty_value'] = $options['empty_value']['day'];
+                $dayOptions['placeholder'] = $options['placeholder']['day'];
             }
 
             // Append generic carry-along options
@@ -171,24 +171,28 @@ class DateType extends AbstractType
             return $options['widget'] !== 'single_text';
         };
 
-        $emptyValue = $emptyValueDefault = function (Options $options) {
+        $emptyValue = $placeholderDefault = function (Options $options) {
             return $options['required'] ? null : '';
         };
 
-        $emptyValueNormalizer = function (Options $options, $emptyValue) use ($emptyValueDefault) {
-            if (is_array($emptyValue)) {
-                $default = $emptyValueDefault($options);
+        $placeholder = function (Options $options) {
+            return $options['empty_value'];
+        };
+
+        $placeholderNormalizer = function (Options $options, $placeholder) use ($placeholderDefault) {
+            if (is_array($placeholder)) {
+                $default = $placeholderDefault($options);
 
                 return array_merge(
                     array('year' => $default, 'month' => $default, 'day' => $default),
-                    $emptyValue
+                    $placeholder
                 );
             }
 
             return array(
-                'year' => $emptyValue,
-                'month' => $emptyValue,
-                'day' => $emptyValue,
+                'year' => $placeholder,
+                'month' => $placeholder,
+                'day' => $placeholder,
             );
         };
 
@@ -205,7 +209,8 @@ class DateType extends AbstractType
             'format'         => $format,
             'model_timezone' => null,
             'view_timezone'  => null,
-            'empty_value'    => $emptyValue,
+            'empty_value'    => $emptyValue, // deprecated
+            'placeholder'    => $placeholder,
             'html5'          => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
@@ -220,7 +225,8 @@ class DateType extends AbstractType
         ));
 
         $resolver->setNormalizers(array(
-            'empty_value' => $emptyValueNormalizer,
+            'empty_value' => $placeholderNormalizer,
+            'placeholder' => $placeholderNormalizer,
         ));
 
         $resolver->setAllowedValues(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -63,7 +63,7 @@ class TimeType extends AbstractType
 
                 // Only pass a subset of the options to children
                 $hourOptions['choices'] = $hours;
-                $hourOptions['empty_value'] = $options['empty_value']['hour'];
+                $hourOptions['placeholder'] = $options['placeholder']['hour'];
 
                 if ($options['with_minutes']) {
                     foreach ($options['minutes'] as $minute) {
@@ -71,7 +71,7 @@ class TimeType extends AbstractType
                     }
 
                     $minuteOptions['choices'] = $minutes;
-                    $minuteOptions['empty_value'] = $options['empty_value']['minute'];
+                    $minuteOptions['placeholder'] = $options['placeholder']['minute'];
                 }
 
                 if ($options['with_seconds']) {
@@ -82,7 +82,7 @@ class TimeType extends AbstractType
                     }
 
                     $secondOptions['choices'] = $seconds;
-                    $secondOptions['empty_value'] = $options['empty_value']['second'];
+                    $secondOptions['placeholder'] = $options['placeholder']['second'];
                 }
 
                 // Append generic carry-along options
@@ -163,24 +163,29 @@ class TimeType extends AbstractType
             return $options['widget'] !== 'single_text';
         };
 
-        $emptyValue = $emptyValueDefault = function (Options $options) {
+        $emptyValue = $placeholderDefault = function (Options $options) {
             return $options['required'] ? null : '';
         };
 
-        $emptyValueNormalizer = function (Options $options, $emptyValue) use ($emptyValueDefault) {
-            if (is_array($emptyValue)) {
-                $default = $emptyValueDefault($options);
+        // for BC with the "empty_value" option
+        $placeholder = function (Options $options) {
+            return $options['empty_value'];
+        };
+
+        $placeholderNormalizer = function (Options $options, $placeholder) use ($placeholderDefault) {
+            if (is_array($placeholder)) {
+                $default = $placeholderDefault($options);
 
                 return array_merge(
                     array('hour' => $default, 'minute' => $default, 'second' => $default),
-                    $emptyValue
+                    $placeholder
                 );
             }
 
             return array(
-                'hour' => $emptyValue,
-                'minute' => $emptyValue,
-                'second' => $emptyValue,
+                'hour' => $placeholder,
+                'minute' => $placeholder,
+                'second' => $placeholder,
             );
         };
 
@@ -194,7 +199,8 @@ class TimeType extends AbstractType
             'with_seconds'   => false,
             'model_timezone' => null,
             'view_timezone'  => null,
-            'empty_value'    => $emptyValue,
+            'empty_value'    => $emptyValue, // deprecated
+            'placeholder'    => $placeholder,
             'html5'          => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
@@ -209,7 +215,8 @@ class TimeType extends AbstractType
         ));
 
         $resolver->setNormalizers(array(
-            'empty_value' => $emptyValueNormalizer,
+            'empty_value' => $placeholderNormalizer,
+            'placeholder' => $placeholderNormalizer,
         ));
 
         $resolver->setAllowedValues(array(

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -525,14 +525,14 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testSingleChoiceWithNonRequiredEmptyValue()
+    public function testSingleChoiceNonRequiredWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
             'required' => false,
-            'empty_value' => 'Select&Anything&Not&Me',
+            'placeholder' => 'Select&Anything&Not&Me',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -549,14 +549,14 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testSingleChoiceRequiredWithEmptyValue()
+    public function testSingleChoiceRequiredWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
             'expanded' => false,
-            'empty_value' => 'Test&Me',
+            'placeholder' => 'Test&Me',
         ));
 
         // The "disabled" attribute was removed again due to a bug in the
@@ -576,7 +576,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testSingleChoiceRequiredWithEmptyValueViaView()
+    public function testSingleChoiceRequiredWithPlaceholderViaView()
     {
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
@@ -588,7 +588,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         // The "disabled" attribute was removed again due to a bug in the
         // BlackBerry 10 browser.
         // See https://github.com/symfony/symfony/pull/7678
-        $this->assertWidgetMatchesXpath($form->createView(), array('empty_value' => ''),
+        $this->assertWidgetMatchesXpath($form->createView(), array('placeholder' => ''),
 '/select
     [@name="name"]
     [@required="required"]
@@ -655,13 +655,13 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testMultipleChoiceSkipsEmptyValue()
+    public function testMultipleChoiceSkipsPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => true,
             'expanded' => false,
-            'empty_value' => 'Test&Me',
+            'placeholder' => 'Test&Me',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -721,13 +721,13 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testSingleChoiceExpandedWithEmptyValue()
+    public function testSingleChoiceExpandedWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
-            'empty_value' => 'Test&Me',
+            'placeholder' => 'Test&Me',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -806,10 +806,10 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testCountryWithEmptyValue()
+    public function testCountryWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'country', 'AT', array(
-            'empty_value' => 'Select&Country',
+            'placeholder' => 'Select&Country',
             'required' => false,
         ));
 
@@ -862,11 +862,11 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testDateTimeWithEmptyValueGlobal()
+    public function testDateTimeWithPlaceholderGlobal()
     {
         $form = $this->factory->createNamed('name', 'datetime', null, array(
             'input' => 'string',
-            'empty_value' => 'Change&Me',
+            'placeholder' => 'Change&Me',
             'required' => false,
         ));
 
@@ -1074,12 +1074,12 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testDateChoiceWithEmptyValueGlobal()
+    public function testDateChoiceWithPlaceholderGlobal()
     {
         $form = $this->factory->createNamed('name', 'date', null, array(
             'input' => 'string',
             'widget' => 'choice',
-            'empty_value' => 'Change&Me',
+            'placeholder' => 'Change&Me',
             'required' => false,
         ));
 
@@ -1101,13 +1101,13 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testDateChoiceWithEmptyValueOnYear()
+    public function testDateChoiceWithPlaceholderOnYear()
     {
         $form = $this->factory->createNamed('name', 'date', null, array(
             'input' => 'string',
             'widget' => 'choice',
             'required' => false,
-            'empty_value' => array('year' => 'Change&Me'),
+            'placeholder' => array('year' => 'Change&Me'),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1208,11 +1208,11 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testBirthDayWithEmptyValue()
+    public function testBirthDayWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'birthday', '1950-01-01', array(
             'input' => 'string',
-            'empty_value' => '',
+            'placeholder' => '',
             'required' => false,
         ));
 
@@ -1649,11 +1649,11 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testTimeWithEmptyValueGlobal()
+    public function testTimeWithPlaceholderGlobal()
     {
         $form = $this->factory->createNamed('name', 'time', null, array(
             'input' => 'string',
-            'empty_value' => 'Change&Me',
+            'placeholder' => 'Change&Me',
             'required' => false,
         ));
 
@@ -1674,12 +1674,12 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testTimeWithEmptyValueOnYear()
+    public function testTimeWithPlaceholderOnYear()
     {
         $form = $this->factory->createNamed('name', 'time', null, array(
             'input' => 'string',
             'required' => false,
-            'empty_value' => array('hour' => 'Change&Me'),
+            'placeholder' => array('hour' => 'Change&Me'),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1729,10 +1729,10 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testTimezoneWithEmptyValue()
+    public function testTimezoneWithPlaceholder()
     {
         $form = $this->factory->createNamed('name', 'timezone', null, array(
-            'empty_value' => 'Select&Timezone',
+            'placeholder' => 'Select&Timezone',
             'required' => false,
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1011,7 +1011,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertTrue($view->vars['expanded']);
     }
 
-    public function testEmptyValueIsNullByDefaultIfRequired()
+    public function testPlaceholderIsNullByDefaultIfRequired()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -1020,10 +1020,10 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         ));
         $view = $form->createView();
 
-        $this->assertNull($view->vars['empty_value']);
+        $this->assertNull($view->vars['placeholder']);
     }
 
-    public function testEmptyValueIsEmptyStringByDefaultIfNotRequired()
+    public function testPlaceholderIsEmptyStringByDefaultIfNotRequired()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -1032,46 +1032,66 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         ));
         $view = $form->createView();
 
-        $this->assertSame('', $view->vars['empty_value']);
+        $this->assertSame('', $view->vars['placeholder']);
     }
 
     /**
-     * @dataProvider getOptionsWithEmptyValue
+     * @dataProvider getOptionsWithPlaceholder
      */
-    public function testPassEmptyValueToView($multiple, $expanded, $required, $emptyValue, $viewValue)
+    public function testPassPlaceholderToView($multiple, $expanded, $required, $placeholder, $viewValue)
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
-            'empty_value' => $emptyValue,
+            'placeholder' => $placeholder,
             'choices' => $this->choices,
         ));
         $view = $form->createView();
 
+        $this->assertEquals($viewValue, $view->vars['placeholder']);
+        $this->assertFalse($view->vars['placeholder_in_choices']);
+    }
+
+    /**
+     * @dataProvider getOptionsWithPlaceholder
+     */
+    public function testPassEmptyValueBC($multiple, $expanded, $required, $placeholder, $viewValue)
+    {
+        $form = $this->factory->create('choice', null, array(
+            'multiple' => $multiple,
+            'expanded' => $expanded,
+            'required' => $required,
+            'empty_value' => $placeholder,
+            'choices' => $this->choices,
+        ));
+        $view = $form->createView();
+
+        $this->assertEquals($viewValue, $view->vars['placeholder']);
+        $this->assertFalse($view->vars['placeholder_in_choices']);
         $this->assertEquals($viewValue, $view->vars['empty_value']);
         $this->assertFalse($view->vars['empty_value_in_choices']);
     }
 
     /**
-     * @dataProvider getOptionsWithEmptyValue
+     * @dataProvider getOptionsWithPlaceholder
      */
-    public function testDontPassEmptyValueIfContainedInChoices($multiple, $expanded, $required, $emptyValue, $viewValue)
+    public function testDontPassPlaceholderIfContainedInChoices($multiple, $expanded, $required, $placeholder, $viewValue)
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
-            'empty_value' => $emptyValue,
+            'placeholder' => $placeholder,
             'choices' => array('a' => 'A', '' => 'Empty'),
         ));
         $view = $form->createView();
 
-        $this->assertNull($view->vars['empty_value']);
-        $this->assertTrue($view->vars['empty_value_in_choices']);
+        $this->assertNull($view->vars['placeholder']);
+        $this->assertTrue($view->vars['placeholder_in_choices']);
     }
 
-    public function getOptionsWithEmptyValue()
+    public function getOptionsWithPlaceholder()
     {
         return array(
             // single non-expanded

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -280,7 +280,7 @@ class DateTimeTypeTest extends TypeTestCase
         $this->assertEquals('datetime', $view->vars['type']);
     }
 
-    public function testPassDefaultEmptyValueToViewIfNotRequired()
+    public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => false,
@@ -288,15 +288,15 @@ class DateTimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('', $view['date']['year']->vars['empty_value']);
-        $this->assertSame('', $view['date']['month']->vars['empty_value']);
-        $this->assertSame('', $view['date']['day']->vars['empty_value']);
-        $this->assertSame('', $view['time']['hour']->vars['empty_value']);
-        $this->assertSame('', $view['time']['minute']->vars['empty_value']);
-        $this->assertSame('', $view['time']['second']->vars['empty_value']);
+        $this->assertSame('', $view['date']['year']->vars['placeholder']);
+        $this->assertSame('', $view['date']['month']->vars['placeholder']);
+        $this->assertSame('', $view['date']['day']->vars['placeholder']);
+        $this->assertSame('', $view['time']['hour']->vars['placeholder']);
+        $this->assertSame('', $view['time']['minute']->vars['placeholder']);
+        $this->assertSame('', $view['time']['second']->vars['placeholder']);
     }
 
-    public function testPassNoEmptyValueToViewIfRequired()
+    public function testPassNoPlaceholderToViewIfRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => true,
@@ -304,15 +304,31 @@ class DateTimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertNull($view['date']['year']->vars['empty_value']);
-        $this->assertNull($view['date']['month']->vars['empty_value']);
-        $this->assertNull($view['date']['day']->vars['empty_value']);
-        $this->assertNull($view['time']['hour']->vars['empty_value']);
-        $this->assertNull($view['time']['minute']->vars['empty_value']);
-        $this->assertNull($view['time']['second']->vars['empty_value']);
+        $this->assertNull($view['date']['year']->vars['placeholder']);
+        $this->assertNull($view['date']['month']->vars['placeholder']);
+        $this->assertNull($view['date']['day']->vars['placeholder']);
+        $this->assertNull($view['time']['hour']->vars['placeholder']);
+        $this->assertNull($view['time']['minute']->vars['placeholder']);
+        $this->assertNull($view['time']['second']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsString()
+    public function testPassPlaceholderAsString()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'placeholder' => 'Empty',
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty', $view['date']['year']->vars['placeholder']);
+        $this->assertSame('Empty', $view['date']['month']->vars['placeholder']);
+        $this->assertSame('Empty', $view['date']['day']->vars['placeholder']);
+        $this->assertSame('Empty', $view['time']['hour']->vars['placeholder']);
+        $this->assertSame('Empty', $view['time']['minute']->vars['placeholder']);
+        $this->assertSame('Empty', $view['time']['second']->vars['placeholder']);
+    }
+
+    public function testPassEmptyValueBC()
     {
         $form = $this->factory->create('datetime', null, array(
             'empty_value' => 'Empty',
@@ -320,6 +336,12 @@ class DateTimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
+        $this->assertSame('Empty', $view['date']['year']->vars['placeholder']);
+        $this->assertSame('Empty', $view['date']['month']->vars['placeholder']);
+        $this->assertSame('Empty', $view['date']['day']->vars['placeholder']);
+        $this->assertSame('Empty', $view['time']['hour']->vars['placeholder']);
+        $this->assertSame('Empty', $view['time']['minute']->vars['placeholder']);
+        $this->assertSame('Empty', $view['time']['second']->vars['placeholder']);
         $this->assertSame('Empty', $view['date']['year']->vars['empty_value']);
         $this->assertSame('Empty', $view['date']['month']->vars['empty_value']);
         $this->assertSame('Empty', $view['date']['day']->vars['empty_value']);
@@ -328,10 +350,10 @@ class DateTimeTypeTest extends TypeTestCase
         $this->assertSame('Empty', $view['time']['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsArray()
+    public function testPassPlaceholderAsArray()
     {
         $form = $this->factory->create('datetime', null, array(
-            'empty_value' => array(
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
                 'day' => 'Empty day',
@@ -343,19 +365,19 @@ class DateTimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty year', $view['date']['year']->vars['empty_value']);
-        $this->assertSame('Empty month', $view['date']['month']->vars['empty_value']);
-        $this->assertSame('Empty day', $view['date']['day']->vars['empty_value']);
-        $this->assertSame('Empty hour', $view['time']['hour']->vars['empty_value']);
-        $this->assertSame('Empty minute', $view['time']['minute']->vars['empty_value']);
-        $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
+        $this->assertSame('Empty year', $view['date']['year']->vars['placeholder']);
+        $this->assertSame('Empty month', $view['date']['month']->vars['placeholder']);
+        $this->assertSame('Empty day', $view['date']['day']->vars['placeholder']);
+        $this->assertSame('Empty hour', $view['time']['hour']->vars['placeholder']);
+        $this->assertSame('Empty minute', $view['time']['minute']->vars['placeholder']);
+        $this->assertSame('Empty second', $view['time']['second']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
+    public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => false,
-            'empty_value' => array(
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'day' => 'Empty day',
                 'hour' => 'Empty hour',
@@ -365,19 +387,19 @@ class DateTimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty year', $view['date']['year']->vars['empty_value']);
-        $this->assertSame('', $view['date']['month']->vars['empty_value']);
-        $this->assertSame('Empty day', $view['date']['day']->vars['empty_value']);
-        $this->assertSame('Empty hour', $view['time']['hour']->vars['empty_value']);
-        $this->assertSame('', $view['time']['minute']->vars['empty_value']);
-        $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
+        $this->assertSame('Empty year', $view['date']['year']->vars['placeholder']);
+        $this->assertSame('', $view['date']['month']->vars['placeholder']);
+        $this->assertSame('Empty day', $view['date']['day']->vars['placeholder']);
+        $this->assertSame('Empty hour', $view['time']['hour']->vars['placeholder']);
+        $this->assertSame('', $view['time']['minute']->vars['placeholder']);
+        $this->assertSame('Empty second', $view['time']['second']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
+    public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => true,
-            'empty_value' => array(
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'day' => 'Empty day',
                 'hour' => 'Empty hour',
@@ -387,12 +409,12 @@ class DateTimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty year', $view['date']['year']->vars['empty_value']);
-        $this->assertNull($view['date']['month']->vars['empty_value']);
-        $this->assertSame('Empty day', $view['date']['day']->vars['empty_value']);
-        $this->assertSame('Empty hour', $view['time']['hour']->vars['empty_value']);
-        $this->assertNull($view['time']['minute']->vars['empty_value']);
-        $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
+        $this->assertSame('Empty year', $view['date']['year']->vars['placeholder']);
+        $this->assertNull($view['date']['month']->vars['placeholder']);
+        $this->assertSame('Empty day', $view['date']['day']->vars['placeholder']);
+        $this->assertSame('Empty hour', $view['time']['hour']->vars['placeholder']);
+        $this->assertNull($view['time']['minute']->vars['placeholder']);
+        $this->assertSame('Empty second', $view['time']['second']->vars['placeholder']);
     }
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -611,46 +611,61 @@ class DateTypeTest extends TypeTestCase
         $this->assertEquals('date', $view->vars['type']);
     }
 
-    public function testPassDefaultEmptyValueToViewIfNotRequired()
+    public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => false,
         ));
 
         $view = $form->createView();
-        $this->assertSame('', $view['year']->vars['empty_value']);
-        $this->assertSame('', $view['month']->vars['empty_value']);
-        $this->assertSame('', $view['day']->vars['empty_value']);
+        $this->assertSame('', $view['year']->vars['placeholder']);
+        $this->assertSame('', $view['month']->vars['placeholder']);
+        $this->assertSame('', $view['day']->vars['placeholder']);
     }
 
-    public function testPassNoEmptyValueToViewIfRequired()
+    public function testPassNoPlaceholderToViewIfRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => true,
         ));
 
         $view = $form->createView();
-        $this->assertNull($view['year']->vars['empty_value']);
-        $this->assertNull($view['month']->vars['empty_value']);
-        $this->assertNull($view['day']->vars['empty_value']);
+        $this->assertNull($view['year']->vars['placeholder']);
+        $this->assertNull($view['month']->vars['placeholder']);
+        $this->assertNull($view['day']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsString()
+    public function testPassPlaceholderAsString()
+    {
+        $form = $this->factory->create('date', null, array(
+            'placeholder' => 'Empty',
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty', $view['year']->vars['placeholder']);
+        $this->assertSame('Empty', $view['month']->vars['placeholder']);
+        $this->assertSame('Empty', $view['day']->vars['placeholder']);
+    }
+
+    public function testPassEmptyValueBC()
     {
         $form = $this->factory->create('date', null, array(
             'empty_value' => 'Empty',
         ));
 
         $view = $form->createView();
+        $this->assertSame('Empty', $view['year']->vars['placeholder']);
+        $this->assertSame('Empty', $view['month']->vars['placeholder']);
+        $this->assertSame('Empty', $view['day']->vars['placeholder']);
         $this->assertSame('Empty', $view['year']->vars['empty_value']);
         $this->assertSame('Empty', $view['month']->vars['empty_value']);
         $this->assertSame('Empty', $view['day']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsArray()
+    public function testPassPlaceholderAsArray()
     {
         $form = $this->factory->create('date', null, array(
-            'empty_value' => array(
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
                 'day' => 'Empty day',
@@ -658,41 +673,41 @@ class DateTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty year', $view['year']->vars['empty_value']);
-        $this->assertSame('Empty month', $view['month']->vars['empty_value']);
-        $this->assertSame('Empty day', $view['day']->vars['empty_value']);
+        $this->assertSame('Empty year', $view['year']->vars['placeholder']);
+        $this->assertSame('Empty month', $view['month']->vars['placeholder']);
+        $this->assertSame('Empty day', $view['day']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
+    public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => false,
-            'empty_value' => array(
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'day' => 'Empty day',
             ),
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty year', $view['year']->vars['empty_value']);
-        $this->assertSame('', $view['month']->vars['empty_value']);
-        $this->assertSame('Empty day', $view['day']->vars['empty_value']);
+        $this->assertSame('Empty year', $view['year']->vars['placeholder']);
+        $this->assertSame('', $view['month']->vars['placeholder']);
+        $this->assertSame('Empty day', $view['day']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
+    public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => true,
-            'empty_value' => array(
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'day' => 'Empty day',
             ),
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty year', $view['year']->vars['empty_value']);
-        $this->assertNull($view['month']->vars['empty_value']);
-        $this->assertSame('Empty day', $view['day']->vars['empty_value']);
+        $this->assertSame('Empty year', $view['year']->vars['placeholder']);
+        $this->assertNull($view['month']->vars['placeholder']);
+        $this->assertSame('Empty day', $view['day']->vars['placeholder']);
     }
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -530,7 +530,7 @@ class TimeTypeTest extends TypeTestCase
         $this->assertFalse(isset($view->vars['type']));
     }
 
-    public function testPassDefaultEmptyValueToViewIfNotRequired()
+    public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => false,
@@ -538,12 +538,12 @@ class TimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('', $view['hour']->vars['empty_value']);
-        $this->assertSame('', $view['minute']->vars['empty_value']);
-        $this->assertSame('', $view['second']->vars['empty_value']);
+        $this->assertSame('', $view['hour']->vars['placeholder']);
+        $this->assertSame('', $view['minute']->vars['placeholder']);
+        $this->assertSame('', $view['second']->vars['placeholder']);
     }
 
-    public function testPassNoEmptyValueToViewIfRequired()
+    public function testPassNoPlaceholderToViewIfRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => true,
@@ -551,12 +551,25 @@ class TimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertNull($view['hour']->vars['empty_value']);
-        $this->assertNull($view['minute']->vars['empty_value']);
-        $this->assertNull($view['second']->vars['empty_value']);
+        $this->assertNull($view['hour']->vars['placeholder']);
+        $this->assertNull($view['minute']->vars['placeholder']);
+        $this->assertNull($view['second']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsString()
+    public function testPassPlaceholderAsString()
+    {
+        $form = $this->factory->create('time', null, array(
+            'placeholder' => 'Empty',
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty', $view['hour']->vars['placeholder']);
+        $this->assertSame('Empty', $view['minute']->vars['placeholder']);
+        $this->assertSame('Empty', $view['second']->vars['placeholder']);
+    }
+
+    public function testPassEmptyValueBC()
     {
         $form = $this->factory->create('time', null, array(
             'empty_value' => 'Empty',
@@ -564,15 +577,18 @@ class TimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
+        $this->assertSame('Empty', $view['hour']->vars['placeholder']);
+        $this->assertSame('Empty', $view['minute']->vars['placeholder']);
+        $this->assertSame('Empty', $view['second']->vars['placeholder']);
         $this->assertSame('Empty', $view['hour']->vars['empty_value']);
         $this->assertSame('Empty', $view['minute']->vars['empty_value']);
         $this->assertSame('Empty', $view['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsArray()
+    public function testPassPlaceholderAsArray()
     {
         $form = $this->factory->create('time', null, array(
-            'empty_value' => array(
+            'placeholder' => array(
                 'hour' => 'Empty hour',
                 'minute' => 'Empty minute',
                 'second' => 'Empty second',
@@ -581,16 +597,16 @@ class TimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty hour', $view['hour']->vars['empty_value']);
-        $this->assertSame('Empty minute', $view['minute']->vars['empty_value']);
-        $this->assertSame('Empty second', $view['second']->vars['empty_value']);
+        $this->assertSame('Empty hour', $view['hour']->vars['placeholder']);
+        $this->assertSame('Empty minute', $view['minute']->vars['placeholder']);
+        $this->assertSame('Empty second', $view['second']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
+    public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => false,
-            'empty_value' => array(
+            'placeholder' => array(
                 'hour' => 'Empty hour',
                 'second' => 'Empty second',
             ),
@@ -598,16 +614,16 @@ class TimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty hour', $view['hour']->vars['empty_value']);
-        $this->assertSame('', $view['minute']->vars['empty_value']);
-        $this->assertSame('Empty second', $view['second']->vars['empty_value']);
+        $this->assertSame('Empty hour', $view['hour']->vars['placeholder']);
+        $this->assertSame('', $view['minute']->vars['placeholder']);
+        $this->assertSame('Empty second', $view['second']->vars['placeholder']);
     }
 
-    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
+    public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => true,
-            'empty_value' => array(
+            'placeholder' => array(
                 'hour' => 'Empty hour',
                 'second' => 'Empty second',
             ),
@@ -615,9 +631,9 @@ class TimeTypeTest extends TypeTestCase
         ));
 
         $view = $form->createView();
-        $this->assertSame('Empty hour', $view['hour']->vars['empty_value']);
-        $this->assertNull($view['minute']->vars['empty_value']);
-        $this->assertSame('Empty second', $view['second']->vars['empty_value']);
+        $this->assertSame('Empty hour', $view['hour']->vars['placeholder']);
+        $this->assertNull($view['minute']->vars['placeholder']);
+        $this->assertSame('Empty second', $view['second']->vars['placeholder']);
     }
 
     public function provideCompoundWidgets()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #5791 |
| License | MIT |
| Doc PR | TODO |

This PR is changing the "empty_value" option to the more understandable name "placeholder".

In a subsequent PR, the "placeholder" option should also be added to all types that support the "placeholder" HTML5 attribute.
