### PR TITLE
[DX] Moved Security constants to a final class instead of a long named interface

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Form/UserLoginFormType.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Form/UserLoginFormType.php
@@ -17,8 +17,8 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Security\Core\Security;
 
 /**
  * Form type for use with the Security component's form-based authentication
@@ -58,10 +58,10 @@ class UserLoginFormType extends AbstractType
          * session for an authentication error and last username.
          */
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($request) {
-            if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
-                $error = $request->attributes->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+            if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+                $error = $request->attributes->get(Security::AUTHENTICATION_ERROR);
             } else {
-                $error = $request->getSession()->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+                $error = $request->getSession()->get(Security::AUTHENTICATION_ERROR);
             }
 
             if ($error) {
@@ -69,7 +69,7 @@ class UserLoginFormType extends AbstractType
             }
 
             $event->setData(array_replace((array) $event->getData(), array(
-                'username' => $request->getSession()->get(SecurityContextInterface::LAST_USERNAME),
+                'username' => $request->getSession()->get(Security::LAST_USERNAME),
             )));
         });
     }

--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\Security\Core;
 
 /**
- * The SecuritySessionStorageInterface.
+ * This class holds security information.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-interface SecuritySessionStorageInterface
+final class Security
 {
     const ACCESS_DENIED_ERROR  = '_security.403_error';
     const AUTHENTICATION_ERROR = '_security.last_error';

--- a/src/Symfony/Component/Security/Core/SecurityContextInterface.php
+++ b/src/Symfony/Component/Security/Core/SecurityContextInterface.php
@@ -20,6 +20,9 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @deprecated Deprecated since version 2.6, to be removed in 3.0.
  */
-interface SecurityContextInterface extends TokenStorageInterface, AuthorizationCheckerInterface, SecuritySessionStorageInterface
+interface SecurityContextInterface extends TokenStorageInterface, AuthorizationCheckerInterface
 {
+    const ACCESS_DENIED_ERROR  = Security::ACCESS_DENIED_ERROR;
+    const AUTHENTICATION_ERROR = Security::AUTHENTICATION_ERROR;
+    const LAST_USERNAME        = Security::LAST_USERNAME;
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Security\Http\Authentication;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Security;
 
 /**
  * Extracts Security Errors from Request
@@ -46,13 +46,13 @@ class AuthenticationUtils
         $session = $request->getSession();
         $authenticationException = null;
 
-        if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
-            $authenticationException = $request->attributes->get(SecurityContextInterface::AUTHENTICATION_ERROR);
-        } elseif ($session !== null && $session->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
-            $authenticationException = $session->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $authenticationException = $request->attributes->get(Security::AUTHENTICATION_ERROR);
+        } elseif ($session !== null && $session->has(Security::AUTHENTICATION_ERROR)) {
+            $authenticationException = $session->get(Security::AUTHENTICATION_ERROR);
 
             if ($clearSession) {
-                $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
+                $session->remove(Security::AUTHENTICATION_ERROR);
             }
         }
 
@@ -66,7 +66,7 @@ class AuthenticationUtils
     {
         $session = $this->getRequest()->getSession();
 
-        return null === $session ? '' : $session->get(SecurityContextInterface::LAST_USERNAME);
+        return null === $session ? '' : $session->get(Security::LAST_USERNAME);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\HttpUtils;
 
 /**
@@ -96,7 +96,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
             }
 
             $subRequest = $this->httpUtils->createRequest($request, $this->options['failure_path']);
-            $subRequest->attributes->set(SecurityContextInterface::AUTHENTICATION_ERROR, $exception);
+            $subRequest->attributes->set(Security::AUTHENTICATION_ERROR, $exception);
 
             return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
         }
@@ -105,7 +105,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
             $this->logger->debug(sprintf('Redirecting to %s', $this->options['failure_path']));
         }
 
-        $request->getSession()->set(SecurityContextInterface::AUTHENTICATION_ERROR, $exception);
+        $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);
 
         return $this->httpUtils->createRedirectResponse($request, $this->options['failure_path']);
     }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterfa
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -218,8 +219,8 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
         $this->securityContext->setToken($token);
 
         $session = $request->getSession();
-        $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
-        $session->remove(SecurityContextInterface::LAST_USERNAME);
+        $session->remove(Security::AUTHENTICATION_ERROR);
+        $session->remove(Security::LAST_USERNAME);
 
         if (null !== $this->dispatcher) {
             $loginEvent = new InteractiveLoginEvent($request, $token);

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
@@ -146,7 +147,7 @@ class ExceptionListener
                 }
             } elseif (null !== $this->errorPage) {
                 $subRequest = $this->httpUtils->createRequest($event->getRequest(), $this->errorPage);
-                $subRequest->attributes->set(SecurityContextInterface::ACCESS_DENIED_ERROR, $exception);
+                $subRequest->attributes->set(Security::ACCESS_DENIED_ERROR, $exception);
 
                 $event->setResponse($event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true));
             }

--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -23,6 +23,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
@@ -114,7 +115,7 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
             $password = $request->get($this->options['password_parameter'], null, true);
         }
 
-        $request->getSession()->set(SecurityContextInterface::LAST_USERNAME, $username);
+        $request->getSession()->set(Security::LAST_USERNAME, $username);
 
         $token = $this->simpleAuthenticator->createToken($request, $username, $password, $this->providerKey);
 

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -25,6 +25,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -93,7 +94,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
             $password = $request->get($this->options['password_parameter'], null, true);
         }
 
-        $request->getSession()->set(SecurityContextInterface::LAST_USERNAME, $username);
+        $request->getSession()->set(Security::LAST_USERNAME, $username);
 
         return $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $password, $this->providerKey));
     }

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Security\Http;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
-
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
@@ -20,6 +18,7 @@ use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Security\Core\Security;
 
 /**
  * Encapsulates the logic needed to create sub-requests, redirect the user, and match URLs.
@@ -77,14 +76,14 @@ class HttpUtils
             $newRequest->setSession($request->getSession());
         }
 
-        if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
-            $newRequest->attributes->set(SecurityContextInterface::AUTHENTICATION_ERROR, $request->attributes->get(SecurityContextInterface::AUTHENTICATION_ERROR));
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $newRequest->attributes->set(Security::AUTHENTICATION_ERROR, $request->attributes->get(Security::AUTHENTICATION_ERROR));
         }
-        if ($request->attributes->has(SecurityContextInterface::ACCESS_DENIED_ERROR)) {
-            $newRequest->attributes->set(SecurityContextInterface::ACCESS_DENIED_ERROR, $request->attributes->get(SecurityContextInterface::ACCESS_DENIED_ERROR));
+        if ($request->attributes->has(Security::ACCESS_DENIED_ERROR)) {
+            $newRequest->attributes->set(Security::ACCESS_DENIED_ERROR, $request->attributes->get(Security::ACCESS_DENIED_ERROR));
         }
-        if ($request->attributes->has(SecurityContextInterface::LAST_USERNAME)) {
-            $newRequest->attributes->set(SecurityContextInterface::LAST_USERNAME, $request->attributes->get(SecurityContextInterface::LAST_USERNAME));
+        if ($request->attributes->has(Security::LAST_USERNAME)) {
+            $newRequest->attributes->set(Security::LAST_USERNAME, $request->attributes->get(Security::LAST_USERNAME));
         }
 
         return $newRequest;

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Authentication;
 
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCase
@@ -47,7 +47,7 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
 
         $subRequest = $this->getRequest();
         $subRequest->attributes->expects($this->once())
-            ->method('set')->with(SecurityContextInterface::AUTHENTICATION_ERROR, $this->exception);
+            ->method('set')->with(Security::AUTHENTICATION_ERROR, $this->exception);
         $this->httpUtils->expects($this->once())
             ->method('createRequest')->with($this->request, '/login')
             ->will($this->returnValue($subRequest));
@@ -79,7 +79,7 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
     public function testExceptionIsPersistedInSession()
     {
         $this->session->expects($this->once())
-            ->method('set')->with(SecurityContextInterface::AUTHENTICATION_ERROR, $this->exception);
+            ->method('set')->with(Security::AUTHENTICATION_ERROR, $this->exception);
 
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, array(), $this->logger);
         $handler->onAuthenticationFailure($this->request, $this->exception);
@@ -91,7 +91,7 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
 
         $subRequest = $this->getRequest();
         $subRequest->attributes->expects($this->once())
-            ->method('set')->with(SecurityContextInterface::AUTHENTICATION_ERROR, $this->exception);
+            ->method('set')->with(Security::AUTHENTICATION_ERROR, $this->exception);
 
         $this->httpUtils->expects($this->once())
             ->method('createRequest')->with($this->request, '/login')

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\Tests;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\HttpUtils;
 
 class HttpUtilsTest extends \PHPUnit_Framework_TestCase
@@ -126,9 +126,9 @@ class HttpUtilsTest extends \PHPUnit_Framework_TestCase
     public function provideSecurityContextAttributes()
     {
         return array(
-            array(SecurityContextInterface::AUTHENTICATION_ERROR),
-            array(SecurityContextInterface::ACCESS_DENIED_ERROR),
-            array(SecurityContextInterface::LAST_USERNAME),
+            array(Security::AUTHENTICATION_ERROR),
+            array(Security::ACCESS_DENIED_ERROR),
+            array(Security::LAST_USERNAME),
         );
     }
 

--- a/src/Symfony/Component/Security/Tests/Core/SecurityContextInterfaceTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/SecurityContextInterfaceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Tests\Core;
+
+use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Security;
+
+class SecurityContextInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test if the BC Layer is working as intended
+     *
+     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
+     */
+    public function testConstantSync()
+    {
+        $this->assertSame(Security::ACCESS_DENIED_ERROR, SecurityContextInterface::ACCESS_DENIED_ERROR);
+        $this->assertSame(Security::AUTHENTICATION_ERROR, SecurityContextInterface::AUTHENTICATION_ERROR);
+        $this->assertSame(Security::LAST_USERNAME, SecurityContextInterface::LAST_USERNAME);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | symfony/symfony-docs#4188 |

This PR is based on feedback from the documentation repository. The DX suggestion was to rename the new `SecuritySessionStorageInterface` to `Security`. This would make it easier to use the constants before 2.6 is released. In this PR I have also update all usages of this constant because an open PR is now merged which used those constants.

List of changes:
- SecurityBundle, usage of constants
- Security Component (core & http), usage of constants
- Tests, usage of constants
- Added a test to verify the sync from `Security` to `SecurityContextInterface` for BC purposes
