### PR TITLE
[EventDispatcher] fix doc bloc on EventDispatcherInterface

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -64,8 +64,8 @@ interface EventDispatcherInterface
     /**
      * Removes an event listener from the specified events.
      *
-     * @param string|array $eventName The event(s) to remove a listener from
-     * @param callable     $listener  The listener to remove
+     * @param string   $eventName The event to remove a listener from
+     * @param callable $listener  The listener to remove
      */
     public function removeListener($eventName, $listener);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The doc block says that an array of event names is accepted as input, but no implementation is compliant with that description.
