### PR TITLE
[Translation][changelog] fix typo.

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added possibility to cache catalogues
  * added TranslatorBagInterface
  * added LoggingTranslator
+ * added Translator::getMessages() for retrieving the message catalogue as an array
 
 2.5.0
 -----
@@ -14,7 +15,6 @@ CHANGELOG
  * added relative file path template to the file dumpers
  * added optional backup to the file dumpers
  * changed IcuResFileDumper to extend FileDumper
- * added Translator::getMessages() for retrieving the message catalogue as an array
 
 2.3.0
 -----


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Translator::getMessages() was added in 2.6.
