### PR TITLE
[VarDumper] Dynamic HTML dumper

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -286,7 +286,7 @@
     max-height: 480px;
     word-wrap: break-word;
     overflow: hidden;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 table.sf-toolbar-ajax-requests {

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -35,12 +35,10 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $dump = $collector->getDumps('html');
         $this->assertTrue(isset($dump[0]['data']));
         $dump[0]['data'] = preg_replace('/^.*?<pre/', '<pre', $dump[0]['data']);
-        preg_match('/sf-dump-(\\d{2,})/', $dump[0]['data'], $matches);
-        $dumpId = $matches[1];
 
         $xDump = array(
             array(
-                'data' => "<pre id=sf-dump-{$dumpId}><span class=sf-dump-0><span class=sf-dump-num>123</span>\n</span></pre><script>Sfjs.dump.instrument()</script>\n",
+                'data' => "<pre class=sf-dump><span class=sf-dump-num>123</span>\n</pre><script>Sfjs.dump.instrument()</script>\n",
                 'name' => 'DumpDataCollectorTest.php',
                 'file' => __FILE__,
                 'line' => $line,

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -224,7 +224,7 @@ class CliDumper extends AbstractDumper
      */
     public function enterResource(Cursor $cursor, $res, $hasChild)
     {
-        $this->enterHash($cursor, 'resource:'.$this->style('note', $res).' {', $hasChild);
+        $this->enterHash($cursor, $this->style('note', ':'.$res).' {', $hasChild);
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -57,7 +57,7 @@ array:25 [
   "str" => "déjà"
   7 => b"é"
   "[]" => []
-  "res" => resource:stream {
+  "res" => :stream {
     wrapper_type: "plainfile"
     stream_type: "STDIO"
     mode: "r"
@@ -68,7 +68,7 @@ array:25 [
     eof: false
     options: []
   }
-  8 => resource:Unknown {}
+  8 => :Unknown {}
   "obj" => Symfony\Component\VarDumper\Tests\Fixture\DumbFoo { #2
     foo: "foo"
     "bar": "bar"

--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -44,14 +44,14 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
         $out = preg_replace('/[ \t]+$/m', '', $out);
         $var['file'] = htmlspecialchars($var['file'], ENT_QUOTES, 'UTF-8');
         $intMax = PHP_INT_MAX;
-        preg_match('/sf-dump-(\\d{2,})/', $out, $matches);
-        $dumpId = $matches[1];
+        preg_match('/sf-dump-\d+/', $out, $dumpId);
+        $dumpId = $dumpId[0];
 
         $this->assertSame(
             <<<EOTXT
-<foo></foo><bar><span class=sf-dump-0><span class=sf-dump-note>array:25</span> [<span name=sf-dump-child>
-  <span class=sf-dump-1>"<span class=sf-dump-meta>number</span>" => <span class=sf-dump-num>1</span>
-  <span class=sf-dump-meta>0</span> => <span class=sf-dump-const>null</span> <span class=sf-dump-ref id="sf-dump-{$dumpId}-ref1">#1</span>
+<foo></foo><bar><span class=sf-dump-note>array:25</span> [<span name=sf-dump-child>
+  "<span class=sf-dump-meta>number</span>" => <span class=sf-dump-num>1</span>
+  <span class=sf-dump-meta>0</span> => <span class=sf-dump-const>null</span> <span class=sf-dump-ref name=sf-dump-ref id="{$dumpId}-ref1">#1</span>
   "<span class=sf-dump-meta>const</span>" => <span class=sf-dump-num>1.1</span>
   <span class=sf-dump-meta>1</span> => <span class=sf-dump-const>true</span>
   <span class=sf-dump-meta>2</span> => <span class=sf-dump-const>false</span>
@@ -62,8 +62,8 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   "<span class=sf-dump-meta>str</span>" => "<span class=sf-dump-str>d&#233;j&#224;</span>"
   <span class=sf-dump-meta>7</span> => b"<span class=sf-dump-str>&#233;</span>"
   "<span class=sf-dump-meta>[]</span>" => []
-  "<span class=sf-dump-meta>res</span>" => resource:<span class=sf-dump-note>stream</span> {<span name=sf-dump-child>
-    <span class=sf-dump-2><span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str>plainfile</span>"
+  "<span class=sf-dump-meta>res</span>" => <abbr title="Resource of type `stream`" class=sf-dump-note>:stream</abbr> {<span name=sf-dump-child>
+    <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str>plainfile</span>"
     <span class=sf-dump-meta>stream_type</span>: "<span class=sf-dump-str>STDIO</span>"
     <span class=sf-dump-meta>mode</span>: "<span class=sf-dump-str>r</span>"
     <span class=sf-dump-meta>unread_bytes</span>: <span class=sf-dump-num>0</span>
@@ -72,14 +72,14 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
     <span class=sf-dump-meta>blocked</span>: <span class=sf-dump-const>true</span>
     <span class=sf-dump-meta>eof</span>: <span class=sf-dump-const>false</span>
     <span class=sf-dump-meta>options</span>: []
-  </span></span>}
-  <span class=sf-dump-meta>8</span> => resource:<span class=sf-dump-note>Unknown</span> {}
-  "<span class=sf-dump-meta>obj</span>" => <span class=sf-dump-note><abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr></span> {<span name=sf-dump-child> <span class=sf-dump-ref id="sf-dump-{$dumpId}-ref2">#2</span>
-    <span class=sf-dump-2><span class=sf-dump-public>foo</span>: "<span class=sf-dump-str>foo</span>"
+  </span>}
+  <span class=sf-dump-meta>8</span> => <abbr title="Resource of type `Unknown`" class=sf-dump-note>:Unknown</abbr> {}
+  "<span class=sf-dump-meta>obj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<span name=sf-dump-child> <span class=sf-dump-ref name=sf-dump-ref id="{$dumpId}-ref2">#2</span>
+    <span class=sf-dump-public>foo</span>: "<span class=sf-dump-str>foo</span>"
     "<span class=sf-dump-public>bar</span>": "<span class=sf-dump-str>bar</span>"
-  </span></span>}
+  </span>}
   "<span class=sf-dump-meta>closure</span>" => <span class=sf-dump-note>Closure</span> {<span name=sf-dump-child>
-    <span class=sf-dump-2><span class=sf-dump-meta>reflection</span>: """
+    <span class=sf-dump-meta>reflection</span>: """
       <span class=sf-dump-str>Closure [ &lt;user&gt; {$closureLabel} Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {</span>
       <span class=sf-dump-str>  @@ {$var['file']} {$var['line']} - {$var['line']}</span>
 
@@ -89,22 +89,22 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
       <span class=sf-dump-str>  }</span>
       <span class=sf-dump-str>}</span>
       """
-  </span></span>}
+  </span>}
   "<span class=sf-dump-meta>line</span>" => <span class=sf-dump-num>{$var['line']}</span>
   "<span class=sf-dump-meta>nobj</span>" => <span class=sf-dump-note>array:1</span> [<span name=sf-dump-child>
-    <span class=sf-dump-2><span class=sf-dump-meta>0</span> => {} <span class=sf-dump-ref id="sf-dump-{$dumpId}-ref3">#3</span>
-  </span></span>]
-  "<span class=sf-dump-meta>recurs</span>" => <span class=sf-dump-note>array:1</span> [<span name=sf-dump-child> <span class=sf-dump-ref id="sf-dump-{$dumpId}-ref4">#4</span>
-    <span class=sf-dump-2><span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref4">&4</a> <span class=sf-dump-note>array:1</span> [<a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref4">@4</a>]
-  </span></span>]
-  <span class=sf-dump-meta>9</span> => <a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref1">&1</a> <span class=sf-dump-const>null</span>
-  "<span class=sf-dump-meta>sobj</span>" => <span class=sf-dump-note><abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr></span> {<a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref2">@2</a>}
-  "<span class=sf-dump-meta>snobj</span>" => <a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref3">&3</a> {<a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref3">@3</a>}
-  "<span class=sf-dump-meta>snobj2</span>" => {<a class=sf-dump-ref href="#sf-dump-{$dumpId}-ref3">@3</a>}
+    <span class=sf-dump-meta>0</span> => {} <span class=sf-dump-ref name=sf-dump-ref id="{$dumpId}-ref3">#3</span>
+  </span>]
+  "<span class=sf-dump-meta>recurs</span>" => <span class=sf-dump-note>array:1</span> [<span name=sf-dump-child> <span class=sf-dump-ref name=sf-dump-ref id="{$dumpId}-ref4">#4</span>
+    <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref4">&4</a> <span class=sf-dump-note>array:1</span> [<a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref4">@4</a>]
+  </span>]
+  <span class=sf-dump-meta>9</span> => <a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref1">&1</a> <span class=sf-dump-const>null</span>
+  "<span class=sf-dump-meta>sobj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref2">@2</a>}
+  "<span class=sf-dump-meta>snobj</span>" => <a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref3">&3</a> {<a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref3">@3</a>}
+  "<span class=sf-dump-meta>snobj2</span>" => {<a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref3">@3</a>}
   "<span class=sf-dump-meta>file</span>" => "<span class=sf-dump-str>{$var['file']}</span>"
   b"<span class=sf-dump-meta>bin-key-&#233;</span>" => ""
-</span></span>]
-</span></bar>
+</span>]
+</bar>
 
 EOTXT
             ,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12109 |
| License | MIT |
| Doc PR | - |

This PR partially reverts #12109 because it didn't take into account that many dumps can share a single style tag.
More importantly, this PR enhance dump rendering with some cute JS navigation effects:
- references highlighting on hovering
- moving references toggling

Here is a screenshot (note the yellow background and the fact that `#2` appears after the first `@2`):
![capture du 2014-10-04 09 45 44](https://cloud.githubusercontent.com/assets/243674/4514936/4431c67e-4b9b-11e4-9809-8d06836be824.png)
