### PR TITLE
[FrameworkBundle] minor fix

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -47,7 +47,7 @@ class ControllerNameParser
     public function parse($controller)
     {
         $originalController = $controller;
-        if (3 != count($parts = explode(':', $controller))) {
+        if (3 !== count($parts = explode(':', $controller))) {
             throw new \InvalidArgumentException(sprintf('The "%s" controller is not a valid "a:b:c" controller string.', $controller));
         }
 


### PR DESCRIPTION
A small fix in the "parse" function of the "ControllerNameParser" Controller.
We should use "!==" instead of "!=" since it's better and faster in this case.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | NA |
| License | MIT |
| Doc PR | NA |
