### PR TITLE
[WIP] [ContainerBuilder] Create your services with lazy loading

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -102,6 +102,35 @@ class XmlDumper extends Dumper
     }
 
     /**
+     * Adds method lazy calls.
+     *
+     * @param array       $methodcalls
+     * @param \DOMElement $parent
+     */
+    private function addMethodLazyCalls(array $methodcalls, \DOMElement $parent)
+    {
+        foreach ($methodcalls as $methodcall) {
+            $call = $this->document->createElement('lazy_call');
+            $call->setAttribute('method', $methodcall[0]);
+            $trigger = $methodcall[2];
+            if (is_array($trigger)) {
+                if (key($trigger) == 'property') {
+                    $call->setAttribute('trigger-property', current($trigger));
+                }
+                if (key($trigger) == 'method') {
+                    $call->setAttribute('trigger-method', current($trigger));
+                }
+            } else if ($trigger) {
+                $call->setAttribute('trigger-method', $trigger);
+            }
+            if (count($methodcall[1])) {
+                $this->convertParameters($methodcall[1], 'argument', $call);
+            }
+            $parent->appendChild($call);
+        }
+    }
+
+    /**
      * Adds a service.
      *
      * @param Definition  $definition
@@ -175,6 +204,7 @@ class XmlDumper extends Dumper
         }
 
         $this->addMethodCalls($definition->getMethodCalls(), $service);
+        $this->addMethodLazyCalls($definition->getMethodLazyCalls(), $service);
 
         if ($callable = $definition->getFactory()) {
             $factory = $this->document->createElement('factory');

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -135,6 +135,10 @@ class YamlDumper extends Dumper
             $code .= sprintf("        calls:\n%s\n", $this->dumper->dump($this->dumpValue($definition->getMethodCalls()), 1, 12));
         }
 
+        if ($definition->getMethodLazyCalls()) {
+            $code .= sprintf("        lazy_calls:\n%s\n", $this->dumper->dump($this->dumpValue($definition->getMethodLazyCalls()), 1, 12)); /** TODO check result here */
+        }
+
         if (ContainerInterface::SCOPE_CONTAINER !== $scope = $definition->getScope()) {
             $code .= sprintf("        scope: %s\n", $scope);
         }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
@@ -28,6 +28,12 @@ class RealServiceInstantiator implements InstantiatorInterface
      */
     public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
     {
-        return call_user_func($realInstantiator);
+        $service = call_user_func($realInstantiator);
+        
+        foreach ($definition->getMethodLazyCalls() as $call) {
+            call_user_func($call[3]);
+        }
+        
+        return $service;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -201,6 +201,17 @@ class XmlFileLoader extends FileLoader
             $definition->addMethodCall($call->getAttribute('method'), $this->getArgumentsAsPhp($call, 'argument'));
         }
 
+        foreach ($this->getChildren($service, 'lazy_call') as $call) {
+            $trigger = null;
+            if ($call->hasAttribute('trigger-property')) {
+                $trigger = ['property' => $call->getAttribute('trigger-property')];
+            }
+            if ($call->hasAttribute('trigger-method')) {
+                $trigger = ['method' => $call->getAttribute('trigger-method')];
+            }
+            $definition->addMethodLazyCall($call->getAttribute('method'), $this->getArgumentsAsPhp($call, 'argument'), $trigger);
+        }
+
         foreach ($this->getChildren($service, 'tag') as $tag) {
             $parameters = array();
             foreach ($tag->attributes as $name => $node) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -250,6 +250,18 @@ class YamlFileLoader extends FileLoader
             }
         }
 
+        if (isset($service['lazy_calls'])) {
+            $calls = $service['lazy_calls'];
+            if (!is_array($calls)) {
+                throw new InvalidArgumentException(sprintf('Parameter "lazy_calls" must be an array for service "%s" in %s. Check your YAML syntax.', $id, $file));
+            }
+
+            foreach ($service['lazy_calls'] as $call) {
+                $args = isset($call[1]) ? $this->resolveServices($call[1]) : array();
+                $definition->addMethodLazyCall($call[0], $args, isset($call[2]) ? $call[2] : null);
+            }
+        }
+
         if (isset($service['tags'])) {
             if (!is_array($service['tags'])) {
                 throw new InvalidArgumentException(sprintf('Parameter "tags" must be an array for service "%s" in %s. Check your YAML syntax.', $id, $file));

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -79,6 +79,7 @@
       <xsd:element name="configurator" type="callable" minOccurs="0" maxOccurs="1" />
       <xsd:element name="factory" type="callable" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="lazy_call" type="lazy_call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
     </xsd:choice>
@@ -154,6 +155,16 @@
       <xsd:element name="service" type="service" />
     </xsd:choice>
     <xsd:attribute name="method" type="xsd:string" />
+  </xsd:complexType>
+
+  <xsd:complexType name="lazy_call" mixed="true">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="argument" type="argument" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="service" type="service" />
+    </xsd:choice>
+    <xsd:attribute name="method" type="xsd:string" />
+    <xsd:attribute name="trigger-method" type="xsd:string" />
+    <xsd:attribute name="trigger-property" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:simpleType name="parameter_type">

--- a/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
@@ -44,13 +44,14 @@ class CrossCheckTest extends \PHPUnit_Framework_TestCase
 
         $dumper = new $dumperClass($container1);
         file_put_contents($tmp, $dumper->dump());
+        file_put_contents($fixture.$type, $dumper->dump());
 
         $container2 = new ContainerBuilder();
         $loader2 = new $loaderClass($container2, new FileLocator());
         $loader2->load($tmp);
 
         unlink($tmp);
-
+        
         $this->assertEquals($container2->getAliases(), $container1->getAliases(), 'loading a dump from a previously loaded container returns the same container');
         $this->assertEquals($container2->getDefinitions(), $container1->getDefinitions(), 'loading a dump from a previously loaded container returns the same container');
         $this->assertEquals($container2->getParameterBag()->all(), $container1->getParameterBag()->all(), '->getParameterBag() returns the same value for both containers');

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -131,6 +131,25 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Symfony\Component\DependencyInjection\Definition::setMethodLazyCalls
+     * @covers Symfony\Component\DependencyInjection\Definition::addMethodLazyCall
+     * @covers Symfony\Component\DependencyInjection\Definition::hasMethodLazyCall
+     * @covers Symfony\Component\DependencyInjection\Definition::removeMethodLazyCall
+     */
+    public function testMethodLazyCalls()
+    {
+        $def = new Definition('stdClass');
+        $this->assertSame($def, $def->setMethodLazyCalls(array(array('setFoo', array('foo')))), '->setMethodLazyCalls() implements a fluent interface');
+        $this->assertEquals(array(array('setFoo', array('foo'), null, null)), $def->getMethodLazyCalls(), '->getMethodLazyCalls() returns the methods to call');
+        $this->assertSame($def, $def->addMethodLazyCall('bar', array('bar'), ['property' => 'bar']), '->addMethodLazyCall() implements a fluent interface');
+        $this->assertEquals(array(array('setFoo', array('foo'), null, null), array('bar', array('bar'), ['property' => 'bar'], null)), $def->getMethodLazyCalls(), '->addMethodLazyCall() adds a method to call');
+        $this->assertTrue($def->hasMethodLazyCall('bar'), '->hasMethodLazyCall() returns true if first argument is a method to call registered');
+        $this->assertFalse($def->hasMethodLazyCall('no_registered'), '->hasMethodLazyCall() returns false if first argument is not a method to call registered');
+        $this->assertSame($def, $def->removeMethodLazyCall('bar'), '->removeMethodLazyCall() implements a fluent interface');
+        $this->assertEquals(array(array('setFoo', array('foo'), null, null)), $def->getMethodLazyCalls(), '->removeMethodLazyCall() removes a method to call');
+    }
+
+    /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @expectedExceptionMessage Method name cannot be empty.
      */

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -35,6 +35,13 @@
       <call method="setBar">
         <argument type="expression">service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")</argument>
       </call>
+      <lazy_call method="setBar" />
+      <lazy_call method="setBar" trigger-property="foo">
+        <argument>foo</argument>
+      </lazy_call>
+      <lazy_call method="setBar" trigger-method="foo">
+          <argument>foo</argument>
+      </lazy_call>
     </service>
     <service id="method_call2" class="FooClass">
       <call method="setBar">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -16,6 +16,10 @@ services:
             - [ setBar, [] ]
             - [ setBar ]
             - [ setBar, ['@=service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")'] ]
+        lazy_calls:
+            - [ setBar, [] ]
+            - [ setBar, [ foo], property : foo ]
+            - [ setBar, [ foo], method : foo ]
     method_call2:
         class: FooClass
         calls:

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -213,6 +213,9 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('BazClass', 'configureStatic'), $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array(array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
+        $this->assertEquals(array('setBar', array(), null, null), $services['method_call1']->getMethodLazyCalls()[0], '->load() parses the method_lazy_call tag');
+        $this->assertEquals(array('setBar', array('foo'), ['property' => 'foo'], null), $services['method_call1']->getMethodLazyCalls()[1], '->load() parses the method_lazy_call tag');
+        $this->assertEquals(array('setBar', array('foo'), ['method' => 'foo'], null), $services['method_call1']->getMethodLazyCalls()[2], '->load() parses the method_lazy_call tag');
         $this->assertNull($services['factory_service']->getClass());
         $this->assertEquals('getInstance', $services['factory_service']->getFactoryMethod());
         $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -140,6 +140,9 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('BazClass', 'configureStatic'), $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array(array('setBar', array()), array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
+        $this->assertEquals(array('setBar', array(), null, null), $services['method_call1']->getMethodLazyCalls()[0], '->load() parses the method_lazy_call tag');
+        $this->assertEquals(array('setBar', array('foo'), ['property' => 'foo'], null), $services['method_call1']->getMethodLazyCalls()[1], '->load() parses the method_lazy_call tag');
+        $this->assertEquals(array('setBar', array('foo'), ['method' => 'foo'], null), $services['method_call1']->getMethodLazyCalls()[2], '->load() parses the method_lazy_call tag');
         $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');
         $this->assertEquals(array(new Reference('baz'), 'getClass'), $services['new_factory2']->getFactory(), '->load() parses the factory tag');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Currently, we can define a service as "lazy". But this behaviour is limited. If we want to use lazy loading with getter/setter inside a big controller (or a big service), there is no real solution. This new feature will bring solution to have lazy loading during your services creation.
- What is a lazy call?

A lazy call config is exactly like a "call" method config, but the method is called lazily. Called on demand, when you need to use your dependence.
- How it works?

You can define a lazy call like a simple call :

``` php
service1:
            lazy_calls:
                        - [ setBar, [ foo ] ]
```

In this case, when you will call `getBar` of your service `service1`, the `setBar` method will be called by the proxy to init your service/controller. Because if your don't define any triggering condition, the method will be base on getter/setter method.

Otherwise, you can define what will be your trigger :

``` php
service1:
            lazy_calls:
                        - [ setBar, [ foo ], property : foo ]
                        - [ setBar, [ foo ], method : foo ]
```

With the first example, when you will use the `foo` property inside your service `service1`, the `setBar` method will be called by the proxy to init your service/controller. 
With the second one, when you will use the `foo` method of your service `service1`, the `setBar` method will be called by the proxy to init your service/controller. 

If you don't use the `ProxyManager` project, the `RealServiceInstanciator' will use lazy calls like classic call. Otherwise, your dependence will be injected when you will use the related property/related method you have defined to trigger the initialization.
- Why do I need this?

Some of your controllers or services will have a lot of dependence but they won't be use all the services injected. If the injection of the Container can be a solution, it's a solution hard to test. The lazy loading will bring more flexibility to remove the dependence of the ContainerBuilder from your code.
Because you will get services on-demand, this lazy loading can prevent circular dependence or memory consumption during your services building.
- What's the remaining work?

I need to have the feedback of @stof and @Ocramius to know if this feature can be integrated in the DependencyInjection component. Then, if yes, there will some work to add : synchronize feature and tests to add, documentation? ... that's a first draft for now.
