### PR TITLE
[Console] Add progress indicator helper

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -1,0 +1,267 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class ProgressIndicator
+{
+    private $output;
+    private $startTime;
+    private $format;
+    private $message = null;
+    private $indicatorValues = array('-', '\\', '|', '/');
+    private $indicatorCurrent = 0;
+    private $lastMessagesLength = 0;
+
+    private static $formatters;
+    private static $formats;
+
+    /**
+     * @param OutputInterface $output
+     */
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+        $this->startTime = time();
+
+        $this->setFormat($this->determineBestFormat());
+    }
+
+    /**
+     * @param string $format
+     */
+    public function setFormat($format)
+    {
+        $this->format = self::getFormatDefinition($format);
+    }
+
+    /**
+     * @param string|null $message
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+
+        $this->display();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param array $values
+     */
+    public function setIndicatorValues(array $values)
+    {
+        $values = array_values($values);
+
+        if (empty($values)) {
+            throw new \InvalidArgumentException('Must have at least 1 value.');
+        }
+
+        $this->indicatorValues = $values;
+    }
+
+    /**
+     * Gets the progress bar start time.
+     *
+     * @return int The progress bar start time
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentValue()
+    {
+        return $this->indicatorValues[$this->indicatorCurrent % count($this->indicatorValues)];
+    }
+
+    public function start($message)
+    {
+        $this->message = $message;
+        $this->startTime = time();
+        $this->indicatorCurrent = 0;
+
+        $this->display();
+    }
+
+    public function advance()
+    {
+        ++$this->indicatorCurrent;
+
+        if ($this->output->isDecorated()) {
+            $this->display();
+        }
+    }
+
+    public function finish($message)
+    {
+        $this->message = $message;
+        $this->display();
+        $this->output->writeln('');
+    }
+
+    /**
+     * Gets the format for a given name.
+     *
+     * @param string $name The format name
+     *
+     * @return string|null A format string
+     */
+    public static function getFormatDefinition($name)
+    {
+        if (!self::$formats) {
+            self::$formats = self::initFormats();
+        }
+
+        return isset(self::$formats[$name]) ? self::$formats[$name] : null;
+    }
+
+    /**
+     * Sets a placeholder formatter for a given name.
+     *
+     * This method also allow you to override an existing placeholder.
+     *
+     * @param string   $name     The placeholder name (including the delimiter char like %)
+     * @param callable $callable A PHP callable
+     */
+    public static function setPlaceholderFormatterDefinition($name, $callable)
+    {
+        if (!self::$formatters) {
+            self::$formatters = self::initPlaceholderFormatters();
+        }
+
+        self::$formatters[$name] = $callable;
+    }
+
+    /**
+     * Gets the placeholder formatter for a given name.
+     *
+     * @param string $name The placeholder name (including the delimiter char like %)
+     *
+     * @return callable|null A PHP callable
+     */
+    public static function getPlaceholderFormatterDefinition($name)
+    {
+        if (!self::$formatters) {
+            self::$formatters = self::initPlaceholderFormatters();
+        }
+
+        return isset(self::$formatters[$name]) ? self::$formatters[$name] : null;
+    }
+
+    private function display()
+    {
+        if (OutputInterface::VERBOSITY_QUIET === $this->output->getVerbosity()) {
+            return;
+        }
+
+        $self = $this;
+
+        $this->overwrite(preg_replace_callback("{%([a-z\-_]+)(?:\:([^%]+))?%}i", function ($matches) use ($self) {
+            if ($formatter = $self::getPlaceholderFormatterDefinition($matches[1])) {
+                return call_user_func($formatter, $self);
+            }
+
+            return $matches[0];
+        }, $this->format));
+    }
+
+    private function determineBestFormat()
+    {
+        switch ($this->output->getVerbosity()) {
+            // OutputInterface::VERBOSITY_QUIET: display is disabled anyway
+            case OutputInterface::VERBOSITY_VERBOSE:
+                return $this->output->isDecorated() ? 'verbose' : 'verbose_no_ansi';
+            case OutputInterface::VERBOSITY_VERY_VERBOSE:
+            case OutputInterface::VERBOSITY_DEBUG:
+                return $this->output->isDecorated() ? 'very_verbose' : 'very_verbose_no_ansi';
+            default:
+                return $this->output->isDecorated() ? 'normal' : 'normal_no_ansi';
+        }
+    }
+
+    /**
+     * Overwrites a previous message to the output.
+     *
+     * @param string $message The message
+     */
+    private function overwrite($message)
+    {
+        // append whitespace to match the line's length
+        if (null !== $this->lastMessagesLength) {
+            if ($this->lastMessagesLength > Helper::strlenWithoutDecoration($this->output->getFormatter(), $message)) {
+                $message = str_pad($message, $this->lastMessagesLength, "\x20", STR_PAD_RIGHT);
+            }
+        }
+
+        if ($this->output->isDecorated()) {
+            $this->output->write("\x0D");
+            $this->output->write($message);
+        } else {
+            $this->output->writeln($message);
+        }
+
+        $this->lastMessagesLength = 0;
+
+        $len = Helper::strlenWithoutDecoration($this->output->getFormatter(), $message);
+
+        if ($len > $this->lastMessagesLength) {
+            $this->lastMessagesLength = $len;
+        }
+    }
+
+    private static function initPlaceholderFormatters()
+    {
+        return array(
+            'indicator' => function (ProgressIndicator $indicator) {
+                return $indicator->getCurrentValue();
+            },
+            'message' => function (ProgressIndicator $indicator) {
+                return $indicator->getMessage();
+            },
+            'elapsed' => function (ProgressIndicator $indicator) {
+                return Helper::formatTime(time() - $indicator->getStartTime());
+            },
+            'memory' => function () {
+                return Helper::formatMemory(memory_get_usage(true));
+            },
+        );
+    }
+
+    private static function initFormats()
+    {
+        return array(
+            'normal' => ' %indicator% %message%',
+            'normal_no_ansi' => ' %message%',
+
+            'verbose' => ' %indicator% %message% (%elapsed:6s%)',
+            'verbose_no_ansi' => ' %message% (%elapsed:6s%)',
+
+            'very_verbose' => ' %indicator% %message% (%elapsed:6s%, %memory:6s%)',
+            'very_verbose_no_ansi' => ' %message% (%elapsed:6s%, %memory:6s%)',
+        );
+    }
+}

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -26,7 +26,8 @@ class ProgressIndicator
     private $indicatorCurrent;
     private $indicatorChangeInterval;
     private $indicatorUpdateTime;
-    private $lastMessagesLength = 0;
+    private $lastMessagesLength;
+    private $started = false;
 
     private static $formatters;
     private static $formats;
@@ -114,7 +115,13 @@ class ProgressIndicator
      */
     public function start($message)
     {
+        if ($this->started) {
+            throw new \LogicException('Progress indicator already started.');
+        }
+
         $this->message = $message;
+        $this->started = true;
+        $this->lastMessagesLength = 0;
         $this->startTime = time();
         $this->indicatorUpdateTime = $this->getCurrentTimeInMilliseconds() + $this->indicatorChangeInterval;
         $this->indicatorCurrent = 0;
@@ -127,6 +134,10 @@ class ProgressIndicator
      */
     public function advance()
     {
+        if (!$this->started) {
+            throw new \LogicException('Progress indicator has not yet been started.');
+        }
+
         if (!$this->output->isDecorated()) {
             return;
         }
@@ -150,9 +161,14 @@ class ProgressIndicator
      */
     public function finish($message)
     {
+        if (!$this->started) {
+            throw new \LogicException('Progress indicator has not yet been started.');
+        }
+
         $this->message = $message;
         $this->display();
         $this->output->writeln('');
+        $this->started = false;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -87,6 +87,8 @@ class ProgressIndicator
      * Gets the progress bar start time.
      *
      * @return int The progress bar start time
+     *
+     * @internal for PHP 5.3 compatibility
      */
     public function getStartTime()
     {
@@ -97,6 +99,8 @@ class ProgressIndicator
      * Gets the current animated indicator character.
      *
      * @return string
+     *
+     * @internal for PHP 5.3 compatibility
      */
     public function getCurrentValue()
     {

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -31,9 +31,6 @@ class ProgressIndicator
     private static $formatters;
     private static $formats;
 
-    /**
-     * @param OutputInterface $output
-     */
     public function __construct(OutputInterface $output)
     {
         $this->output = $output;
@@ -43,6 +40,8 @@ class ProgressIndicator
     }
 
     /**
+     * Sets the progress indicator format.
+     *
      * @param string $format
      */
     public function setFormat($format)
@@ -51,6 +50,8 @@ class ProgressIndicator
     }
 
     /**
+     * Sets the indicator change interval in milliseconds.
+     *
      * @param int $milliseconds
      */
     public function setIndicatorChangeInterval($milliseconds)
@@ -59,6 +60,8 @@ class ProgressIndicator
     }
 
     /**
+     * Sets the current indicator message.
+     *
      * @param string|null $message
      */
     public function setMessage($message)
@@ -69,6 +72,8 @@ class ProgressIndicator
     }
 
     /**
+     * Gets the current indicator message.
+     *
      * @return string|null
      */
     public function getMessage()
@@ -77,14 +82,16 @@ class ProgressIndicator
     }
 
     /**
+     * Sets the animated indicator characters.
+     *
      * @param array $values
      */
     public function setIndicatorValues(array $values)
     {
         $values = array_values($values);
 
-        if (empty($values)) {
-            throw new \InvalidArgumentException('Must have at least 1 value.');
+        if (2 > count($values)) {
+            throw new \InvalidArgumentException('Must have at least 2 values.');
         }
 
         $this->indicatorValues = $values;
@@ -101,6 +108,8 @@ class ProgressIndicator
     }
 
     /**
+     * Gets the current animated indicator character.
+     *
      * @return string
      */
     public function getCurrentValue()
@@ -108,6 +117,11 @@ class ProgressIndicator
         return $this->indicatorValues[$this->indicatorCurrent % count($this->indicatorValues)];
     }
 
+    /**
+     * Starts the indicator output.
+     *
+     * @param $message
+     */
     public function start($message)
     {
         $this->message = $message;
@@ -118,6 +132,9 @@ class ProgressIndicator
         $this->display();
     }
 
+    /**
+     * Advances the indicator.
+     */
     public function advance()
     {
         if (!$this->output->isDecorated()) {
@@ -136,6 +153,11 @@ class ProgressIndicator
         $this->display();
     }
 
+    /**
+     * Finish the indicator with message.
+     *
+     * @param $message
+     */
     public function finish($message)
     {
         $this->message = $message;

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -78,6 +78,8 @@ class ProgressIndicator
      * Gets the current indicator message.
      *
      * @return string|null
+     *
+     * @internal for PHP 5.3 compatibility
      */
     public function getMessage()
     {

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -21,42 +21,44 @@ class ProgressIndicator
     private $output;
     private $startTime;
     private $format;
-    private $message = null;
-    private $indicatorValues = array('-', '\\', '|', '/');
-    private $indicatorCurrent = 0;
-    private $indicatorChangeInterval = 100;
+    private $message;
+    private $indicatorValues;
+    private $indicatorCurrent;
+    private $indicatorChangeInterval;
     private $indicatorUpdateTime;
     private $lastMessagesLength = 0;
 
     private static $formatters;
     private static $formats;
 
-    public function __construct(OutputInterface $output)
+    /**
+     * @param OutputInterface $output
+     * @param string|null     $format                  Indicator format
+     * @param int             $indicatorChangeInterval Change interval in milliseconds
+     * @param array|null      $indicatorValues         Animated indicator characters
+     */
+    public function __construct(OutputInterface $output, $format = null, $indicatorChangeInterval = 100, $indicatorValues = null)
     {
         $this->output = $output;
-        $this->startTime = time();
 
-        $this->setFormat($this->determineBestFormat());
-    }
+        if (null === $format) {
+            $format = $this->determineBestFormat();
+        }
 
-    /**
-     * Sets the progress indicator format.
-     *
-     * @param string $format
-     */
-    public function setFormat($format)
-    {
+        if (null === $indicatorValues) {
+            $indicatorValues = array('-', '\\', '|', '/');
+        }
+
+        $indicatorValues = array_values($indicatorValues);
+
+        if (2 > count($indicatorValues)) {
+            throw new \InvalidArgumentException('Must have at least 2 indicator value characters.');
+        }
+
         $this->format = self::getFormatDefinition($format);
-    }
-
-    /**
-     * Sets the indicator change interval in milliseconds.
-     *
-     * @param int $milliseconds
-     */
-    public function setIndicatorChangeInterval($milliseconds)
-    {
-        $this->indicatorChangeInterval = $milliseconds;
+        $this->indicatorChangeInterval = $indicatorChangeInterval;
+        $this->indicatorValues = $indicatorValues;
+        $this->startTime = time();
     }
 
     /**
@@ -79,22 +81,6 @@ class ProgressIndicator
     public function getMessage()
     {
         return $this->message;
-    }
-
-    /**
-     * Sets the animated indicator characters.
-     *
-     * @param array $values
-     */
-    public function setIndicatorValues(array $values)
-    {
-        $values = array_values($values);
-
-        if (2 > count($values)) {
-            throw new \InvalidArgumentException('Must have at least 2 values.');
-        }
-
-        $this->indicatorValues = $values;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -67,8 +67,7 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomIndicatorValues()
     {
-        $bar = new ProgressIndicator($output = $this->getOutputStream());
-        $bar->setIndicatorValues(array('a', 'b', 'c'));
+        $bar = new ProgressIndicator($output = $this->getOutputStream(), null, 100, array('a', 'b', 'c'));
 
         $bar->start('Starting...');
         usleep(101000);
@@ -94,8 +93,7 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormats($format)
     {
-        $bar = new ProgressIndicator($output = $this->getOutputStream());
-        $bar->setFormat($format);
+        $bar = new ProgressIndicator($output = $this->getOutputStream(), $format);
         $bar->start('Starting...');
         $bar->advance();
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use Symfony\Component\Console\Helper\ProgressIndicator;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultIndicator()
+    {
+        $bar = new ProgressIndicator($output = $this->getOutputStream());
+        $bar->start('Starting...');
+        $bar->advance();
+        $bar->advance();
+        $bar->advance();
+        $bar->advance();
+        $bar->advance();
+        $bar->setMessage('Advancing...');
+        $bar->advance();
+        $bar->finish('Done...');
+
+        rewind($output->getStream());
+
+        $this->assertEquals(
+            $this->generateOutput(' - Starting...').
+            $this->generateOutput(' \\ Starting...').
+            $this->generateOutput(' | Starting...').
+            $this->generateOutput(' / Starting...').
+            $this->generateOutput(' - Starting...').
+            $this->generateOutput(' \\ Starting...').
+            $this->generateOutput(' \\ Advancing...').
+            $this->generateOutput(' | Advancing...').
+            $this->generateOutput(' | Done...     ').
+            "\n",
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testNonDecoratedOutput()
+    {
+        $bar = new ProgressIndicator($output = $this->getOutputStream(false));
+
+        $bar->start('Starting...');
+        $bar->advance();
+        $bar->advance();
+        $bar->setMessage('Midway...');
+        $bar->advance();
+        $bar->advance();
+        $bar->finish('Done...');
+
+        rewind($output->getStream());
+
+        $this->assertEquals(
+            ' Starting...'.PHP_EOL.
+            ' Midway...  '.PHP_EOL.
+            ' Done...    '.PHP_EOL.PHP_EOL,
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testCustomIndicatorValues()
+    {
+        $bar = new ProgressIndicator($output = $this->getOutputStream());
+        $bar->setIndicatorValues(array('a', 'b', 'c'));
+
+        $bar->start('Starting...');
+        $bar->advance();
+        $bar->advance();
+        $bar->advance();
+
+        rewind($output->getStream());
+
+        $this->assertEquals(
+            $this->generateOutput(' a Starting...').
+            $this->generateOutput(' b Starting...').
+            $this->generateOutput(' c Starting...').
+            $this->generateOutput(' a Starting...'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    /**
+     * @dataProvider provideFormat
+     */
+    public function testFormats($format)
+    {
+        $bar = new ProgressIndicator($output = $this->getOutputStream());
+        $bar->setFormat($format);
+        $bar->start('Starting...');
+        $bar->advance();
+
+        rewind($output->getStream());
+
+        $this->assertNotEmpty(stream_get_contents($output->getStream()));
+    }
+
+    /**
+     * Provides each defined format.
+     *
+     * @return array
+     */
+    public function provideFormat()
+    {
+        return array(
+            array('normal'),
+            array('verbose'),
+            array('very_verbose'),
+            array('debug'),
+        );
+    }
+
+    protected function getOutputStream($decorated = true, $verbosity = StreamOutput::VERBOSITY_NORMAL)
+    {
+        return new StreamOutput(fopen('php://memory', 'r+', false), $verbosity, $decorated);
+    }
+
+    protected function generateOutput($expected)
+    {
+        $count = substr_count($expected, "\n");
+
+        return "\x0D".($count ? sprintf("\033[%dA", $count) : '').$expected;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -11,11 +11,17 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
     {
         $bar = new ProgressIndicator($output = $this->getOutputStream());
         $bar->start('Starting...');
+        usleep(101000);
         $bar->advance();
+        usleep(101000);
         $bar->advance();
+        usleep(101000);
         $bar->advance();
+        usleep(101000);
         $bar->advance();
+        usleep(101000);
         $bar->advance();
+        usleep(101000);
         $bar->setMessage('Advancing...');
         $bar->advance();
         $bar->finish('Done...');
@@ -65,8 +71,11 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
         $bar->setIndicatorValues(array('a', 'b', 'c'));
 
         $bar->start('Starting...');
+        usleep(101000);
         $bar->advance();
+        usleep(101000);
         $bar->advance();
+        usleep(101000);
         $bar->advance();
 
         rewind($output->getStream());

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -42,11 +42,11 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
             $this->generateOutput(' \\ Advancing...').
             $this->generateOutput(' | Advancing...').
             $this->generateOutput(' | Done...     ').
-            "\n".
+            PHP_EOL.
             $this->generateOutput(' - Starting Again...').
             $this->generateOutput(' \\ Starting Again...').
             $this->generateOutput(' \\ Done Again...    ').
-            "\n",
+            PHP_EOL,
             stream_get_contents($output->getStream())
         );
     }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -25,6 +25,10 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
         $bar->setMessage('Advancing...');
         $bar->advance();
         $bar->finish('Done...');
+        $bar->start('Starting Again...');
+        usleep(101000);
+        $bar->advance();
+        $bar->finish('Done Again...');
 
         rewind($output->getStream());
 
@@ -38,6 +42,10 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
             $this->generateOutput(' \\ Advancing...').
             $this->generateOutput(' | Advancing...').
             $this->generateOutput(' | Done...     ').
+            "\n".
+            $this->generateOutput(' - Starting Again...').
+            $this->generateOutput(' \\ Starting Again...').
+            $this->generateOutput(' \\ Done Again...    ').
             "\n",
             stream_get_contents($output->getStream())
         );
@@ -86,6 +94,46 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
             $this->generateOutput(' a Starting...'),
             stream_get_contents($output->getStream())
         );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Must have at least 2 indicator value characters.
+     */
+    public function testCannotSetInvalidIndicatorCharacters()
+    {
+        $bar = new ProgressIndicator($this->getOutputStream(), null, 100, array('1'));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Progress indicator already started.
+     */
+    public function testCannotStartAlreadyStartedIndicator()
+    {
+        $bar = new ProgressIndicator($this->getOutputStream());
+        $bar->start('Starting...');
+        $bar->start('Starting Again.');
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Progress indicator has not yet been started.
+     */
+    public function testCannotAdvanceUnstartedIndicator()
+    {
+        $bar = new ProgressIndicator($this->getOutputStream());
+        $bar->advance();
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Progress indicator has not yet been started.
+     */
+    public function testCannotFinishUnstartedIndicator()
+    {
+        $bar = new ProgressIndicator($this->getOutputStream());
+        $bar->finish('Finished');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | _todo_ |

This is an alternative to the `ProgressBar` helper _without a max_ inspired by the `npm` cli.  You can use the `ProgressBar` but IMO it doesn't look great or fallback nicely in non-ansi environments.

A lot of work needs to be done still but thought I would get some comments on this idea.
##### Example code

``` php
$progress = new ProgressIndicator($output);
$progress->start('Starting...');

for ($i = 0; $i < 100; $i++) {
    usleep(25000);
    $progress->advance();

    switch ($i) {
        case 20:
            $progress->setMessage('Just started...');
            break;
        case 50:
            $progress->setMessage('Half way...');
            break;
        case 90:
            $progress->setMessage('Almost Done...');
            break;
    }
}

$progress->finish('Done.');
```
##### Screenshot

![output](https://cloud.githubusercontent.com/assets/127811/4511167/95302026-4b31-11e4-824e-5cb26f96e4cb.gif)
