### PR TITLE
[Validator] Fixed StaticMethodLoaderTest to actually test something

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AbstractStaticMethodLoader.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AbstractStaticMethodLoader.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\Validator\Tests\Mapping\Loader;
 
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
-abstract class AbstractMethodStaticLoader
+abstract class AbstractStaticMethodLoader
 {
     abstract public static function loadMetadata(ClassMetadata $metadata);
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -90,22 +90,19 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadClassMetadataIgnoresAbstractMethods()
     {
-        error_reporting(E_ALL | E_STRICT);
+        // Disable error reporting, as AbstractStaticMethodLoader produces a
+        // strict standards error
+        error_reporting(0);
+
+        if (0 !== error_reporting()) {
+            $this->markTestSkipped('Could not disable error reporting');
+        }
+
+        include __DIR__.'/AbstractStaticMethodLoader.php';
+
+        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticMethodLoader');
 
         $loader = new StaticMethodLoader('loadMetadata');
-        $caught = false;
-        try {
-            include __DIR__.'/AbstractMethodStaticLoader.php';
-        } catch (\Exception $e) {
-            // catching the PHP notice that is converted to an exception by PHPUnit
-            $caught = true;
-        }
-
-        if (!$caught) {
-            $this->fail('AbstractMethodStaticLoader should produce a strict standard error.');
-        }
-
-        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractMethodStaticLoader');
         $loader->loadClassMetadata($metadata);
 
         $this->assertCount(0, $metadata->getConstraints());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This test is not testing anything, except for whether PHP throws a strict standards error when invalid code is loaded.

I disabled error reporting for this test, so that the actual functionality (ignoring static+abstract functions) is tested.
