### PR TITLE
[DependencyInjection] Added closure service factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "symfony/security-bundle": "self.version",
         "symfony/serializer": "self.version",
         "symfony/stopwatch": "self.version",
+        "symfony/superclosure-bridge": "self.version",
         "symfony/swiftmailer-bridge": "self.version",
         "symfony/templating": "self.version",
         "symfony/translation": "self.version",
@@ -76,7 +77,8 @@
         "propel/propel1": "1.6.*",
         "ircmaxell/password-compat": "1.0.*",
         "ocramius/proxy-manager": ">=0.3.1,<0.6-dev",
-        "egulias/email-validator": "~1.2"
+        "egulias/email-validator": "~1.2",
+        "jeremeamia/superclosure": "~1.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\": "src/" },

--- a/src/Symfony/Bridge/SuperClosure/.gitignore
+++ b/src/Symfony/Bridge/SuperClosure/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Bridge/SuperClosure/CHANGELOG.md
+++ b/src/Symfony/Bridge/SuperClosure/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+2.6.0
+-----
+
+ * Added the `Symfony\Bridge\SuperClosure` bridge

--- a/src/Symfony/Bridge/SuperClosure/ClosureDumper/SuperClosureDumper.php
+++ b/src/Symfony/Bridge/SuperClosure/ClosureDumper/SuperClosureDumper.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\SuperClosure\ClosureDumper;
+
+use Jeremeamia\SuperClosure\ClosureParser;
+use Symfony\Component\DependencyInjection\Dumper\ClosureDumper\ClosureDumperInterface;
+use Symfony\Component\DependencyInjection\Exception\DumpingClosureException;
+
+/**
+ * @author Nikita Konstantinov <unk91nd@gmail.com>
+ */
+class SuperClosureDumper implements ClosureDumperInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function dump(\Closure $closure)
+    {
+        $parser = ClosureParser::fromClosure($closure);
+
+        if ($parser->getUsedVariables()) {
+            throw new DumpingClosureException($closure, 'Closure must not depend on context (use statement)');
+        }
+
+        try {
+            // Remove trailing ";"
+            return substr($parser->getCode(), 0, -1);
+        } catch (\Exception $e) {
+            throw new DumpingClosureException($closure, $e->getMessage(), 0, $e);
+        }
+    }
+}

--- a/src/Symfony/Bridge/SuperClosure/LICENSE
+++ b/src/Symfony/Bridge/SuperClosure/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2014 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Bridge/SuperClosure/Tests/Fixtures/php/services_with_closure_factory.php
+++ b/src/Symfony/Bridge/SuperClosure/Tests/Fixtures/php/services_with_closure_factory.php
@@ -1,0 +1,129 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * ProjectServiceContainerWithClosures
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ */
+class ProjectServiceContainerWithClosures extends Container
+{
+    private static $parameters = array(
+            'baz' => 42,
+        );
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services =
+        $this->scopedServices =
+        $this->scopeStacks = array();
+
+        $this->set('service_container', $this);
+
+        $this->scopes = array();
+        $this->scopeChildren = array();
+        $this->methodMap = array(
+            'bar' => 'getBarService',
+            'foo' => 'getFooService',
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped frozen container.');
+    }
+
+    /**
+     * Gets the 'bar' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance.
+     */
+    protected function getBarService()
+    {
+        return $this->services['bar'] = call_user_func(function (\stdClass $foo) {
+    $bar = clone $foo;
+    $bar->bar = 'bar';
+    return $bar;
+}, $this->get('foo'));
+    }
+
+    /**
+     * Gets the 'foo' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance.
+     */
+    protected function getFooService()
+    {
+        return $this->services['foo'] = call_user_func(function ($baz) {
+    $foo = new \stdClass();
+    $foo->foo = $baz;
+    return $foo;
+}, 42);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameter($name)
+    {
+        $name = strtolower($name);
+
+        if (!(isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters))) {
+            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
+        }
+
+        return self::$parameters[$name];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasParameter($name)
+    {
+        $name = strtolower($name);
+
+        return isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParameter($name, $value)
+    {
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameterBag()
+    {
+        if (null === $this->parameterBag) {
+            $this->parameterBag = new FrozenParameterBag(self::$parameters);
+        }
+
+        return $this->parameterBag;
+    }
+}

--- a/src/Symfony/Bridge/SuperClosure/Tests/PhpDumperTest.php
+++ b/src/Symfony/Bridge/SuperClosure/Tests/PhpDumperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\SuperClosure\Tests;
+
+use Symfony\Bridge\SuperClosure\ClosureDumper\SuperClosureDumper;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Integration tests of {@see \Symfony\Component\DependencyInjection\Dumper\PhpDumper} and SuperClosureDumper
+ *
+ * @author Nikita Konstantinov <unk91nd@gmail.com>
+ */
+class PhpDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatPhpDumperCanDumpClosure()
+    {
+        $container = new ContainerBuilder();
+
+        $container->setParameter('baz', 42);
+
+        $container
+            ->register('foo', 'stdClass')
+            ->setFactory(function ($baz) {
+                $foo = new \stdClass();
+                $foo->foo = $baz;
+
+                return $foo;
+            })
+            ->addArgument('%baz%')
+        ;
+
+        $container
+            ->register('bar', 'stdClass')
+            ->setFactory(function (\stdClass $foo) {
+                $bar = clone $foo;
+                $bar->bar = 'bar';
+
+                return $bar;
+            })
+            ->addArgument(new Reference('foo'))
+        ;
+
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dumper->setClosureDumper(new SuperClosureDumper());
+
+        $options = array('class' => 'ProjectServiceContainerWithClosures');
+
+        $this->assertStringEqualsFile(__DIR__.'/Fixtures/php/services_with_closure_factory.php', $dumper->dump($options));
+    }
+
+    public function testThatDumpedContainerWorks()
+    {
+        require_once __DIR__.'/Fixtures/php/services_with_closure_factory.php';
+
+        $container = new \ProjectServiceContainerWithClosures();
+
+        $expectedBar = new \stdClass();
+        $expectedBar->foo = 42;
+        $expectedBar->bar = 'bar';
+
+        $this->assertEquals($expectedBar, $container->get('bar'));
+    }
+}

--- a/src/Symfony/Bridge/SuperClosure/Tests/SuperClosureDumperTest.php
+++ b/src/Symfony/Bridge/SuperClosure/Tests/SuperClosureDumperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\SuperClosure\Tests;
+
+use Symfony\Bridge\SuperClosure\ClosureDumper\SuperClosureDumper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author Nikita Konstantinov <unk91nd@gmail.com>
+ */
+class SuperClosureDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatClosureDumps()
+    {
+        $dumper = new SuperClosureDumper();
+
+        $expectedCode = <<<'CODE'
+function (\Symfony\Component\DependencyInjection\ContainerInterface $container) {
+    return $container->get('foo');
+}
+CODE;
+
+        $actualCode = $dumper->dump(function (ContainerInterface $container) {
+            return $container->get('foo');
+        });
+
+        $this->assertSame($expectedCode, $actualCode);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\DumpingClosureException
+     */
+    public function testThatContextDependentClosureCannotBeDumped()
+    {
+        $dumper = new SuperClosureDumper();
+
+        $dumper->dump(function () use ($dumper) {
+            return new \stdClass();
+        });
+    }
+}

--- a/src/Symfony/Bridge/SuperClosure/composer.json
+++ b/src/Symfony/Bridge/SuperClosure/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "symfony/superclosure-bridge",
+    "type": "symfony-bridge",
+    "description": "Symfony SuperClosure Bridge",
+    "keywords": [],
+    "homepage": "http://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "http://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3",
+        "symfony/dependency-injection": "~2.6",
+        "jeremeamia/superclosure": "~1.0"
+    },
+    "autoload": {
+        "psr-0": { "Symfony\\Bridge\\SuperClosure\\": "" }
+    },
+    "target-dir": "Symfony/Bridge/SuperClosure",
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.6-dev"
+        }
+    }
+}

--- a/src/Symfony/Bridge/SuperClosure/phpunit.xml.dist
+++ b/src/Symfony/Bridge/SuperClosure/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+        >
+    <testsuites>
+        <testsuite name="Symfony SuperClosure Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -948,6 +948,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 $callable = $definition->getFactory();
             } elseif (is_array($factory)) {
                 $callable = array($this->resolveServices($factory[0]), $factory[1]);
+            } elseif ($factory instanceof \Closure) {
+                $callable = $factory;
             } else {
                 throw new RuntimeException(sprintf('Cannot create service "%s" because of invalid factory', $id));
             }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -60,7 +60,7 @@ class Definition
     /**
      * Sets a factory.
      *
-     * @param string|array $factory A PHP function or an array containing a class/Reference and a method to call
+     * @param string|array|\Closure $factory A PHP function/closure or an array containing a class/Reference and a method to call
      *
      * @return Definition The current instance
      */
@@ -78,7 +78,7 @@ class Definition
     /**
      * Gets the factory.
      *
-     * @return string|array The PHP function or an array containing a class/Reference and a method to call
+     * @return string|array|\Closure The PHP function/closure or an array containing a class/Reference and a method to call
      */
     public function getFactory()
     {
@@ -141,7 +141,7 @@ class Definition
      *
      * @return Definition The current instance
      *
-     * @throws InvalidArgumentException In case the decorated service id and the new decorated service id are equals.
+     * @throws \InvalidArgumentException In case the decorated service id and the new decorated service id are equals.
      */
     public function setDecoratedService($id, $renamedId = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Dumper/ClosureDumper/ClosureDumperInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/ClosureDumper/ClosureDumperInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Dumper\ClosureDumper;
+
+use Symfony\Component\DependencyInjection\Exception\DumpingClosureException;
+
+/**
+ * @author Nikita Konstantinov <unk91nd@gmail.com>
+ *
+ * @api
+ */
+interface ClosureDumperInterface
+{
+    /**
+     * @param \Closure $closure
+     * @return string
+     *
+     * @throws DumpingClosureException If closure couldn't be dumped
+     */
+    public function dump(\Closure $closure);
+}

--- a/src/Symfony/Component/DependencyInjection/Exception/DumpingClosureException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/DumpingClosureException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+/**
+ * This exception is thrown when closure is not dumpable, e.g. if closure depends on context
+ *
+ * @author Nikita Konstantinov <unk91nd@gmail.com>
+ */
+class DumpingClosureException extends \RuntimeException implements ExceptionInterface
+{
+    public function __construct(\Closure $closure, $message, $code = 0, \Exception $previous = null)
+    {
+        $reflection = new \ReflectionFunction($closure);
+
+        parent::__construct(sprintf(
+            'Closure defined in %s at line %d could not be dumped: %s',
+            $reflection->getFileName(),
+            $reflection->getStartLine(),
+            $message
+        ), $code, $previous);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -398,6 +398,23 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
+     */
+    public function testCreateServiceByClosure()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('bar', 'stdClass');
+        $builder->register('foo', 'Bar\FooClass')->setFactory(function (\stdClass $bar) {
+            $foo = new \Bar\FooClass();
+            $foo->setBar($bar);
+
+            return $foo;
+        })->addArgument(new Reference('bar'));
+
+        $this->assertSame($builder->get('bar'), $builder->get('foo')->bar, '->createService() creates service from a closure with passed service as an argument');
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
      * @expectedException \RuntimeException
      */
     public function testCreateSyntheticService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -1,0 +1,67 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+/**
+ * ProjectServiceContainer
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ */
+class ProjectServiceContainer extends Container
+{
+    private static $parameters = array(
+
+        );
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(new ParameterBag(self::$parameters));
+        $this->methodMap = array(
+            'bar' => 'getBarService',
+            'foo' => 'getFooService',
+        );
+    }
+
+    /**
+     * Gets the 'bar' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance.
+     */
+    protected function getBarService()
+    {
+        return $this->services['bar'] = call_user_func(function (\stdClass $foo) {
+            $bar = clone $foo;
+            $bar->bar = 42;
+
+            return $bar;
+        }, $this->get('foo'));
+    }
+
+    /**
+     * Gets the 'foo' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance.
+     */
+    protected function getFooService()
+    {
+        return $this->services['foo'] = call_user_func(function () {
+            return new \stdClass();
+        });
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -26,7 +26,8 @@
     "suggest": {
         "symfony/yaml": "",
         "symfony/config": "",
-        "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
+        "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+        "symfony/superclosure-bridge": "Allow to dump closure factories"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\DependencyInjection\\": "" }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel;
 
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
+use Symfony\Bridge\SuperClosure\ClosureDumper\SuperClosureDumper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
@@ -708,6 +709,13 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
         if (class_exists('ProxyManager\Configuration')) {
             $dumper->setProxyDumper(new ProxyDumper());
+        }
+
+        if (
+            class_exists('Symfony\Bridge\SuperClosure\ClosureDumper\SuperClosureDumper')
+            && class_exists('Jeremeamia\SuperClosure\ClosureParser')
+        ) {
+            $dumper->setClosureDumper(new SuperClosureDumper());
         }
 
         $content = $dumper->dump(array('class' => $class, 'base_class' => $baseClass));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR adds closure service factories for the `DependencyInjection` component. There are 2 kinds of closures:

``` php
use Symfony\Component\DependencyInjection\ContainerInterface;

// Closure with services/parameters as arguments
$container
    ->register('bar1', 'Bar')
    ->setFactory(function (Foo $foo, $bar) {
        return new Bar($foo->getQux(), $bar);
    })
    ->addArgument(new Reference('foo'))
    ->addArgument('%bar%')
;

// Pimple-like closure with container as an argument
$container
    ->register('bar2', 'Bar')
    ->setFactory(function (ContainerInterface $container) {
        return new Bar($container->get('foo')->getQux(), $container->getParameter('bar'));
    })
;
```

It would be useful for something like `ArrayFileLoader` described in #11953.
