### PR TITLE
Require PHP 5.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/icu": "~1.0",
         "doctrine/common": "~2.2",
         "twig/twig": "~1.12",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

PHP 5.3 [has reached its end of life](http://php.net/archive/2014.php#id2014-08-14-1). The 5.3 series is not maintained anymore. People still using it must upgrade to a newer version.

It's time for new releases of Symfony to depend of PHP 5.4+. Coding standard should be updated too allowing the use of [new features](http://php.net/manual/en/migration54.new-features.php) such as traits and short array syntax.
