### PR TITLE
[EventDispatcher] Moves the logic of addSubscriberService to the compiler pass

### DIFF
--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -144,7 +144,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
                 $this->listenerIds[$eventName][] = array($serviceId, $params, 0);
             } elseif (is_string($params[0])) {
                 $this->listenerIds[$eventName][] = array($serviceId, $params[0], isset($params[1]) ? $params[1] : 0);
-            } else {
+            } elseif (is_array($params[0])) {
                 foreach ($params as $listener) {
                     $this->listenerIds[$eventName][] = array($serviceId, $listener[0], isset($listener[1]) ? $listener[1] : 0);
                 }

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -100,7 +100,17 @@ class RegisterListenersPass implements CompilerPassInterface
                 throw new \InvalidArgumentException(sprintf('Service "%s" must implement interface "%s".', $id, $interface));
             }
 
-            $definition->addMethodCall('addSubscriberService', array($id, $class));
+            foreach ($class::getSubscribedEvents() as $eventName => $params) {
+                if (is_string($params)) {
+                    $definition->addMethodCall('addListenerService', array($eventName, array($id, $params), 0));
+                } elseif (is_string($params[0])) {
+                    $definition->addMethodCall('addListenerService', array($eventName, array($id, $params[0]), isset($params[1]) ? $params[1] : 0));
+                } elseif (is_array($params[0])) {
+                    foreach ($params as $listener) {
+                        $definition->addMethodCall('addListenerService', array($eventName, array($id, $listener[0]), isset($listener[1]) ? $listener[1] : 0));
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -138,5 +138,6 @@ class SubscriberService implements \Symfony\Component\EventDispatcher\EventSubsc
 {
     public static function getSubscribedEvents()
     {
+        return array();
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently when an event subscribers is registered as a to be lazy loaded service, the corresponding class (and so at least a file) is loaded and parsed even if this subscriber isn't used at all. And when you have a lot of events subscribers (with phpBB extensions we can easily have dozens of subscribers) it could represent a lot of files (due to the use statements we rarely have only one file to load) and on some systems (i.e if you don't have an opcode cache) it can be important on the performance side.
