### PR TITLE
[Framework][DX] Set the proper validator class according to the configured api version

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -725,6 +725,9 @@ class FrameworkExtension extends Extension
                 break;
             case '2.5':
                 $api = Validation::API_VERSION_2_5;
+                // the validation class needs to be changed only for the 2.5 api since the deprecated interface is
+                // set as the default interface
+                $container->setParameter('validator.class', 'Symfony\Component\Validator\Validator\ValidatorInterface');
                 break;
             default:
                 $api = Validation::API_VERSION_2_5_BC;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -384,6 +384,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(array('loadValidatorMetadata'), $calls[4][1]);
         $this->assertSame('setApiVersion', $calls[5][0]);
         $this->assertSame(array(Validation::API_VERSION_2_4), $calls[5][1]);
+        $this->assertSame('Symfony\Component\Validator\ValidatorInterface', $container->getParameter('validator.class'));
         // no cache, no annotations
     }
 
@@ -399,6 +400,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(array('loadValidatorMetadata'), $calls[4][1]);
         $this->assertSame('setApiVersion', $calls[5][0]);
         $this->assertSame(array(Validation::API_VERSION_2_5), $calls[5][1]);
+        $this->assertSame('Symfony\Component\Validator\Validator\ValidatorInterface', $container->getParameter('validator.class'));
         // no cache, no annotations
     }
 
@@ -414,6 +416,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(array('loadValidatorMetadata'), $calls[4][1]);
         $this->assertSame('setApiVersion', $calls[5][0]);
         $this->assertSame(array(Validation::API_VERSION_2_5_BC), $calls[5][1]);
+        $this->assertSame('Symfony\Component\Validator\ValidatorInterface', $container->getParameter('validator.class'));
         // no cache, no annotations
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

With this change the proper validator class will be dumped and therefore used for code completion in IDE's like PhpStorm which rely on the dumped container.

If you have 2.4 or 2.5-bc API the class will be 

```
Symfony\Component\Validator\ValidatorInterface
```

If you use the 2.5 API the class will be

```
Symfony\Component\Validator\Validator\ValidatorInterface
```

I consider this also as important for the developer experience since a wrong type hint can easily cause issues since the method signatures of the validate() method have changed.

From 

``` php
    public function validate($value, $groups = null, $traverse = false, $deep = false);
```

To

``` php
    public function validate($value, $constraints = null, $groups = null);
```

So if you want to validate specific groups you now have to pass them as the third argument instead of the second.
