### PR TITLE
[VarDumper] encode non-ASCII UTF-8 chars as HTML numeric entities

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -51,7 +51,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
             <<<EOTXT
 <foo></foo><bar><span class=sf-dump-0><span class=sf-dump-note>array:25</span> [<span name=sf-dump-child>
   <span class=sf-dump-1>"<span class=sf-dump-meta>number</span>" => <span class=sf-dump-num>1</span>
-  <span class=sf-dump-meta>0</span> => <span class=sf-dump-const>null</span> <a class=sf-dump-ref name="sf-dump-{$dumpId}-ref1">#1</a>
+  <span class=sf-dump-meta>0</span> => <span class=sf-dump-const>null</span> <span class=sf-dump-ref id="sf-dump-{$dumpId}-ref1">#1</span>
   "<span class=sf-dump-meta>const</span>" => <span class=sf-dump-num>1.1</span>
   <span class=sf-dump-meta>1</span> => <span class=sf-dump-const>true</span>
   <span class=sf-dump-meta>2</span> => <span class=sf-dump-const>false</span>
@@ -59,8 +59,8 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   <span class=sf-dump-meta>4</span> => <span class=sf-dump-num>INF</span>
   <span class=sf-dump-meta>5</span> => <span class=sf-dump-num>-INF</span>
   <span class=sf-dump-meta>6</span> => <span class=sf-dump-num>{$intMax}</span>
-  "<span class=sf-dump-meta>str</span>" => "<span class=sf-dump-str>déjà</span>"
-  <span class=sf-dump-meta>7</span> => b"<span class=sf-dump-str>é</span>"
+  "<span class=sf-dump-meta>str</span>" => "<span class=sf-dump-str>d&#233;j&#224;</span>"
+  <span class=sf-dump-meta>7</span> => b"<span class=sf-dump-str>&#233;</span>"
   "<span class=sf-dump-meta>[]</span>" => []
   "<span class=sf-dump-meta>res</span>" => resource:<span class=sf-dump-note>stream</span> {<span name=sf-dump-child>
     <span class=sf-dump-2><span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str>plainfile</span>"
@@ -74,7 +74,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
     <span class=sf-dump-meta>options</span>: []
   </span></span>}
   <span class=sf-dump-meta>8</span> => resource:<span class=sf-dump-note>Unknown</span> {}
-  "<span class=sf-dump-meta>obj</span>" => <span class=sf-dump-note><abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr></span> {<span name=sf-dump-child> <a class=sf-dump-ref name="sf-dump-{$dumpId}-ref2">#2</a>
+  "<span class=sf-dump-meta>obj</span>" => <span class=sf-dump-note><abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr></span> {<span name=sf-dump-child> <span class=sf-dump-ref id="sf-dump-{$dumpId}-ref2">#2</span>
     <span class=sf-dump-2><span class=sf-dump-public>foo</span>: "<span class=sf-dump-str>foo</span>"
     "<span class=sf-dump-public>bar</span>": "<span class=sf-dump-str>bar</span>"
   </span></span>}
@@ -92,9 +92,9 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   </span></span>}
   "<span class=sf-dump-meta>line</span>" => <span class=sf-dump-num>{$var['line']}</span>
   "<span class=sf-dump-meta>nobj</span>" => <span class=sf-dump-note>array:1</span> [<span name=sf-dump-child>
-    <span class=sf-dump-2><span class=sf-dump-meta>0</span> => {} <a class=sf-dump-ref name="sf-dump-{$dumpId}-ref3">#3</a>
+    <span class=sf-dump-2><span class=sf-dump-meta>0</span> => {} <span class=sf-dump-ref id="sf-dump-{$dumpId}-ref3">#3</span>
   </span></span>]
-  "<span class=sf-dump-meta>recurs</span>" => <span class=sf-dump-note>array:1</span> [<span name=sf-dump-child> <a class=sf-dump-ref name="sf-dump-{$dumpId}-ref4">#4</a>
+  "<span class=sf-dump-meta>recurs</span>" => <span class=sf-dump-note>array:1</span> [<span name=sf-dump-child> <span class=sf-dump-ref id="sf-dump-{$dumpId}-ref4">#4</span>
     <span class=sf-dump-2><span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref4">&4</a> <span class=sf-dump-note>array:1</span> [<a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref4">@4</a>]
   </span></span>]
   <span class=sf-dump-meta>9</span> => <a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref1">&1</a> <span class=sf-dump-const>null</span>
@@ -102,7 +102,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   "<span class=sf-dump-meta>snobj</span>" => <a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref3">&3</a> {<a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref3">@3</a>}
   "<span class=sf-dump-meta>snobj2</span>" => {<a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref3">@3</a>}
   "<span class=sf-dump-meta>file</span>" => "<span class=sf-dump-str>{$var['file']}</span>"
-  b"<span class=sf-dump-meta>bin-key-é</span>" => ""
+  b"<span class=sf-dump-meta>bin-key-&#233;</span>" => ""
 </span></span>]
 </span></bar>
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
