### PR TITLE
[Security][Http][Authentication] Make a test pass on HHVM

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -37,8 +37,8 @@ class SimpleAuthenticationHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $this->token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $this->authenticationException = $this->getMock('Symfony\Component\Security\Core\Exception\AuthenticationException',
-                                                        null /*do not mock any methods (the exception is merely passed around)*/);
+        // No methods are invoked on the exception; we just assert on its class
+        $this->authenticationException = new \Symfony\Component\Security\Core\Exception\AuthenticationException();
 
         $this->response = $this->getMock('Symfony\Component\HttpFoundation\Response');
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -37,7 +37,8 @@ class SimpleAuthenticationHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $this->token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $this->authenticationException = $this->getMock('Symfony\Component\Security\Core\Exception\AuthenticationException');
+        $this->authenticationException = $this->getMock('Symfony\Component\Security\Core\Exception\AuthenticationException',
+                                                        null /*do not mock any methods (the exception is merely passed around)*/);
 
         $this->response = $this->getMock('Symfony\Component\HttpFoundation\Response');
     }


### PR DESCRIPTION
The test mocks AuthenticationException mocking all its (and its ancestors') methods. In HHVM's implementation of \Exception, a static method is called upon instantiation. Mock object generator, however, mocks static methods with 'throw' statements. All of these cause the SimpleAuthenticationHandlerTest to fail on HHVM when attempting to instantiate the mock.

The solution is to disable method mocking for AuthenticationException. An instance of this class is merely passed around between the authentication handler and the failure handler, and no methods are invoked on it. Hence, disabling method mocking should not weaken the unit test.

| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [none] |
| License | MIT |
| Doc PR | [none] |
