### PR TITLE
[DX][Form] Change default value of "required" option to false

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -243,6 +243,7 @@ class EntityTypeTest extends TypeTestCase
     public function testSubmitSingleExpandedNull()
     {
         $field = $this->factory->createNamed('name', 'entity', null, array(
+            'required' => true,
             'multiple' => false,
             'expanded' => true,
             'em' => 'default',
@@ -257,6 +258,7 @@ class EntityTypeTest extends TypeTestCase
     public function testSubmitSingleNonExpandedNull()
     {
         $field = $this->factory->createNamed('name', 'entity', null, array(
+            'required' => true,
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -271,6 +273,7 @@ class EntityTypeTest extends TypeTestCase
     public function testSubmitMultipleNull()
     {
         $field = $this->factory->createNamed('name', 'entity', null, array(
+            'required' => true,
             'multiple' => true,
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added "html5" option to Date, Time and DateTimeFormType to be able to
    enable/disable HTML5 input date when widget option is "single_text"
+ * the default value of the "required" option was changed to false
 
 2.5.0
 ------

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -268,6 +268,7 @@ class ChoiceType extends AbstractType
                 $choiceOpts = array(
                     'value' => $choiceView->value,
                     'label' => $choiceView->label,
+                    'required' => $options['required'],
                     'translation_domain' => $options['translation_domain'],
                 );
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -190,7 +190,7 @@ class FormType extends BaseType
             'data_class'         => $dataClass,
             'empty_data'         => $emptyData,
             'trim'               => true,
-            'required'           => true,
+            'required'           => false,
             'read_only'          => false,
             'max_length'         => null,
             'pattern'            => null,

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -84,18 +84,18 @@ class TimeType extends AbstractType
                     $secondOptions['choices'] = $seconds;
                     $secondOptions['placeholder'] = $options['placeholder']['second'];
                 }
+            }
 
-                // Append generic carry-along options
-                foreach (array('required', 'translation_domain') as $passOpt) {
-                    $hourOptions[$passOpt] = $options[$passOpt];
+            // Append generic carry-along options
+            foreach (array('required', 'translation_domain') as $passOpt) {
+                $hourOptions[$passOpt] = $options[$passOpt];
 
-                    if ($options['with_minutes']) {
-                        $minuteOptions[$passOpt] = $options[$passOpt];
-                    }
+                if ($options['with_minutes']) {
+                    $minuteOptions[$passOpt] = $options[$passOpt];
+                }
 
-                    if ($options['with_seconds']) {
-                        $secondOptions[$passOpt] = $options[$passOpt];
-                    }
+                if ($options['with_seconds']) {
+                    $secondOptions[$passOpt] = $options[$passOpt];
                 }
             }
 

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -110,7 +110,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * @var bool
      */
-    private $required = true;
+    private $required = false;
 
     /**
      * @var bool

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -49,6 +49,25 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         $this->assertMatchesXpath($html,
 '/div
     [
+        ./label[@for="name"][@class="my&label&class"][.="[trans]foo&bar[/trans]"]
+        /following-sibling::input[@id="name"][@class="my&class"]
+    ]
+'
+        );
+    }
+
+    public function testRowOverrideVariablesRequiredField()
+    {
+        $view = $this->factory->createNamed('name', 'text', null, array('required' => true))->createView();
+        $html = $this->renderRow($view, array(
+            'attr' => array('class' => 'my&class'),
+            'label' => 'foo&bar',
+            'label_attr' => array('class' => 'my&label&class'),
+        ));
+
+        $this->assertMatchesXpath($html,
+'/div
+    [
         ./label[@for="name"][@class="my&label&class required"][.="[trans]foo&bar[/trans]"]
         /following-sibling::input[@id="name"][@class="my&class"]
     ]
@@ -525,7 +544,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('name', 'repeated', null, array(
             // the global required value cannot be overridden
-            'first_options'  => array('label' => 'Test', 'required' => false),
+            'first_options'  => array('label' => 'Test', 'required' => true),
             'second_options' => array('label' => 'Test2'),
         ));
 
@@ -535,12 +554,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         ./div
             [
                 ./label[@for="name_first"][.="[trans]Test[/trans]"]
-                /following-sibling::input[@type="text"][@id="name_first"][@required="required"]
+                /following-sibling::input[@type="text"][@id="name_first"]
             ]
         /following-sibling::div
             [
                 ./label[@for="name_second"][.="[trans]Test2[/trans]"]
-                /following-sibling::input[@type="text"][@id="name_second"][@required="required"]
+                /following-sibling::input[@type="text"][@id="name_second"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -152,15 +152,18 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testLabelOnForm()
+    public function testLabelForRequiredField()
     {
-        $form = $this->factory->createNamed('name', 'date');
+        $form = $this->factory->createNamed('name', 'text', null, array(
+            'required' => true,
+        ));
         $view = $form->createView();
         $this->renderWidget($view, array('label' => 'foo'));
         $html = $this->renderLabel($view);
 
         $this->assertMatchesXpath($html,
 '/label
+    [@for="name"]
     [@class="required"]
     [.="[trans]Name[/trans]"]
 '
@@ -222,7 +225,6 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="required"]
 '
         );
     }
@@ -230,6 +232,25 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testLabelWithCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', 'text');
+        $html = $this->renderLabel($form->createView(), null, array(
+            'label_attr' => array(
+                'class' => 'my&class',
+            ),
+        ));
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="name"]
+    [@class="my&class"]
+'
+        );
+    }
+
+    public function testRequiredLabelWithCustomClass()
+    {
+        $form = $this->factory->createNamed('name', 'text', null, array(
+            'required' => true,
+        ));
         $html = $this->renderLabel($form->createView(), null, array(
             'label_attr' => array(
                 'class' => 'my&class',
@@ -256,7 +277,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="my&class required"]
+    [@class="my&class"]
     [.="[trans]Custom label[/trans]"]
 '
         );
@@ -277,7 +298,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html,
             '/label
     [@for="name"]
-    [@class="my&class required"]
+    [@class="my&class"]
     [.="[trans]Custom label[/trans]"]
 '
         );
@@ -366,6 +387,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
+            'required' => true,
             'multiple' => false,
             'expanded' => false,
         ));
@@ -400,6 +422,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
+            'required' => true,
             'multiple' => false,
             'expanded' => false,
         ));
@@ -423,6 +446,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
+            'required' => true,
             'multiple' => false,
             'expanded' => false,
         ));
@@ -445,6 +469,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
+            'required' => true,
             'multiple' => false,
             'expanded' => false,
         ));
@@ -468,6 +493,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&a', '&b'),
+            'required' => true,
             'multiple' => false,
             'expanded' => false,
         ));
@@ -703,6 +729,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
+            'required' => true,
             'multiple' => false,
             'expanded' => true,
         ));
@@ -725,6 +752,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $form = $this->factory->createNamed('name', 'choice', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
+            'required' => true,
             'multiple' => false,
             'expanded' => true,
             'placeholder' => 'Test&Me',
@@ -750,6 +778,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $form = $this->factory->createNamed('name', 'choice', true, array(
             'choices' => array('1' => 'Choice&A', '0' => 'Choice&B'),
+            'required' => true,
             'multiple' => false,
             'expanded' => true,
         ));
@@ -772,9 +801,9 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
+            'required' => true,
             'multiple' => true,
             'expanded' => true,
-            'required' => true,
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -1618,6 +1647,35 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
             [@name="name[hour]"]
             [@value="04"]
             [@size="1"]
+        /following-sibling::input
+            [@type="text"]
+            [@id="name_minute"]
+            [@name="name[minute]"]
+            [@value="05"]
+            [@size="1"]
+    ]
+    [count(./input)=2]
+'
+        );
+    }
+
+    public function testTimeTextRequired()
+    {
+        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+            'input' => 'string',
+            'widget' => 'text',
+            'required' => true,
+        ));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/div
+    [
+        ./input
+            [@type="text"]
+            [@id="name_hour"]
+            [@name="name[hour]"]
+            [@value="04"]
+            [@size="1"]
             [@required="required"]
         /following-sibling::input
             [@type="text"]
@@ -1918,7 +1976,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $html = $this->renderWidget($form->createView());
 
         // foo="foo"
-        $this->assertSame('<input type="text" id="text" name="text" required="required" foo="foo" value="value" />', $html);
+        $this->assertSame('<input type="text" id="text" name="text" foo="foo" value="value" />', $html);
     }
 
     public function testWidgetAttributeHiddenIfFalse()

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -401,7 +401,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('name', 'repeated', 'foobar', array(
             'type'           => 'password',
-            'first_options'  => array('label' => 'Test', 'required' => false),
+            'first_options'  => array('label' => 'Test', 'required' => true),
             'second_options' => array('label' => 'Test2'),
         ));
 
@@ -413,14 +413,14 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
                 ./td
                     [./label[@for="name_first"][.="[trans]Test[/trans]"]]
                 /following-sibling::td
-                    [./input[@type="password"][@id="name_first"][@required="required"]]
+                    [./input[@type="password"][@id="name_first"]]
             ]
         /following-sibling::tr
             [
                 ./td
                     [./label[@for="name_second"][.="[trans]Test2[/trans]"]]
                 /following-sibling::td
-                    [./input[@type="password"][@id="name_second"][@required="required"]]
+                    [./input[@type="password"][@id="name_second"]]
             ]
         /following-sibling::tr[@style="display: none"]
             [./td[@colspan="2"]/input

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -94,8 +94,9 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testExpandedChoicesOptionsTurnIntoChildren()
     {
         $form = $this->factory->create('choice', null, array(
-            'expanded'  => true,
-            'choices'   => $this->choices,
+            'expanded' => true,
+            'required' => true,
+            'choices' => $this->choices,
         ));
 
         $this->assertCount(count($this->choices), $form, 'Each choice should become a new field');
@@ -104,10 +105,10 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPlaceholderPresentOnNonRequiredExpandedSingleChoice()
     {
         $form = $this->factory->create('choice', null, array(
-            'multiple'  => false,
-            'expanded'  => true,
-            'required'  => false,
-            'choices'   => $this->choices,
+            'multiple' => false,
+            'expanded' => true,
+            'required' => false,
+            'choices' => $this->choices,
         ));
 
         $this->assertTrue(isset($form['placeholder']));
@@ -117,10 +118,10 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPlaceholderNotPresentIfRequired()
     {
         $form = $this->factory->create('choice', null, array(
-            'multiple'  => false,
-            'expanded'  => true,
-            'required'  => true,
-            'choices'   => $this->choices,
+            'multiple' => false,
+            'expanded' => true,
+            'required' => true,
+            'choices' => $this->choices,
         ));
 
         $this->assertFalse(isset($form['placeholder']));
@@ -130,10 +131,10 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPlaceholderNotPresentIfMultiple()
     {
         $form = $this->factory->create('choice', null, array(
-            'multiple'  => true,
-            'expanded'  => true,
-            'required'  => false,
-            'choices'   => $this->choices,
+            'multiple' => true,
+            'expanded' => true,
+            'required' => false,
+            'choices' => $this->choices,
         ));
 
         $this->assertFalse(isset($form['placeholder']));
@@ -143,9 +144,9 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPlaceholderNotPresentIfEmptyChoice()
     {
         $form = $this->factory->create('choice', null, array(
-            'multiple'  => false,
-            'expanded'  => true,
-            'required'  => false,
+            'multiple' => false,
+            'expanded' => true,
+            'required' => false,
             'choices' => array(
                 '' => 'Empty',
                 1 => 'Not empty',
@@ -159,8 +160,9 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testExpandedChoicesOptionsAreFlattened()
     {
         $form = $this->factory->create('choice', null, array(
-            'expanded'  => true,
-            'choices'   => $this->groupedChoices,
+            'expanded' => true,
+            'required' => true,
+            'choices' => $this->groupedChoices,
         ));
 
         $flattened = array();
@@ -971,6 +973,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPassRequiredToView()
     {
         $form = $this->factory->create('choice', null, array(
+            'required' => true,
             'choices' => $this->choices,
         ));
         $view = $form->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -36,7 +36,8 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testSetOptions()
     {
         $form = $this->factory->create('repeated', null, array(
-            'type'    => 'text',
+            'required' => true,
+            'type' => 'text',
             'options' => array('label' => 'Global'),
         ));
 
@@ -50,6 +51,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $form = $this->factory->create('repeated', null, array(
             // the global required value cannot be overridden
+            'required'       => true,
             'type'           => 'text',
             'first_options'  => array('label' => 'Test', 'required' => false),
             'second_options' => array('label' => 'Test2'),
@@ -117,8 +119,6 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertEquals('Label', $form['first']->getConfig()->getOption('label'));
         $this->assertEquals('Second label', $form['second']->getConfig()->getOption('label'));
-        $this->assertTrue($form['first']->isRequired());
-        $this->assertTrue($form['second']->isRequired());
     }
 
     public function testSubmitUnequal()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5365 |
| License | MIT |
| Doc PR | - |

This is an attempt to set the default value of the "required" option of all form types to false. Let's list the usage scenarios that we have at the moment:

| validation constraints | "required" option | HTML5 attribute |
| --- | --- | --- |
| `NotNull`/`NotBlank` | none | `required` |
| none | none | `required` |
| `NotNull`/`NotBlank` | `true` | `required` |
| none | `true` | `required` |
| `NotNull`/`NotBlank` | `false` | none |
| none | `false` | none |

By setting the default of the "required" option to false, only one case changes:

| validation constraints | "required" option | HTML5 attribute |
| --- | --- | --- |
| none | none | none |

This obviously makes more sense than validating a value on the client side that isn't validated on the server side.

**Consequences**
- Text fields without explicit "required" option and without server-side validation won't have the `required` attribute anymore
- Select fields without explicit "required" option and without server-side validation will display an empty value by default
- Unit tests break if the tested behavior depends on the "required" option and that option is not explicitly set
- We need to inspect the "constraints" option to check whether it contains a `NotNull`/`NotBlank` constraint. In that case, "required" should be set to true by default

The only major consequence I see is if people don't use the Validator component for validation, but some custom mechanism. In that case, we can't detect whether a field is validated or not, so all fields without explicit "required" option loose their HTML attribute. However:
1. I'm not aware of anybody using the Form component without the Validator component.
2. This affects client-side validation only, not server-side validation.

So even there, I don't think the consequences are very serious.

What do you think?

**Todos** (in case a majority votes for this PR)
- [ ] Inspect "constraints" option to set "required" option to true when `NotBlank`/`NotNull` is given
