### PR TITLE
[Validator] Fix Binary Format when maxSize is smaller than uploadLimit

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -53,13 +53,16 @@ class FileValidator extends ConstraintValidator
         if ($value instanceof UploadedFile && !$value->isValid()) {
             switch ($value->getError()) {
                 case UPLOAD_ERR_INI_SIZE:
-                    if ($constraint->maxSize) {
-                        $limitInBytes = min(UploadedFile::getMaxFilesize(), $constraint->maxSize);
+                    $iniLimitSize = UploadedFile::getMaxFilesize();
+                    if ($constraint->maxSize && $constraint->maxSize < $iniLimitSize) {
+                        $limitInBytes = $constraint->maxSize;
+                        $binaryFormat = $constraint->binaryFormat;
                     } else {
-                        $limitInBytes = UploadedFile::getMaxFilesize();
+                        $limitInBytes = $iniLimitSize;
+                        $binaryFormat = true;
                     }
 
-                    list($sizeAsString, $limitAsString, $suffix) = $this->factorizeSizes(0, $limitInBytes, true);
+                    list($sizeAsString, $limitAsString, $suffix) = $this->factorizeSizes(0, $limitInBytes, $binaryFormat);
                     $this->buildViolation($constraint->uploadIniSizeErrorMessage)
                         ->setParameter('{{ limit }}', $limitAsString)
                         ->setParameter('{{ suffix }}', $suffix)

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -461,6 +461,13 @@ abstract class FileValidatorTest extends AbstractConstraintValidatorTest
                 '{{ limit }}' => UploadedFile::getMaxFilesize() / 1048576,
                 '{{ suffix }}' => 'MiB',
             ), '1000M');
+
+            // it correctly parses the maxSize option and not only uses simple string comparison
+            // 1000M should be bigger than the ini value
+            $tests[] = array(UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', array(
+                '{{ limit }}' => '0.1',
+                '{{ suffix }}' => 'MB',
+            ), '100K');
         }
 
         return $tests;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | NA |
| License | MIT |
| Doc PR | NA |

Add a small fix to #12103.
If constraint `maxSize` is defined with base10 (K or M) and is smaller than ini `upload_max_filesize` (defined with base2 (Ki, Mi, Gi, ...) then the error message will not be nicely displayed.
