### PR TITLE
[Validator] Fixed LegacyValidator when only a constraint is validated

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Validator;
 
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -64,6 +65,13 @@ abstract class Abstract2Dot5ApiTest extends AbstractValidatorTest
     protected function validatePropertyValue($object, $propertyName, $value, $groups = null)
     {
         return $this->validator->validatePropertyValue($object, $propertyName, $value, $groups);
+    }
+
+    public function testValidateConstraintWithoutGroup()
+    {
+        $violations = $this->validator->validate(null, new NotNull());
+
+        $this->assertCount(1, $violations);
     }
 
     public function testGroupSequenceAbortsAfterFailedGroup()

--- a/src/Symfony/Component/Validator/Validator/LegacyValidator.php
+++ b/src/Symfony/Component/Validator/Validator/LegacyValidator.php
@@ -44,7 +44,7 @@ class LegacyValidator extends RecursiveValidator implements LegacyValidatorInter
         $numArgs = func_num_args();
 
         // Use new signature if constraints are given in the second argument
-        if (self::testConstraints($groups) && ($numArgs < 2 || 3 === $numArgs && self::testGroups($traverse))) {
+        if (self::testConstraints($groups) && ($numArgs < 3 || 3 === $numArgs && self::testGroups($traverse))) {
             // Rename to avoid total confusion ;)
             $constraints = $groups;
             $groups = $traverse;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The 2.5-BC API is currently broken for the following use case:

``` php
$validator->validate($value, $constraint);
```

This is fixed now.
