### PR TITLE
[Debug] expose object_handle

### DIFF
--- a/src/Symfony/Component/Debug/Resources/ext/README.rst
+++ b/src/Symfony/Component/Debug/Resources/ext/README.rst
@@ -33,12 +33,13 @@ Its behavior is about the same as:
                     'object_class' => get_class($array[$key]),
                     'object_refcount' => /* internal object refcount of $array[$key] */,
                     'object_hash' => spl_object_hash($array[$key]),
+                    'object_handle' => /* internal object handle $array[$key] */,
                 );
                 break;
 
             case 'resource':
                 $info += array(
-                    'resource_id' => (int) substr((string) $array[$key], 13),
+                    'resource_handle' => (int) $array[$key],
                     'resource_type' => get_resource_type($array[$key]),
                     'resource_refcount' => /* internal resource refcount of $array[$key] */,
                 );

--- a/src/Symfony/Component/Debug/Resources/ext/symfony_debug.c
+++ b/src/Symfony/Component/Debug/Resources/ext/symfony_debug.c
@@ -72,10 +72,11 @@ PHP_FUNCTION(symfony_zval_info)
 		add_assoc_stringl(return_value, "object_class", (char *)Z_OBJCE_P(arg)->name, Z_OBJCE_P(arg)->name_length, 1);
 		add_assoc_long(return_value, "object_refcount", EG(objects_store).object_buckets[Z_OBJ_HANDLE_P(arg)].bucket.obj.refcount);
 		add_assoc_string(return_value, "object_hash", hash, 1);
+		add_assoc_long(return_value, "object_handle", Z_OBJ_HANDLE_P(arg));
 	} else if (Z_TYPE_P(arg) == IS_ARRAY) {
 		add_assoc_long(return_value, "array_count", zend_hash_num_elements(Z_ARRVAL_P(arg)));
 	} else if(Z_TYPE_P(arg) == IS_RESOURCE) {
-		add_assoc_long(return_value, "resource_id", Z_LVAL_P(arg));
+		add_assoc_long(return_value, "resource_handle", Z_LVAL_P(arg));
 		add_assoc_string(return_value, "resource_type", (char *)_symfony_debug_get_resource_type(Z_LVAL_P(arg)), 1);
 		add_assoc_long(return_value, "resource_refcount", _symfony_debug_get_resource_refcount(Z_LVAL_P(arg)));
 	} else if (Z_TYPE_P(arg) == IS_STRING) {

--- a/src/Symfony/Component/Debug/Resources/ext/tests/001.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/001.phpt
@@ -72,7 +72,7 @@ array(5) {
   ["strlen"]=>
   int(6)
 }
-array(7) {
+array(8) {
   ["type"]=>
   string(6) "object"
   ["zval_hash"]=>
@@ -87,6 +87,8 @@ array(7) {
   int(1)
   ["object_hash"]=>
   string(32) "%s"
+  ["object_handle"]=>
+  int(1)
 }
 array(5) {
   ["type"]=>
@@ -109,7 +111,7 @@ array(7) {
   int(2)
   ["zval_isref"]=>
   bool(false)
-  ["resource_id"]=>
+  ["resource_handle"]=>
   int(4)
   ["resource_type"]=>
   string(6) "stream"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is a small enhancement to the symfony debug C extension that allows fetching an object's handle.
This is the `#number` as displayed by var_dump():
`class stdClass**#1** (0) {}`

This is required for VarDumper to be able to expose objects' handles and thus have more precise dumps.
It will allow inspecting "same" relationships between two _different_ dumps.
