### PR TITLE
[Validator] Added ConstraintValidator::buildViolation() helper for BC with the 2.4 API

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -262,12 +262,19 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($entity1, $constraint);
 
-        $this->assertViolation('myMessage', array(), 'property.path.name', 'Foo');
+        $this->buildViolation('myMessage')
+            ->atPath('property.path.name')
+            ->setInvalidValue('Foo')
+            ->assertRaised();
+
         $this->context->getViolations()->remove(0);
 
         $this->validator->validate($entity2, $constraint);
 
-        $this->assertViolation('myMessage', array(), 'property.path.name', 'Foo');
+        $this->buildViolation('myMessage')
+            ->atPath('property.path.name')
+            ->setInvalidValue('Foo')
+            ->assertRaised();
     }
 
     public function testValidateUniquenessUsingCustomRepositoryMethod()

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -13,7 +13,6 @@ namespace Symfony\Bridge\Doctrine\Validator\Constraints;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -137,14 +136,9 @@ class UniqueEntityValidator extends ConstraintValidator
 
         $errorPath = null !== $constraint->errorPath ? $constraint->errorPath : $fields[0];
 
-        if ($this->context instanceof ExecutionContextInterface) {
-            $this->context->buildViolation($constraint->message)
-                          ->atPath($errorPath)
-                          ->setInvalidValue($criteria[$fields[0]])
-                          ->addViolation();
-        } else {
-            // 2.4 API
-            $this->context->addViolationAt($errorPath, $constraint->message, array(), $criteria[$fields[0]]);
-        }
+        $this->buildViolation($constraint->message)
+            ->atPath($errorPath)
+            ->setInvalidValue($criteria[$fields[0]])
+            ->addViolation();
     }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -99,40 +99,20 @@ class FormValidator extends ConstraintValidator
                     ? (string) $form->getViewData()
                     : gettype($form->getViewData());
 
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($config->getOption('invalid_message'))
-                        ->setParameters(array_replace(array('{{ value }}' => $clientDataAsString), $config->getOption('invalid_message_parameters')))
-                        ->setInvalidValue($form->getViewData())
-                        ->setCode(Form::ERR_INVALID)
-                        ->addViolation();
-                } else {
-                    // 2.4 API
-                    $this->context->addViolation(
-                        $config->getOption('invalid_message'),
-                        array_replace(array('{{ value }}' => $clientDataAsString), $config->getOption('invalid_message_parameters')),
-                        $form->getViewData(),
-                        null,
-                        Form::ERR_INVALID
-                    );
-                }
+                $this->buildViolation($config->getOption('invalid_message'))
+                    ->setParameters(array_replace(array('{{ value }}' => $clientDataAsString), $config->getOption('invalid_message_parameters')))
+                    ->setInvalidValue($form->getViewData())
+                    ->setCode(Form::ERR_INVALID)
+                    ->addViolation();
             }
         }
 
         // Mark the form with an error if it contains extra fields
         if (count($form->getExtraData()) > 0) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($config->getOption('extra_fields_message'))
-                    ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
-                    ->setInvalidValue($form->getExtraData())
-                    ->addViolation();
-            } else {
-                // 2.4 API
-                $this->context->addViolation(
-                    $config->getOption('extra_fields_message'),
-                    array('{{ extra_fields }}' => implode('", "', array_keys($form->getExtraData()))),
-                    $form->getExtraData()
-                );
-            }
+            $this->buildViolation($config->getOption('extra_fields_message'))
+                ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
+                ->setInvalidValue($form->getExtraData())
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
@@ -92,7 +92,8 @@ class UserPasswordValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate('secret', $constraint);
 
-        $this->assertViolation('myMessage');
+        $this->buildViolation('myMessage')
+            ->assertRaised();
     }
 
     /**

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Validator;
 
+use Symfony\Component\Validator\Context\ExecutionContextInterface as ExecutionContextInterface2Dot5;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+use Symfony\Component\Validator\Violation\LegacyConstraintViolationBuilder;
+
 /**
  * Base class for constraint validators
  *
@@ -24,14 +28,14 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      * Whether to format {@link \DateTime} objects as RFC-3339 dates
      * ("Y-m-d H:i:s").
      *
-     * @var integer
+     * @var int
      */
     const PRETTY_DATE = 1;
 
     /**
      * Whether to cast objects with a "__toString()" method to strings.
      *
-     * @var integer
+     * @var int
      */
     const OBJECT_TO_STRING = 2;
 
@@ -46,6 +50,47 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     public function initialize(ExecutionContextInterface $context)
     {
         $this->context = $context;
+    }
+
+    /**
+     * Wrapper for {@link ExecutionContextInterface::buildViolation} that
+     * supports the 2.4 context API.
+     *
+     * @param string $message    The violation message
+     * @param array  $parameters The message parameters
+     *
+     * @return ConstraintViolationBuilderInterface The violation builder
+     *
+     * @deprecated This method will be removed in Symfony 3.0.
+     */
+    protected function buildViolation($message, array $parameters = array())
+    {
+        if ($this->context instanceof ExecutionContextInterface2Dot5) {
+            return $this->context->buildViolation($message, $parameters);
+        }
+
+        return new LegacyConstraintViolationBuilder($this->context, $message, $parameters);
+    }
+
+    /**
+     * Wrapper for {@link ExecutionContextInterface::buildViolation} that
+     * supports the 2.4 context API.
+     *
+     * @param ExecutionContextInterface $context    The context to use
+     * @param string                          $message    The violation message
+     * @param array                           $parameters The message parameters
+     *
+     * @return ConstraintViolationBuilderInterface The violation builder
+     *
+     * @deprecated This method will be removed in Symfony 3.0.
+     */
+    protected function buildViolationInContext(ExecutionContextInterface $context, $message, array $parameters = array())
+    {
+        if ($context instanceof ExecutionContextInterface2Dot5) {
+            return $context->buildViolation($message, $parameters);
+        }
+
+        return new LegacyConstraintViolationBuilder($context, $message, $parameters);
     }
 
     /**
@@ -82,7 +127,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      * confused by the violation message.
      *
      * @param mixed   $value  The value to format as string
-     * @param integer $format A bitwise combination of the format
+     * @param int     $format A bitwise combination of the format
      *                        constants in this class
      *
      * @return string The string representation of the passed value
@@ -142,7 +187,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      * {@link formatValue()}. The values are then concatenated with commas.
      *
      * @param array   $values A list of values
-     * @param integer $format A bitwise combination of the format
+     * @param int     $format A bitwise combination of the format
      *                        constants in this class
      *
      * @return string The string representation of the value list

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -19,6 +19,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * Provides a base class for the validation of property comparisons.
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class AbstractComparisonValidator extends ConstraintValidator
 {
@@ -35,12 +36,14 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
             return;
         }
 
-        if (!$this->compareValues($value, $constraint->value)) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE),
-                '{{ compared_value }}' => $this->formatValue($constraint->value, self::OBJECT_TO_STRING | self::PRETTY_DATE),
-                '{{ compared_value_type }}' => $this->formatTypeOf($constraint->value),
-            ));
+        $comparedValue = $constraint->value;
+
+        if (!$this->compareValues($value, $comparedValue)) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE))
+                ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE))
+                ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($comparedValue))
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -32,9 +32,9 @@ class BlankValidator extends ConstraintValidator
         }
 
         if ('' !== $value && null !== $value) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CardScheme.php
+++ b/src/Symfony/Component/Validator/Constraints/CardScheme.php
@@ -18,6 +18,8 @@ use Symfony\Component\Validator\Constraint;
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Tim Nagel <t.nagel@infinite.net.au>
  */
 class CardScheme extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -18,9 +18,11 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * Validates that a card number belongs to a specified scheme.
  *
+ * @author Tim Nagel <t.nagel@infinite.net.au>
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @see http://en.wikipedia.org/wiki/Bank_card_number
  * @see http://www.regular-expressions.info/creditcard.html
- * @author Tim Nagel <t.nagel@infinite.net.au>
  */
 class CardSchemeValidator extends ConstraintValidator
 {
@@ -113,9 +115,9 @@ class CardSchemeValidator extends ConstraintValidator
         }
 
         if (!is_numeric($value)) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
 
             return;
         }
@@ -131,8 +133,8 @@ class CardSchemeValidator extends ConstraintValidator
             }
         }
 
-        $this->context->addViolation($constraint->message, array(
-            '{{ value }}' => $this->formatValue($value),
-        ));
+        $this->buildViolation($constraint->message)
+            ->setParameter('{{ value }}', $this->formatValue($value))
+            ->addViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
@@ -64,63 +63,38 @@ class ChoiceValidator extends ConstraintValidator
         if ($constraint->multiple) {
             foreach ($value as $_value) {
                 if (!in_array($_value, $choices, $constraint->strict)) {
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->multipleMessage)
-                            ->setParameter('{{ value }}', $this->formatValue($_value))
-                            ->addViolation();
-                    } else {
-                        // 2.4 API
-                        $this->context->addViolation($constraint->multipleMessage, array(
-                            '{{ value }}' => $this->formatValue($_value),
-                        ));
-                    }
+                    $this->buildViolation($constraint->multipleMessage)
+                        ->setParameter('{{ value }}', $this->formatValue($_value))
+                        ->setInvalidValue($_value)
+                        ->addViolation();
+
+                    return;
                 }
             }
 
             $count = count($value);
 
             if ($constraint->min !== null && $count < $constraint->min) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->minMessage)
-                        ->setParameter('{{ limit }}', $constraint->min)
-                        ->setPlural((int) $constraint->min)
-                        ->addViolation();
-                } else {
-                    // 2.4 API
-                    $this->context->addViolation($constraint->minMessage, array(
-                        '{{ limit }}' => $constraint->min,
-                    ), $value, (int) $constraint->min);
-                }
+                $this->buildViolation($constraint->minMessage)
+                    ->setParameter('{{ limit }}', $constraint->min)
+                    ->setPlural((int) $constraint->min)
+                    ->addViolation();
 
                 return;
             }
 
             if ($constraint->max !== null && $count > $constraint->max) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->maxMessage)
-                        ->setParameter('{{ limit }}', $constraint->max)
-                        ->setPlural((int) $constraint->max)
-                        ->addViolation();
-                } else {
-                    // 2.4 API
-                    $this->context->addViolation($constraint->maxMessage, array(
-                        '{{ limit }}' => $constraint->max,
-                    ), $value, (int) $constraint->max);
-                }
+                $this->buildViolation($constraint->maxMessage)
+                    ->setParameter('{{ limit }}', $constraint->max)
+                    ->setPlural((int) $constraint->max)
+                    ->addViolation();
 
                 return;
             }
         } elseif (!in_array($value, $choices, $constraint->strict)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->addViolation();
-            } else {
-                // 2.4 API
-                $this->context->addViolation($constraint->message, array(
-                    '{{ value }}' => $this->formatValue($value),
-                ));
-            }
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -70,36 +70,22 @@ class CollectionValidator extends ConstraintValidator
                     }
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
-                if ($context instanceof ExecutionContextInterface) {
-                    $context->buildViolation($constraint->missingFieldsMessage)
-                        ->atPath('['.$field.']')
-                        ->setParameter('{{ field }}', $this->formatValue($field))
-                        ->setInvalidValue(null)
-                        ->addViolation();
-                } else {
-                    // 2.4 API
-                    $context->addViolationAt('['.$field.']', $constraint->missingFieldsMessage, array(
-                        '{{ field }}' => $this->formatValue($field),
-                    ), null);
-                }
+                $this->buildViolationInContext($context, $constraint->missingFieldsMessage)
+                    ->atPath('['.$field.']')
+                    ->setParameter('{{ field }}', $this->formatValue($field))
+                    ->setInvalidValue(null)
+                    ->addViolation();
             }
         }
 
         if (!$constraint->allowExtraFields) {
             foreach ($value as $field => $fieldValue) {
                 if (!isset($constraint->fields[$field])) {
-                    if ($context instanceof ExecutionContextInterface) {
-                        $context->buildViolation($constraint->extraFieldsMessage)
-                            ->atPath('['.$field.']')
-                            ->setParameter('{{ field }}', $this->formatValue($field))
-                            ->setInvalidValue($fieldValue)
-                            ->addViolation();
-                    } else {
-                        // 2.4 API
-                        $context->addViolationAt('['.$field.']', $constraint->extraFieldsMessage, array(
-                            '{{ field }}' => $this->formatValue($field),
-                        ), $fieldValue);
-                    }
+                    $this->buildViolationInContext($context, $constraint->extraFieldsMessage)
+                        ->atPath('['.$field.']')
+                        ->setParameter('{{ field }}', $this->formatValue($field))
+                        ->setInvalidValue($fieldValue)
+                        ->addViolation();
                 }
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
@@ -36,59 +35,24 @@ class CountValidator extends ConstraintValidator
 
         $count = count($value);
 
-        if ($constraint->min == $constraint->max && $count != $constraint->min) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->exactMessage)
-                    ->setParameter('{{ count }}', $count)
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->min)
-                    ->addViolation();
-            } else {
-                // 2.4 API
-                $this->context->addViolation($constraint->exactMessage, array(
-                    '{{ count }}' => $count,
-                    '{{ limit }}' => $constraint->min,
-                ), $value, (int) $constraint->min);
-            }
-
-            return;
-        }
-
         if (null !== $constraint->max && $count > $constraint->max) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->maxMessage)
-                    ->setParameter('{{ count }}', $count)
-                    ->setParameter('{{ limit }}', $constraint->max)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->max)
-                    ->addViolation();
-            } else {
-                // 2.4 API
-                $this->context->addViolation($constraint->maxMessage, array(
-                    '{{ count }}' => $count,
-                    '{{ limit }}' => $constraint->max,
-                ), $value, (int) $constraint->max);
-            }
+            $this->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
+                ->setParameter('{{ count }}', $count)
+                ->setParameter('{{ limit }}', $constraint->max)
+                ->setInvalidValue($value)
+                ->setPlural((int) $constraint->max)
+                ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->min && $count < $constraint->min) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->minMessage)
-                    ->setParameter('{{ count }}', $count)
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->min)
-                    ->addViolation();
-            } else {
-                // 2.4 API
-                $this->context->addViolation($constraint->minMessage, array(
-                    '{{ count }}' => $count,
-                    '{{ limit }}' => $constraint->min,
-                ), $value, (int) $constraint->min);
-            }
+            $this->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
+                ->setParameter('{{ count }}', $count)
+                ->setParameter('{{ limit }}', $constraint->min)
+                ->setInvalidValue($value)
+                ->setPlural((int) $constraint->min)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -46,9 +46,9 @@ class CountryValidator extends ConstraintValidator
         $countries = Intl::getRegionBundle()->getCountryNames();
 
         if (!isset($countries[$value])) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
@@ -46,9 +46,9 @@ class CurrencyValidator extends ConstraintValidator
         $currencies = Intl::getCurrencyBundle()->getCurrencyNames();
 
         if (!isset($currencies[$value])) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class DateTimeValidator extends DateValidator
 {
-    const PATTERN = '/^(\d{4})-(\d{2})-(\d{2}) (0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/';
+    const PATTERN = '/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/';
 
     /**
      * {@inheritdoc}
@@ -42,10 +42,24 @@ class DateTimeValidator extends DateValidator
 
         $value = (string) $value;
 
-        if (!preg_match(static::PATTERN, $value, $matches) || !checkdate($matches[2], $matches[3], $matches[1])) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+        if (!preg_match(static::PATTERN, $value, $matches)) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
+
+            return;
+        }
+
+        if (!DateValidator::checkDate($matches[1], $matches[2], $matches[3])) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
+        }
+
+        if (!TimeValidator::checkTime($matches[4], $matches[5], $matches[6])) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -25,6 +25,22 @@ class DateValidator extends ConstraintValidator
     const PATTERN = '/^(\d{4})-(\d{2})-(\d{2})$/';
 
     /**
+     * Checks whether a date is valid.
+     *
+     * @param int $year  The year
+     * @param int $month The month
+     * @param int $day   The day
+     *
+     * @return bool Whether the date is valid
+     *
+     * @internal
+     */
+    public static function checkDate($year, $month, $day)
+    {
+        return checkdate($month, $day, $year);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
@@ -43,10 +59,18 @@ class DateValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        if (!preg_match(static::PATTERN, $value, $matches) || !checkdate($matches[2], $matches[3], $matches[1])) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+        if (!preg_match(static::PATTERN, $value, $matches)) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
+
+            return;
+        }
+
+        if (!self::checkDate($matches[1], $matches[2], $matches[3])) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -89,7 +89,9 @@ class ExpressionValidator extends ConstraintValidator
         }
 
         if (!$this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
-            $this->context->addViolation($constraint->message);
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -35,8 +35,8 @@ class FalseValidator extends ConstraintValidator
             return;
         }
 
-        $this->context->addViolation($constraint->message, array(
-            '{{ value }}' => $this->formatValue($value),
-        ));
+        $this->buildViolation($constraint->message)
+            ->setParameter('{{ value }}', $this->formatValue($value))
+            ->addViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Iban.php
+++ b/src/Symfony/Component/Validator/Constraints/Iban.php
@@ -16,6 +16,9 @@ use Symfony\Component\Validator\Constraint;
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Manuel Reinhard <manu@sprain.ch>
+ * @author Michael Schummel
  */
 class Iban extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Validator\Constraints;
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
+ * @author Benjamin Dulau <benjamin.dulau@gmail.com>
+ *
  * @api
  */
 class Image extends File
@@ -30,6 +32,7 @@ class Image extends File
     public $allowLandscape = true;
     public $allowPortrait = true;
 
+    // The constant for a wrong MIME type is taken from the parent class.
     public $mimeTypesMessage = 'This file is not a valid image.';
     public $sizeNotDetectedMessage = 'The size of the image could not be detected.';
     public $maxWidthMessage = 'The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.';

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * against minWidth, maxWidth, minHeight and maxHeight constraints
  *
  * @author Benjamin Dulau <benjamin.dulau@gmail.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class ImageValidator extends FileValidator
 {
@@ -50,8 +51,10 @@ class ImageValidator extends FileValidator
         }
 
         $size = @getimagesize($value);
+
         if (empty($size) || ($size[0] === 0) || ($size[1] === 0)) {
-            $this->context->addViolation($constraint->sizeNotDetectedMessage);
+            $this->buildViolation($constraint->sizeNotDetectedMessage)
+                ->addViolation();
 
             return;
         }
@@ -65,10 +68,10 @@ class ImageValidator extends FileValidator
             }
 
             if ($width < $constraint->minWidth) {
-                $this->context->addViolation($constraint->minWidthMessage, array(
-                    '{{ width }}'    => $width,
-                    '{{ min_width }}' => $constraint->minWidth,
-                ));
+                $this->buildViolation($constraint->minWidthMessage)
+                    ->setParameter('{{ width }}', $width)
+                    ->setParameter('{{ min_width }}', $constraint->minWidth)
+                    ->addViolation();
 
                 return;
             }
@@ -80,10 +83,10 @@ class ImageValidator extends FileValidator
             }
 
             if ($width > $constraint->maxWidth) {
-                $this->context->addViolation($constraint->maxWidthMessage, array(
-                    '{{ width }}'    => $width,
-                    '{{ max_width }}' => $constraint->maxWidth,
-                ));
+                $this->buildViolation($constraint->maxWidthMessage)
+                    ->setParameter('{{ width }}', $width)
+                    ->setParameter('{{ max_width }}', $constraint->maxWidth)
+                    ->addViolation();
 
                 return;
             }
@@ -95,10 +98,10 @@ class ImageValidator extends FileValidator
             }
 
             if ($height < $constraint->minHeight) {
-                $this->context->addViolation($constraint->minHeightMessage, array(
-                    '{{ height }}'    => $height,
-                    '{{ min_height }}' => $constraint->minHeight,
-                ));
+                $this->buildViolation($constraint->minHeightMessage)
+                    ->setParameter('{{ height }}', $height)
+                    ->setParameter('{{ min_height }}', $constraint->minHeight)
+                    ->addViolation();
 
                 return;
             }
@@ -110,10 +113,10 @@ class ImageValidator extends FileValidator
             }
 
             if ($height > $constraint->maxHeight) {
-                $this->context->addViolation($constraint->maxHeightMessage, array(
-                    '{{ height }}'    => $height,
-                    '{{ max_height }}' => $constraint->maxHeight,
-                ));
+                $this->buildViolation($constraint->maxHeightMessage)
+                    ->setParameter('{{ height }}', $height)
+                    ->setParameter('{{ max_height }}', $constraint->maxHeight)
+                    ->addViolation();
             }
         }
 
@@ -125,10 +128,10 @@ class ImageValidator extends FileValidator
             }
 
             if ($ratio < $constraint->minRatio) {
-                $this->context->addViolation($constraint->minRatioMessage, array(
-                    '{{ ratio }}' => $ratio,
-                    '{{ min_ratio }}' => $constraint->minRatio,
-                ));
+                $this->buildViolation($constraint->minRatioMessage)
+                    ->setParameter('{{ ratio }}', $ratio)
+                    ->setParameter('{{ min_ratio }}', $constraint->minRatio)
+                    ->addViolation();
             }
         }
 
@@ -138,32 +141,32 @@ class ImageValidator extends FileValidator
             }
 
             if ($ratio > $constraint->maxRatio) {
-                $this->context->addViolation($constraint->maxRatioMessage, array(
-                    '{{ ratio }}' => $ratio,
-                    '{{ max_ratio }}' => $constraint->maxRatio,
-                ));
+                $this->buildViolation($constraint->maxRatioMessage)
+                    ->setParameter('{{ ratio }}', $ratio)
+                    ->setParameter('{{ max_ratio }}', $constraint->maxRatio)
+                    ->addViolation();
             }
         }
 
         if (!$constraint->allowSquare && $width == $height) {
-            $this->context->addViolation($constraint->allowSquareMessage, array(
-                '{{ width }}' => $width,
-                '{{ height }}' => $height,
-            ));
+            $this->buildViolation($constraint->allowSquareMessage)
+                ->setParameter('{{ width }}', $width)
+                ->setParameter('{{ height }}', $height)
+                ->addViolation();
         }
 
         if (!$constraint->allowLandscape && $width > $height) {
-            $this->context->addViolation($constraint->allowLandscapeMessage, array(
-                '{{ width }}' => $width,
-                '{{ height }}' => $height,
-            ));
+            $this->buildViolation($constraint->allowLandscapeMessage)
+                ->setParameter('{{ width }}', $width)
+                ->setParameter('{{ height }}', $height)
+                ->addViolation();
         }
 
         if (!$constraint->allowPortrait && $width < $height) {
-            $this->context->addViolation($constraint->allowPortraitMessage, array(
-                '{{ width }}' => $width,
-                '{{ height }}' => $height,
-            ));
+            $this->buildViolation($constraint->allowPortraitMessage)
+                ->setParameter('{{ width }}', $width)
+                ->setParameter('{{ height }}', $height)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -95,9 +95,9 @@ class IpValidator extends ConstraintValidator
         }
 
         if (!filter_var($value, FILTER_VALIDATE_IP, $flag)) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -46,9 +46,9 @@ class LanguageValidator extends ConstraintValidator
         $languages = Intl::getLanguageBundle()->getLanguageNames();
 
         if (!isset($languages[$value])) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
@@ -48,59 +47,24 @@ class LengthValidator extends ConstraintValidator
             $length = strlen($stringValue);
         }
 
-        if ($constraint->min == $constraint->max && $length != $constraint->min) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->exactMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->min)
-                    ->addViolation();
-            } else {
-                // 2.4 API
-                $this->context->addViolation($constraint->exactMessage, array(
-                    '{{ value }}' => $this->formatValue($stringValue),
-                    '{{ limit }}' => $constraint->min,
-                ), $value, (int) $constraint->min);
-            }
-
-            return;
-        }
-
         if (null !== $constraint->max && $length > $constraint->max) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->maxMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ limit }}', $constraint->max)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->max)
-                    ->addViolation();
-            } else {
-                // 2.4 API
-                $this->context->addViolation($constraint->maxMessage, array(
-                    '{{ value }}' => $this->formatValue($stringValue),
-                    '{{ limit }}' => $constraint->max,
-                ), $value, (int) $constraint->max);
-            }
+            $this->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
+                ->setParameter('{{ value }}', $this->formatValue($stringValue))
+                ->setParameter('{{ limit }}', $constraint->max)
+                ->setInvalidValue($value)
+                ->setPlural((int) $constraint->max)
+                ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->min && $length < $constraint->min) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->minMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->min)
-                    ->addViolation();
-            } else {
-                // 2.4 API
-                $this->context->addViolation($constraint->minMessage, array(
-                    '{{ value }}' => $this->formatValue($stringValue),
-                    '{{ limit }}' => $constraint->min,
-                ), $value, (int) $constraint->min);
-            }
+            $this->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
+                ->setParameter('{{ value }}', $this->formatValue($stringValue))
+                ->setParameter('{{ limit }}', $constraint->min)
+                ->setInvalidValue($value)
+                ->setPlural((int) $constraint->min)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -46,9 +46,9 @@ class LocaleValidator extends ConstraintValidator
         $locales = Intl::getLocaleBundle()->getLocaleNames();
 
         if (!isset($locales[$value])) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Luhn.php
+++ b/src/Symfony/Component/Validator/Constraints/Luhn.php
@@ -18,6 +18,9 @@ use Symfony\Component\Validator\Constraint;
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Tim Nagel <t.nagel@infinite.net.au>
+ * @author Greg Knapp http://gregk.me/2011/php-implementation-of-bank-card-luhn-algorithm/
  */
 class Luhn extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -55,9 +55,9 @@ class LuhnValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (!ctype_digit($value)) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
 
             return;
         }
@@ -85,9 +85,9 @@ class LuhnValidator extends ConstraintValidator
         }
 
         if (0 === $checkSum || 0 !== $checkSum % 10) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -32,9 +32,9 @@ class NotBlankValidator extends ConstraintValidator
         }
 
         if (false === $value || (empty($value) && '0' != $value)) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/NullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NullValidator.php
@@ -32,9 +32,9 @@ class NullValidator extends ConstraintValidator
         }
 
         if (null !== $value) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -34,27 +34,27 @@ class RangeValidator extends ConstraintValidator
         }
 
         if (!is_numeric($value)) {
-            $this->context->addViolation($constraint->invalidMessage, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->invalidMessage)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->max && $value > $constraint->max) {
-            $this->context->addViolation($constraint->maxMessage, array(
-                '{{ value }}' => $value,
-                '{{ limit }}' => $constraint->max,
-            ));
+            $this->buildViolation($constraint->maxMessage)
+                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ limit }}', $constraint->max)
+                ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->min && $value < $constraint->min) {
-            $this->context->addViolation($constraint->minMessage, array(
-                '{{ value }}' => $value,
-                '{{ limit }}' => $constraint->min,
-            ));
+            $this->buildViolation($constraint->minMessage)
+                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ limit }}', $constraint->min)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -45,9 +45,9 @@ class RegexValidator extends ConstraintValidator
         $value = (string) $value;
 
         if ($constraint->match xor preg_match($constraint->pattern, $value)) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -22,7 +22,23 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class TimeValidator extends ConstraintValidator
 {
-    const PATTERN = '/^(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/';
+    const PATTERN = '/^(\d{2}):(\d{2}):(\d{2})$/';
+
+    /**
+     * Checks whether a time is valid.
+     *
+     * @param int $hour   The hour
+     * @param int $minute The minute
+     * @param int $second The second
+     *
+     * @return bool Whether the time is valid
+     *
+     * @internal
+     */
+    public static function checkTime($hour, $minute, $second)
+    {
+        return $hour >= 0 && $hour < 24 && $minute >= 0 && $minute < 60 && $second >= 0 && $second < 60;
+    }
 
     /**
      * {@inheritdoc}
@@ -43,10 +59,18 @@ class TimeValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        if (!preg_match(static::PATTERN, $value)) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+        if (!preg_match(static::PATTERN, $value, $matches)) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
+
+            return;
+        }
+
+        if (!self::checkTime($matches[1], $matches[2], $matches[3])) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -36,9 +36,9 @@ class TrueValidator extends ConstraintValidator
         }
 
         if (true !== $value && 1 !== $value && '1' !== $value) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -48,9 +48,9 @@ class TypeValidator extends ConstraintValidator
             return;
         }
 
-        $this->context->addViolation($constraint->message, array(
-            '{{ value }}' => $this->formatValue($value),
-            '{{ type }}'  => $constraint->type,
-        ));
+        $this->buildViolation($constraint->message)
+            ->setParameter('{{ value }}', $this->formatValue($value))
+            ->setParameter('{{ type }}', $constraint->type)
+            ->addViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -59,9 +59,9 @@ class UrlValidator extends ConstraintValidator
         $pattern = sprintf(static::PATTERN, implode('|', $constraint->protocols));
 
         if (!preg_match($pattern, $value)) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -82,9 +82,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($object, $constraint);
 
-        $this->assertViolation('My message', array(
-            '{{ value }}' => 'foobar',
-        ));
+        $this->buildViolation('My message')
+            ->setParameter('{{ value }}', 'foobar')
+            ->assertRaised();
     }
 
     public function testSingleStaticMethod()
@@ -94,9 +94,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($object, $constraint);
 
-        $this->assertViolation('Static message', array(
-            '{{ value }}' => 'baz',
-        ));
+        $this->buildViolation('Static message')
+            ->setParameter('{{ value }}', 'baz')
+            ->assertRaised();
     }
 
     public function testClosure()
@@ -110,9 +110,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($object, $constraint);
 
-        $this->assertViolation('My message', array(
-            '{{ value }}' => 'foobar',
-        ));
+        $this->buildViolation('My message')
+            ->setParameter('{{ value }}', 'foobar')
+            ->assertRaised();
     }
 
     public function testClosureNullObject()
@@ -125,9 +125,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate(null, $constraint);
 
-        $this->assertViolation('My message', array(
-            '{{ value }}' => 'foobar',
-        ));
+        $this->buildViolation('My message')
+            ->setParameter('{{ value }}', 'foobar')
+            ->assertRaised();
     }
 
     public function testClosureExplicitName()
@@ -143,9 +143,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($object, $constraint);
 
-        $this->assertViolation('My message', array(
-            '{{ value }}' => 'foobar',
-        ));
+        $this->buildViolation('My message')
+            ->setParameter('{{ value }}', 'foobar')
+            ->assertRaised();
     }
 
     public function testArrayCallable()
@@ -155,9 +155,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($object, $constraint);
 
-        $this->assertViolation('Callback message', array(
-            '{{ value }}' => 'foobar',
-        ));
+        $this->buildViolation('Callback message')
+            ->setParameter('{{ value }}', 'foobar')
+            ->assertRaised();
     }
 
     public function testArrayCallableNullObject()
@@ -166,9 +166,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate(null, $constraint);
 
-        $this->assertViolation('Callback message', array(
-            '{{ value }}' => 'foobar',
-        ));
+        $this->buildViolation('Callback message')
+            ->setParameter('{{ value }}', 'foobar')
+            ->assertRaised();
     }
 
     public function testArrayCallableExplicitName()
@@ -180,9 +180,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($object, $constraint);
 
-        $this->assertViolation('Callback message', array(
-            '{{ value }}' => 'foobar',
-        ));
+        $this->buildViolation('Callback message')
+            ->setParameter('{{ value }}', 'foobar')
+            ->assertRaised();
     }
 
     // BC with Symfony < 2.4
@@ -193,9 +193,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($object, $constraint);
 
-        $this->assertViolation('My message', array(
-            '{{ value }}' => 'foobar',
-        ));
+        $this->buildViolation('My message')
+            ->setParameter('{{ value }}', 'foobar')
+            ->assertRaised();
     }
 
     // BC with Symfony < 2.4

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -161,6 +161,7 @@ class ChoiceValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"baz"')
+            ->setInvalidValue('baz')
             ->assertRaised();
     }
 
@@ -274,6 +275,7 @@ class ChoiceValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"3"')
+            ->setInvalidValue('3')
             ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -65,14 +65,6 @@ abstract class CountValidatorTest extends AbstractConstraintValidatorTest
         );
     }
 
-    public function getNotFourElements()
-    {
-        return array_merge(
-            $this->getThreeOrLessElements(),
-            $this->getFiveOrMoreElements()
-        );
-    }
-
     public function getFiveOrMoreElements()
     {
         return array(
@@ -118,7 +110,7 @@ abstract class CountValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getFiveOrMoreElements
      */
-    public function testInvalidValuesMax($value)
+    public function testTooManyValues($value)
     {
         $constraint = new Count(array(
             'max' => 4,
@@ -138,7 +130,7 @@ abstract class CountValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getThreeOrLessElements
      */
-    public function testInvalidValuesMin($value)
+    public function testTooFewValues($value)
     {
         $constraint = new Count(array(
             'min' => 4,
@@ -156,9 +148,30 @@ abstract class CountValidatorTest extends AbstractConstraintValidatorTest
     }
 
     /**
-     * @dataProvider getNotFourElements
+     * @dataProvider getFiveOrMoreElements
      */
-    public function testInvalidValuesExact($value)
+    public function testTooManyValuesExact($value)
+    {
+        $constraint = new Count(array(
+            'min' => 4,
+            'max' => 4,
+            'exactMessage' => 'myMessage',
+        ));
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ count }}', count($value))
+            ->setParameter('{{ limit }}', 4)
+            ->setInvalidValue($value)
+            ->setPlural(4)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getThreeOrLessElements
+     */
+    public function testTooFewValuesExact($value)
     {
         $constraint = new Count(array(
             'min' => 4,

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -71,7 +71,9 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($object, $constraint);
 
-        $this->assertViolation('myMessage');
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'object')
+            ->assertRaised();
     }
 
     public function testSucceedingExpressionAtPropertyLevel()
@@ -106,7 +108,10 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate('2', $constraint);
 
-        $this->assertViolation('myMessage', array(), 'data');
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"2"')
+            ->atPath('data')
+            ->assertRaised();
     }
 
     public function testSucceedingExpressionAtNestedPropertyLevel()
@@ -147,7 +152,10 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate('2', $constraint);
 
-        $this->assertViolation('myMessage', array(), 'reference.data');
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"2"')
+            ->atPath('reference.data')
+            ->assertRaised();
     }
 
     /**
@@ -184,6 +192,9 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate('2', $constraint);
 
-        $this->assertViolation('myMessage', array(), '');
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"2"')
+            ->atPath('')
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -202,10 +202,10 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($this->image, $constraint);
 
-        $this->assertViolation('myMessage', array(
-            '{{ ratio }}' => 1,
-            '{{ min_ratio }}' => 2,
-        ));
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ ratio }}', 1)
+            ->setParameter('{{ min_ratio }}', 2)
+            ->assertRaised();
     }
 
     public function testRatioTooBig()
@@ -217,10 +217,10 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($this->image, $constraint);
 
-        $this->assertViolation('myMessage', array(
-            '{{ ratio }}' => 1,
-            '{{ max_ratio }}' => 0.5,
-        ));
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ ratio }}', 1)
+            ->setParameter('{{ max_ratio }}', 0.5)
+            ->assertRaised();
     }
 
     public function testMaxRatioUsesTwoDecimalsOnly()
@@ -267,10 +267,10 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($this->image, $constraint);
 
-        $this->assertViolation('myMessage', array(
-            '{{ width }}' => 2,
-            '{{ height }}' => 2,
-        ));
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 2)
+            ->setParameter('{{ height }}', 2)
+            ->assertRaised();
     }
 
     public function testLandscapeNotAllowed()
@@ -282,10 +282,10 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($this->imageLandscape, $constraint);
 
-        $this->assertViolation('myMessage', array(
-            '{{ width }}' => 2,
-            '{{ height }}' => 1,
-        ));
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 2)
+            ->setParameter('{{ height }}', 1)
+            ->assertRaised();
     }
 
     public function testPortraitNotAllowed()
@@ -297,9 +297,9 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($this->imagePortrait, $constraint);
 
-        $this->assertViolation('myMessage', array(
-            '{{ width }}' => 1,
-            '{{ height }}' => 2,
-        ));
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ width }}', 1)
+            ->setParameter('{{ height }}', 2)
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
@@ -52,10 +52,11 @@ class IsbnValidatorTest extends AbstractConstraintValidatorTest
     public function getInvalidIsbn10()
     {
         return array(
+            array('27234422841'),
+            array('272344228'),
+            array('0-4712-9231'),
             array('1234567890'),
-            array('987'),
             array('0987656789'),
-            array(0),
             array('7-35622-5444'),
             array('0-4X19-92611'),
             array('0_45122_5244'),
@@ -89,16 +90,16 @@ class IsbnValidatorTest extends AbstractConstraintValidatorTest
     public function getInvalidIsbn13()
     {
         return array(
-            array('1234567890'),
-            array('987'),
-            array('0987656789'),
-            array(0),
-            array('0-4X19-9261981'),
+            array('978-27234422821'),
+            array('978-272344228'),
+            array('978-2723442-82'),
+            array('978-2723442281'),
             array('978-0321513774'),
             array('979-0431225385'),
             array('980-0474292319'),
-            array('978_0451225245'),
-            array('978#0471292319'),
+            array('0-4X19-92619812'),
+            array('978_2723442282'),
+            array('978#2723442282'),
             array('978-272C442282'),
             // chr(1) evaluates to 0
             // 978-2070546817 is valid
@@ -213,7 +214,7 @@ class IsbnValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getValidIsbn
      */
-    public function testValidIsbn($isbn)
+    public function testValidIsbnAny($isbn)
     {
         $constraint = new Isbn();
 
@@ -223,9 +224,25 @@ class IsbnValidatorTest extends AbstractConstraintValidatorTest
     }
 
     /**
-     * @dataProvider getInvalidIsbn
+     * @dataProvider getInvalidIsbn10
      */
-    public function testInvalidIsbn($isbn)
+    public function testInvalidIsbnAnyIsbn10($isbn)
+    {
+        $constraint = new Isbn(array(
+            'bothIsbnMessage' => 'myMessage',
+        ));
+
+        $this->validator->validate($isbn, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$isbn.'"')
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getInvalidIsbn13
+     */
+    public function testInvalidIsbnAnyIsbn13($isbn)
     {
         $constraint = new Isbn(array(
             'bothIsbnMessage' => 'myMessage',

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
@@ -79,31 +79,17 @@ class IssnValidatorTest extends AbstractConstraintValidatorTest
         );
     }
 
-    public function getInvalidFormatedIssn()
+    public function getInvalidIssn()
     {
         return array(
             array(0),
             array('1539'),
             array('2156-537A'),
-        );
-    }
-
-    public function getInvalidValueIssn()
-    {
-        return array(
             array('1119-0231'),
             array('1684-5312'),
             array('1996-0783'),
             array('1684-537X'),
             array('1996-0795'),
-        );
-    }
-
-    public function getInvalidIssn()
-    {
-        return array_merge(
-            $this->getInvalidFormatedIssn(),
-            $this->getInvalidValueIssn()
         );
     }
 
@@ -178,38 +164,6 @@ class IssnValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($issn, $constraint);
 
         $this->assertNoViolation();
-    }
-
-    /**
-     * @dataProvider getInvalidFormatedIssn
-     */
-    public function testInvalidFormatIssn($issn)
-    {
-        $constraint = new Issn(array(
-            'message' => 'myMessage',
-        ));
-
-        $this->validator->validate($issn, $constraint);
-
-        $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '"'.$issn.'"')
-            ->assertRaised();
-    }
-
-    /**
-     * @dataProvider getInvalidValueIssn
-     */
-    public function testInvalidValueIssn($issn)
-    {
-        $constraint = new Issn(array(
-            'message' => 'myMessage',
-        ));
-
-        $this->validator->validate($issn, $constraint);
-
-        $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '"'.$issn.'"')
-            ->assertRaised();
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -73,14 +73,6 @@ class LengthValidatorTest extends AbstractConstraintValidatorTest
         );
     }
 
-    public function getNotFourCharacters()
-    {
-        return array_merge(
-            $this->getThreeOrLessCharacters(),
-            $this->getFiveOrMoreCharacters()
-        );
-    }
-
     public function getFiveOrMoreCharacters()
     {
         return array(
@@ -189,9 +181,34 @@ class LengthValidatorTest extends AbstractConstraintValidatorTest
     }
 
     /**
-     * @dataProvider getNotFourCharacters
+     * @dataProvider getThreeOrLessCharacters
      */
-    public function testInvalidValuesExact($value, $mbOnly = false)
+    public function testInvalidValuesExactLessThanFour($value, $mbOnly = false)
+    {
+        if ($mbOnly && !function_exists('mb_strlen')) {
+            $this->markTestSkipped('mb_strlen does not exist');
+        }
+
+        $constraint = new Length(array(
+            'min' => 4,
+            'max' => 4,
+            'exactMessage' => 'myMessage',
+        ));
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$value.'"')
+            ->setParameter('{{ limit }}', 4)
+            ->setInvalidValue($value)
+            ->setPlural(4)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getFiveOrMoreCharacters
+     */
+    public function testInvalidValuesExactMoreThanFour($value, $mbOnly = false)
     {
         if ($mbOnly && !function_exists('mb_strlen')) {
             $this->markTestSkipped('mb_strlen does not exist');

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -97,6 +97,8 @@ class LuhnValidatorTest extends AbstractConstraintValidatorTest
             array('1234567812345678'),
             array('4222222222222222'),
             array('0000000000000000'),
+            array('000000!000000000'),
+            array('42-22222222222222'),
         );
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -188,38 +188,6 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         );
     }
 
-    public function testMinMessageIsSet()
-    {
-        $constraint = new Range(array(
-            'min' => 10,
-            'max' => 20,
-            'minMessage' => 'myMessage',
-        ));
-
-        $this->validator->validate(9, $constraint);
-
-        $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', 9)
-            ->setParameter('{{ limit }}', 10)
-            ->assertRaised();
-    }
-
-    public function testMaxMessageIsSet()
-    {
-        $constraint = new Range(array(
-            'min' => 10,
-            'max' => 20,
-            'maxMessage' => 'myMessage',
-        ));
-
-        $this->validator->validate(21, $constraint);
-
-        $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', 21)
-            ->setParameter('{{ limit }}', 20)
-            ->assertRaised();
-    }
-
     public function testNonNumeric()
     {
         $this->validator->validate('abcd', new Range(array(

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -83,9 +83,9 @@ class UuidValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($uuid, $constraint);
 
-        $this->assertViolation('testMessage', array(
-            '{{ value }}' => $uuid,
-        ));
+        $this->buildViolation('testMessage')
+            ->setParameter('{{ value }}', '"'.$uuid.'"')
+            ->assertRaised();
     }
 
     public function getInvalidStrictUuids()
@@ -130,9 +130,9 @@ class UuidValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($uuid, $constraint);
 
-        $this->assertViolation('myMessage', array(
-            '{{ value }}' => $uuid,
-        ));
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$uuid.'"')
+            ->assertRaised();
     }
 
     /**
@@ -177,9 +177,9 @@ class UuidValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($uuid, $constraint);
 
-        $this->assertViolation('myMessage', array(
-            '{{ value }}' => $uuid,
-        ));
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$uuid.'"')
+            ->assertRaised();
     }
 
     public function getInvalidNonStrictUuids()

--- a/src/Symfony/Component/Validator/Violation/LegacyConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/LegacyConstraintViolationBuilder.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Violation;
+
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Util\PropertyPath;
+
+/**
+ * Backwards-compatible implementation of {@link ConstraintViolationBuilderInterface}.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal You should not instantiate or use this class. Code against
+ *           {@link ConstraintViolationBuilderInterface} instead.
+ *
+ * @deprecated This class will be removed in Symfony 3.0.
+ */
+class LegacyConstraintViolationBuilder implements ConstraintViolationBuilderInterface
+{
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $context;
+
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    /**
+     * @var mixed
+     */
+    private $root;
+
+    /**
+     * @var mixed
+     */
+    private $invalidValue;
+
+    /**
+     * @var string
+     */
+    private $propertyPath;
+
+    /**
+     * @var int|null
+     */
+    private $plural;
+
+    /**
+     * @var mixed
+     */
+    private $code;
+
+    public function __construct(ExecutionContextInterface $context, $message, array $parameters)
+    {
+        $this->context = $context;
+        $this->message = $message;
+        $this->parameters = $parameters;
+        $this->root = $context->getRoot();
+        $this->invalidValue = $context->getValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function atPath($path)
+    {
+        $this->propertyPath = $path;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParameter($key, $value)
+    {
+        $this->parameters[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTranslationDomain($translationDomain)
+    {
+        // can't be set in the old API
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setInvalidValue($invalidValue)
+    {
+        $this->invalidValue = $invalidValue;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPlural($number)
+    {
+        $this->plural = $number;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addViolation()
+    {
+        if ($this->propertyPath) {
+            $this->context->addViolationAt($this->propertyPath, $this->message, $this->parameters, $this->invalidValue, $this->plural, $this->code);
+
+            return;
+        }
+
+        $this->context->addViolation($this->message, $this->parameters, $this->invalidValue, $this->plural, $this->code);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR adds a `buildViolation()` helper method to the base `ConstraintValidator` to remove the API checks (2.4 vs. 2.5) from the constraint validator implementations. Once the 2.4 API is removed, this helper method will be removed as well.

**Todos**
- [x] Backport changes from #12021
