### PR TITLE
fixed translator locale when dealing with sub-requests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -63,23 +63,6 @@ class Translator extends BaseTranslator
     /**
      * {@inheritdoc}
      */
-    public function getLocale()
-    {
-        if (null === $this->locale && $request = $this->container->get('request_stack')->getCurrentRequest()) {
-            $this->locale = $request->getLocale();
-            try {
-                $this->setLocale($request->getLocale());
-            } catch (\InvalidArgumentException $e) {
-                $this->setLocale($request->getDefaultLocale());
-            }
-        }
-
-        return $this->locale;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function initializeCatalogue($locale)
     {
         $this->initialize();

--- a/src/Symfony/Component/HttpKernel/EventListener/TranslatorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TranslatorListener.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translator\TranslatorInterface;
+
+/**
+ * Synchronizes the locale between the request and the translator.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TranslatorListener implements EventSubscriberInterface
+{
+    private $translator;
+    private $requestStack;
+
+    public function __construct(TranslatorInterface $translator, RequestStack $requestStack)
+    {
+        $this->translator = $translator;
+        $this->requestStack = $requestStack;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $this->translator->setLocale($event->getRequest()->getLocale());
+    }
+
+    public function onKernelFinishRequest(FinishRequestEvent $event)
+    {
+        if (null !== $parentRequest = $this->requestStack->getParentRequest()) {
+            $this->translator->setLocale($parentRequest->getLocale());
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            // must be registered after the Locale listener
+            KernelEvents::REQUEST => array(array('onKernelRequest', 10)),
+            KernelEvents::FINISH_REQUEST => array(array('onKernelFinishRequest', 0)),
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -32,7 +32,8 @@
         "symfony/process": "~2.0",
         "symfony/routing": "~2.2",
         "symfony/stopwatch": "~2.2",
-        "symfony/templating": "~2.2"
+        "symfony/templating": "~2.2",
+        "symfony/translator": "~2.0"
     },
     "suggest": {
         "symfony/browser-kit": "",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes, kinda |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This fixes the (edge) case where the locale of a sub-requests is different from the locale of the master request. The listener synchronizes the translator locale with the one from the request.
