### PR TITLE
[FrameworkBundle] output failed matched path for clarification

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -89,7 +89,7 @@ EOF
         }
 
         if (!$matches) {
-            $output->writeln('<fg=red>None of the routes match</>');
+            $output->writeln(sprintf('<fg=red>None of the routes match the path "%s"</>', $input->getArgument('path_info')));
 
             return 1;
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11780 |
| License | MIT |
| Doc PR | - |

Because cygwin resolves the path behind the scenes, it is otherwise very unclear what path is actually used for matching.
