### PR TITLE
[Validator] Made it possible to store the cause of a constraint violation

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * deprecated `ClassMetadata::addMemberMetadata()`
  * [BC BREAK] added `Mapping\MetadataInterface::getConstraints()`
  * added generic "payload" option to all constraints for attaching domain-specific data
+ * [BC BREAK] added `ConstraintViolationBuilderInterface::setCause()`
 
 2.5.0
 -----

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -64,6 +64,11 @@ class ConstraintViolation implements ConstraintViolationInterface
     private $code;
 
     /**
+     * @var mixed
+     */
+    private $cause;
+
+    /**
      * Creates a new constraint violation.
      *
      * @param string          $message         The violation message
@@ -79,10 +84,11 @@ class ConstraintViolation implements ConstraintViolationInterface
      * @param int|null        $plural          The number for determining the plural
      *                                         form when translating the message
      * @param mixed           $code            The error code of the violation
-     * @param Constraint|null $constraint      The constraint that caused the
-     *                                         violation
+     * @param Constraint|null $constraint      The constraint whose validation
+     *                                         caused the violation
+     * @param mixed           $cause           The cause of the violation
      */
-    public function __construct($message, $messageTemplate, array $parameters, $root, $propertyPath, $invalidValue, $plural = null, $code = null, Constraint $constraint = null)
+    public function __construct($message, $messageTemplate, array $parameters, $root, $propertyPath, $invalidValue, $plural = null, $code = null, Constraint $constraint = null, $cause = null)
     {
         $this->message = $message;
         $this->messageTemplate = $messageTemplate;
@@ -93,6 +99,7 @@ class ConstraintViolation implements ConstraintViolationInterface
         $this->invalidValue = $invalidValue;
         $this->constraint = $constraint;
         $this->code = $code;
+        $this->cause = $cause;
     }
 
     /**
@@ -197,13 +204,23 @@ class ConstraintViolation implements ConstraintViolationInterface
     }
 
     /**
-     * Returns the constraint that caused the violation.
+     * Returns the constraint whose validation caused the violation.
      *
      * @return Constraint|null The constraint or null if it is not known
      */
     public function getConstraint()
     {
         return $this->constraint;
+    }
+
+    /**
+     * Returns the cause of the violation.
+     *
+     * @return mixed
+     */
+    public function getCause()
+    {
+        return $this->cause;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -428,6 +428,7 @@ class ConstraintViolationAssertion
     private $plural;
     private $code;
     private $constraint;
+    private $cause;
 
     public function __construct(LegacyExecutionContextInterface $context, $message, Constraint $constraint = null, array $assertions = array())
     {
@@ -486,6 +487,13 @@ class ConstraintViolationAssertion
         return $this;
     }
 
+    public function setCause($cause)
+    {
+        $this->cause = $cause;
+
+        return $this;
+    }
+
     public function buildNextViolation($message)
     {
         $assertions = $this->assertions;
@@ -525,7 +533,8 @@ class ConstraintViolationAssertion
             $this->invalidValue,
             $this->plural,
             $this->code,
-            $this->constraint
+            $this->constraint,
+            $this->cause
         );
     }
 }

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -83,6 +83,11 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
      */
     private $code;
 
+    /**
+     * @var mixed
+     */
+    private $cause;
+
     public function __construct(ConstraintViolationList $violations, Constraint $constraint, $message, array $parameters, $root, $propertyPath, $invalidValue, TranslatorInterface $translator, $translationDomain = null)
     {
         $this->violations = $violations;
@@ -169,6 +174,16 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function setCause($cause)
+    {
+        $this->cause = $cause;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function addViolation()
     {
         if (null === $this->plural) {
@@ -203,7 +218,8 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
             $this->invalidValue,
             $this->plural,
             $this->code,
-            $this->constraint
+            $this->constraint,
+            $this->cause
         ));
     }
 }

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -102,6 +102,15 @@ interface ConstraintViolationBuilderInterface
     public function setCode($code);
 
     /**
+     * Sets the cause of the violation.
+     *
+     * @param mixed $cause The cause of the violation
+     *
+     * @return ConstraintViolationBuilderInterface This builder
+     */
+    public function setCause($cause);
+
+    /**
      * Adds the violation to the current execution context.
      */
     public function addViolation();

--- a/src/Symfony/Component/Validator/Violation/LegacyConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/LegacyConstraintViolationBuilder.php
@@ -11,12 +11,7 @@
 
 namespace Symfony\Component\Validator\Violation;
 
-use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\ConstraintViolation;
-use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ExecutionContextInterface;
-use Symfony\Component\Validator\Util\PropertyPath;
 
 /**
  * Backwards-compatible implementation of {@link ConstraintViolationBuilderInterface}.
@@ -145,6 +140,16 @@ class LegacyConstraintViolationBuilder implements ConstraintViolationBuilderInte
     public function setCode($code)
     {
         $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCause($cause)
+    {
+        // do nothing - we can't save the cause through the old API
 
         return $this;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | TODO |

This change makes it possible to store the cause of a violation (e.g. an exception). This way it is possible to follow the trace of violations caused by exceptions up to their root.

``` php
try {
    // ...
} catch (Exception $e) {
    $this->context->buildViolation('Error!')
        ->setCause($e)
        ->addViolation();
}
```

This is one step to solve #5607. See #12054.
