### PR TITLE
[FrameworkBundle] Added unit-tests for GlobalVariables::getUser()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -56,9 +56,11 @@ class GlobalVariables
      */
     public function getUser()
     {
-        if (!$tokenStorage = $this->container->get('security.token_storage')) {
+        if (!$this->container->has('security.token_storage')) {
             return;
         }
+
+        $tokenStorage = $this->container->get('security.token_storage');
 
         if (!$token = $tokenStorage->getToken()) {
             return;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Tests added should explain that `getUser()` should return `null` when a string is found as user. If this is not correct, a PR should be made. However, this would result in a huge BC break due to people using `{% if app.user %}` which would return `null` if an anonymous token was found. If this suddenly returns a string, this check will fail.

While at it, I have also added `getUser()` tests to verify the unhappy flow is working. These tests uncovered that  if `$container->get('security.token_storage')` fails, it will throw an exception rather than return `null`. This issue is now fixed.
## List of changes
- The old `testGetUser` has been refactored to be tested with multiple variations of return types to verify the return type to work as the code tells. 
- `get('security.token_storage')` is now only executed if `has('security.token_storage')` returns true

@fabpot I think this PR should be merged before 2.6, because it fixes an uncaught exception bug in my previous PR which splits the security context
