### PR TITLE
[Doctrine][DependencyInjection] Make a test less fragile.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -132,7 +132,11 @@ class RegisterEventListenersAndSubscribersPassTest extends \PHPUnit_Framework_Te
         ;
 
         $this->process($container);
-        $this->assertEquals(array('c', 'd', 'e', 'b', 'a'), $this->getServiceOrder($container, 'addEventSubscriber'));
+        $serviceOrder = $this->getServiceOrder($container, 'addEventSubscriber');
+        $unordered = array_splice($serviceOrder, 0, 3);
+        sort($unordered);
+        $this->assertEquals(array('c', 'd', 'e'), $unordered);
+        $this->assertEquals(array('b', 'a'), $serviceOrder);
     }
 
     public function testProcessNoTaggedServices()


### PR DESCRIPTION
The test checks that a few items are ordered according to the value of their 'priority' attribute. However, a few of the items have the same value of this attribute. RegisterEventListenersAndSubscribersPass doesn't use a stable sorting, yet the test asserts that items that are 'equal' shall go in the original order. Modified so that the order of the original items is not checked.

| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [none] |
| License | MIT |
| Doc PR | [none] |
