### PR TITLE
Add an action to show *error* pages in kernel.debug mode

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
  * ExceptionController.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Matthias Pigulla <mp@webfactory.de>
  */
 class ExceptionController
 {
@@ -60,6 +61,34 @@ class ExceptionController
                 'currentContent' => $currentContent,
             )
         ));
+    }
+
+    /**
+     * Displays the error page for arbitrary status codes and formats.
+     *
+     * @param Request   $request The request
+     * @param int       $code    The HTTP status code to show the error page for.
+     *
+     * @return Response
+     *
+     * @throws \InvalidArgumentException When the error template does not exist
+     */
+    public function testErrorPageAction(Request $request, $code)
+    {
+        try {
+            throw new \Exception("Something has intentionally gone wrong.");
+        } catch (\Exception $exception) {
+            return new Response($this->twig->render(
+                $this->findTemplate($request, $request->getRequestFormat(), $code, false),
+                array(
+                    'status_code' => $code,
+                    'status_text' => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
+                    'exception' => new FlattenException($exception),
+                    'logger' => null,
+                    'currentContent' => '',
+                )
+            ));
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -147,7 +147,7 @@ class ExceptionController
      *
      * @return Response
      */
-    private function createResponse(Request $request, FlattenException $exception, $debug, DebugLoggerInterface $logger = null, $currentContent = '')
+    protected function createResponse(Request $request, FlattenException $exception, $debug, DebugLoggerInterface $logger = null, $currentContent = '')
     {
         $code = $exception->getStatusCode();
 

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -75,20 +75,18 @@ class ExceptionController
      */
     public function testErrorPageAction(Request $request, $code)
     {
-        try {
-            throw new \Exception("Something has intentionally gone wrong.");
-        } catch (\Exception $exception) {
-            return new Response($this->twig->render(
-                $this->findTemplate($request, $request->getRequestFormat(), $code, false),
-                array(
-                    'status_code' => $code,
-                    'status_text' => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
-                    'exception' => new FlattenException($exception),
-                    'logger' => null,
-                    'currentContent' => '',
-                )
-            ));
-        }
+        $exception = new \Exception("Something has intentionally gone wrong.");
+
+        return new Response($this->twig->render(
+            $this->findTemplate($request, $request->getRequestFormat(), $code, false),
+            array(
+                'status_code' => $code,
+                'status_text' => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
+                'exception' => new FlattenException($exception),
+                'logger' => null,
+                'currentContent' => '',
+            )
+        ));
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -147,7 +147,7 @@ class ExceptionController
      *
      * @return Response
      */
-    protected function createResponse(Request $request, FlattenException $exception, $debug, DebugLoggerInterface $logger = null, $currentContent = '')
+    private function createResponse(Request $request, FlattenException $exception, $debug, DebugLoggerInterface $logger = null, $currentContent = '')
     {
         $code = $exception->getStatusCode();
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/routing/errors.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/routing/errors.xml
@@ -4,15 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_twig_error_test" pattern="/{code}/">
+    <route id="_twig_error_test" path="/{code}.{_format}">
         <default key="_controller">twig.controller.exception:testErrorPageAction</default>
         <default key="_format">html</default>
         <requirement key="code">\d+</requirement>
     </route>
-
-    <route id="_twig_error_test_format" pattern="/{code}/{_format}/">
-        <default key="_controller">twig.controller.exception:testErrorPageAction</default>
-        <requirement key="code">\d+</requirement>
-    </route>
-
 </routes>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/routing/errors.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/routing/errors.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="_twig_error_test" pattern="/{code}/">
+        <default key="_controller">twig.controller.exception:testErrorPageAction</default>
+        <default key="_format">html</default>
+        <requirement key="code">\d+</requirement>
+    </route>
+
+    <route id="_twig_error_test_format" pattern="/{code}/{_format}/">
+        <default key="_controller">twig.controller.exception:testErrorPageAction</default>
+        <requirement key="code">\d+</requirement>
+    </route>
+
+</routes>

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -64,4 +64,22 @@ class ExceptionControllerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode()); // successful request
         $this->assertEquals('OK', $response->getContent());  // content of the error404.html template
     }
+
+    public function testFallbackToHtmlIfNoTemplateForRequestedFormat()
+    {
+        $twig = new \Twig_Environment(
+            new \Twig_Loader_Array(array(
+                'TwigBundle:Exception:error.html.twig' => 'html',
+            ))
+        );
+
+        $request = Request::create('whatever');
+        $request->setRequestFormat('txt');
+
+        $controller = new ExceptionController($twig, false);
+        $response = $controller->testErrorPageAction($request, 42);
+
+        $this->assertEquals('html', $request->getRequestFormat());
+    }
+
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -41,4 +41,27 @@ class ExceptionControllerTest extends TestCase
         $controller = new ExceptionController($twig, false);
         $controller->showAction($request, $flatten);
     }
+
+    public function testErrorPagesInDebugMode()
+    {
+        $twig = new \Twig_Environment(
+            new \Twig_Loader_Array(array(
+                'TwigBundle:Exception:error404.html.twig' => '
+                    {%- if exception is defined and status_text is defined and status_code is defined -%}
+                        OK
+                    {%- else -%}
+                        "exception" variable is missing
+                    {%- endif -%}
+                ',
+            ))
+        );
+
+        $request = Request::create('whatever');
+
+        $controller = new ExceptionController($twig, /* "debug" set to --> */ true);
+        $response = $controller->testErrorPageAction($request, 404);
+
+        $this->assertEquals(200, $response->getStatusCode()); // successful request
+        $this->assertEquals('OK', $response->getContent());  // content of the error404.html template
+    }
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -81,5 +81,4 @@ class ExceptionControllerTest extends TestCase
 
         $this->assertEquals('html', $request->getRequestFormat());
     }
-
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7446, #1486, #11327 |
| License | MIT |
| Doc PR | symfony/symfony-docs#4293 |

See #7446 for the initial reasoning. In short, add to your `routing_development.yml` file the following

``` yaml
_errors:
    resource: "@TwigBundle/Resources/config/routing/errors.xml"
    prefix:   /_error
```

Then you can use `http://localhost/app_dev.php/_error/xxx` to preview the HTML _error_ page that the default `ExceptionController` (from `TwigBundle`) would pick for the XXX status code. 

You can also use `http://localhost/app_dev.php/_error/xxx.{some_format}` to show error pages for other formats than HTML, most notably `txt`.

Note that the status code will be 500 for all exceptions [that do not implement `HttpExceptionInterface`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Debug/Exception/FlattenException.php#L47).
##### Want to test with a custom exception?

~~Folks might want to display (part of) the exception even on error pages and thus need to work with generic (own) exceptions.~~

~~They could write an arbitrary controller and throw their exception there. By default, the `ExceptionController` would be used to handle this, only that it would not show _error_ pages in `kernel.debug` mode.~~

~~Thus, a simple public setter to change the `debug` flag after construction could help. Do we want to add that as well?~~

If you want to test error pages with your own exceptions, 
- create a subclass of `ExceptionController`
- set the protected `debug` flag to false
- register it as twig.exception_controller in the config
- throw your custom exception from any controller.

That should give you the error page also in `kernel.debug` mode.
##### To-Do
- [x] Update docs
- [x] Add route in symfony/symfony-default
