### PR TITLE
Removing Controller::getRequest() deprecation note

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -274,41 +274,6 @@ UPGRADE FROM 2.x to 3.0
 
 ### FrameworkBundle
 
- * The `getRequest` method of the base `Controller` class has been deprecated
-   since Symfony 2.4 and must be therefore removed in 3.0. The only reliable
-   way to get the `Request` object is to inject it in the action method.
-
-   Before:
-
-   ```
-   namespace Acme\FooBundle\Controller;
-
-   class DemoController
-   {
-       public function showAction()
-       {
-           $request = $this->getRequest();
-           // ...
-       }
-   }
-   ```
-
-   After:
-
-   ```
-   namespace Acme\FooBundle\Controller;
-
-   use Symfony\Component\HttpFoundation\Request;
-
-   class DemoController
-   {
-       public function showAction(Request $request)
-       {
-           // ...
-       }
-   }
-   ```
-
  * The `request` service was removed. You must inject the `request_stack`
    service instead.
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -265,10 +265,6 @@ class Controller extends ContainerAware
      * Shortcut to return the request service.
      *
      * @return Request
-     *
-     * @deprecated Deprecated since version 2.4, to be removed in 3.0. Ask
-     *             Symfony to inject the Request object into your controller
-     *             method instead by type hinting it in the method's signature.
      */
     public function getRequest()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | not yet :angel: |

Hi guys!

When the `request_stack` was introduced, we deprecated `Controller::getRequest()` - #9553.

I would argue that there _is_ value to this method, as it saves me from needing to add a `use` statement in my controller to get the request. This is similar to why we have the `redirect` shortcut method.

Since the method _does_ use the `request_stack`, I don't see the disadvantage to having this.

Thanks!
