### PR TITLE
[DX][Translation][3.0] Adding support for intl message formatter and decoupling default formatter

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\Translation\Translator;
-use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Formatter\DefaultMessageFormatter;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 
 class TranslationExtensionTest extends \PHPUnit_Framework_TestCase
@@ -34,7 +34,7 @@ class TranslationExtensionTest extends \PHPUnit_Framework_TestCase
             print $template."\n";
             $loader = new \Twig_Loader_Array(array('index' => $template));
             $twig = new \Twig_Environment($loader, array('debug' => true, 'cache' => false));
-            $twig->addExtension(new TranslationExtension(new Translator('en', new MessageSelector())));
+            $twig->addExtension(new TranslationExtension(new Translator('en', new DefaultMessageFormatter())));
 
             echo $twig->compile($twig->parse($twig->tokenize($twig->getLoader()->getSource('index'), 'index')))."\n\n";
             $this->assertEquals($expected, $this->getTemplate($template)->render($variables));
@@ -136,7 +136,7 @@ class TranslationExtensionTest extends \PHPUnit_Framework_TestCase
             ',
         );
 
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foo (messages)'), 'en');
         $translator->addResource('array', array('foo' => 'foo (custom)'), 'en', 'custom');
@@ -150,7 +150,7 @@ class TranslationExtensionTest extends \PHPUnit_Framework_TestCase
     protected function getTemplate($template, $translator = null)
     {
         if (null === $translator) {
-            $translator = new Translator('en', new MessageSelector());
+            $translator = new Translator('en', new DefaultMessageFormatter());
         }
 
         if (is_array($template)) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -450,6 +450,7 @@ class Configuration implements ConfigurationInterface
                     ->info('translator configuration')
                     ->canBeEnabled()
                     ->children()
+                        ->scalarNode('formatter')->defaultValue('default')->end()
                         ->scalarNode('fallback')->defaultValue('en')->end()
                         ->booleanNode('logging')->defaultValue($this->debug)->end()
                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -637,6 +637,9 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('translator.logging', $config['logging']);
 
+        // Modify translator formatter
+        $container->setAlias('translator.formatter', 'translator.formatter.' . $config['formatter']);
+
         // Discover translation directories
         $dirs = array();
         if (class_exists('Symfony\Component\Validator\Validator')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -158,6 +158,7 @@
 
     <xsd:complexType name="translator">
         <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="formatter" type="xsd:string" />
         <xsd:attribute name="fallback" type="xsd:string" />
     </xsd:complexType>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -8,7 +8,9 @@
         <parameter key="translator.class">Symfony\Bundle\FrameworkBundle\Translation\Translator</parameter>
         <parameter key="translator.logging.class">Symfony\Component\Translation\LoggingTranslator</parameter>
         <parameter key="translator.identity.class">Symfony\Component\Translation\IdentityTranslator</parameter>
-        <parameter key="translator.selector.class">Symfony\Component\Translation\MessageSelector</parameter>
+        <parameter key="translator.formatter.intl.class">Symfony\Component\Translation\Formatter\IntlMessageFormatter</parameter>
+        <parameter key="translator.formatter.default.class">Symfony\Component\Translation\Formatter\DefaultMessageFormatter</parameter>
+        <parameter key="translator.selector.class">Symfony\Component\Translation\Formatter\MessageSelector</parameter>
         <parameter key="translation.loader.php.class">Symfony\Component\Translation\Loader\PhpFileLoader</parameter>
         <parameter key="translation.loader.yml.class">Symfony\Component\Translation\Loader\YamlFileLoader</parameter>
         <parameter key="translation.loader.xliff.class">Symfony\Component\Translation\Loader\XliffFileLoader</parameter>
@@ -39,7 +41,7 @@
     <services>
         <service id="translator.default" class="%translator.class%">
             <argument type="service" id="service_container" />
-            <argument type="service" id="translator.selector" />
+            <argument type="service" id="translator.formatter" />
             <argument type="collection" /> <!-- translation loaders -->
             <argument type="collection">
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>
@@ -54,6 +56,14 @@
         </service>
 
         <service id="translator" class="%translator.identity.class%">
+            <argument type="service" id="translator.formatter" />
+        </service>
+
+        <service id="translator.formatter" alias="translator.formatter.default" />
+
+        <service id="translator.formatter.intl" class="%translator.formatter.intl.class%" public="false" />
+
+        <service id="translator.formatter.default" class="%translator.formatter.default.class%" public="false">
             <argument type="service" id="translator.selector" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -121,9 +121,10 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'collect'              => true,
             ),
             'translator'          => array(
-                'enabled'  => false,
-                'fallback' => 'en',
-                'logging'  => true,
+                'enabled'   => false,
+                'formatter' => 'default',
+                'fallback'  => 'en',
+                'logging'   => true,
             ),
             'validation'          => array(
                 'enabled'            => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Formatter\DefaultMessageFormatter;
 
 class TranslatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -128,7 +128,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($requestStack))
         ;
 
-        $translator = new Translator($container, new MessageSelector());
+        $translator = new Translator($container, new DefaultMessageFormatter());
 
         if ($inRequestScope) {
             $this->assertSame('en', $translator->getLocale());
@@ -171,7 +171,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($requestStack))
         ;
 
-        $translator = new Translator($container, new MessageSelector());
+        $translator = new Translator($container, new DefaultMessageFormatter());
         $this->assertSame('en-US', $translator->getLocale());
     }
 
@@ -259,7 +259,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     {
         $translator = new $translatorClass(
             $this->getContainer($loader),
-            new MessageSelector(),
+            new DefaultMessageFormatter(),
             array('loader' => array('loader')),
             $options
         );

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Translation;
 
 use Symfony\Component\Translation\Translator as BaseTranslator;
-use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -38,14 +38,14 @@ class Translator extends BaseTranslator
      *   * cache_dir: The cache directory (or null to disable caching)
      *   * debug:     Whether to enable debugging or not (false by default)
      *
-     * @param ContainerInterface $container A ContainerInterface instance
-     * @param MessageSelector    $selector  The message selector for pluralization
-     * @param array              $loaderIds An array of loader Ids
-     * @param array              $options   An array of options
+     * @param ContainerInterface        $container A ContainerInterface instance
+     * @param MessageFormatterInterface $selector  The message formatter
+     * @param array                     $loaderIds An array of loader Ids
+     * @param array                     $options   An array of options
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array())
+    public function __construct(ContainerInterface $container, MessageFormatterInterface $formatter, $loaderIds = array(), array $options = array())
     {
         $this->container = $container;
         $this->loaderIds = $loaderIds;
@@ -57,7 +57,7 @@ class Translator extends BaseTranslator
 
         $this->options = array_merge($this->options, $options);
 
-        parent::__construct(null, $selector, $this->options['cache_dir'], $this->options['debug']);
+        parent::__construct(null, $formatter, $this->options['cache_dir'], $this->options['debug']);
     }
 
     /**

--- a/src/Symfony/Component/Translation/Formatter/DefaultMessageFormatter.php
+++ b/src/Symfony/Component/Translation/Formatter/DefaultMessageFormatter.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Formatter;
+
+/**
+ * DefaultMessageFormatter.
+ *
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ *
+ * @api
+ */
+class DefaultMessageFormatter implements MessageFormatterInterface
+{
+    /**
+     * @var MessageSelector
+     */
+    protected $selector;
+
+    /**
+     * Constructor.
+     *
+     * @param MessageSelector $selector Message selector to choose pluralization messages.
+     */
+    public function __construct(MessageSelector $selector = null)
+    {
+        $this->selector = $selector ?: new MessageSelector();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function format($locale, $id, $number = null, array $arguments = array())
+    {
+        $pattern = ($number !== null)
+            ? $this->selector->choose($id, (int) $number, $locale)
+            : $id;
+
+        return strtr($pattern, $arguments);
+    }
+}

--- a/src/Symfony/Component/Translation/Formatter/Interval.php
+++ b/src/Symfony/Component/Translation/Formatter/Interval.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Translation;
+namespace Symfony\Component\Translation\Formatter;
 
 /**
  * Tests if a given number belongs to a given math interval.

--- a/src/Symfony/Component/Translation/Formatter/IntlMessageFormatter.php
+++ b/src/Symfony/Component/Translation/Formatter/IntlMessageFormatter.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Formatter;
+
+/**
+ * IntlMessageFormatter.
+ *
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ *
+ * @api
+ */
+class IntlMessageFormatter implements MessageFormatterInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function format($locale, $id, $number = null, array $arguments = array())
+    {
+        if ($number !== null) {
+            array_unshift($arguments, $number);
+        }
+
+        $formatter = new \MessageFormatter($locale, $id);
+
+        if ( ! $formatter) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid message format. Reason: %s (error #%d)',
+                    $formatter->getErrorMessage(),
+                    $formatter->getErrorCode()
+                )
+            );
+        }
+
+        $message = $formatter->format($arguments);
+
+        if ($formatter->getErrorCode() !== U_ZERO_ERROR) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unable to format message. Reason: %s (error #%s)',
+                    $formatter->getErrorMessage(),
+                    $formatter->getErrorCode()
+                )
+            );
+        }
+
+        return $message;
+    }
+}

--- a/src/Symfony/Component/Translation/Formatter/MessageFormatterInterface.php
+++ b/src/Symfony/Component/Translation/Formatter/MessageFormatterInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Formatter;
+
+/**
+ * MessageFormatterInterface.
+ *
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ *
+ * @api
+ */
+interface MessageFormatterInterface
+{
+    /**
+     * Formats a lozalized message pattern with given arguments.
+     *
+     * @param string       $locale    The message locale
+     * @param string       $id        The message id (may also be an object that can be cast to string)
+     * @param integer|null $number    The number to use to find the indice of the message (if exists)
+     * @param array        $arguments An array of parameters for the message
+     *
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @api
+     */
+    public function format($locale, $id, $number = null, array $arguments = array());
+}

--- a/src/Symfony/Component/Translation/Formatter/MessageSelector.php
+++ b/src/Symfony/Component/Translation/Formatter/MessageSelector.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Translation;
+namespace Symfony\Component\Translation\Formatter;
 
 /**
  * MessageSelector.

--- a/src/Symfony/Component/Translation/Formatter/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/Formatter/PluralizationRules.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Translation;
+namespace Symfony\Component\Translation\Formatter;
 
 /**
  * Returns the plural rules for a given locale.

--- a/src/Symfony/Component/Translation/IdentityTranslator.php
+++ b/src/Symfony/Component/Translation/IdentityTranslator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Translation;
 
+use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
+
 /**
  * IdentityTranslator does not translate anything.
  *
@@ -20,19 +22,19 @@ namespace Symfony\Component\Translation;
  */
 class IdentityTranslator implements TranslatorInterface
 {
-    private $selector;
+    private $formatter;
     private $locale;
 
     /**
      * Constructor.
      *
-     * @param MessageSelector|null $selector The message selector for pluralization
+     * @param MessageFormatterInterface $formatter The message formatter
      *
      * @api
      */
-    public function __construct(MessageSelector $selector = null)
+    public function __construct(MessageFormatterInterface $formatter)
     {
-        $this->selector = $selector ?: new MessageSelector();
+        $this->formatter = $formatter;
     }
 
     /**
@@ -62,7 +64,11 @@ class IdentityTranslator implements TranslatorInterface
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
-        return strtr((string) $id, $parameters);
+        if (!$locale) {
+            $locale = $this->getLocale();
+        }
+
+        return $this->formatter->format($locale, (string) $id, null, $parameters);
     }
 
     /**
@@ -72,6 +78,10 @@ class IdentityTranslator implements TranslatorInterface
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
-        return strtr($this->selector->choose((string) $id, (int) $number, $locale ?: $this->getLocale()), $parameters);
+        if (!$locale) {
+            $locale = $this->getLocale();
+        }
+
+        return $this->formatter->format($locale, (string) $id, (integer) $number, $parameters);
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Formatter/DefaultMessageFormatterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/DefaultMessageFormatterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Formatter;
+
+use Symfony\Component\Translation\Formatter\DefaultMessageFormatter;
+
+class DefaultMessageFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideDataForFormat
+     */
+    public function testFormat($expected, $message, $number, $arguments)
+    {
+        $formatter = new DefaultMessageFormatter();
+
+        $this->assertEquals($expected, $formatter->format('en', $message, $number, $arguments));
+    }
+
+    public function provideDataForFormat()
+    {
+        return array(
+            array(
+                'There is one apple',
+                'There is one apple',
+                null,
+                array(),
+            ),
+            array(
+                'There are 5 apples',
+                'There are %count% apples',
+                null,
+                array('%count%' => 5),
+            ),
+            array(
+                'There are 10 apples',
+                '{0} There are no apples|{1} There is one apple|]1,Inf[ There are %count% apples',
+                10,
+                array('%count%' => 10),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideDataForFormatShouldCallChooseWithNumber
+     */
+    public function testFormatShouldCallChooseWithNumber($willCallChoose, $number)
+    {
+        $selector  = $this->mockMessageSelector($willCallChoose);
+        $formatter = new DefaultMessageFormatter($selector);
+
+        $formatter->format('en', 'message_id', $number, array());
+    }
+
+    public function provideDataForFormatShouldCallChooseWithNumber()
+    {
+        return array(
+            array(false, null),
+            array(true, 2),
+        );
+    }
+
+    private function mockMessageSelector($willCallChoose)
+    {
+        $mock = $this->getMock('Symfony\Component\Translation\Formatter\MessageSelector');
+
+        $mock->expects($willCallChoose ? $this->once() : $this->never())
+             ->method('choose')
+             ->will($this->returnValue('Message'));
+
+        return $mock;
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Formatter/IntervalTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/IntervalTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Translation\Tests;
+namespace Symfony\Component\Translation\Tests\Formatter;
 
-use Symfony\Component\Translation\Interval;
+use Symfony\Component\Translation\Formatter\Interval;
 
 class IntervalTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/Translation/Tests/Formatter/IntlMessageFormatterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/IntlMessageFormatterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Formatter;
+
+use Symfony\Component\Translation\Formatter\IntlMessageFormatter;
+
+class IntlMessageFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped(
+              'The Intl extension is not available.'
+            );
+        }
+    }
+
+    /**
+     * @dataProvider provideDataForFormat
+     */
+    public function testFormat($expected, $message, $number, $arguments)
+    {
+        $formatter = new IntlMessageFormatter();
+
+        $this->assertEquals($expected, trim($formatter->format('en', $message, $number, $arguments)));
+    }
+
+    public function provideDataForFormat()
+    {
+        $intlSampleChooseMessage = trim('
+        {gender_of_host, select, 
+            female {
+                {num_guests, plural, offset:1 
+                    =0 {{host} does not give a party.}
+                    =1 {{host} invites {guest} to her party.}
+                    =2 {{host} invites {guest} and one other person to her party.}
+                    other {{host} invites {guest} and # other people to her party.}}}
+            male {
+                {num_guests, plural, offset:1 
+                    =0 {{host} does not give a party.}
+                    =1 {{host} invites {guest} to his party.}
+                    =2 {{host} invites {guest} and one other person to his party.}
+                    other {{host} invites {guest} and # other people to his party.}}}
+            other {
+                {num_guests, plural, offset:1 
+                    =0 {{host} does not give a party.}
+                    =1 {{host} invites {guest} to their party.}
+                    =2 {{host} invites {guest} and one other person to their party.}
+                    other {{host} invites {guest} and # other people to their party.}
+                }
+            }
+        }
+        ');
+
+        return array(
+            array(
+                'There is one apple',
+                'There is one apple',
+                null,
+                array(),
+            ),
+            array(
+                '4,560 monkeys on 123 trees make 37.073 monkeys per tree',
+                '{0,number,integer} monkeys on {1,number,integer} trees make {2,number} monkeys per tree',
+                null,
+                array(4560, 123, 4560/123),
+            ),
+            array(
+                'Fabien invites Guilherme and 9 other people to his party.',
+                $intlSampleChooseMessage,
+                10,
+                array(
+                    'gender_of_host' => 'male',
+                    'num_guests'     => 10,
+                    'host'           => 'Fabien',
+                    'guest'          => 'Guilherme',
+                ),
+            ),
+        );
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Formatter/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/MessageSelectorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Translation\Tests;
+namespace Symfony\Component\Translation\Tests\Formatter;
 
-use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Formatter\MessageSelector;
 
 class MessageSelectorTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/Translation/Tests/Formatter/PluralizationRulesTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/PluralizationRulesTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Translation\Tests;
+namespace Symfony\Component\Translation\Tests\Formatter;
 
-use Symfony\Component\Translation\PluralizationRules;
+use Symfony\Component\Translation\Formatter\PluralizationRules;
 
 /**
  * Test should cover all languages mentioned on http://translate.sourceforge.net/wiki/l10n/pluralforms

--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Translation\Tests;
 
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Translation\Formatter\DefaultMessageFormatter;
 
 class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,7 +22,7 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTrans($expected, $id, $parameters)
     {
-        $translator = new IdentityTranslator();
+        $translator = new IdentityTranslator(new DefaultMessageFormatter());
 
         $this->assertEquals($expected, $translator->trans($id, $parameters));
     }
@@ -31,7 +32,7 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransChoiceWithExplicitLocale($expected, $id, $number, $parameters)
     {
-        $translator = new IdentityTranslator();
+        $translator = new IdentityTranslator(new DefaultMessageFormatter());
         $translator->setLocale('en');
 
         $this->assertEquals($expected, $translator->transChoice($id, $number, $parameters));
@@ -44,14 +45,14 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
     {
         \Locale::setDefault('en');
 
-        $translator = new IdentityTranslator();
+        $translator = new IdentityTranslator(new DefaultMessageFormatter());
 
         $this->assertEquals($expected, $translator->transChoice($id, $number, $parameters));
     }
 
     public function testGetSetLocale()
     {
-        $translator = new IdentityTranslator();
+        $translator = new IdentityTranslator(new DefaultMessageFormatter());
         $translator->setLocale('en');
 
         $this->assertEquals('en', $translator->getLocale());
@@ -62,7 +63,7 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
         // in order to test with "pt_BR"
         IntlTestHelper::requireFullIntl($this);
 
-        $translator = new IdentityTranslator();
+        $translator = new IdentityTranslator(new DefaultMessageFormatter());
 
         \Locale::setDefault('en');
         $this->assertEquals('en', $translator->getLocale());

--- a/src/Symfony/Component/Translation/Tests/LoggingTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/LoggingTranslatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Translation\Tests;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\LoggingTranslator;
 use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Formatter\DefaultMessageFormatter;
 
 class LoggingTranslatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -32,7 +33,7 @@ class LoggingTranslatorTest extends \PHPUnit_Framework_TestCase
             ->with('Translation not found.')
         ;
 
-        $translator = new Translator('ar');
+        $translator = new Translator('ar', new DefaultMessageFormatter());
         $loggableTranslator = new LoggingTranslator($translator, $logger);
         $loggableTranslator->transChoice('some_message2', 10, array('%count%' => 10));
         $loggableTranslator->trans('bar');
@@ -46,7 +47,7 @@ class LoggingTranslatorTest extends \PHPUnit_Framework_TestCase
             ->with('Translation use fallback catalogue.')
         ;
 
-        $translator = new Translator('ar');
+        $translator = new Translator('ar', new DefaultMessageFormatter());
         $translator->setFallbackLocales(array('en'));
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('some_message2' => 'one thing|%count% things'), 'en');

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Translation\Tests;
 
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\MessageCatalogue;
-use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Formatter\DefaultMessageFormatter;
 
 class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
 {
@@ -199,7 +199,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
 
     public function getTranslator($loader, $cacheDir = null, $translatorClass = '\Symfony\Component\Translation\Translator')
     {
-        $translator = new $translatorClass('fr', new MessageSelector(), $cacheDir);
+        $translator = new $translatorClass('fr', new DefaultMessageFormatter(), $cacheDir);
 
         $translator->addLoader('loader', $loader);
         $translator->addResource('loader', 'foo', 'fr');

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Translation\Tests;
 
 use Symfony\Component\Translation\Translator;
-use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Formatter\DefaultMessageFormatter;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -24,7 +24,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorInvalidLocale($locale)
     {
-        $translator = new Translator($locale, new MessageSelector());
+        $translator = new Translator($locale, new DefaultMessageFormatter());
     }
 
     /**
@@ -32,21 +32,21 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorValidLocale($locale)
     {
-        $translator = new Translator($locale, new MessageSelector());
+        $translator = new Translator($locale, new DefaultMessageFormatter());
 
         $this->assertEquals($locale, $translator->getLocale());
     }
 
     public function testConstructorWithoutLocale()
     {
-        $translator = new Translator(null, new MessageSelector());
+        $translator = new Translator(null, new DefaultMessageFormatter());
 
         $this->assertNull($translator->getLocale());
     }
 
     public function testSetGetLocale()
     {
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
 
         $this->assertEquals('en', $translator->getLocale());
 
@@ -60,7 +60,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetInvalidLocale($locale)
     {
-        $translator = new Translator('fr', new MessageSelector());
+        $translator = new Translator('fr', new DefaultMessageFormatter());
         $translator->setLocale($locale);
     }
 
@@ -69,7 +69,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetValidLocale($locale)
     {
-        $translator = new Translator($locale, new MessageSelector());
+        $translator = new Translator($locale, new DefaultMessageFormatter());
         $translator->setLocale($locale);
 
         $this->assertEquals($locale, $translator->getLocale());
@@ -77,7 +77,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCatalogue()
     {
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
 
         $this->assertEquals(new MessageCatalogue('en'), $translator->getCatalogue());
 
@@ -87,7 +87,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFallbackLocales()
     {
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en');
         $translator->addResource('array', array('bar' => 'foobar'), 'fr');
@@ -101,7 +101,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFallbackLocalesMultiple()
     {
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foo (en)'), 'en');
         $translator->addResource('array', array('bar' => 'bar (fr)'), 'fr');
@@ -119,7 +119,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetFallbackInvalidLocales($locale)
     {
-        $translator = new Translator('fr', new MessageSelector());
+        $translator = new Translator('fr', new DefaultMessageFormatter());
         $translator->setFallbackLocales(array('fr', $locale));
     }
 
@@ -128,14 +128,14 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetFallbackValidLocales($locale)
     {
-        $translator = new Translator($locale, new MessageSelector());
+        $translator = new Translator($locale, new DefaultMessageFormatter());
         $translator->setFallbackLocales(array('fr', $locale));
         // no assertion. this method just asserts that no exception is thrown
     }
 
     public function testTransWithFallbackLocale()
     {
-        $translator = new Translator('fr_FR');
+        $translator = new Translator('fr_FR', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en_US');
         $translator->addResource('array', array('bar' => 'foobar'), 'en');
@@ -151,7 +151,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddResourceInvalidLocales($locale)
     {
-        $translator = new Translator('fr', new MessageSelector());
+        $translator = new Translator('fr', new DefaultMessageFormatter());
         $translator->addResource('array', array('foo' => 'foofoo'), $locale);
     }
 
@@ -160,14 +160,14 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddResourceValidLocales($locale)
     {
-        $translator = new Translator('fr', new MessageSelector());
+        $translator = new Translator('fr', new DefaultMessageFormatter());
         $translator->addResource('array', array('foo' => 'foofoo'), $locale);
         // no assertion. this method just asserts that no exception is thrown
     }
 
     public function testAddResourceAfterTrans()
     {
-        $translator = new Translator('fr');
+        $translator = new Translator('fr', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
 
         $translator->setFallbackLocale(array('en'));
@@ -186,7 +186,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     public function testTransWithoutFallbackLocaleFile($format, $loader)
     {
         $loaderClass = 'Symfony\\Component\\Translation\\Loader\\'.$loader;
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader($format, new $loaderClass());
         $translator->addResource($format, __DIR__.'/fixtures/non-existing', 'en');
         $translator->addResource($format, __DIR__.'/fixtures/resources.'.$format, 'en');
@@ -201,7 +201,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     public function testTransWithFallbackLocaleFile($format, $loader)
     {
         $loaderClass = 'Symfony\\Component\\Translation\\Loader\\'.$loader;
-        $translator = new Translator('en_GB');
+        $translator = new Translator('en_GB', new DefaultMessageFormatter());
         $translator->addLoader($format, new $loaderClass());
         $translator->addResource($format, __DIR__.'/fixtures/non-existing', 'en_GB');
         $translator->addResource($format, __DIR__.'/fixtures/resources.'.$format, 'en', 'resources');
@@ -211,7 +211,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransWithFallbackLocaleBis()
     {
-        $translator = new Translator('en_US');
+        $translator = new Translator('en_US', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en_US');
         $translator->addResource('array', array('bar' => 'foobar'), 'en');
@@ -220,7 +220,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransWithFallbackLocaleTer()
     {
-        $translator = new Translator('fr_FR');
+        $translator = new Translator('fr_FR', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foo (en_US)'), 'en_US');
         $translator->addResource('array', array('bar' => 'bar (en)'), 'en');
@@ -233,7 +233,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransNonExistentWithFallback()
     {
-        $translator = new Translator('fr');
+        $translator = new Translator('fr', new DefaultMessageFormatter());
         $translator->setFallbackLocales(array('en'));
         $translator->addLoader('array', new ArrayLoader());
         $this->assertEquals('non-existent', $translator->trans('non-existent'));
@@ -244,7 +244,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testWhenAResourceHasNoRegisteredLoader()
     {
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en');
 
         $translator->trans('foo');
@@ -255,7 +255,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTrans($expected, $id, $translation, $parameters, $locale, $domain)
     {
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array((string) $id => $translation), $locale, $domain);
 
@@ -268,7 +268,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransInvalidLocale($locale)
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en');
 
@@ -280,7 +280,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransValidLocale($locale)
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en');
 
@@ -293,7 +293,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testFlattenedTrans($expected, $messages, $id)
     {
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', $messages, 'fr', '');
 
@@ -305,7 +305,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransChoice($expected, $id, $translation, $number, $parameters, $locale, $domain)
     {
-        $translator = new Translator('en');
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array((string) $id => $translation), $locale, $domain);
 
@@ -318,7 +318,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransChoiceInvalidLocale($locale)
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en');
 
@@ -330,7 +330,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransChoiceValidLocale($locale)
     {
-        $translator = new Translator('en', new MessageSelector());
+        $translator = new Translator('en', new DefaultMessageFormatter());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en');
 
@@ -444,7 +444,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransChoiceFallback()
     {
-        $translator = new Translator('ru');
+        $translator = new Translator('ru', new DefaultMessageFormatter());
         $translator->setFallbackLocales(array('en'));
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('some_message2' => 'one thing|%count% things'), 'en');
@@ -454,7 +454,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransChoiceFallbackBis()
     {
-        $translator = new Translator('ru');
+        $translator = new Translator('ru', new DefaultMessageFormatter());
         $translator->setFallbackLocales(array('en_US', 'en'));
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('some_message2' => 'one thing|%count% things'), 'en_US');
@@ -464,7 +464,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransChoiceFallbackWithNoTranslation()
     {
-        $translator = new Translator('ru');
+        $translator = new Translator('ru', new DefaultMessageFormatter());
         $translator->setFallbackLocales(array('en'));
         $translator->addLoader('array', new ArrayLoader());
 
@@ -482,7 +482,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $_locale = !is_null($locale) ? $locale : reset($locales);
         $locales = array_slice($locales, 0, array_search($_locale, $locales));
 
-        $translator = new Translator($_locale, new MessageSelector());
+        $translator = new Translator($_locale, new DefaultMessageFormatter());
         $translator->setFallbackLocales(array_reverse($locales));
         $translator->addLoader('array', new ArrayLoader());
         foreach ($resources as $_locale => $domainMessages) {


### PR DESCRIPTION
Adding support for intl message formatter and decoupling default formatter.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #4797, #4884, #5547, #6009, #10152, #10671, #10684, one item in #11742, #11948, one item in #12050 |
| License | MIT |
| Doc PR | n/a |
