### PR TITLE
[FrameworkBundle] fix LoggingTranslatorPass

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
@@ -25,15 +25,21 @@ class LoggingTranslatorPass implements CompilerPassInterface
             return;
         }
 
-        if ($container->getParameter('translator.logging')) {
-            $translatorAlias = $container->getAlias('translator');
-            $definition = $container->getDefinition((string) $translatorAlias);
-            $class = $container->getParameterBag()->resolveValue($definition->getClass());
+        if (!$container->hasParameter('translator.logging')) {
+            return;
+        }
 
-            $refClass = new \ReflectionClass($class);
-            if ($refClass->implementsInterface('Symfony\Component\Translation\TranslatorInterface') && $refClass->implementsInterface('Symfony\Component\Translation\TranslatorBagInterface')) {
-                $container->getDefinition('translator.logging')->setDecoratedService('translator');
-            }
+        if (!$container->getParameter('translator.logging')) {
+            return;
+        }
+
+        $translatorAlias = $container->getAlias('translator');
+        $definition = $container->getDefinition((string) $translatorAlias);
+        $class = $container->getParameterBag()->resolveValue($definition->getClass());
+
+        $refClass = new \ReflectionClass($class);
+        if ($refClass->implementsInterface('Symfony\Component\Translation\TranslatorInterface') && $refClass->implementsInterface('Symfony\Component\Translation\TranslatorBagInterface')) {
+            $container->getDefinition('translator.logging')->setDecoratedService('translator');
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggingTranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggingTranslatorPassTest.php
@@ -28,6 +28,10 @@ class LoggingTranslatorPassTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $container->expects($this->once())
+            ->method('hasParameter')
+            ->will($this->returnValue(true));
+
+        $container->expects($this->once())
             ->method('getParameter')
             ->will($this->returnValue(true));
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The param was not present because of: https://github.com/symfony/symfony/blob/cc04ce15c01e61eabf1f3d76bbcb9cbf7faf2125/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L626-L628
