### PR TITLE
[Serializer] Add deserializing to an array of objects

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -99,6 +99,37 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     }
 
     /**
+     * Deserializes data into an array of the given type.
+     *
+     * @param mixed  $data
+     * @param string $type
+     * @param string $format
+     * @param array  $context
+     *
+     * @return object
+     *
+     * @throws UnexpectedValueException
+     */
+    public function deserializeCollection($data, $type, $format, array $context = array())
+    {
+        if (!$this->supportsDecoding($format)) {
+            throw new UnexpectedValueException(sprintf('Deserialization for the format %s is not supported', $format));
+        }
+
+        $data = $this->decode($data, $format, $context);
+
+        if (!is_array($data)) {
+            throw new UnexpectedValueException(sprintf('Could not deserialize value into array: %s.', $data));
+        }
+
+        foreach ($data as $key => $val) {
+            $data[$key] = $this->denormalizeObject($datum, $type, $format, $context);
+        }
+
+        return $data;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function normalize($data, $format = null, array $context = array())

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -124,6 +124,23 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, $result->toArray());
     }
 
+    public function testDeserializeCollection()
+    {
+        $this->serializer = new Serializer(array(new GetSetMethodNormalizer()), array('json' => new JsonEncoder()));
+        $data = array(array('title' => 'foo', 'numbers' => array(5, 3)), array('title' => 'bar', 'numbers' => array(2, 8)));
+        $result = $this->serializer->deserializeCollection(json_encode($data), '\Symfony\Component\Serializer\Tests\Model', 'json');
+        $this->assertContainsOnlyInstancesOf('\Symfony\Component\Serializer\Tests\Model', $result);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     */
+    public function testDeserializeInvalidCollection()
+    {
+        $this->serializer = new Serializer(array(new GetSetMethodNormalizer()), array('json' => new JsonEncoder()));
+        $this->serializer->deserializeCollection('foo', '\Symfony\Component\Serializer\Tests\Model', 'json');
+    }
+
     public function testDeserializeUseCache()
     {
         $this->serializer = new Serializer(array(new GetSetMethodNormalizer()), array('json' => new JsonEncoder()));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | m/a |
| License | MIT |
| Doc PR | tbc |

Adds a `deserializeCollection` method to the Serializer so that collections of models can be deserialized without  having to split out the decoding and denormalization stages yourself, or having to create a custom denormalizer for the collection.
