### PR TITLE
[Form] Added "label_format" option

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -177,7 +177,14 @@
 
 {% block button_widget -%}
     {% if label is empty -%}
-        {% set label = name|humanize %}
+        {%- if label_format is not empty -%}
+            {% set label = label_format|replace({
+                '%name%': name,
+                '%id%': id,
+            }) %}
+        {%- else -%}
+            {% set label = name|humanize %}
+        {%- endif -%}
     {%- endif -%}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ label|trans({}, translation_domain) }}</button>
 {%- endblock button_widget %}
@@ -203,7 +210,14 @@
             {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
         {%- endif %}
         {% if label is empty -%}
-            {% set label = name|humanize %}
+            {%- if label_format is not empty -%}
+                {% set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) %}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
         {%- endif -%}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
     {%- endif %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/button_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/button_widget.html.php
@@ -1,2 +1,4 @@
-<?php if (!$label) { $label = $view['form']->humanize($name); } ?>
+<?php if (!$label) { $label = isset($label_format)
+    ? strtr($label_format, array('%name%' => $name, '%id%' => $id))
+    : $view['form']->humanize($name); } ?>
 <button type="<?php echo isset($type) ? $view->escape($type) : 'button' ?>" <?php echo $view['form']->block($form, 'button_attributes') ?>><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></button>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -1,6 +1,8 @@
 <?php if (false !== $label): ?>
 <?php if ($required) { $label_attr['class'] = trim((isset($label_attr['class']) ? $label_attr['class'] : '').' required'); } ?>
 <?php if (!$compound) { $label_attr['for'] = $id; } ?>
-<?php if (!$label) { $label = $view['form']->humanize($name); } ?>
+<?php if (!$label) { $label = isset($label_format)
+    ? strtr($label_format, array('%name%' => $name, '%id%' => $id))
+    : $view['form']->humanize($name); } ?>
 <label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>
 <?php endif ?>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added "html5" option to Date, Time and DateTimeFormType to be able to
    enable/disable HTML5 input date when widget option is "single_text"
+ * added "label_format" option with possible placeholders "%name%" and "%id%"
 
 2.5.0
 ------

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -44,6 +44,7 @@ abstract class BaseType extends AbstractType
         $name = $form->getName();
         $blockName = $options['block_name'] ?: $form->getName();
         $translationDomain = $options['translation_domain'];
+        $labelFormat = $options['label_format'];
 
         if ($view->parent) {
             if ('' !== ($parentFullName = $view->parent->vars['full_name'])) {
@@ -58,6 +59,10 @@ abstract class BaseType extends AbstractType
 
             if (!$translationDomain) {
                 $translationDomain = $view->parent->vars['translation_domain'];
+            }
+
+            if (!$labelFormat) {
+                $labelFormat = $view->parent->vars['label_format'];
             }
         } else {
             $id = $name;
@@ -87,6 +92,7 @@ abstract class BaseType extends AbstractType
             'full_name'           => $fullName,
             'disabled'            => $form->isDisabled(),
             'label'               => $options['label'],
+            'label_format'        => $labelFormat,
             'multipart'           => false,
             'attr'                => $options['attr'],
             'block_prefixes'      => $blockPrefixes,
@@ -111,6 +117,7 @@ abstract class BaseType extends AbstractType
             'block_name'         => null,
             'disabled'           => false,
             'label'              => null,
+            'label_format'       => null,
             'attr'               => array(),
             'translation_domain' => null,
             'auto_initialize'    => true,

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -283,6 +283,108 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
+    public function testLabelFormatName()
+    {
+        $form = $this->factory->createNamedBuilder('myform')
+            ->add('myfield', 'text')
+            ->getForm();
+        $view = $form->get('myfield')->createView();
+        $html = $this->renderLabel($view, null, array('label_format' => 'form.%name%'));
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="myform_myfield"]
+    [.="[trans]form.myfield[/trans]"]
+'
+        );
+    }
+
+    public function testLabelFormatId()
+    {
+        $form = $this->factory->createNamedBuilder('myform')
+            ->add('myfield', 'text')
+            ->getForm();
+        $view = $form->get('myfield')->createView();
+        $html = $this->renderLabel($view, null, array('label_format' => 'form.%id%'));
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="myform_myfield"]
+    [.="[trans]form.myform_myfield[/trans]"]
+'
+        );
+    }
+
+    public function testLabelFormatAsFormOption()
+    {
+        $options = array('label_format' => 'form.%name%');
+
+        $form = $this->factory->createNamedBuilder('myform', 'form', null, $options)
+            ->add('myfield', 'text')
+            ->getForm();
+        $view = $form->get('myfield')->createView();
+        $html = $this->renderLabel($view);
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="myform_myfield"]
+    [.="[trans]form.myfield[/trans]"]
+'
+        );
+    }
+
+    public function testLabelFormatOverriddenOption()
+    {
+        $options = array('label_format' => 'form.%name%');
+
+        $form = $this->factory->createNamedBuilder('myform', 'form', null, $options)
+            ->add('myfield', 'text', array('label_format' => 'field.%name%'))
+            ->getForm();
+        $view = $form->get('myfield')->createView();
+        $html = $this->renderLabel($view);
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="myform_myfield"]
+    [.="[trans]field.myfield[/trans]"]
+'
+        );
+    }
+
+    public function testLabelFormatOnButton()
+    {
+        $form = $this->factory->createNamedBuilder('myform')
+            ->add('mybutton', 'button')
+            ->getForm();
+        $view = $form->get('mybutton')->createView();
+        $html = $this->renderWidget($view, array('label_format' => 'form.%name%'));
+
+        $this->assertMatchesXpath($html,
+'/button
+    [@type="button"]
+    [@name="myform[mybutton]"]
+    [.="[trans]form.mybutton[/trans]"]
+'
+        );
+    }
+
+    public function testLabelFormatOnButtonId()
+    {
+        $form = $this->factory->createNamedBuilder('myform')
+            ->add('mybutton', 'button')
+            ->getForm();
+        $view = $form->get('mybutton')->createView();
+        $html = $this->renderWidget($view, array('label_format' => 'form.%id%'));
+
+        $this->assertMatchesXpath($html,
+'/button
+    [@type="button"]
+    [@name="myform[mybutton]"]
+    [.="[trans]form.myform_mybutton[/trans]"]
+'
+        );
+    }
+
     public function testErrors()
     {
         $form = $this->factory->createNamed('name', 'text');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11456 |
| License | MIT |
| Doc PR | TODO |

This PR replaces #11456. It adds a "label_format" option which allows to configure a format for generating labels. Two placeholders are available: `%name%` and `%id%`.

**Feedback wanted**: Should we change the placeholders to `{{ name }}` and `{{ id }}`?

The option is inherited from the parent form if not set explicitly on a field:

``` php
$form = $this->createForm('myform', $data, array('label_format' => 'form.label.%id%'));
```

Follow-up PR: Make the default label format and translation domain configurable in config.yml.
