### PR TITLE
[Validator] YamlLoader: always check array presence

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -23,20 +23,18 @@ class YamlFileLoader extends FileLoader
      *
      * @var array
      */
-    protected $classes = null;
+    protected $classes;
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException
      */
     public function loadClassMetadata(ClassMetadata $metadata)
     {
         if (null === $this->classes) {
             if (!stream_is_local($this->file)) {
                 throw new \InvalidArgumentException(sprintf('This is not a local file "%s".', $this->file));
-            }
-
-            if (!file_exists($this->file)) {
-                throw new \InvalidArgumentException(sprintf('File "%s" not found.', $this->file));
             }
 
             if (null === $this->yamlParser) {
@@ -52,6 +50,7 @@ class YamlFileLoader extends FileLoader
 
             // not an array
             if (!is_array($this->classes)) {
+                $this->classes = null;
                 throw new \InvalidArgumentException(sprintf('The file "%s" must contain a YAML array.', $this->file));
             }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -43,6 +43,22 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->loadClassMetadata($metadata);
     }
 
+    /**
+     * Bug #12158
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadClassMetadataThrowsExceptionIfNotAnArrayTheSecondCall()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/nonvalid-mapping.yml');
+        $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+        try {
+            $loader->loadClassMetadata($metadata);
+        } catch (\InvalidArgumentException $e) {
+            $loader->loadClassMetadata($metadata);
+        }
+    }
+
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
         $loader = new YamlFileLoader(__DIR__.'/constraint-mapping.yml');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | n/a |
- Removes the useless `file_exists` check (already done by `is_file()` in the `FileLoader` constructor)
- Reset `$this->classes` to `null` before throwing an exception. Currently, the exception is not thrown the second time if `loadClassMetadata()` is called 2 times.
