### PR TITLE
[HttpKernel] Initialize DataCollector data as array

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
  */
 abstract class DataCollector implements DataCollectorInterface, \Serializable
 {
-    protected $data;
+    protected $data = array();
 
     /**
      * @var ValueExporter


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Without this I'm getting an exception when I open the debug panel without collected data.

```
ContextErrorException: Warning: Invalid argument supplied for foreach()   -
in vendor/symfony/symfony/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php at line 165 
```
