### PR TITLE
[Form] Removed constructor argument from FormTypeHttpFoundationExtension for forward compatibility with 2.5

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -151,11 +151,8 @@
         </service>
 
         <!-- FormTypeHttpFoundationExtension -->
-        <service id="form.server_params" class="Symfony\Component\Form\Util\ServerParams" public="false"/>
-
         <service id="form.type_extension.form.http_foundation" class="Symfony\Component\Form\Extension\HttpFoundation\Type\FormTypeHttpFoundationExtension">
             <tag name="form.type_extension" alias="form" />
-            <argument type="service" id="form.server_params"/>
         </service>
 
         <!-- FormTypeValidatorExtension -->

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationExtension.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Extension\HttpFoundation;
 
 use Symfony\Component\Form\AbstractExtension;
-use Symfony\Component\Form\Util\ServerParams;
 
 /**
  * Integrates the HttpFoundation component with the Form library.
@@ -21,20 +20,10 @@ use Symfony\Component\Form\Util\ServerParams;
  */
 class HttpFoundationExtension extends AbstractExtension
 {
-    /**
-     * @var ServerParams
-     */
-    private $serverParams;
-
-    public function __construct(ServerParams $serverParams = null)
-    {
-        $this->serverParams = $serverParams;
-    }
-
     protected function loadTypeExtensions()
     {
         return array(
-            new Type\FormTypeHttpFoundationExtension($this->serverParams),
+            new Type\FormTypeHttpFoundationExtension(),
         );
     }
 }

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/Type/FormTypeHttpFoundationExtension.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/Type/FormTypeHttpFoundationExtension.php
@@ -15,7 +15,6 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\HttpFoundation\EventListener\BindRequestListener;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\Util\ServerParams;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -32,10 +31,10 @@ class FormTypeHttpFoundationExtension extends AbstractTypeExtension
      */
     private $requestHandler;
 
-    public function __construct(ServerParams $serverParams = null)
+    public function __construct()
     {
         $this->listener = new BindRequestListener();
-        $this->requestHandler = new HttpFoundationRequestHandler($serverParams);
+        $this->requestHandler = new HttpFoundationRequestHandler();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This argument was introduced in #11924. No release was made of the 2.3 branch after merging that PR.

Since a different constructor argument (`$requestHandler`) was added to FormTypeHttpFoundationExtension in the 2.5 branch, we cannot merge this forward in a BC fashion. For this reason, I removed the argument again.
