### PR TITLE
Expression language extensibility

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Registers the expression language providers.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AddExpressionLanguageProvidersPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        // routing
+        if ($container->hasDefinition('router')) {
+            $definition = $container->findDefinition('router');
+            foreach ($container->findTaggedServiceIds('routing.expression_language_provider') as $id => $attributes) {
+                $definition->addMethodCall('addExpressionLanguageProvider', array(new Reference($id)));
+            }
+        }
+
+        // security
+        if ($container->hasDefinition('security.access.expression_voter')) {
+            $definition = $container->findDefinition('security.access.expression_voter');
+            foreach ($container->findTaggedServiceIds('security.expression_language_provider') as $id => $attributes) {
+                $definition->addMethodCall('addExpressionLanguageProvider', array(new Reference($id)));
+            }
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggingTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheWarmerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheClearerPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CompilerDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationExtractorPass;
@@ -81,6 +82,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new LoggingTranslatorPass());
         $container->addCompilerPass(new AddCacheWarmerPass());
         $container->addCompilerPass(new AddCacheClearerPass());
+        $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
         $container->addCompilerPass(new TranslationExtractorPass());
         $container->addCompilerPass(new TranslationDumperPass());
         $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass;
+
+class AddExpressionLanguageProvidersPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessForRouter()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
+
+        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition->addTag('routing.expression_language_provider');
+        $container->setDefinition('some_routing_provider', $definition);
+
+        $container->register('router', '\stdClass');
+        $container->compile();
+
+        $router = $container->getDefinition('router');
+        $calls = $router->getMethodCalls();
+        $this->assertCount(1, $calls);
+        $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
+        $this->assertEquals(new Reference('some_routing_provider'), $calls[0][1][0]);
+    }
+
+    public function testProcessForSecurity()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
+
+        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition->addTag('security.expression_language_provider');
+        $container->setDefinition('some_security_provider', $definition);
+
+        $container->register('security.access.expression_voter', '\stdClass');
+        $container->compile();
+
+        $router = $container->getDefinition('security.access.expression_voter');
+        $calls = $router->getMethodCalls();
+        $this->assertCount(1, $calls);
+        $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
+        $this->assertEquals(new Reference('some_security_provider'), $calls[0][1][0]);
+    }
+}
+
+class TestProvider
+{
+}

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -25,6 +25,7 @@ use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\InstantiatorInterface;
 use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\RealServiceInstantiator;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
 /**
  * ContainerBuilder is a DI container that provides an API to easily describe services.
@@ -83,6 +84,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @var ExpressionLanguage|null
      */
     private $expressionLanguage;
+
+    /**
+     * @var ExpressionFunctionProviderInterface[]
+     */
+    private $expressionLanguageProviders = array();
 
     /**
      * Sets the track resources flag.
@@ -1056,6 +1062,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         return array_unique($tags);
     }
 
+    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
+    {
+        $this->expressionLanguageProviders[] = $provider;
+    }
+
     /**
      * Returns the Service Conditionals.
      *
@@ -1161,7 +1172,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
                 throw new RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
-            $this->expressionLanguage = new ExpressionLanguage();
+            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
         }
 
         return $this->expressionLanguage;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -25,6 +25,7 @@ use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface as
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\NullDumper;
 use Symfony\Component\DependencyInjection\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
 /**
  * PhpDumper dumps a service container as a PHP class.
@@ -54,6 +55,11 @@ class PhpDumper extends Dumper
     private $variableCount;
     private $reservedVariables = array('instance', 'class');
     private $expressionLanguage;
+
+    /**
+     * @var ExpressionFunctionProviderInterface[]
+     */
+    private $expressionLanguageProviders = array();
 
     /**
      * @var \Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface
@@ -1335,6 +1341,11 @@ EOF;
         return sprintf("\$this->getParameter('%s')", strtolower($name));
     }
 
+    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
+    {
+        $this->expressionLanguageProviders[] = $provider;
+    }
+
     /**
      * Gets a service call
      *
@@ -1424,7 +1435,7 @@ EOF;
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
                 throw new RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
-            $this->expressionLanguage = new ExpressionLanguage();
+            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
         }
 
         return $this->expressionLanguage;

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
@@ -25,7 +25,8 @@ class ExpressionLanguage extends BaseExpressionLanguage
 {
     public function __construct(ParserCacheInterface $cache = null, array $providers = array())
     {
-        $providers[] = new ExpressionLanguageProvider();
+        // prepend the default provider to let users overide it easily
+        array_unshift($providers, new ExpressionLanguageProvider());
 
         parent::__construct($cache, $providers);
     }

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
@@ -12,31 +12,21 @@
 namespace Symfony\Component\DependencyInjection;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface;
 
 /**
  * Adds some function to the default ExpressionLanguage.
  *
- * To get a service, use service('request').
- * To get a parameter, use parameter('kernel.debug').
- *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @see ExpressionLanguageProvider
  */
 class ExpressionLanguage extends BaseExpressionLanguage
 {
-    protected function registerFunctions()
+    public function __construct(ParserCacheInterface $cache = null, array $providers = array())
     {
-        parent::registerFunctions();
+        $providers[] = new ExpressionLanguageProvider();
 
-        $this->register('service', function ($arg) {
-            return sprintf('$this->get(%s)', $arg);
-        }, function (array $variables, $value) {
-            return $variables['container']->get($value);
-        });
-
-        $this->register('parameter', function ($arg) {
-            return sprintf('$this->getParameter(%s)', $arg);
-        }, function (array $variables, $value) {
-            return $variables['container']->getParameter($value);
-        });
+        parent::__construct($cache, $providers);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * Define some ExpressionLanguage functions.
+ *
+ * To get a service, use service('request').
+ * To get a parameter, use parameter('kernel.debug').
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions()
+    {
+        return array(
+            new ExpressionFunction('service', function ($arg) {
+                return sprintf('$this->get(%s)', $arg);
+            }, function (array $variables, $value) {
+                return $variables['container']->get($value);
+            }),
+
+            new ExpressionFunction('parameter', function ($arg) {
+                return sprintf('$this->getParameter(%s)', $arg);
+            }, function (array $variables, $value) {
+                return $variables['container']->getParameter($value);
+            }),
+        );
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * Added ExpressionFunction and ExpressionFunctionProviderInterface
+
 2.4.0
 -----
 

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionFunction.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionFunction.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage;
+
+/**
+ * Represents a function that can be used in an expression.
+ *
+ * A function is defined by two PHP callables. The callables are used
+ * by the language to compile and/or evaluate the function.
+ *
+ * The "compiler" function is used at compilation time and must return a
+ * PHP representation of the function call (it receives the function
+ * arguments as arguments).
+ *
+ * The "evaluator" function is used for expression evaluation and must return
+ * the value of the function call based on the values defined for the
+ * expression (it receives the values as a first argument and the function
+ * arguments as remaining arguments).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ExpressionFunction
+{
+    private $name;
+    private $compiler;
+    private $evaluator;
+
+    /**
+     * Constructor.
+     *
+     * @param string   $name      The function name
+     * @param callable $compiler  A callable able to compile the function
+     * @param callable $evaluator A callable able to evaluate the function
+     */
+   public function __construct($name, $compiler, $evaluator)
+   {
+       $this->name = $name;
+       $this->compiler = $compiler;
+       $this->evaluator = $evaluator;
+   }
+
+   public function getName()
+   {
+       return $this->name;
+   }
+
+   public function getCompiler()
+   {
+       return $this->compiler;
+   }
+
+   public function getEvaluator()
+   {
+       return $this->evaluator;
+   }
+}

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionFunctionProviderInterface.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionFunctionProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface ExpressionFunctionProviderInterface
+{
+    /**
+     * @return ExpressionFunction[] An array of Function instances
+     */
+    public function getFunctions();
+}

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -31,10 +31,17 @@ class ExpressionLanguage
 
     protected $functions = array();
 
-    public function __construct(ParserCacheInterface $cache = null)
+    /**
+     * @param ParserCacheInterface $cache
+     * @param ExpressionFunctionProviderInterface[] $providers
+     */
+    public function __construct(ParserCacheInterface $cache = null, array $providers = array())
     {
         $this->cache = $cache ?: new ArrayParserCache();
         $this->registerFunctions();
+        foreach ($providers as $provider) {
+            $this->registerProvider($provider);
+        }
     }
 
     /**
@@ -92,25 +99,27 @@ class ExpressionLanguage
     /**
      * Registers a function.
      *
-     * A function is defined by two PHP callables. The callables are used
-     * by the language to compile and/or evaluate the function.
-     *
-     * The first function is used at compilation time and must return a
-     * PHP representation of the function call (it receives the function
-     * arguments as arguments).
-     *
-     * The second function is used for expression evaluation and must return
-     * the value of the function call based on the values defined for the
-     * expression (it receives the values as a first argument and the function
-     * arguments as remaining arguments).
-     *
      * @param string   $name      The function name
      * @param callable $compiler  A callable able to compile the function
      * @param callable $evaluator A callable able to evaluate the function
+     *
+     * @see ExpressionFunction
      */
     public function register($name, $compiler, $evaluator)
     {
         $this->functions[$name] = array('compiler' => $compiler, 'evaluator' => $evaluator);
+    }
+
+    public function addFunction(ExpressionFunction $function)
+    {
+        $this->register($function->getName(), $function->getCompiler(), $function->getEvaluator());
+    }
+
+    public function registerProvider(ExpressionFunctionProviderInterface $provider)
+    {
+        foreach ($provider->getFunctions() as $function) {
+            $this->addFunction($function);
+        }
     }
 
     protected function registerFunctions()

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ExpressionLanguage\Tests;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\Tests\Fixtures\TestProvider;
 
 class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
 {
@@ -52,6 +53,13 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
 
         $expressionLanguage = new ExpressionLanguage();
         $this->assertEquals('constant("PHP_VERSION")', $expressionLanguage->compile('constant("PHP_VERSION")'));
+    }
+
+    public function testProviders()
+    {
+        $expressionLanguage = new ExpressionLanguage(null, array(new TestProvider));
+        $this->assertEquals('foo', $expressionLanguage->evaluate('identity("foo")'));
+        $this->assertEquals('"foo"', $expressionLanguage->compile('identity("foo")'));
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Fixtures/TestProvider.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Fixtures/TestProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Tests\Fixtures;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+class TestProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions()
+    {
+        return array(
+            new ExpressionFunction('identity', function ($input) {
+                return $input;
+            }, function (array $values, $input) {
+                return $input;
+            }),
+        );
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Routing\Matcher\Dumper;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
 /**
  * PhpMatcherDumper creates a PHP class able to match URLs for a given set of routes.
@@ -25,6 +26,11 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 class PhpMatcherDumper extends MatcherDumper
 {
     private $expressionLanguage;
+
+    /**
+     * @var ExpressionFunctionProviderInterface[]
+     */
+    private $expressionLanguageProviders = array();
 
     /**
      * Dumps a set of routes to a PHP class.
@@ -76,6 +82,11 @@ class {$options['class']} extends {$options['base_class']}
 }
 
 EOF;
+    }
+
+    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
+    {
+        $this->expressionLanguageProviders[] = $provider;
     }
 
     /**
@@ -393,7 +404,7 @@ EOF;
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
                 throw new \RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
-            $this->expressionLanguage = new ExpressionLanguage();
+            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
         }
 
         return $this->expressionLanguage;

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -18,6 +18,7 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
 /**
  * UrlMatcher matches URL based on a set of routes.
@@ -49,6 +50,11 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
 
     protected $request;
     protected $expressionLanguage;
+
+    /**
+     * @var ExpressionFunctionProviderInterface[]
+     */
+    protected $expressionLanguageProviders = array();
 
     /**
      * Constructor.
@@ -108,6 +114,11 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
         $this->request = null;
 
         return $ret;
+    }
+
+    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
+    {
+        $this->expressionLanguageProviders[] = $provider;
     }
 
     /**
@@ -236,7 +247,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
                 throw new \RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
-            $this->expressionLanguage = new ExpressionLanguage();
+            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
         }
 
         return $this->expressionLanguage;

--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
@@ -12,46 +12,22 @@
 namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface;
 
 /**
  * Adds some function to the default ExpressionLanguage.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @see ExpressionLanguageProvider
  */
 class ExpressionLanguage extends BaseExpressionLanguage
 {
-    protected function registerFunctions()
+    public function __construct(ParserCacheInterface $cache = null, array $providers = array())
     {
-        parent::registerFunctions();
+        // prepend the default provider to let users overide it easily
+        array_unshift($providers, new ExpressionLanguageProvider());
 
-        $this->register('is_anonymous', function () {
-            return '$trust_resolver->isAnonymous($token)';
-        }, function (array $variables) {
-            return $variables['trust_resolver']->isAnonymous($variables['token']);
-        });
-
-        $this->register('is_authenticated', function () {
-            return '$token && !$trust_resolver->isAnonymous($token)';
-        }, function (array $variables) {
-            return $variables['token'] && !$variables['trust_resolver']->isAnonymous($variables['token']);
-        });
-
-        $this->register('is_fully_authenticated', function () {
-            return '$trust_resolver->isFullFledged($token)';
-        }, function (array $variables) {
-            return $variables['trust_resolver']->isFullFledged($variables['token']);
-        });
-
-        $this->register('is_remember_me', function () {
-            return '$trust_resolver->isRememberMe($token)';
-        }, function (array $variables) {
-            return $variables['trust_resolver']->isRememberMe($variables['token']);
-        });
-
-        $this->register('has_role', function ($role) {
-            return sprintf('in_array(%s, $roles)', $role);
-        }, function (array $variables, $role) {
-            return in_array($role, $variables['roles']);
-        });
+        parent::__construct($cache, $providers);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * Define some ExpressionLanguage functions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions()
+    {
+        return array(
+            new ExpressionFunction('is_anonymous', function () {
+                return '$trust_resolver->isAnonymous($token)';
+            }, function (array $variables) {
+                return $variables['trust_resolver']->isAnonymous($variables['token']);
+            }),
+
+            new ExpressionFunction('is_authenticated', function () {
+                return '$token && !$trust_resolver->isAnonymous($token)';
+            }, function (array $variables) {
+                return $variables['token'] && !$variables['trust_resolver']->isAnonymous($variables['token']);
+            }),
+
+            new ExpressionFunction('is_fully_authenticated', function () {
+                return '$trust_resolver->isFullFledged($token)';
+            }, function (array $variables) {
+                return $variables['trust_resolver']->isFullFledged($variables['token']);
+            }),
+
+            new ExpressionFunction('is_remember_me', function () {
+                return '$trust_resolver->isRememberMe($token)';
+            }, function (array $variables) {
+                return $variables['trust_resolver']->isRememberMe($variables['token']);
+            }),
+
+            new ExpressionFunction('has_role', function ($role) {
+                return sprintf('in_array(%s, $roles)', $role);
+            }, function (array $variables, $role) {
+                return in_array($role, $variables['roles']);
+            }),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10512 |
| License | MIT |
| Doc PR | not yet |

The way we can add functions to an ExpressionLanguage instance is by using inheritance. #10512 tries to make the expression language in the routing flexible but using inheritance won't work when several bundles want to add functions.

So, this PR takes another approach to solve the problem globally.

Todo:
- [x] add some more tests
- [ ] add some docs
