### PR TITLE
[Console] clean handling of :: passed to find()

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1076,7 +1076,7 @@ class Application
                 }
 
                 $lev = levenshtein($subname, $parts[$i]);
-                if ($lev <= strlen($subname) / 3 || false !== strpos($parts[$i], $subname)) {
+                if ($lev <= strlen($subname) / 3 || '' !== $subname && false !== strpos($parts[$i], $subname)) {
                     $alternatives[$collectionName] = $exists ? $alternatives[$collectionName] + $lev : $lev;
                 } elseif ($exists) {
                     $alternatives[$collectionName] += $threshold;

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -445,6 +445,18 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo:sublong', $application->findNamespace('f:sub'));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Command "foo::bar" is not defined.
+     */
+    public function testFindWithDoubleColonInNameThrowsException()
+    {
+        $application = new Application();
+        $application->add(new \FooCommand());
+        $application->add(new \Foo4Command());
+        $application->find('foo::bar');
+    }
+
     public function testSetCatchExceptions()
     {
         $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12104 |
| License | MIT |
| Doc PR |  |

Commands cannot have a double colon in their name (for example, a command can't be named `foo::bar`). However, one might try to retrieve a `foo::bar` command from the application like this:

``` php
$command = $application->find('foo::bar');
```

The `findAlternatives()` method of the `Application` class fails to handle these strings when there are commands registered with a name consisting of at least three parts (e.g. a command is named `foo:bar:baz`). In this case, an empty string is passed to `strpos()` causing PHP to raise a warning.

In a "real" Symfony application, calling `php ./app/console cache::clear` now results in the following error message:

```
  [InvalidArgumentException]                                
  There are no commands defined in the "cache:" namespace.  
  Did you mean this?                                        
      cache
```
