### PR TITLE
[DependencyInjection] Add a new Syntax to define factories as callables

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -86,6 +86,11 @@ UPGRADE FROM 2.x to 3.0
    $table->render();
    ```
 
+### DependencyInjection
+
+ * The methods `setFactoryClass()`, `setFactoryMethod()` and `setFactoryService()` have been removed in favor of `setFactory()`.
+   Services defined using YAML or XML use the same syntax as configurators.
+
 ### EventDispatcher
 
  * The interface `Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface`

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -88,8 +88,10 @@ UPGRADE FROM 2.x to 3.0
 
 ### DependencyInjection
 
- * The methods `setFactoryClass()`, `setFactoryMethod()` and `setFactoryService()` have been removed in favor of `setFactory()`.
-   Services defined using YAML or XML use the same syntax as configurators.
+ * The methods `Definition::setFactoryClass()`,
+   `Definition::setFactoryMethod()`, and `Definition::setFactoryService()` have
+   been removed in favor of `Definition::setFactory()`. Services defined using
+   YAML or XML use the same syntax as configurators.
 
 ### EventDispatcher
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * added new factory syntax and deprecated the old one
+
 2.5.0
 -----
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -81,6 +81,9 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
                 if ($definition->getConfigurator()) {
                     $this->processArguments(array($definition->getConfigurator()));
                 }
+                if ($definition->getFactory()) {
+                    $this->processArguments(array($definition->getFactory()));
+                }
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -42,35 +42,22 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
         foreach ($container->getDefinitions() as $id => $definition) {
             // synthetic service is public
             if ($definition->isSynthetic() && !$definition->isPublic()) {
-                throw new RuntimeException(sprintf(
-                    'A synthetic service ("%s") must be public.',
-                    $id
-                ));
+                throw new RuntimeException(sprintf('A synthetic service ("%s") must be public.', $id));
             }
 
             // synthetic service has non-prototype scope
             if ($definition->isSynthetic() && ContainerInterface::SCOPE_PROTOTYPE === $definition->getScope()) {
-                throw new RuntimeException(sprintf(
-                    'A synthetic service ("%s") cannot be of scope "prototype".',
-                    $id
-                ));
+                throw new RuntimeException(sprintf('A synthetic service ("%s") cannot be of scope "prototype".', $id));
             }
 
             if ($definition->getFactory() && ($definition->getFactoryClass() || $definition->getFactoryService() || $definition->getFactoryMethod())) {
-                throw new RuntimeException(sprintf(
-                   'A service ("%s") can use either the old or the new factory syntax, not both.',
-                   $id
-                ));
+                throw new RuntimeException(sprintf('A service ("%s") can use either the old or the new factory syntax, not both.', $id));
             }
 
             // non-synthetic, non-abstract service has class
             if (!$definition->isAbstract() && !$definition->isSynthetic() && !$definition->getClass()) {
                 if ($definition->getFactory() || $definition->getFactoryClass() || $definition->getFactoryService()) {
-                    throw new RuntimeException(sprintf(
-                        'Please add the class to service "%s" even if it is constructed by a factory '
-                       .'since we might need to add method calls based on compile-time checks.',
-                       $id
-                    ));
+                    throw new RuntimeException(sprintf('Please add the class to service "%s" even if it is constructed by a factory since we might need to add method calls based on compile-time checks.', $id));
                 }
 
                 throw new RuntimeException(sprintf(

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -56,9 +56,16 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
                 ));
             }
 
+            if ($definition->getFactory() && ($definition->getFactoryClass() || $definition->getFactoryService() || $definition->getFactoryMethod())) {
+                throw new RuntimeException(sprintf(
+                   'A service ("%s") can use either the old or the new factory syntax, not both.',
+                   $id
+                ));
+            }
+
             // non-synthetic, non-abstract service has class
             if (!$definition->isAbstract() && !$definition->isSynthetic() && !$definition->getClass()) {
-                if ($definition->getFactoryClass() || $definition->getFactoryService()) {
+                if ($definition->getFactory() || $definition->getFactoryClass() || $definition->getFactoryService()) {
                     throw new RuntimeException(sprintf(
                         'Please add the class to service "%s" even if it is constructed by a factory '
                        .'since we might need to add method calls based on compile-time checks.',

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -64,14 +64,10 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             );
 
             $configurator = $this->inlineArguments($container, array($definition->getConfigurator()));
-            $definition->setConfigurator(
-                $configurator[0]
-            );
+            $definition->setConfigurator($configurator[0]);
 
             $factory = $this->inlineArguments($container, array($definition->getFactory()));
-            $definition->setFactory(
-                $factory[0]
-            );
+            $definition->setFactory($factory[0]);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -67,6 +67,11 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             $definition->setConfigurator(
                 $configurator[0]
             );
+
+            $factory = $this->inlineArguments($container, array($definition->getFactory()));
+            $definition->setFactory(
+                $factory[0]
+            );
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -103,6 +103,9 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         if (isset($changes['factory_service'])) {
             $def->setFactoryService($definition->getFactoryService());
         }
+        if (isset($changes['factory'])) {
+            $def->setFactory($definition->getFactory());
+        }
         if (isset($changes['configurator'])) {
             $def->setConfigurator($definition->getConfigurator());
         }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -25,6 +25,7 @@ class Definition
 {
     private $class;
     private $file;
+    private $factory;
     private $factoryClass;
     private $factoryMethod;
     private $factoryService;
@@ -57,6 +58,34 @@ class Definition
     }
 
     /**
+     * Sets a factory
+     *
+     * @param callable $factory The PHP callable to call or an array containing a Reference and a method to call
+     *
+     * @return Definition The current instance
+     *
+     * @api
+     */
+    public function setFactory($factory)
+    {
+        $this->factory = $factory;
+
+        return $this;
+    }
+
+    /**
+     * Gets the factory .
+     *
+     * @return callable|array The PHP callable to call or an array containing a Reference and a method to call
+     *
+     * @api
+     */
+    public function getFactory()
+    {
+        return $this->factory;
+    }
+
+    /**
      * Sets the name of the class that acts as a factory using the factory method,
      * which will be invoked statically.
      *
@@ -65,6 +94,7 @@ class Definition
      * @return Definition The current instance
      *
      * @api
+     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
      */
     public function setFactoryClass($factoryClass)
     {
@@ -79,6 +109,7 @@ class Definition
      * @return string|null The factory class name
      *
      * @api
+     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
      */
     public function getFactoryClass()
     {
@@ -93,6 +124,7 @@ class Definition
      * @return Definition The current instance
      *
      * @api
+     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
      */
     public function setFactoryMethod($factoryMethod)
     {
@@ -142,6 +174,7 @@ class Definition
      * @return string|null The factory method name
      *
      * @api
+     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
      */
     public function getFactoryMethod()
     {
@@ -156,6 +189,7 @@ class Definition
      * @return Definition The current instance
      *
      * @api
+     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
      */
     public function setFactoryService($factoryService)
     {
@@ -170,6 +204,7 @@ class Definition
      * @return string|null The factory service id
      *
      * @api
+     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
      */
     public function getFactoryService()
     {

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -58,13 +58,11 @@ class Definition
     }
 
     /**
-     * Sets a factory
+     * Sets a factory.
      *
-     * @param callable $factory The PHP callable to call or an array containing a Reference and a method to call
+     * @param string|array $factory A PHP function or an array containing a class/Reference and a method to call
      *
      * @return Definition The current instance
-     *
-     * @api
      */
     public function setFactory($factory)
     {
@@ -74,11 +72,9 @@ class Definition
     }
 
     /**
-     * Gets the factory .
+     * Gets the factory.
      *
-     * @return callable|array The PHP callable to call or an array containing a Reference and a method to call
-     *
-     * @api
+     * @return string|array The PHP function or an array containing a class/Reference and a method to call
      */
     public function getFactory()
     {
@@ -94,7 +90,7 @@ class Definition
      * @return Definition The current instance
      *
      * @api
-     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     public function setFactoryClass($factoryClass)
     {
@@ -109,7 +105,7 @@ class Definition
      * @return string|null The factory class name
      *
      * @api
-     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     public function getFactoryClass()
     {
@@ -124,7 +120,7 @@ class Definition
      * @return Definition The current instance
      *
      * @api
-     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     public function setFactoryMethod($factoryMethod)
     {
@@ -174,7 +170,7 @@ class Definition
      * @return string|null The factory method name
      *
      * @api
-     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     public function getFactoryMethod()
     {
@@ -189,7 +185,7 @@ class Definition
      * @return Definition The current instance
      *
      * @api
-     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     public function setFactoryService($factoryService)
     {
@@ -204,7 +200,7 @@ class Definition
      * @return string|null The factory service id
      *
      * @api
-     * @deprecated Deprecated since version 2.5, to be removed in 3.0.
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     public function getFactoryService()
     {

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -78,8 +78,6 @@ class DefinitionDecorator extends Definition
 
     /**
      * {@inheritdoc}
-     *
-     * @api
      */
     public function setFactory($callable)
     {
@@ -89,7 +87,7 @@ class DefinitionDecorator extends Definition
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -81,6 +81,18 @@ class DefinitionDecorator extends Definition
      *
      * @api
      */
+    public function setFactory($callable)
+    {
+        $this->changes['factory'] = true;
+
+        return parent::setFactory($callable);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     */
     public function setFactoryClass($class)
     {
         $this->changes['factory_class'] = true;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -529,7 +529,7 @@ class PhpDumper extends Dumper
             if (is_string($factory)) {
                 $return[] = sprintf('@return object An instance returned by %s().', $factory);
             } elseif (is_array($factory) && (is_string($factory[0]) || $factory[0] instanceof Definition || $factory[0] instanceof Reference)) {
-                if (is_string($factory[0] || $factory[0] instanceof Reference)) {
+                if (is_string($factory[0]) || $factory[0] instanceof Reference) {
                     $return[] = sprintf('@return object An instance returned by %s::%s().', (string) $factory[0], $factory[1]);
                 } elseif ($factory[0] instanceof Definition) {
                     $return[] = sprintf('@return object An instance returned by %s::%s().', $factory[0]->getClass(), $factory[1]);
@@ -731,7 +731,6 @@ EOF;
             }
 
             return sprintf("        $return{$instantiation}%s(%s);\n", $callable, $arguments ? implode(', ', $arguments) : '');
-
         } elseif (null !== $definition->getFactoryMethod()) {
             if (null !== $definition->getFactoryClass()) {
                 $class = $this->dumpValue($definition->getFactoryClass());

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -176,6 +176,17 @@ class XmlDumper extends Dumper
 
         $this->addMethodCalls($definition->getMethodCalls(), $service);
 
+        if ($callable = $definition->getFactory()) {
+            $factory = $this->document->createElement('factory');
+            if (is_array($callable)) {
+                $factory->setAttribute($callable[0] instanceof Reference ? 'service' : 'class', $callable[0]);
+                $factory->setAttribute('method', $callable[1]);
+            } else {
+                $factory->setAttribute('function', $callable);
+            }
+            $service->appendChild($factory);
+        }
+
         if ($callable = $definition->getConfigurator()) {
             $configurator = $this->document->createElement('configurator');
             if (is_array($callable)) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -147,16 +147,12 @@ class YamlDumper extends Dumper
             }
         }
 
-        if ($callable = $definition->getConfigurator()) {
-            if (is_array($callable)) {
-                if ($callable[0] instanceof Reference) {
-                    $callable = array($this->getServiceCall((string) $callable[0], $callable[0]), $callable[1]);
-                } else {
-                    $callable = array($callable[0], $callable[1]);
-                }
-            }
+        if ($callable = $definition->getFactory()) {
+            $code .= sprintf("        factory: %s\n", $this->dumper->dump($this->dumpCallable($callable), 0));
+        }
 
-            $code .= sprintf("        configurator: %s\n", $this->dumper->dump($callable, 0));
+        if ($callable = $definition->getConfigurator()) {
+            $code .= sprintf("        configurator: %s\n", $this->dumper->dump($this->dumpCallable($callable), 0));
         }
 
         return $code;
@@ -220,6 +216,26 @@ class YamlDumper extends Dumper
         $parameters = $this->prepareParameters($this->container->getParameterBag()->all(), $this->container->isFrozen());
 
         return $this->dumper->dump(array('parameters' => $parameters), 2);
+    }
+
+    /**
+     * Dumps callable to YAML format
+     *
+     * @param callable $callable
+     *
+     * @return callable
+     */
+    private function dumpCallable($callable)
+    {
+        if (is_array($callable)) {
+            if ($callable[0] instanceof Reference) {
+                $callable = array($this->getServiceCall((string) $callable[0], $callable[0]), $callable[1]);
+            } else {
+                $callable = array($callable[0], $callable[1]);
+            }
+        }
+
+        return $callable;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -167,6 +167,21 @@ class XmlFileLoader extends FileLoader
         $definition->setArguments($this->getArgumentsAsPhp($service, 'argument'));
         $definition->setProperties($this->getArgumentsAsPhp($service, 'property'));
 
+        if ($factories = $this->getChildren($service, 'factory')) {
+            $factory = $factories[0];
+            if ($function = $factory->getAttribute('function')) {
+                $definition->setFactory($function);
+            } else {
+                if ($childService = $factory->getAttribute('service')) {
+                    $class = new Reference($childService, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false);
+                } else {
+                    $class = $factory->getAttribute('class');
+                }
+
+                $definition->setFactory(array($class, $factory->getAttribute('method')));
+            }
+        }
+
         if ($configurators = $this->getChildren($service, 'configurator')) {
             $configurator = $configurators[0];
             if ($function = $configurator->getAttribute('function')) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -194,6 +194,19 @@ class YamlFileLoader extends FileLoader
             $definition->setAbstract($service['abstract']);
         }
 
+        if (isset($service['factory'])) {
+            if (is_string($service['factory'])) {
+               if (strpos($service['factory'], ':')) {
+                    $parts = explode(':', $service['factory']);
+                    $definition->setFactory(array($this->resolveServices('@'.$parts[0]), $parts[1]));
+                } else {
+                    $definition->setFactory($service['factory']);
+                }
+            } else {
+                $definition->setFactory(array($this->resolveServices($service['factory'][0]), $service['factory'][1]));
+            }
+        }
+
         if (isset($service['factory_class'])) {
             $definition->setFactoryClass($service['factory_class']);
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -196,7 +196,7 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['factory'])) {
             if (is_string($service['factory'])) {
-               if (strpos($service['factory'], ':')) {
+                if (strpos($service['factory'], ':')) {
                     $parts = explode(':', $service['factory']);
                     $definition->setFactory(array($this->resolveServices('@'.$parts[0]), $parts[1]));
                 } else {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -64,7 +64,7 @@
     <xsd:attribute name="ignore-errors" type="boolean" />
   </xsd:complexType>
 
-  <xsd:complexType name="configurator">
+  <xsd:complexType name="callable">
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="service" type="xsd:string" />
     <xsd:attribute name="class" type="xsd:string" />
@@ -76,7 +76,8 @@
     <xsd:choice maxOccurs="unbounded">
       <xsd:element name="file" type="xsd:string" minOccurs="0" maxOccurs="1" />
       <xsd:element name="argument" type="argument" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="configurator" type="configurator" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="configurator" type="callable" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="factory" type="callable" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />

--- a/src/Symfony/Component/DependencyInjection/README.md
+++ b/src/Symfony/Component/DependencyInjection/README.md
@@ -38,8 +38,7 @@ If your service is retrieved by calling a static method:
 
     $sc
         ->register('bar', '%bar.class%')
-        ->setFactoryClass('%bar.class%')
-        ->setFactoryMethod('getInstance')
+        ->setFactory(array('%bar.class%', 'getInstance'))
         ->addArgument('Aarrg!!!')
     ;
     $sc->setParameter('bar.class', 'Bar');

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -50,6 +50,17 @@ class CheckDefinitionValidityPassTest extends \PHPUnit_Framework_TestCase
         $this->process($container);
     }
 
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     */
+    public function testProcessDetectsBothFactorySyntaxesUsed()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a')->setFactory(array('a', 'b'))->setFactoryClass('a');
+
+        $this->process($container);
+    }
+
     public function testProcess()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionDecoratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionDecoratorTest.php
@@ -43,6 +43,7 @@ class DefinitionDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('class', 'class'),
+            array('factory', 'factory'),
             array('factoryClass', 'factory_class'),
             array('factoryMethod', 'factory_method'),
             array('factoryService', 'factory_service'),

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -27,6 +27,17 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo'), $def->getArguments(), '__construct() takes an optional array of arguments as its second argument');
     }
 
+    /**
+     * @covers Symfony\Component\DependencyInjection\Definition::setFactory
+     * @covers Symfony\Component\DependencyInjection\Definition::getFactory
+     */
+    public function testSetGetFactory()
+    {
+        $def = new Definition('stdClass');
+        $this->assertSame($def, $def->setFactory('foo'), '->setFactory() implements a fluent interface');
+        $this->assertEquals('foo', $def->getFactory(), '->getFactory() returns the factory');
+    }
+
     public function testSetGetFactoryClass()
     {
         $def = new Definition('stdClass');

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -103,5 +103,16 @@ $container
     ->register('decorator_service_with_name', 'stdClass')
     ->setDecoratedService('decorated', 'decorated.pif-pouf')
 ;
+$container
+    ->register('new_factory', 'FactoryClass')
+    ->setProperty('foo', 'bar')
+    ->setScope('container')
+    ->setPublic(false)
+;
+$container
+    ->register('new_factory_service', 'FooBarBaz')
+    ->setProperty('foo', 'bar')
+    ->setFactory(array(new Reference('new_factory'), 'getInstance'))
+;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
@@ -19,6 +19,8 @@ digraph sc {
   node_decorated [label="decorated\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_decorator_service [label="decorator_service\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_decorator_service_with_name [label="decorator_service_with_name\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_new_factory [label="new_factory\nFactoryClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_new_factory_service [label="new_factory_service\nFooBarBaz\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];
   node_foo2 [label="foo2\n\n", shape=record, fillcolor="#ff9999", style="filled"];
   node_foo3 [label="foo3\n\n", shape=record, fillcolor="#ff9999", style="filled"];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -38,6 +38,8 @@ class ProjectServiceContainer extends Container
             'foo_with_inline' => 'getFooWithInlineService',
             'inlined' => 'getInlinedService',
             'method_call1' => 'getMethodCall1Service',
+            'new_factory' => 'getNewFactoryService',
+            'new_factory_service' => 'getNewFactoryServiceService',
             'request' => 'getRequestService',
         );
         $this->aliases = array(
@@ -266,6 +268,23 @@ class ProjectServiceContainer extends Container
     }
 
     /**
+     * Gets the 'new_factory_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \FooBarBaz A FooBarBaz instance.
+     */
+    protected function getNewFactoryServiceService()
+    {
+        $this->services['new_factory_service'] = $instance = $this->get('new_factory')->getInstance();
+
+        $instance->foo = 'bar';
+
+        return $instance;
+    }
+
+    /**
      * Gets the 'request' service.
      *
      * This service is shared.
@@ -327,6 +346,27 @@ class ProjectServiceContainer extends Container
 
         $instance->setBaz($this->get('baz'));
         $instance->pub = 'pub';
+
+        return $instance;
+    }
+
+    /**
+     * Gets the 'new_factory' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * This service is private.
+     * If you want to be able to request this service from the container directly,
+     * make it public, otherwise you might end up with broken code.
+     *
+     * @return \FactoryClass A FactoryClass instance.
+     */
+    protected function getNewFactoryService()
+    {
+        $this->services['new_factory'] = $instance = new \FactoryClass();
+
+        $instance->foo = 'bar';
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -46,6 +46,7 @@ class ProjectServiceContainer extends Container
             'foo_bar' => 'getFooBarService',
             'foo_with_inline' => 'getFooWithInlineService',
             'method_call1' => 'getMethodCall1Service',
+            'new_factory_service' => 'getNewFactoryServiceService',
             'request' => 'getRequestService',
         );
         $this->aliases = array(
@@ -265,6 +266,26 @@ class ProjectServiceContainer extends Container
         $instance->setBar($this->get('foo'));
         $instance->setBar(NULL);
         $instance->setBar(($this->get("foo")->foo() . $this->getParameter("foo")));
+
+        return $instance;
+    }
+
+    /**
+     * Gets the 'new_factory_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \FooBarBaz A FooBarBaz instance.
+     */
+    protected function getNewFactoryServiceService()
+    {
+        $a = new \FactoryClass();
+        $a->foo = 'bar';
+
+        $this->services['new_factory_service'] = $instance = $a->getInstance();
+
+        $instance->foo = 'bar';
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -52,5 +52,14 @@
     <service id="request" class="Request" synthetic="true" synchronized="true" lazy="true"/>
     <service id="decorator_service" decorates="decorated" />
     <service id="decorator_service_with_name" decorates="decorated" decoration-inner-name="decorated.pif-pouf"/>
+    <service id="new_factory1" class="FooBarClass">
+      <factory function="factory" />
+    </service>
+    <service id="new_factory2" class="FooBarClass">
+      <factory service="baz" method="getClass" />
+    </service>
+    <service id="new_factory3" class="FooBarClass">
+      <factory class="BazClass" method="getInstance" />
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -91,6 +91,13 @@
     <service id="decorated" class="stdClass"/>
     <service id="decorator_service" class="stdClass" decorates="decorated"/>
     <service id="decorator_service_with_name" class="stdClass" decorates="decorated" decoration-inner-name="decorated.pif-pouf"/>
+    <service id="new_factory" class="FactoryClass" public="false">
+      <property name="foo">bar</property>
+    </service>
+    <service id="new_factory_service" class="FooBarBaz">
+      <property name="foo">bar</property>
+      <factory service="new_factory" method="getInstance"/>
+    </service>
     <service id="alias_for_foo" alias="foo"/>
     <service id="alias_for_alias" alias="foo"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services14.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services14.yml
@@ -1,0 +1,2 @@
+services:
+    factory: { class: FooBarClass, factory: baz:getClass}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -35,3 +35,6 @@ services:
     decorator_service_with_name:
         decorates: decorated
         decoration_inner_name: decorated.pif-pouf
+    new_factory1: { class: FooBarClass, factory: factory}
+    new_factory2: { class: FooBarClass, factory: [@baz, getClass]}
+    new_factory3: { class: FooBarClass, factory: [BazClass, getInstance]}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -88,5 +88,13 @@ services:
         class: stdClass
         decorates: decorated
         decoration_inner_name: decorated.pif-pouf
+    new_factory:
+        class: FactoryClass
+        public: false
+        properties: { foo: bar }
+    new_factory_service:
+        class: FooBarBaz
+        properties: { foo: bar }
+        factory: ['@new_factory', getInstance]
     alias_for_foo: @foo
     alias_for_alias: @foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -216,6 +216,9 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($services['factory_service']->getClass());
         $this->assertEquals('getInstance', $services['factory_service']->getFactoryMethod());
         $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
+        $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');
+        $this->assertEquals(array(new Reference('baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false), 'getClass'), $services['new_factory2']->getFactory(), '->load() parses the factory tag');
+        $this->assertEquals(array('BazClass', 'getInstance'), $services['new_factory3']->getFactory(), '->load() parses the factory tag');
 
         $this->assertTrue($services['request']->isSynthetic(), '->load() parses the synthetic flag');
         $this->assertTrue($services['request']->isSynchronized(), '->load() parses the synchronized flag');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -141,6 +141,9 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(array('setBar', array()), array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ parameter("foo")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
+        $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');
+        $this->assertEquals(array(new Reference('baz'), 'getClass'), $services['new_factory2']->getFactory(), '->load() parses the factory tag');
+        $this->assertEquals(array('BazClass', 'getInstance'), $services['new_factory3']->getFactory(), '->load() parses the factory tag');
 
         $this->assertTrue($services['request']->isSynthetic(), '->load() parses the synthetic flag');
         $this->assertTrue($services['request']->isSynchronized(), '->load() parses the synchronized flag');
@@ -157,6 +160,16 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($services['request']->getDecoratedService());
         $this->assertEquals(array('decorated', null), $services['decorator_service']->getDecoratedService());
         $this->assertEquals(array('decorated', 'decorated.pif-pouf'), $services['decorator_service_with_name']->getDecoratedService());
+    }
+
+    public function testLoadFactoryShortSyntax()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services14.yml');
+        $services = $container->getDefinitions();
+
+        $this->assertEquals(array(new Reference('baz'), 'getClass'), $services['factory']->getFactory(), '->load() parses the factory tag');
     }
 
     public function testExtensions()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

From the original PR #9839:

"This pull requests adds a new syntax to define factories based on the syntax for configurators. This is more flexible than the old syntax (factoryMethod and either of factoryClass or factoryService), as it also allows for functions as factories.

Since the service is now a Reference to a Definition it also allows us to inline factories for a small performance improvement and better encapsulation.

Lastly this prevents a bug where a private factory is simple removed because it's not referenced in the graph.

I did not change any of the existing definitions (there's one use of a factory in FrameworkBundle) or automatically use the new internal representation when parsing YAML or XML definitions because this could introduce subtle B/C issues.
"
