### PR TITLE
[ContainerBuilder] Fix calls method for lazy loading

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -926,11 +926,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                     $definition,
                     $id, function () use ($definition, $id, $container) {
                         $service = $container->createService($definition, $id, false);
+                        $container->callMethods($service, $definition->getMethodCalls());
 
-                        foreach ($definition->getMethodCalls() as $call) {
-                            $container->callMethod($service, $call);
-                        }
-                        
                         return $service;
                     }
                 );
@@ -978,10 +975,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         if ($tryProxy || !$definition->isLazy()) {
             // share only if proxying failed, or if not a proxy
             $this->shareService($definition, $service, $id);
-
-            foreach ($definition->getMethodCalls() as $call) {
-                $this->callMethod($service, $call);
-            }
+            $this->callMethods($service, $definition->getMethodCalls());
         }        
 
         $properties = $this->resolveServices($parameterBag->resolveValue($definition->getProperties()));
@@ -1140,6 +1134,13 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                     }
                 }
             }
+        }
+    }
+
+    private function callMethods($service, $calls)
+    {
+        foreach ($calls as $call) {
+            $this->callMethod($service, $call);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -925,7 +925,13 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                     $container,
                     $definition,
                     $id, function () use ($definition, $id, $container) {
-                        return $container->createService($definition, $id, false);
+                        $service = $container->createService($definition, $id, false);
+
+                        foreach ($definition->getMethodCalls() as $call) {
+                            $container->callMethod($service, $call);
+                        }
+                        
+                        return $service;
                     }
                 );
             $this->shareService($definition, $proxy, $id);
@@ -972,11 +978,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         if ($tryProxy || !$definition->isLazy()) {
             // share only if proxying failed, or if not a proxy
             $this->shareService($definition, $service, $id);
-        }
 
-        foreach ($definition->getMethodCalls() as $call) {
-            $this->callMethod($service, $call);
-        }
+            foreach ($definition->getMethodCalls() as $call) {
+                $this->callMethod($service, $call);
+            }
+        }        
 
         $properties = $this->resolveServices($parameterBag->resolveValue($definition->getProperties()));
         foreach ($properties as $name => $value) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -312,10 +312,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($foo1, $builder->get('foo1'), 'The same proxy is retrieved on multiple subsequent calls');
         $this->assertInstanceOf('Bar\FooClass', $foo1);
         
-        $reflection = new \ReflectionObject($foo1);
-        $value = $reflection->getProperty('bar')->getValue($foo1);
-        
-        $this->assertNull($value);
+        $this->assertNotNull($foo1->getProxyInitializer());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -299,6 +299,10 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCanCreateProxyWithRuntimeServiceInstantiatorAndLazyCalls()
     {
+        if (!interface_exists('ProxyManager\Proxy\ProxyInterface')) {
+            $this->markTestSkipped('The proxy-manager project is not available');   
+        }
+
         $builder = new ContainerBuilder();
         $builder->setProxyInstantiator(new RuntimeInstantiator());
 
@@ -312,6 +316,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($foo1, $builder->get('foo1'), 'The same proxy is retrieved on multiple subsequent calls');
         $this->assertInstanceOf('Bar\FooClass', $foo1);
         
+        $this->assertInstanceOf('ProxyManager\Proxy\LazyLoadingInterface', $foo1);
         $this->assertNotNull($foo1->getProxyInitializer());
     }
 


### PR DESCRIPTION
Currently, when a definition is marked as lazy, if the definition has some calls methods, the lazy become useless because the object is created. We need to call this method lazily.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
