### PR TITLE
[FrameworkBundle] remove invalid tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Translation;
 
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\MessageSelector;
@@ -101,78 +100,6 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('\InvalidArgumentException');
         $translator->trans('foo');
-    }
-
-    /**
-     * @dataProvider getGetLocaleData
-     */
-    public function testGetLocale($inRequestScope)
-    {
-        $requestStack = new RequestStack();
-        if ($inRequestScope) {
-            $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-            $request
-                ->expects($this->any())
-                ->method('getLocale')
-                ->will($this->returnValue('en'))
-            ;
-
-            $requestStack->push($request);
-        }
-
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container
-            ->expects($this->once())
-            ->method('get')
-            ->with('request_stack')
-            ->will($this->returnValue($requestStack))
-        ;
-
-        $translator = new Translator($container, new MessageSelector());
-
-        if ($inRequestScope) {
-            $this->assertSame('en', $translator->getLocale());
-        } else {
-            $this->assertNull($translator->getLocale());
-        }
-    }
-
-    public function getGetLocaleData()
-    {
-        return array(
-            array(false),
-            array(true),
-        );
-    }
-
-    public function testGetLocaleWithInvalidLocale()
-    {
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-
-        $request
-            ->expects($this->any())
-            ->method('getLocale')
-            ->will($this->returnValue('foo bar'))
-        ;
-        $request
-            ->expects($this->once())
-            ->method('getDefaultLocale')
-            ->will($this->returnValue('en-US'))
-        ;
-
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
-
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container
-            ->expects($this->once())
-            ->method('get')
-            ->with('request_stack')
-            ->will($this->returnValue($requestStack))
-        ;
-
-        $translator = new Translator($container, new MessageSelector());
-        $this->assertSame('en-US', $translator->getLocale());
     }
 
     protected function getCatalogue($locale, $messages)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

With #12046, the `getLocale()` method isn't overriden anymore by the `Translator` from the FrameworkBundle, but the locale is set by the new `TranslatorListener`. Therefore, the tests ensuring the old behavior are removed.
