### PR TITLE
[Form] The trace of form errors is now displayed in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -473,14 +473,28 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if error.cause is empty %}
-                            <em>Unknown.</em>
-                        {% elseif error.cause.root is defined %}
-                            <strong>Constraint Violation</strong><br/>
-                            <pre>{{ error.cause.root }}{% if error.cause.path is not empty %}{% if error.cause.path|first != '[' %}.{% endif %}{{ error.cause.path }}{% endif %} = {{ error.cause.value }}</pre>
+                        {% for trace in error.trace %}
+                            {% if not loop.first %}
+                                <br/>Caused by:<br/><br/>
+                            {% endif %}
+                            {% if trace.root is defined %}
+                                <strong>{{ trace.class }}</strong><br/>
+                                <pre>
+                                    {{- trace.root -}}
+                                    {%- if trace.path is not empty -%}
+                                        {%- if trace.path|first != '[' %}.{% endif -%}
+                                        {{- trace.path -}}
+                                    {%- endif %} = {{ trace.value -}}
+                                </pre>
+                            {% elseif trace.message is defined %}
+                                <strong>{{ trace.class }}</strong><br/>
+                                <pre>{{ trace.message }}</pre>
+                            {% else %}
+                                <pre>{{ trace }}</pre>
+                            {% endif %}
                         {% else %}
-                            <pre>{{ error.cause }}</pre>
-                        {% endif %}
+                            <em>Unknown.</em>
+                        {% endfor %}
                     </td>
                 </tr>
                 {% endfor %}

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -347,6 +347,15 @@ class Button implements \IteratorAggregate, FormInterface
     /**
      * Unsupported method.
      *
+     * @return null Always returns null
+     */
+    public function getTransformationFailure()
+    {
+    }
+
+    /**
+     * Unsupported method.
+     *
      * @throws BadMethodCallException
      */
     public function initialize()

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * ObjectChoiceList now compares choices by their value, if a value path is
    given
  * you can now pass interface names in the "data_class" option
+ * [BC BREAK] added `FormInterface::getTransformationFailure()`
 
 2.4.0
 -----

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -103,6 +103,7 @@ class FormValidator extends ConstraintValidator
                     ->setParameters(array_replace(array('{{ value }}' => $clientDataAsString), $config->getOption('invalid_message_parameters')))
                     ->setInvalidValue($form->getViewData())
                     ->setCode(Form::ERR_INVALID)
+                    ->setCause($form->getTransformationFailure())
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -121,12 +121,10 @@ class Form implements \IteratorAggregate, FormInterface
     private $extraData = array();
 
     /**
-     * Whether the data in model, normalized and view format is
-     * synchronized. Data may not be synchronized if transformation errors
-     * occur.
-     * @var bool
+     * Returns the transformation failure generated during submission, if any
+     * @var TransformationFailedException|null
      */
-    private $synchronized = true;
+    private $transformationFailure;
 
     /**
      * Whether the form's data has been initialized.
@@ -634,7 +632,7 @@ class Form implements \IteratorAggregate, FormInterface
                 $viewData = $this->normToView($normData);
             }
         } catch (TransformationFailedException $e) {
-            $this->synchronized = false;
+            $this->transformationFailure = $e;
 
             // If $viewData was not yet set, set it to $submittedData so that
             // the erroneous data is accessible on the form.
@@ -711,7 +709,15 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function isSynchronized()
     {
-        return $this->synchronized;
+        return null === $this->transformationFailure;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTransformationFailure()
+    {
+        return $this->transformationFailure;
     }
 
     /**

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
 /**
  * A form group bundling multiple forms in a hierarchical structure.
  *
@@ -230,9 +232,19 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the data in the different formats is synchronized.
      *
+     * If the data is not synchronized, you can get the transformation failure
+     * by calling {@link getTransformationFailure()}.
+     *
      * @return bool
      */
     public function isSynchronized();
+
+    /**
+     * Returns the data transformation failure, if any.
+     *
+     * @return TransformationFailedException|null The transformation failure
+     */
+    public function getTransformationFailure();
 
     /**
      * Initializes the form tree.

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -319,7 +319,7 @@ class FormDataExtractorTest extends \PHPUnit_Framework_TestCase
                 'norm' => "'Foobar'",
             ),
             'errors' => array(
-                array('message' => 'Invalid!', 'origin' => null, 'cause' => null),
+                array('message' => 'Invalid!', 'origin' => null, 'trace' => array()),
             ),
             'synchronized' => 'true',
         ), $this->dataExtractor->extractSubmittedData($form));
@@ -340,7 +340,7 @@ class FormDataExtractorTest extends \PHPUnit_Framework_TestCase
                 'norm' => "'Foobar'",
             ),
             'errors' => array(
-                array('message' => 'Invalid!', 'origin' => spl_object_hash($form), 'cause' => null),
+                array('message' => 'Invalid!', 'origin' => spl_object_hash($form), 'trace' => array()),
             ),
             'synchronized' => 'true',
         ), $this->dataExtractor->extractSubmittedData($form));
@@ -360,7 +360,12 @@ class FormDataExtractorTest extends \PHPUnit_Framework_TestCase
                 'norm' => "'Foobar'",
             ),
             'errors' => array(
-                array('message' => 'Invalid!', 'origin' => null, 'cause' => 'object(Exception)'),
+                array('message' => 'Invalid!', 'origin' => null, 'trace' => array(
+                    array(
+                        'class' => "'Exception'",
+                        'message' => "''",
+                    ),
+                )),
             ),
             'synchronized' => 'true',
         ), $this->dataExtractor->extractSubmittedData($form));

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -225,11 +225,14 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($form, new Form());
 
+        $is2Dot4Api = Validation::API_VERSION_2_4 === $this->getApiVersion();
+
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
             ->setParameter('{{ foo }}', 'bar')
             ->setInvalidValue('foo')
             ->setCode(Form::ERR_INVALID)
+            ->setCause($is2Dot4Api ? null : $form->getTransformationFailure())
             ->assertRaised();
     }
 
@@ -259,11 +262,14 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($form, new Form());
 
+        $is2Dot4Api = Validation::API_VERSION_2_4 === $this->getApiVersion();
+
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
             ->setParameter('{{ foo }}', 'bar')
             ->setInvalidValue('foo')
             ->setCode(Form::ERR_INVALID)
+            ->setCause($is2Dot4Api ? null : $form->getTransformationFailure())
             ->assertRaised();
     }
 
@@ -293,10 +299,13 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($form, new Form());
 
+        $is2Dot4Api = Validation::API_VERSION_2_4 === $this->getApiVersion();
+
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
             ->setInvalidValue('foo')
             ->setCode(Form::ERR_INVALID)
+            ->setCause($is2Dot4Api ? null : $form->getTransformationFailure())
             ->assertRaised();
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5607 |
| License | MIT |
| Doc PR | - |

This is a follow-up PR for #12052. With this change, the full trace of form errors is now displayed in the web debugger:

![error](https://cloud.githubusercontent.com/assets/176399/4419637/85facd14-456d-11e4-8c70-0e8802a586ec.png)

If a violation was caused by a TransformationFailedException, the exception is now accessible through the `getCause()` method of the violation. Additionally, you can access `Form::getTransformationFailure()` to retrieve the exception.
