### PR TITLE
[Validator] Added "payload" option to all constraints for attaching domain-specific data

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * deprecated `ClassMetadata::getMemberMetadatas()`
  * deprecated `ClassMetadata::addMemberMetadata()`
  * [BC BREAK] added `Mapping\MetadataInterface::getConstraints()`
+ * added generic "payload" option to all constraints for attaching domain-specific data
 
 2.5.0
 -----

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -51,6 +51,12 @@ abstract class Constraint
     const PROPERTY_CONSTRAINT = 'property';
 
     /**
+     * Domain-specific data attached to a constraint
+     * @var mixed
+     */
+    public $payload;
+
+    /**
      * Initializes the constraint with options.
      *
      * You should pass an associative array. The keys should be the names of


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7273 |
| License | MIT |
| Doc PR | TODO |

The "payload" option can be used to pass whatever data should be attached to a constraint for an application:

``` php
/**
 * Domain-specific error codes
 * @NotNull(payload="100")
 */

/**
 * Structured domain-specific data
 * @NotNull(payload={"display": "inline", "highlight": false})
 */
```

The term "payload" is borrowed from JSR-303.
