### PR TITLE
ensure to store the compiled route

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -110,6 +110,7 @@ class Route implements \Serializable
             'schemes'      => $this->schemes,
             'methods'      => $this->methods,
             'condition'    => $this->condition,
+            'compiled'     => $this->compiled,
         ));
     }
 
@@ -124,6 +125,7 @@ class Route implements \Serializable
         $this->schemes = $data['schemes'];
         $this->methods = $data['methods'];
         $this->condition = $data['condition'];
+        $this->compiled = $data['compiled'];
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -204,7 +204,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     public function testCondition()
     {
         $route = new Route('/');
-        $this->assertEquals(null, $route->getCondition());
+        $this->assertSame('', $route->getCondition());
         $route->setCondition('context.getMethod() == "GET"');
         $this->assertEquals('context.getMethod() == "GET"', $route->getCondition());
     }

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -234,6 +234,20 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $serialized = serialize($route);
         $unserialized = unserialize($serialized);
 
+        $this->assertAttributeEmpty('compiled', $route);
+        $this->assertEquals($route, $unserialized);
+        $this->assertNotSame($route, $unserialized);
+    }
+
+    public function testSerializedWithCompiled()
+    {
+        $route = new Route('/{foo}', array('foo' => 'default'), array('foo' => '\d+'));
+        $route->compile();
+
+        $serialized = serialize($route);
+        $unserialized = unserialize($serialized);
+
+        $this->assertAttributeNotEmpty('compiled', $route);
         $this->assertEquals($route, $unserialized);
         $this->assertNotSame($route, $unserialized);
     }


### PR DESCRIPTION
Let's store the compiled route to improve speedup for cases using symfony CMF routing, which do store serialized variants of the routes.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? |  |
| Fixed tickets |  |
| License | MIT |
