### PR TITLE
[Validator] Display a nice upload limit message

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -59,9 +59,10 @@ class FileValidator extends ConstraintValidator
                         $limitInBytes = UploadedFile::getMaxFilesize();
                     }
 
+                    list($sizeAsString, $limitAsString, $suffix) = $this->factorizeSizes(0, $limitInBytes, true);
                     $this->buildViolation($constraint->uploadIniSizeErrorMessage)
-                        ->setParameter('{{ limit }}', $limitInBytes)
-                        ->setParameter('{{ suffix }}', 'bytes')
+                        ->setParameter('{{ limit }}', $limitAsString)
+                        ->setParameter('{{ suffix }}', $suffix)
                         ->setCode(UPLOAD_ERR_INI_SIZE)
                         ->addViolation();
 
@@ -150,41 +151,12 @@ class FileValidator extends ConstraintValidator
             $limitInBytes = $constraint->maxSize;
 
             if ($sizeInBytes > $limitInBytes) {
-                // Convert the limit to the smallest possible number
-                // (i.e. try "MB", then "kB", then "bytes")
-                if ($constraint->binaryFormat) {
-                    $coef = self::MIB_BYTES;
-                    $coefFactor = self::KIB_BYTES;
-                } else {
-                    $coef = self::MB_BYTES;
-                    $coefFactor = self::KB_BYTES;
-                }
-
-                $limitAsString = (string) ($limitInBytes / $coef);
-
-                // Restrict the limit to 2 decimals (without rounding! we
-                // need the precise value)
-                while (self::moreDecimalsThan($limitAsString, 2)) {
-                    $coef /= $coefFactor;
-                    $limitAsString = (string) ($limitInBytes / $coef);
-                }
-
-                // Convert size to the same measure, but round to 2 decimals
-                $sizeAsString = (string) round($sizeInBytes / $coef, 2);
-
-                // If the size and limit produce the same string output
-                // (due to rounding), reduce the coefficient
-                while ($sizeAsString === $limitAsString) {
-                    $coef /= $coefFactor;
-                    $limitAsString = (string) ($limitInBytes / $coef);
-                    $sizeAsString = (string) round($sizeInBytes / $coef, 2);
-                }
-
+                list($sizeAsString, $limitAsString, $suffix) = $this->factorizeSizes($sizeInBytes, $limitInBytes, $constraint->binaryFormat);
                 $this->buildViolation($constraint->maxSizeMessage)
                     ->setParameter('{{ file }}', $this->formatValue($path))
                     ->setParameter('{{ size }}', $sizeAsString)
                     ->setParameter('{{ limit }}', $limitAsString)
-                    ->setParameter('{{ suffix }}', self::$suffices[$coef])
+                    ->setParameter('{{ suffix }}', $suffix)
                     ->setCode(File::TOO_LARGE_ERROR)
                     ->addViolation();
 
@@ -224,5 +196,42 @@ class FileValidator extends ConstraintValidator
     private static function moreDecimalsThan($double, $numberOfDecimals)
     {
         return strlen((string) $double) > strlen(round($double, $numberOfDecimals));
+    }
+
+    /**
+     * Convert the limit to the smallest possible number
+     * (i.e. try "MB", then "kB", then "bytes")
+     */
+    private function factorizeSizes($size, $limit, $binaryFormat)
+    {
+        if ($binaryFormat) {
+            $coef = self::MIB_BYTES;
+            $coefFactor = self::KIB_BYTES;
+        } else {
+            $coef = self::MB_BYTES;
+            $coefFactor = self::KB_BYTES;
+        }
+
+        $limitAsString = (string) ($limit / $coef);
+
+        // Restrict the limit to 2 decimals (without rounding! we
+        // need the precise value)
+        while (self::moreDecimalsThan($limitAsString, 2)) {
+            $coef /= $coefFactor;
+            $limitAsString = (string) ($limit / $coef);
+        }
+
+        // Convert size to the same measure, but round to 2 decimals
+        $sizeAsString = (string) round($size / $coef, 2);
+
+        // If the size and limit produce the same string output
+        // (due to rounding), reduce the coefficient
+        while ($sizeAsString === $limitAsString) {
+            $coef /= $coefFactor;
+            $limitAsString = (string) ($limit / $coef);
+            $sizeAsString = (string) round($size / $coef, 2);
+        }
+
+        return array($sizeAsString, $limitAsString, self::$suffices[$coef]);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -445,8 +445,8 @@ abstract class FileValidatorTest extends AbstractConstraintValidatorTest
         if (class_exists('Symfony\Component\HttpFoundation\File\UploadedFile')) {
             // when no maxSize is specified on constraint, it should use the ini value
             $tests[] = array(UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', array(
-                '{{ limit }}' => UploadedFile::getMaxFilesize(),
-                '{{ suffix }}' => 'bytes',
+                '{{ limit }}' => UploadedFile::getMaxFilesize() / 1048576,
+                '{{ suffix }}' => 'MiB',
             ));
 
             // it should use the smaller limitation (maxSize option in this case)
@@ -458,8 +458,8 @@ abstract class FileValidatorTest extends AbstractConstraintValidatorTest
             // it correctly parses the maxSize option and not only uses simple string comparison
             // 1000M should be bigger than the ini value
             $tests[] = array(UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', array(
-                '{{ limit }}' => UploadedFile::getMaxFilesize(),
-                '{{ suffix }}' => 'bytes',
+                '{{ limit }}' => UploadedFile::getMaxFilesize() / 1048576,
+                '{{ suffix }}' => 'MiB',
             ), '1000M');
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | NA |
| License | MIT |
| Doc PR | NA |

Actualy when a user upload a file who exceed the upload limit, the error messag looks like `The file is too large. Allowed maximum size is 2097152 bytes.` which is not very readable.
This PR use the same method who generate the `maxSize` error message by gessing the smallest possible number.
The error message became `The file is too large. Allowed maximum size is 2 MiB.`
