### PR TITLE
[FrameworkBundle] make assets-install --relative equivalent to --symlink --relative

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -80,10 +80,13 @@ EOT
         $bundlesDir = $targetArg.'/bundles/';
         $filesystem->mkdir($bundlesDir, 0777);
 
-        if ($input->getOption('symlink')) {
-            $output->writeln('Trying to install assets as symbolic links.');
+        // relative implies symlink
+        $symlink = $input->getOption('symlink') || $input->getOption('relative');
+
+        if ($symlink) {
+            $output->writeln('Trying to install assets as <comment>symbolic links</comment>.');
         } else {
-            $output->writeln('Installing assets as <comment>hard copies</comment>');
+            $output->writeln('Installing assets as <comment>hard copies</comment>.');
         }
 
         foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
@@ -94,7 +97,7 @@ EOT
 
                 $filesystem->remove($targetDir);
 
-                if ($input->getOption('symlink')) {
+                if ($symlink) {
                     if ($input->getOption('relative')) {
                         $relativeOriginDir = $filesystem->makePathRelative($originDir, realpath($bundlesDir));
                     } else {
@@ -105,8 +108,19 @@ EOT
                         $filesystem->symlink($relativeOriginDir, $targetDir);
                         $output->writeln('The assets were installed using symbolic links.');
                     } catch (IOException $e) {
-                        $this->hardCopy($originDir, $targetDir);
-                        $output->writeln('It looks like your system doesn\'t support symbolic links, so the assets were installed by copying them.');
+                        if (!$input->getOption('relative')) {
+                            $this->hardCopy($originDir, $targetDir);
+                            $output->writeln('It looks like your system doesn\'t support symbolic links, so the assets were installed by copying them.');
+                        }
+
+                        // try again without the relative option
+                        try {
+                            $filesystem->symlink($originDir, $targetDir);
+                            $output->writeln('It looks like your system doesn\'t support relative symbolic links, so the assets were installed by using absolute symbolic links.');
+                        } catch (IOException $e) {
+                            $this->hardCopy($originDir, $targetDir);
+                            $output->writeln('It looks like your system doesn\'t support symbolic links, so the assets were installed by copying them.');
+                        }
                     }
                 } else {
                     $this->hardCopy($originDir, $targetDir);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kinda |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The `--relative` option of `assets:install` only makes sense when asking for symlinks. Before this change, you were forced to pass the two options: `--symlink --relative`. This PR lets you just use `--relative` and the `--symlink` option will be set for you.

This PR also fallbacks to absolute symlinks when relative ones do not work.
