### PR TITLE
[Serializer] Handle circular references

### DIFF
--- a/src/Symfony/Component/Serializer/Exception/CircularReferenceException.php
+++ b/src/Symfony/Component/Serializer/Exception/CircularReferenceException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * CircularReferenceException
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class CircularReferenceException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class CircularReferenceDummy
+{
+    public function getMe()
+    {
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/SiblingHolder.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/SiblingHolder.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class SiblingHolder
+{
+    private $sibling0;
+    private $sibling1;
+    private $sibling2;
+
+    public function __construct()
+    {
+        $sibling = new Sibling();
+        $this->sibling0 = $sibling;
+        $this->sibling1 = $sibling;
+        $this->sibling2 = $sibling;
+    }
+
+    public function getSibling0()
+    {
+        return $this->sibling0;
+    }
+
+    public function getSibling1()
+    {
+        return $this->sibling1;
+    }
+
+    public function getSibling2()
+    {
+        return $this->sibling2;
+    }
+}
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class Sibling
+{
+    public function getCoopTilleuls()
+    {
+        return 'Les-Tilleuls.coop';
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -12,8 +12,11 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 
 class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 {
@@ -270,6 +273,49 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $obj->setObject($object);
 
         $this->normalizer->normalize($obj, 'any');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\CircularReferenceException
+     */
+    public function testUnableToNormalizeCircularReference()
+    {
+        $serializer = new Serializer(array($this->normalizer));
+        $this->normalizer->setSerializer($serializer);
+        $this->normalizer->setCircularReferenceLimit(2);
+
+        $obj = new CircularReferenceDummy();
+
+        $this->normalizer->normalize($obj);
+    }
+
+    public function testSiblingReference()
+    {
+        $serializer = new Serializer(array($this->normalizer));
+        $this->normalizer->setSerializer($serializer);
+
+        $siblingHolder = new SiblingHolder();
+
+        $expected = array(
+            'sibling0' => array('coopTilleuls' => 'Les-Tilleuls.coop'),
+            'sibling1' => array('coopTilleuls' => 'Les-Tilleuls.coop'),
+            'sibling2' => array('coopTilleuls' => 'Les-Tilleuls.coop'),
+        );
+        $this->assertEquals($expected, $this->normalizer->normalize($siblingHolder));
+    }
+
+    public function testCircularReferenceHandler()
+    {
+        $serializer = new Serializer(array($this->normalizer));
+        $this->normalizer->setSerializer($serializer);
+        $this->normalizer->setCircularReferenceHandler(function ($obj) {
+            return get_class($obj);
+        });
+
+        $obj = new CircularReferenceDummy();
+
+        $expected = array('me' => 'Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy');
+        $this->assertEquals($expected, $this->normalizer->normalize($obj));
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Yes: avoid infinite loops. Allows to improve #5347 |
| New feature? | yes (circular reference handler) |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | symfony/symfony-docs#4299 |

This PR adds handling of circular references in the `Serializer` component.
The number of allowed iterations is configurable (one by default).
The behavior when a circular reference is detected is configurable. By default an exception is thrown. Instead of throwing an exception, it's possible to register a custom handler (e.g.: a Doctrine Handler returning the object ID).

Usage:

``` php
use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
use Symfony\Component\Serializer\Serializer;

class MyObj
{
    private $id = 1312;

    public function getId()
    {
        return $this->getId();
    }

    public function getMe()
    {
        return $this;
    }
}

$normalizer = new GetSetMethodNormalizer();
$normalizer->setCircularReferenceLimit(3);
$normalizer->setCircularReferenceHandler(function ($obj) {
    return $obj->getId();
});

$serializer = new Serializer([$normalizer]);
$serializer->normalize(new MyObj());
```
