### PR TITLE
[TwigBundle] Fix error page preview for custom twig.exception_controller

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -27,30 +27,37 @@ use Symfony\Component\HttpFoundation\Response;
 class ExceptionController
 {
     protected $twig;
-    protected $showException;
 
-    public function __construct(\Twig_Environment $twig, $showException)
+    /**
+     * @var bool Show error (false) or exception (true) pages by default.
+     */
+    protected $debug;
+
+    public function __construct(\Twig_Environment $twig, $debug)
     {
         $this->twig = $twig;
-        $this->showException = $showException;
+        $this->debug = $debug;
     }
 
     /**
      * Converts an Exception to a Response.
      *
-     * @param Request              $request       The request
-     * @param FlattenException     $exception     A FlattenException instance
-     * @param DebugLoggerInterface $logger        A DebugLoggerInterface instance
-     * @param bool|null            $showException Whether an exception or error page shall be displayed. If null, it defaults to the value given in the constructor.
+     * A "showException" request parameter can be used to force display of an error page (when set to false) or
+     * the exception page (when true). If it is not present, the "debug" value passed into the constructor will
+     * be used.
+     *
+     * @param Request              $request   The request
+     * @param FlattenException     $exception A FlattenException instance
+     * @param DebugLoggerInterface $logger    A DebugLoggerInterface instance
      *
      * @return Response
      *
      * @throws \InvalidArgumentException When the exception template does not exist
      */
-    public function showAction(Request $request, FlattenException $exception, DebugLoggerInterface $logger = null, $showException = null)
+    public function showAction(Request $request, FlattenException $exception, DebugLoggerInterface $logger = null)
     {
         $currentContent = $this->getAndCleanOutputBuffering($request->headers->get('X-Php-Ob-Level', -1));
-        $showException = ($showException !== null) ? $showException : $this->showException;
+        $showException = $request->get('showException', $this->debug); // As opposed to an additional parameter, this maintains BC
 
         $code = $exception->getStatusCode();
 

--- a/src/Symfony/Bundle/TwigBundle/Controller/PreviewErrorController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/PreviewErrorController.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Controller;
+
+use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * PreviewErrorController can be used to test error pages.
+ *
+ * It will create a test exception and forward it to another controller.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+class PreviewErrorController
+{
+    protected $kernel;
+    protected $controller;
+
+    public function __construct(HttpKernelInterface $kernel, $controller)
+    {
+        $this->kernel = $kernel;
+        $this->controller = $controller;
+    }
+
+    public function previewErrorPageAction(Request $request, $code)
+    {
+        $exception = FlattenException::create(new \Exception("Something has intentionally gone wrong."), $code);
+
+        /*
+         * This Request mimics the parameters set by
+         * \Symfony\Component\HttpKernel\EventListener\ExceptionListener::duplicateRequest, with
+         * the additional "showException" flag.
+         */
+
+        $subRequest = $request->duplicate(null, null, array(
+            '_controller' => $this->controller,
+            'exception' => $exception,
+            'logger' => null,
+            'format' => $request->getRequestFormat(),
+            'showException' => false,
+        ));
+
+        return $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/routing/errors.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/routing/errors.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="_twig_error_test" path="/{code}.{_format}">
-        <default key="_controller">twig.controller.exception:testErrorPageAction</default>
+        <default key="_controller">twig.controller.preview_error:previewErrorPageAction</default>
         <default key="_format">html</default>
         <requirement key="code">\d+</requirement>
     </route>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -25,6 +25,7 @@
         <parameter key="twig.translation.extractor.class">Symfony\Bridge\Twig\Translation\TwigExtractor</parameter>
         <parameter key="twig.exception_listener.class">Symfony\Component\HttpKernel\EventListener\ExceptionListener</parameter>
         <parameter key="twig.controller.exception.class">Symfony\Bundle\TwigBundle\Controller\ExceptionController</parameter>
+        <parameter key="twig.controller.preview_error.class">Symfony\Bundle\TwigBundle\Controller\PreviewErrorController</parameter>
     </parameters>
 
     <services>
@@ -132,6 +133,11 @@
         <service id="twig.controller.exception" class="%twig.controller.exception.class%">
             <argument type="service" id="twig" />
             <argument>%kernel.debug%</argument>
+        </service>
+
+        <service id="twig.controller.preview_error" class="%twig.controller.preview_error.class%">
+            <argument type="service" id="http_kernel" />
+            <argument>%twig.exception_listener.controller%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -51,11 +51,11 @@ class ExceptionControllerTest extends TestCase
             ))
         );
 
-        $request = Request::create('whatever');
+        $request = Request::create('whatever', 'GET', array('showException' => false));
         $exception = FlattenException::create(new \Exception(), 404);
         $controller = new ExceptionController($twig, /* "showException" defaults to --> */ true);
 
-        $response = $controller->showAction($request, $exception, null, /* "showException" per-request set to --> */ false);
+        $response = $controller->showAction($request, $exception, null);
 
         $this->assertEquals(200, $response->getStatusCode()); // successful request
         $this->assertEquals('ok', $response->getContent());  // content of the error404.html template

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/PreviewErrorControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/PreviewErrorControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Tests\Controller;
+
+use Symfony\Bundle\TwigBundle\Controller\PreviewErrorController;
+use Symfony\Bundle\TwigBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class PreviewErrorControllerTest extends TestCase
+{
+    public function testForwardRequestToConfiguredController()
+    {
+        $self = $this;
+
+        $request = Request::create('whatever');
+        $response = new Response("");
+        $code = 123;
+        $logicalControllerName = 'foo:bar:baz';
+
+        $kernel = $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel
+            ->expects($this->once())
+            ->method('handle')
+            ->with(
+                $this->callback(function (Request $request) use ($self, $logicalControllerName, $code) {
+
+                    $self->assertEquals($logicalControllerName, $request->attributes->get('_controller'));
+
+                    $exception = $request->attributes->get('exception');
+                    $self->assertInstanceOf('Symfony\Component\HttpKernel\Exception\FlattenException', $exception);
+                    $self->assertEquals($code, $exception->getStatusCode());
+
+                    $self->assertFalse($request->attributes->get('showException'));
+
+                    return true;
+                }),
+                $this->equalTo(HttpKernelInterface::SUB_REQUEST)
+            )
+            ->will($this->returnValue($response));
+
+        $controller = new PreviewErrorController($kernel, $logicalControllerName);
+
+        $this->assertSame($response, $controller->previewErrorPageAction($request, $code));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12147 |
| License | MIT |
| Doc PR | n/a |

The `testErrorPageAction()` always used the `showAction()` of TwigBundle's `ExceptionController`.
You can, however, configure an alternate controller by setting `twig.exception_controller`.

Thus, in order to get a proper preview, we need to forward to this configured controller (which
may be the default one).

This requires us to pass an additional parameter to `ExceptionController::showAction` to be able to
get the _error_ page even if configured otherwise in the constructor.

(The other approach would have been to fiddle around with `ExceptionController`'s `debug` flag through a setter when going through the preview action, but that would have been even more messy.)
