### PR TITLE
Update the Controller to be consistent

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -109,7 +109,7 @@ class Controller extends ContainerAware
             throw new \LogicException('You can not use the addFlash method if sessions are disabled.');
         }
 
-        $this->get('session')->getFlashBag()->add($type, $message);
+        $this->container->get('session')->getFlashBag()->add($type, $message);
     }
 
     /**
@@ -127,7 +127,7 @@ class Controller extends ContainerAware
             throw new \LogicException('The SecurityBundle is not registered in your application.');
         }
 
-        return $this->get('security.context')->isGranted($attributes, $object);
+        return $this->container->get('security.context')->isGranted($attributes, $object);
     }
 
     /**


### PR DESCRIPTION
We are always using $this->container->get() and now we're using the short-cut sometimes to access to a service.
It could be nice to stay with $this->container->get() to stay consistent and for those who copy and paste the Controller to create a ControllerUtils, they wont have to change it (in fact neither ControllerUtils::get() nor ControllerUtils::has() exists).
See: http://www.whitewashing.de/2013/06/27/extending_symfony2__controller_utilities.html
