### PR TITLE
[Framework+SecurityBundle] remove recently introduced *.class parameters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -15,7 +15,6 @@
         <parameter key="data_collector.router.class">Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector</parameter>
         <parameter key="data_collector.form.class">Symfony\Component\Form\Extension\DataCollector\FormDataCollector</parameter>
         <parameter key="data_collector.form.extractor.class">Symfony\Component\Form\Extension\DataCollector\FormDataExtractor</parameter>
-        <parameter key="data_collector.ajax.class">Symfony\Bundle\FrameworkBundle\DataCollector\AjaxDataCollector</parameter>
     </parameters>
 
     <services>
@@ -29,7 +28,7 @@
             <tag name="data_collector" template="@WebProfiler/Collector/request.html.twig" id="request" priority="255" />
         </service>
 
-        <service id="data_collector.ajax" class="%data_collector.ajax.class%" public="false">
+        <service id="data_collector.ajax" class="Symfony\Bundle\FrameworkBundle\DataCollector\AjaxDataCollector" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/ajax.html.twig" id="ajax" priority="255" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -10,7 +10,6 @@
         <parameter key="fragment.renderer.hinclude.class">Symfony\Bundle\FrameworkBundle\Fragment\ContainerAwareHIncludeFragmentRenderer</parameter>
         <parameter key="fragment.renderer.hinclude.global_template"></parameter>
         <parameter key="fragment.renderer.esi.class">Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer</parameter>
-        <parameter key="fragment.renderer.ssi.class">Symfony\Component\HttpKernel\Fragment\SsiFragmentRenderer</parameter>
         <parameter key="fragment.path">/_fragment</parameter>
     </parameters>
 
@@ -44,7 +43,7 @@
             <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
         </service>
 
-        <service id="fragment.renderer.ssi" class="%fragment.renderer.ssi.class%">
+        <service id="fragment.renderer.ssi" class="Symfony\Component\HttpKernel\Fragment\SsiFragmentRenderer">
             <tag name="kernel.fragment_renderer" />
             <argument type="service" id="ssi" on-invalid="null" />
             <argument type="service" id="fragment.renderer.inline" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/ssi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/ssi.xml
@@ -4,15 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="ssi.class">Symfony\Component\HttpKernel\HttpCache\Ssi</parameter>
-        <parameter key="ssi_listener.class">Symfony\Component\HttpKernel\EventListener\SurrogateListener</parameter>
-    </parameters>
-
     <services>
-        <service id="ssi" class="%ssi.class%" />
+        <service id="ssi" class="Symfony\Component\HttpKernel\HttpCache\Ssi" />
 
-        <service id="ssi_listener" class="%ssi_listener.class%">
+        <service id="ssi_listener" class="Symfony\Component\HttpKernel\EventListener\SurrogateListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="ssi" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -6,7 +6,6 @@
 
     <parameters>
         <parameter key="translator.class">Symfony\Bundle\FrameworkBundle\Translation\Translator</parameter>
-        <parameter key="translator.logging.class">Symfony\Component\Translation\LoggingTranslator</parameter>
         <parameter key="translator.identity.class">Symfony\Component\Translation\IdentityTranslator</parameter>
         <parameter key="translator.selector.class">Symfony\Component\Translation\MessageSelector</parameter>
         <parameter key="translation.loader.php.class">Symfony\Component\Translation\Loader\PhpFileLoader</parameter>
@@ -47,7 +46,7 @@
             </argument>
         </service>
 
-        <service id="translator.logging" class="%translator.logging.class%" public="false">
+        <service id="translator.logging" class="Symfony\Component\Translation\LoggingTranslator" public="false">
             <argument type="service" id="translator.logging.inner" />
             <argument type="service" id="logger" />
             <tag name="monolog.logger" channel="translation" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -6,13 +6,10 @@
 
     <parameters>
         <parameter key="security.context.class">Symfony\Component\Security\Core\SecurityContext</parameter>
-        <parameter key="security.authorization_checker.class">Symfony\Component\Security\Core\Authorization\AuthorizationChecker</parameter>
-        <parameter key="security.token_storage.class">Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage</parameter>
 
         <parameter key="security.user_checker.class">Symfony\Component\Security\Core\User\UserChecker</parameter>
 
         <parameter key="security.encoder_factory.generic.class">Symfony\Component\Security\Core\Encoder\EncoderFactory</parameter>
-        <parameter key="security.user_password_encoder.generic.class">Symfony\Component\Security\Core\Encoder\UserPasswordEncoder</parameter>
         <parameter key="security.encoder.digest.class">Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder</parameter>
         <parameter key="security.encoder.plain.class">Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder</parameter>
         <parameter key="security.encoder.pbkdf2.class">Symfony\Component\Security\Core\Encoder\Pbkdf2PasswordEncoder</parameter>
@@ -50,8 +47,6 @@
         <parameter key="security.validator.user_password.class">Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator</parameter>
 
         <parameter key="security.expression_language.class">Symfony\Component\Security\Core\Authorization\ExpressionLanguage</parameter>
-
-        <parameter key="security.authentication_utils.class">Symfony\Component\Security\Http\Authentication\AuthenticationUtils</parameter>
     </parameters>
 
     <services>
@@ -60,14 +55,14 @@
             <argument type="service" id="security.authorization_checker" />
         </service>
 
-        <service id="security.authorization_checker" class="%security.authorization_checker.class%">
+        <service id="security.authorization_checker" class="Symfony\Component\Security\Core\Authorization\AuthorizationChecker">
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="security.access.decision_manager" />
             <argument>%security.access.always_authenticate_before_granting%</argument>
         </service>
 
-        <service id="security.token_storage" class="%security.token_storage.class%" />
+        <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" />
 
         <!-- Authentication related services -->
         <service id="security.authentication.manager" class="%security.authentication.manager.class%" public="false">
@@ -93,7 +88,7 @@
 
         <service id="security.encoder_factory" alias="security.encoder_factory.generic"></service>
 
-        <service id="security.user_password_encoder.generic" class="%security.user_password_encoder.generic.class%" public="false">
+        <service id="security.user_password_encoder.generic" class="Symfony\Component\Security\Core\Encoder\UserPasswordEncoder" public="false">
             <argument type="service" id="security.encoder_factory"></argument>
         </service>
 
@@ -103,7 +98,7 @@
 
         <service id="security.expression_language" class="%security.expression_language.class%" public="false" />
 
-        <service id="security.authentication_utils" class="%security.authentication_utils.class%">
+        <service id="security.authentication_utils" class="Symfony\Component\Security\Http\Authentication\AuthenticationUtils">
             <argument type="service" id="request_stack" />
         </service>
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -24,8 +24,6 @@
 
         <parameter key="security.authentication.listener.x509.class">Symfony\Component\Security\Http\Firewall\X509AuthenticationListener</parameter>
 
-        <parameter key="security.authentication.listener.remote_user.class">Symfony\Component\Security\Http\Firewall\RemoteUserAuthenticationListener</parameter>
-
         <parameter key="security.authentication.listener.anonymous.class">Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener</parameter>
 
         <parameter key="security.authentication.switchuser_listener.class">Symfony\Component\Security\Http\Firewall\SwitchUserListener</parameter>
@@ -48,8 +46,6 @@
 
         <parameter key="security.authentication.success_handler.class">Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler</parameter>
         <parameter key="security.authentication.failure_handler.class">Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler</parameter>
-        <parameter key="security.authentication.custom_success_handler.class">Symfony\Component\Security\Http\Authentication\CustomAuthenticationSuccessHandler</parameter>
-        <parameter key="security.authentication.custom_failure_handler.class">Symfony\Component\Security\Http\Authentication\CustomAuthenticationFailureHandler</parameter>
         <parameter key="security.authentication.simple_success_failure_handler.class">Symfony\Component\Security\Http\Authentication\SimpleAuthenticationHandler</parameter>
     </parameters>
 
@@ -125,7 +121,7 @@
             <argument type="service" id="event_dispatcher" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.custom_success_handler" class="%security.authentication.custom_success_handler.class%" abstract="true" public="false">
+        <service id="security.authentication.custom_success_handler" class="Symfony\Component\Security\Http\Authentication\CustomAuthenticationSuccessHandler" abstract="true" public="false">
             <argument /> <!-- The custom success handler service id -->
             <argument type="collection" /> <!-- Options -->
             <argument /> <!-- Provider-shared Key -->
@@ -136,7 +132,7 @@
             <argument type="collection" /> <!-- Options -->
         </service>
 
-        <service id="security.authentication.custom_failure_handler" class="%security.authentication.custom_failure_handler.class%" abstract="true" public="false">
+        <service id="security.authentication.custom_failure_handler" class="Symfony\Component\Security\Http\Authentication\CustomAuthenticationFailureHandler" abstract="true" public="false">
             <argument /> <!-- The custom failure handler service id -->
             <argument type="collection" /> <!-- Options -->
         </service>
@@ -189,7 +185,7 @@
             <argument type="service" id="event_dispatcher" on-invalid="null"/>
         </service>
 
-        <service id="security.authentication.listener.remote_user" class="%security.authentication.listener.remote_user.class%" public="false" abstract="true">
+        <service id="security.authentication.listener.remote_user" class="Symfony\Component\Security\Http\Firewall\RemoteUserAuthenticationListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is just a cleanup that removes `*.class` parameters introduced in the master branch (and not in the 2.5 one).
#12145 also removes the remaining params for the Debug/TwigBundle
