### PR TITLE
fix components tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
@@ -27,7 +27,10 @@ class AddCacheWarmerPassTest extends \PHPUnit_Framework_TestCase
         );
 
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('findTaggedServiceIds', 'getDefinition', 'hasDefinition')
+        );
 
         $container->expects($this->atLeastOnce())
             ->method('findTaggedServiceIds')
@@ -56,7 +59,10 @@ class AddCacheWarmerPassTest extends \PHPUnit_Framework_TestCase
     public function testThatCompilerPassIsIgnoredIfThereIsNoCacheWarmerDefinition()
     {
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'getDefinition')
+        );
 
         $container->expects($this->never())->method('findTaggedServiceIds');
         $container->expects($this->never())->method('getDefinition');
@@ -73,7 +79,10 @@ class AddCacheWarmerPassTest extends \PHPUnit_Framework_TestCase
     public function testThatCacheWarmersMightBeNotDefined()
     {
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'getDefinition')
+        );
 
         $container->expects($this->atLeastOnce())
             ->method('findTaggedServiceIds')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FragmentRendererPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FragmentRendererPassTest.php
@@ -37,7 +37,10 @@ class FragmentRendererPassTest extends \PHPUnit_Framework_TestCase
             ->method('getClass')
             ->will($this->returnValue('stdClass'));
 
-        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $builder = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'getDefinition')
+        );
         $builder->expects($this->any())
             ->method('hasDefinition')
             ->will($this->returnValue(true));
@@ -73,7 +76,10 @@ class FragmentRendererPassTest extends \PHPUnit_Framework_TestCase
             ->method('getClass')
             ->will($this->returnValue('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\RendererService'));
 
-        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $builder = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'getDefinition')
+        );
         $builder->expects($this->any())
             ->method('hasDefinition')
             ->will($this->returnValue(true));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -17,6 +17,13 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 
 class ProfilerPassTest extends \PHPUnit_Framework_TestCase
 {
+    private $profilerDefinition;
+
+    protected function setUp()
+    {
+        $this->profilerDefinition = new Definition('ProfilerClass');
+    }
+
     /**
      * Tests that collectors that specify a template but no "id" will throw
      * an exception (both are needed if the template is specified). Thus,
@@ -31,10 +38,7 @@ class ProfilerPassTest extends \PHPUnit_Framework_TestCase
             'my_collector_service' => array(0 => array('template' => 'foo')),
         );
 
-        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
-        $builder->expects($this->atLeastOnce())
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue($services));
+        $builder = $this->createContainerMock($services);
 
         $this->setExpectedException('InvalidArgumentException');
 
@@ -49,16 +53,11 @@ class ProfilerPassTest extends \PHPUnit_Framework_TestCase
             'my_collector_service' => array(0 => array('template' => 'foo', 'id' => 'my_collector')),
         );
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
-        $container->expects($this->atLeastOnce())
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue($services));
+        $container = $this->createContainerMock($services);
 
         // fake the getDefinition() to return a Profiler definition
-        $definition = new Definition('ProfilerClass');
         $container->expects($this->atLeastOnce())
-            ->method('getDefinition')
-            ->will($this->returnValue($definition));
+            ->method('getDefinition');
 
         // assert that the data_collector.templates parameter should be set
         $container->expects($this->once())
@@ -69,8 +68,28 @@ class ProfilerPassTest extends \PHPUnit_Framework_TestCase
         $profilerPass->process($container);
 
         // grab the method calls off of the "profiler" definition
-        $methodCalls = $definition->getMethodCalls();
+        $methodCalls = $this->profilerDefinition->getMethodCalls();
         $this->assertCount(1, $methodCalls);
         $this->assertEquals('add', $methodCalls[0][0]); // grab the method part of the first call
+    }
+
+    private function createContainerMock($services)
+    {
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'getDefinition', 'findTaggedServiceIds', 'setParameter')
+        );
+        $container->expects($this->any())
+            ->method('hasDefinition')
+            ->with($this->equalTo('profiler'))
+            ->will($this->returnValue(true));
+        $container->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnValue($this->profilerDefinition));
+        $container->expects($this->atLeastOnce())
+            ->method('findTaggedServiceIds')
+            ->will($this->returnValue($services));
+
+        return $container;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
@@ -24,7 +24,7 @@ class SerializerPassTest extends \PHPUnit_Framework_TestCase
 {
     public function testThrowExceptionWhenNoNormalizers()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder', array('hasDefinition', 'findTaggedServiceIds'));
 
         $container->expects($this->once())
             ->method('hasDefinition')
@@ -45,7 +45,10 @@ class SerializerPassTest extends \PHPUnit_Framework_TestCase
     public function testThrowExceptionWhenNoEncoders()
     {
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'getDefinition')
+        );
 
         $container->expects($this->once())
             ->method('hasDefinition')
@@ -83,7 +86,7 @@ class SerializerPassTest extends \PHPUnit_Framework_TestCase
            new Reference('n3'),
        );
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder', array('findTaggedServiceIds'));
 
         $container->expects($this->atLeastOnce())
             ->method('findTaggedServiceIds')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
@@ -27,7 +27,10 @@ class TranslatorPassTest extends \PHPUnit_Framework_TestCase
             ->method('addMethodCall')
             ->with('addLoader', array('xlf', new Reference('xliff')));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'getDefinition', 'findTaggedServiceIds', 'findDefinition')
+        );
         $container->expects($this->any())
             ->method('hasDefinition')
             ->will($this->returnValue(true));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
@@ -46,7 +46,7 @@ class ConstraintValidatorFactoryTest extends \PHPUnit_Framework_TestCase
         $validator = $this->getMockForAbstractClass('Symfony\\Component\\Validator\\ConstraintValidator');
 
         // mock ContainerBuilder b/c it implements TaggedContainerInterface
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', array('get'));
         $container
             ->expects($this->once())
             ->method('get')

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -19,7 +19,10 @@ class TwigLoaderPassTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $this->builder = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'setAlias', 'getDefinition')
+        );
         $this->chainLoader = new Definition('loader');
         $this->pass = new TwigLoaderPass();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/MergeExtensionConfigurationPassTest.php
@@ -28,7 +28,10 @@ class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoloadMainExtension()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $container = $this->getMock(
+            'Symfony\\Component\\DependencyInjection\\ContainerBuilder',
+            array('getExtensionConfig', 'loadFromExtension', 'getParameterBag')
+        );
         $params = $this->getMock('Symfony\\Component\\DependencyInjection\\ParameterBag\\ParameterBag');
 
         $container->expects($this->at(0))

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -37,7 +37,10 @@ class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
             ->method('getClass')
             ->will($this->returnValue('stdClass'));
 
-        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $builder = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'getDefinition')
+        );
         $builder->expects($this->any())
             ->method('hasDefinition')
             ->will($this->returnValue(true));
@@ -69,7 +72,10 @@ class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
             ->method('getClass')
             ->will($this->returnValue('Symfony\Component\HttpKernel\Tests\DependencyInjection\SubscriberService'));
 
-        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $builder = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'getDefinition')
+        );
         $builder->expects($this->any())
             ->method('hasDefinition')
             ->will($this->returnValue(true));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Since #12006, the `ContainerBuilder` contains the `addExpressionLanguageProvider()` method which references a class from the ExpressionLanguage component. By default, the PHPUnit mock API tries to mock all methods of the class being doubled. Since the ExpressionLanguage component is not required to run the tests, creating the mock objects fails when the mock API fails to mock the `addExpressionLanguageProvider()` method.
