### PR TITLE
Adding createResponse and createJsonResponse to Controller

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -198,6 +199,34 @@ class Controller extends ContainerAware
         $response->setCallback($callback);
 
         return $response;
+    }
+
+    /**
+     * Creates and returns a Response object
+     *
+     * @param mixed   $content The response content, see setContent()
+     * @param int     $status  The response status code
+     * @param array   $headers An array of response headers
+     *
+     * @return Response
+     */
+    public function createResponse($content = '', $status = 200, $headers = array())
+    {
+        return new Response($content, $status, $headers);
+    }
+
+    /**
+     * Creates and returns a JSON response
+     *
+     * @param mixed   $data    The response data - commonly an array
+     * @param int     $status  The response status code
+     * @param array   $headers An array of response headers
+     *
+     * @return JsonResponse
+     */
+    public function createJsonResponse($data = null, $status = 200, $headers = array())
+    {
+        return new JsonResponse($data, $status, $headers);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | not yet :angel: |

Hi guys!

Apologies for the late edition! This introduces 2 shortcut Controller methods:
- `createResponse`
- `createJsonResponse`

Since Symfony requires you to return a Response object (not just a string), creating simple pages - especially for beginners - takes a bit more effort because you need to add the long `use` statement to return `Hello World`. I think this makes life much easier, without obviously sacrificing the nice reality that we always return a Response.

**Before**:

``` php
use Symfony\Component\HttpFoundation\Response;

public function helloAction()
{
    return Response('Hello world!');
}
```

**After**:

``` php
public function helloAction()
{
    return $this->createResponse('Hello world!');
}
```

Thanks!
