### PR TITLE
[wip] [Debug] Improvements, compat and Object tracer

### DIFF
--- a/src/Symfony/Component/Debug/Resources/ext/README.md
+++ b/src/Symfony/Component/Debug/Resources/ext/README.md
@@ -119,6 +119,88 @@ array(3) {
 */
 ```
 
+symfony_debug_object_tracer_set_logger(Psr\Log\LoggerInterface $logger)
+---------------------------------------------------------
+
+Collector for object traces. Object traces is a tracer - enabled when a logger object is passed to symfony_debug_set_logger() - that traces objects creation / cloning and destruction from a PHP instance.
+The PSR3 Logger is used to log object traces, the debug() method is used, receiving a general message, and as context, the object class, the object handle, the filename and line where happening (except in shutdown sequence) and the type of event beeing logged : SYMFONY_DEBUG_OBJECT_TRACE_TYPE_NEW (object creation), SYMFONY_DEBUG_OBJECT_TRACE_TYPE_CLONE (object clone) or SYMFONY_DEBUG_OBJECT_TRACE_TYPE_DESTROY (object destruction).
+
+```php
+class TestLog implements Psr\Log\LoggerInterface {
+    public function emergency($message, array $context = array()) { }
+    public function alert($message, array $context = array()) { }
+    public function critical($message, array $context = array()) { }
+    public function error($message, array $context = array()) { }
+    public function warning($message, array $context = array()) { }
+    public function notice($message, array $context = array()) { }
+    public function info($message, array $context = array()) { }
+    public function debug($message, array $context = array()) { printf("$message \n"); }
+    public function log($level, $message, array $context = array()) { }
+}
+
+/* Exemple filtering only on object destruction */
+class LogFilter extends TestLog
+{
+	public function debug($message, array $context = array())
+	{ 
+		if($context['trace_type'] & SYMFONY_DEBUG_OBJECT_TRACE_TYPE_DESTROY) {
+			printf('destroying');
+		}
+	}
+}
+
+$log = new TestLog;
+symfony_debug_object_tracer_set_logger($log); 
+
+$a = new StdClass;
+
+$b = clone $a;
+
+unset($b);
+
+/* This will output :
+Creating an object of class stdClass in foo.php:15 
+Cloning object #2 of class stdClass in foo.php:17 
+Destroying object #3 of class stdClass at foo.php:19 
+Destroying object #2 of class stdClass at [no active file]:0
+*/
+```
+
+symfony_debug_get_error_handler() - symfony_debug_get_error_handlers()
+----------------------------------------------------------
+
+Simply dumps the current user error handler(s).
+
+```php
+
+function my_eh() { }
+
+set_error_handler(function () { });
+set_error_handler('my_eh');
+
+var_dump(symfony_debug_get_error_handler());
+var_dump(symfony_debug_get_error_handlers());
+
+/*
+string(5) "my_eh"
+
+array(2) {
+  [0]=>
+  object(Closure)#1 (0) {
+  }
+  [1]=>
+  string(5) "my_eh"
+}
+*/
+
+```
+
+symfony_debug_enable_var_dumper_dump()
+--------------------------------------
+
+Replaces PHP's var_dump() function by Symfony\\Component\\VarDumper\\VarDumper::dump();
+Supports Xdebug.
+
 Usage
 -----
 

--- a/src/Symfony/Component/Debug/Resources/ext/php_symfony_debug.h
+++ b/src/Symfony/Component/Debug/Resources/ext/php_symfony_debug.h
@@ -5,13 +5,20 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ *
+ * Julien PAULI <jpauli@php.net>
  */
 
 #ifndef PHP_SYMFONY_DEBUG_H
 #define PHP_SYMFONY_DEBUG_H
 
+#include "sensiolabs_php_compat.h"
+
 extern zend_module_entry symfony_debug_module_entry;
 #define phpext_symfony_debug_ptr &symfony_debug_module_entry
+#ifdef COMPILE_DL_SYMFONY_DEBUG
+zend_module_entry *get_module(void);
+#endif
 
 #define PHP_SYMFONY_DEBUG_VERSION "2.7"
 
@@ -28,9 +35,13 @@ extern zend_module_entry symfony_debug_module_entry;
 #endif
 
 ZEND_BEGIN_MODULE_GLOBALS(symfony_debug)
-	intptr_t req_rand_init;
 	void (*old_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
 	zval *debug_bt;
+	zval *psr3_logger;
+	zend_function *psr3_logger_cache;
+	zend_function *php_var_dump;
+	intptr_t req_rand_init;
+	zend_bool in_logger;
 ZEND_END_MODULE_GLOBALS(symfony_debug)
 
 PHP_MINIT_FUNCTION(symfony_debug);
@@ -43,13 +54,112 @@ PHP_GSHUTDOWN_FUNCTION(symfony_debug);
 
 PHP_FUNCTION(symfony_zval_info);
 PHP_FUNCTION(symfony_debug_backtrace);
+PHP_FUNCTION(symfony_debug_object_tracer_set_logger);
+PHP_FUNCTION(symfony_debug_get_error_handlers);
+PHP_FUNCTION(symfony_debug_get_error_handler);
+PHP_FUNCTION(symfony_debug_enable_var_dumper_dump);
 
 static char *_symfony_debug_memory_address_hash(void * TSRMLS_DC);
 static const char *_symfony_debug_zval_type(zval *);
 static const char* _symfony_debug_get_resource_type(long TSRMLS_DC);
 static int _symfony_debug_get_resource_refcount(long TSRMLS_DC);
+static int symfony_debug_post_deactivate(void);
+static const char sensiolabs_logo[] = "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHYAAAAUCAMAAABvRTlyAAAAz1BMVEUAAAAAAAAAAAAsThWB5j4AAACD6T8AAACC6D+C6D6C6D+C6D4AAAAAAACC6D4AAAAAAACC6D8AAAAAAAAAAAAAAAAAAAAAAACC6D4AAAAAAAAAAACC6D4AAAAAAAAAAAAAAAAAAAAAAACC6D8AAACC6D4AAAAAAAAAAAAAAAAAAACC6D8AAACC6D6C6D+B6D+C6D+C6D+C6D8AAACC6D6C6D4AAACC6D/K/2KC6D+B6D6C6D6C6D+C6D8sTxUyWRhEeiEAAACC6D+C5z6B6D7drnEVAAAAQXRSTlMAE3oCNSUuDHFHzxaF9UFsu+irX+zlKzYimaJXktyOSFD6BolxqT7QGMMdarMIpuO28r9EolXKgR16OphfXYd4V14GtB4AAAMpSURBVEjHvVSJctowEF1jjME2RziMwUCoMfd9heZqG4n//6buLpJjkmYm03byZmxJa2nf6u2uQcG2bfhqRN4LoTKBzyGDm68M7mAwcOEdjo4zhA/Rf9Go/CVtTgiRhXfIC3EDH8F/eUX1/9KexRo+QgOdtHDsEe/sM7QT32/+K61Z1LFXcXJxN4pTbu1aTQUzuy2PIA0rDo0/0Aa5XFaJvKaVTrubywXvaa1Wq4Vu/Snr3Y7Aojh4VccwykW2N2oQ8wmjyut6+Q1t5ywIG5Npj1sh5E0B7YOzFDjfuRfaOh3O+MbbVNfTWS9COZk3Obd2su5d0a6IU9KLREbw8gEehWSr1r2sPWciXLG38r5NdW0xu9eioU87omjC9yNaMi5GNf6WppVSOqXCFkmCvMB3p9SROLoYQn5pDgQOujA1xjYvqH+plUdkwnmII8VxR/PKYkrfLLomhVlE3b/LhNbNr7hp0H2JaOc4v8dFB58HSsFTSafaqtY1sT3GO8wsy5rhokYPlRJdjPMajyYqTt1EHF/2uqSWQWmAjCUSmQ1MS3g8Btf1XOsy7YIC0CB1b5Xw1Vhba0zbxiCAQLH9TNPmHJXQUtJAN0KcDsoqLxsNvJrJExa7mKIdp2lRE2WexiS4pqWk/0jROlw6K6bV9YOBDGAuqMJ0bnuUKGB0L27bxgRhGEbzihbhxxXaQC88Vkwq8ldCi86RApWUb0Q+4VDosBCc+1s81lUdnBavH4Zp2mm3O44USwOfvSo9oBiwpFg71lMS1VKJLKljS3j9p+fOTvXXlsSNuEv6YPaZda9uRope0VJfKdo7fPiYfSmvFjXQbkhY0d9hCbBWIktRgEDieDhf1N3wbbkmNNgRy8hyl620yGQat/grV3HMpc2HDKTVmOPFz6ylPCKt/nXcAyV260jaAowwIW0YuBzrOgb/KrddZS9OmJaLgpWK4JX2DDuklcLZSDGcn8Vmx9YDNvT6UsjyBApRyFQVX7Vxm9TGxE16nmfRd8/zQoDmggQOTRh5Hv8pMt9Q/L2JmSwkMCE7dA4BuDjHJwfu0Om4QAhOjrN5XkIatglfiN/bUPdCQFjTYgAAAABJRU5ErkJggg==\">";
 
 void symfony_debug_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
+
+typedef enum {
+	SYMFONY_DEBUG_OBJECT_TRACE_TYPE_NEW,
+	SYMFONY_DEBUG_OBJECT_TRACE_TYPE_CLONE,
+	SYMFONY_DEBUG_OBJECT_TRACE_TYPE_DESTROY
+} symfony_debug_object_trace_type;
+
+typedef struct _symfony_debug_object_trace {
+	zend_class_entry *ce;
+	zend_object_handle handle;
+	const char*filename;
+	char *msg;
+	uint lineno;
+	symfony_debug_object_trace_type trace_type;
+} symfony_debug_object_trace;
+
+static symfony_debug_object_trace _symfony_debug_new_object_trace(zend_class_entry *ce, zend_object_handle handle, symfony_debug_object_trace_type type TSRMLS_DC);
+static char *_symfony_debug_memory_address_hash(void * TSRMLS_DC);
+static const char* _symfony_debug_get_resource_type(long TSRMLS_DC);
+static int _symfony_debug_get_resource_refcount(long TSRMLS_DC);
+static zend_object_value _symfony_debug_obj_handlers_clone_handler(zval *obj TSRMLS_DC);
+static void _symfony_debug_log_using_psr3_logger(symfony_debug_object_trace trace TSRMLS_DC);
+static int _symfony_debug_opcode_handler_new(ZEND_OPCODE_HANDLER_ARGS);
+
+void symfony_debug_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
+
+#define HANDLER_LIST_M(m) if(handlers->m != default_handlers->m) { add_next_index_string(modified_object_handlers, #m, 1); }
+
+#if IS_AT_LEAST_PHP_54
+#define OBJ_HANDLERS_CHECK \
+	HANDLER_LIST_M(add_ref) \
+	HANDLER_LIST_M(del_ref) \
+	HANDLER_LIST_M(clone_obj) \
+	HANDLER_LIST_M(read_property) \
+	HANDLER_LIST_M(write_property) \
+	HANDLER_LIST_M(read_dimension) \
+	HANDLER_LIST_M(write_dimension) \
+	HANDLER_LIST_M(get_property_ptr_ptr) \
+	HANDLER_LIST_M(get) \
+	HANDLER_LIST_M(set) \
+	HANDLER_LIST_M(has_property) \
+	HANDLER_LIST_M(unset_property) \
+	HANDLER_LIST_M(has_dimension) \
+	HANDLER_LIST_M(unset_dimension) \
+	HANDLER_LIST_M(get_properties) \
+	HANDLER_LIST_M(get_method) \
+	HANDLER_LIST_M(call_method) \
+	HANDLER_LIST_M(get_constructor) \
+	HANDLER_LIST_M(get_class_entry) \
+	HANDLER_LIST_M(get_class_name) \
+	HANDLER_LIST_M(compare_objects) \
+	HANDLER_LIST_M(cast_object) \
+	HANDLER_LIST_M(count_elements) \
+	HANDLER_LIST_M(get_debug_info) \
+	HANDLER_LIST_M(get_closure) \
+	HANDLER_LIST_M(get_gc)
+#else
+#define OBJ_HANDLERS_CHECK \
+	HANDLER_LIST_M(add_ref) \
+	HANDLER_LIST_M(del_ref) \
+	HANDLER_LIST_M(clone_obj) \
+	HANDLER_LIST_M(read_property) \
+	HANDLER_LIST_M(write_property) \
+	HANDLER_LIST_M(read_dimension) \
+	HANDLER_LIST_M(write_dimension) \
+	HANDLER_LIST_M(get_property_ptr_ptr) \
+	HANDLER_LIST_M(get) \
+	HANDLER_LIST_M(set) \
+	HANDLER_LIST_M(has_property) \
+	HANDLER_LIST_M(unset_property) \
+	HANDLER_LIST_M(has_dimension) \
+	HANDLER_LIST_M(unset_dimension) \
+	HANDLER_LIST_M(get_properties) \
+	HANDLER_LIST_M(get_method) \
+	HANDLER_LIST_M(call_method) \
+	HANDLER_LIST_M(get_constructor) \
+	HANDLER_LIST_M(get_class_entry) \
+	HANDLER_LIST_M(get_class_name) \
+	HANDLER_LIST_M(compare_objects) \
+	HANDLER_LIST_M(cast_object) \
+	HANDLER_LIST_M(count_elements) \
+	HANDLER_LIST_M(get_debug_info) \
+	HANDLER_LIST_M(get_closure)
+#endif
+
+#define LOG_TRACE(class_entry, obj_handle, trace_type) do { \
+	if (SYMFONY_DEBUG_G(psr3_logger)) { \
+		symfony_debug_object_trace trace; \
+		trace = _symfony_debug_new_object_trace((class_entry), (obj_handle), (trace_type) TSRMLS_CC); \
+	\
+		_symfony_debug_log_using_psr3_logger(trace TSRMLS_CC); \
+	} \
+} while (0);
 
 #ifdef ZTS
 #define SYMFONY_DEBUG_G(v) TSRMG(symfony_debug_globals_id, zend_symfony_debug_globals *, v)

--- a/src/Symfony/Component/Debug/Resources/ext/sensiolabs_php_compat.h
+++ b/src/Symfony/Component/Debug/Resources/ext/sensiolabs_php_compat.h
@@ -1,0 +1,310 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Julien PAULI <jpauli@php.net>
+ */
+
+#ifndef SENSIOLABS_PHP_COMPAT_H_
+#define SENSIOLABS_PHP_COMPAT_H_
+
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#if defined(HAVE_INTTYPES_H)
+#include <inttypes.h>
+#elif defined(HAVE_STDINT_H)
+#include <stdint.h>
+#endif
+
+#ifdef PHP_WIN32
+# include "win32/php_stdint.h"
+#else
+# ifndef HAVE_INT32_T
+#  if SIZEOF_INT == 4
+typedef int int32_t;
+#  elif SIZEOF_LONG == 4
+typedef long int int32_t;
+#  endif
+# endif
+
+# ifndef HAVE_UINT32_T
+#  if SIZEOF_INT == 4
+typedef unsigned int uint32_t;
+#  elif SIZEOF_LONG == 4
+typedef unsigned long int uint32_t;
+#  endif
+# endif
+#endif
+
+#include "Zend/zend_extensions.h" /* for ZEND_EXTENSION_API_NO */
+#include "Zend/zend_execute.h" /* for temp_variable */
+#include "Zend/zend_compile.h"
+#include "TSRM.h"
+
+#define PHP_5_0_X_API_NO		220040412
+#define PHP_5_1_X_API_NO		220051025
+#define PHP_5_2_X_API_NO		220060519
+#define PHP_5_3_X_API_NO		220090626
+#define PHP_5_4_X_API_NO		220100525
+#define PHP_5_5_X_API_NO		220121212
+#define PHP_5_6_X_API_NO		220131226
+
+#define IS_PHP_56 ZEND_EXTENSION_API_NO == PHP_5_6_X_API_NO
+#define IS_AT_LEAST_PHP_56 ZEND_EXTENSION_API_NO >= PHP_5_6_X_API_NO
+
+#define IS_PHP_55 ZEND_EXTENSION_API_NO == PHP_5_5_X_API_NO
+#define IS_AT_LEAST_PHP_55 ZEND_EXTENSION_API_NO >= PHP_5_5_X_API_NO
+
+#define IS_PHP_54 ZEND_EXTENSION_API_NO == PHP_5_4_X_API_NO
+#define IS_AT_LEAST_PHP_54 ZEND_EXTENSION_API_NO >= PHP_5_4_X_API_NO
+
+#define IS_PHP_53 ZEND_EXTENSION_API_NO == PHP_5_3_X_API_NO
+#define IS_AT_LEAST_PHP_53 ZEND_EXTENSION_API_NO >= PHP_5_3_X_API_NO
+
+#ifndef ZEND_EXT_API
+# if WIN32|WINNT
+#  define ZEND_EXT_API __declspec(dllexport)
+# elif defined(__GNUC__) && __GNUC__ >= 4
+#  define ZEND_EXT_API __attribute__ ((visibility("default")))
+# else
+#  define ZEND_EXT_API
+# endif
+#endif
+
+#if IS_PHP_53
+
+#ifndef PHP_FE_END /* PHP <= 5.3.2 */
+#define ZEND_FE_END { NULL, NULL, NULL, 0, 0 }
+#define PHP_FE_END ZEND_FE_END
+#define ZEND_MOD_END { NULL, NULL, NULL, 0 }
+#endif
+
+// not defined because introduced in PHP 5.3.4
+#ifndef zval_copy_property_ctor
+#ifdef ZTS
+extern void zval_property_ctor(zval **);
+# define zval_shared_property_ctor zval_property_ctor
+#else
+# define zval_shared_property_ctor zval_add_ref
+#endif
+# define zval_copy_property_ctor(ce) ((copy_ctor_func_t) (((ce)->type == ZEND_INTERNAL_CLASS) ? zval_shared_property_ctor : zval_add_ref))
+#endif
+
+#define object_properties_init(obj, ce) do { \
+		 zend_hash_copy(obj->properties, &ce->default_properties, zval_copy_property_ctor(ce), NULL, sizeof(zval *)); \
+		} while (0);
+
+typedef struct _zend_literal {
+	zval       constant;
+	zend_ulong hash_value;
+	zend_uint  cache_slot;
+} zend_literal;
+
+#define GET_CLASS_FILENAME(class) (class)->filename
+
+#else
+#define GET_CLASS_FILENAME(class) (class)->info.user.filename
+#endif
+
+#define ZEND_OBJ_INIT(obj, ce) do { \
+		zend_object_std_init(obj, ce TSRMLS_CC); \
+		object_properties_init((obj), (ce)); \
+	} while(0);
+
+#if IS_PHP_53 || IS_PHP_54
+static void zend_hash_get_current_key_zval_ex(const HashTable *ht, zval *key, HashPosition *pos)
+{
+	Bucket *p;
+
+	p = pos ? (*pos) : ht->pInternalPointer;
+
+	if (!p) {
+		Z_TYPE_P(key) = IS_NULL;
+	} else if (p->nKeyLength) {
+		Z_TYPE_P(key) = IS_STRING;
+		Z_STRVAL_P(key) = estrndup(p->arKey, p->nKeyLength - 1);
+		Z_STRLEN_P(key) = p->nKeyLength - 1;
+	} else {
+		Z_TYPE_P(key) = IS_LONG;
+		Z_LVAL_P(key) = p->h;
+	}
+}
+
+static zend_always_inline int zend_vm_stack_get_args_count_ex(zend_execute_data *ex)
+{
+	if (ex) {
+		void **p = ex->function_state.arguments;
+		return (int)(zend_uintptr_t) *p;
+	} else {
+		return 0;
+	}
+}
+
+static zend_always_inline zval** zend_vm_stack_get_arg_ex(zend_execute_data *ex, int requested_arg)
+{
+	void **p = ex->function_state.arguments;
+	int arg_count = (int)(zend_uintptr_t) *p;
+
+	if (UNEXPECTED(requested_arg > arg_count)) {
+		return NULL;
+	}
+	return (zval**)p - arg_count + requested_arg - 1;
+}
+#endif
+
+#if IS_AT_LEAST_PHP_55
+#define SO_EX_CV(i)     (*EX_CV_NUM(execute_data, i))
+#define SO_EX_T(offset) (*EX_TMP_VAR(execute_data, offset))
+#define ZEND_GET_OP_TYPE(opline, opnum) opline->opnum##_type
+#define ZEND_GET_OP_VAR(opline, opnum) SO_EX_T(opline->opnum.var)
+#define ZEND_GET_NODE_CONST(znode) znode.zv
+
+#define ZEND_GET_ZVAL_PTR(opnum, execute_data, res) do { \
+	const znode_op *node = &execute_data->opline->opnum; \
+\
+	switch (ZEND_GET_OP_TYPE(execute_data->opline, opnum)) { \
+			case IS_CONST: \
+				res = node->zv; \
+				break; \
+			case IS_TMP_VAR: \
+				res = &SO_EX_T(node->var).tmp_var; \
+				break; \
+			case IS_VAR: \
+				res = SO_EX_T(node->var).var.ptr; \
+				break; \
+			case IS_CV: { \
+				zval **tmp = SO_EX_CV(node->var); /* We are assuming BP_VAR_RW or BP_VAR_W here */ \
+				res = tmp ? *tmp : NULL; \
+				break; \
+			} \
+			default: \
+				res = NULL; \
+		} \
+} while (0);
+
+#define ZEND_GET_ZVAL_PTR_PTR(opnum, execute_data, res) do { \
+	const znode_op *node = &execute_data->opline->opnum; \
+	\
+	switch (ZEND_GET_OP_TYPE(execute_data->opline, opnum)) { \
+			case IS_VAR: \
+				res = SO_EX_T(node->var).var.ptr_ptr; \
+				break; \
+			case IS_CV: { \
+				zval **tmp = SO_EX_CV(node->var); /* We are assuming BP_VAR_RW or BP_VAR_W here */ \
+				res = tmp ? tmp : NULL; \
+				break; \
+			} \
+			default: \
+				res = NULL; \
+	} \
+} while (0);
+
+#elif IS_PHP_54
+#define SO_EX_CV(i)     EG(current_execute_data)->CVs[(i)]
+#define SO_EX_T(offset) (*(temp_variable *) ((char *) execute_data->Ts + offset))
+#define ZEND_GET_OP_TYPE(opline, opnum) opline->opnum##_type
+#define ZEND_GET_OP_VAR(opline, opnum) SO_EX_T(opline->opnum.var)
+#define ZEND_GET_NODE_CONST(znode) znode.zv
+
+#define ZEND_GET_ZVAL_PTR(opnum, execute_data, result) do { \
+	const znode_op *node    = &execute_data->opline->opnum; \
+	const temp_variable *Ts = execute_data->Ts; \
+	\
+	switch (ZEND_GET_OP_TYPE(execute_data->opline, opnum)) { \
+			case IS_CONST: \
+				result = node->zv; \
+				break; \
+			case IS_TMP_VAR: \
+				result = &SO_EX_T(node->var).tmp_var; \
+				break; \
+			case IS_VAR: \
+				result = SO_EX_T(node->var).var.ptr; \
+				break; \
+			case IS_CV: { \
+				zval **tmp = SO_EX_CV(node->var); \
+				result = tmp ? *tmp : NULL; \
+				break; \
+			} \
+			default: \
+				result = NULL; \
+		} \
+} while (0);
+
+#define ZEND_GET_ZVAL_PTR_PTR(opnum, execute_data, result) do { \
+	const znode_op *node    = &execute_data->opline->opnum; \
+	const temp_variable *Ts = execute_data->Ts; \
+	\
+	switch (ZEND_GET_OP_TYPE(execute_data->opline, opnum)) { \
+		case IS_VAR: \
+			result = SO_EX_T(node->var).var.ptr_ptr; \
+			break; \
+		case IS_CV: { \
+			zval **tmp = SO_EX_CV(node->var); /* We are assuming BP_VAR_RW or BP_VAR_W here */ \
+			result = tmp ? tmp : NULL; \
+			break; \
+		} \
+		default: \
+			result = NULL; \
+	} \
+} while (0);
+
+#else /* PHP 5.3 */
+#define SO_EX_CV(i)     EG(current_execute_data)->CVs[(i)]
+#define SO_EX_T(offset) (*(temp_variable *) ((char *) execute_data->Ts + offset))
+#define ZEND_GET_OP_TYPE(opline, opnum) opline->opnum.op_type
+#define ZEND_GET_OP_VAR(opline, opnum) SO_EX_T(opline->opnum.u.var)
+#define ZEND_GET_NODE_CONST(znode) &znode.u.constant
+
+#define ZEND_GET_ZVAL_PTR(opnum, execute_data, result) do { \
+	znode *node = &execute_data->opline->opnum; \
+	\
+	switch (ZEND_GET_OP_TYPE(execute_data->opline, opnum)) { \
+			case IS_CONST: \
+				result = &node->u.constant; \
+				 break; \
+			case IS_TMP_VAR: \
+				result = &SO_EX_T(node->u.var).tmp_var; \
+				break; \
+			case IS_VAR: \
+				result = SO_EX_T(node->u.var).var.ptr; \
+				break; \
+			case IS_CV: { \
+				zval **tmp = SO_EX_CV(node->u.var); \
+				result = tmp ? *tmp : NULL; \
+				break; \
+			} \
+			default: \
+				result = NULL; \
+		} \
+} while (0);
+
+#define ZEND_GET_ZVAL_PTR_PTR(opnum, execute_data, result) do { \
+	znode *node = &execute_data->opline->opnum; \
+	\
+	switch (ZEND_GET_OP_TYPE(execute_data->opline, opnum)) { \
+		case IS_VAR: \
+			result = SO_EX_T(node->u.var).var.ptr_ptr; \
+			break; \
+		case IS_CV: { \
+			zval **tmp = SO_EX_CV(node->u.var); /* We are assuming BP_VAR_RW or BP_VAR_W here */ \
+			result = tmp ? tmp : NULL; \
+			break; \
+		} \
+		default: \
+			result = NULL; \
+	} \
+} while (0);
+
+#endif
+
+#endif /* SENSIOLABS_PHP_COMPAT_H_ */

--- a/src/Symfony/Component/Debug/Resources/ext/sensiolabs_php_utils.h
+++ b/src/Symfony/Component/Debug/Resources/ext/sensiolabs_php_utils.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Julien PAULI <jpauli@php.net>
+ */
+
+#ifndef SENSIOLABS_PHP_UTILS_H_
+#define SENSIOLABS_PHP_UTILS_H_
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#define STRINGIFY(x) #x
+#define XSTRINGIFY(a) STRINGIFY(a)
+
+#define FETCH_OBJECT(type, name) type *name = (type *)zend_object_store_get_object(getThis() TSRMLS_CC);
+
+#define ZEND_HASH_ITERATE_START(ht, data) { \
+	HashPosition pos; \
+	for(zend_hash_internal_pointer_reset_ex((ht), &pos); \
+		zend_hash_get_current_data_ex((ht), (void **)&(data), &pos) == SUCCESS; \
+		zend_hash_move_forward_ex((ht), &pos)) {
+#define ZEND_HASH_ITERATE_END }}
+#define ZEND_HASH_ITERATE_SKIP continue;
+
+#define THIS(var) zend_read_property(Z_OBJCE_P(getThis()), getThis(), (var), sizeof((var))-1, 0 TSRMLS_CC)
+
+#define RETURN_THIS RETURN_ZVAL(getThis(), 1, 0)
+
+#define FETCH_AUTO_GLOBAL(var) zval *_##var = NULL; zend_is_auto_global(STRINGIFY(_##var), sizeof(STRINGIFY(_##var)) - 1 TSRMLS_CC); _##var = PG(http_globals)[TRACK_VARS_##var];
+
+#define PHP_MINIT_PROXY_CALL(module_name) PHP_MINIT(module_name)(INIT_FUNC_ARGS_PASSTHRU);
+#define PHP_MSHUTDOWN_PROXY_CALL(module_name) PHP_MSHUTDOWN(module_name)(SHUTDOWN_FUNC_ARGS_PASSTHRU);
+
+#ifdef ZTS
+#define ZEND_INI_MH_BASE_DECL char *base; base = (char *) ts_resource(*((int *) mh_arg2));
+#define ZEND_DESTROY_MODULE_GLOBALS(module_name, globals_dtor)
+#define ZEND_MODULE_GLOBALS_DTOR_PROXY_CALL(module) ZEND_MODULE_GLOBALS_DTOR_N(module)\
+	( (zend_##module##_globals*) (*((void ***) tsrm_ls))[TSRM_UNSHUFFLE_RSRC_ID(module##_globals_id)] TSRMLS_CC);
+#else
+#define ZEND_INI_MH_BASE_DECL char *base; base = (char *) mh_arg2;
+#define ZEND_DESTROY_MODULE_GLOBALS(module_name, globals_dtor)	globals_dtor(&module_name##_globals);
+#define ZEND_MODULE_GLOBALS_DTOR_PROXY_CALL(module) ZEND_MODULE_GLOBALS_DTOR_N(module)(&module##_globals TSRMLS_CC);
+#endif
+
+#define zend_ptr_stack_clean_and_destroy(stack, dtor, free) zend_ptr_stack_clean(stack, dtor, free); zend_ptr_stack_destroy(stack);
+
+#endif /* SENSIOLABS_PHP_UTILS_H_ */

--- a/src/Symfony/Component/Debug/Resources/ext/symfony_debug.c
+++ b/src/Symfony/Component/Debug/Resources/ext/symfony_debug.c
@@ -5,6 +5,8 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ *
+ * Julien PAULI <jpauli@php.net>
  */
 
 #ifdef HAVE_CONFIG_H
@@ -18,6 +20,7 @@
 #include "php_ini.h"
 #include "ext/standard/info.h"
 #include "php_symfony_debug.h"
+#include "sensiolabs_php_utils.h"
 #include "ext/standard/php_rand.h"
 #include "ext/standard/php_lcg.h"
 #include "ext/spl/php_spl.h"
@@ -28,8 +31,6 @@
 #include "Zend/zend_interfaces.h"
 #include "SAPI.h"
 
-#define IS_PHP_53 ZEND_EXTENSION_API_NO == 220090626
-
 ZEND_DECLARE_MODULE_GLOBALS(symfony_debug)
 
 ZEND_BEGIN_ARG_INFO_EX(symfony_zval_arginfo, 0, 0, 2)
@@ -38,11 +39,66 @@ ZEND_BEGIN_ARG_INFO_EX(symfony_zval_arginfo, 0, 0, 2)
 	ZEND_ARG_INFO(0, options)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(symfony_debug_object_tracer_set_logger_arginfo, 0, 0, 1)
+	ZEND_ARG_OBJ_INFO(0, logger, Psr\\Log\\LoggerInterface, 0)
+ZEND_END_ARG_INFO()
+
 const zend_function_entry symfony_debug_functions[] = {
 	PHP_FE(symfony_zval_info,	symfony_zval_arginfo)
 	PHP_FE(symfony_debug_backtrace, NULL)
+	PHP_FE(symfony_debug_get_error_handlers, NULL)
+	PHP_FE(symfony_debug_get_error_handler, NULL)
+	PHP_FE(symfony_debug_enable_var_dumper_dump, NULL)
+	PHP_FE(symfony_debug_object_tracer_set_logger, symfony_debug_object_tracer_set_logger_arginfo)
 	PHP_FE_END
 };
+
+PHP_FUNCTION(symfony_debug_enable_var_dumper_dump)
+{
+	zend_class_entry **var_dumper;
+	zend_function *var_dumper_dump;
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	if (SYMFONY_DEBUG_G(php_var_dump)) {
+		return;
+	}
+
+	if (zend_lookup_class("Symfony\\Component\\VarDumper\\VarDumper", strlen("Symfony\\Component\\VarDumper\\VarDumper"), &var_dumper TSRMLS_CC) == FAILURE) {
+		php_error(E_WARNING, "Can't find Symfony\\Component\\VarDumper\\VarDumper class");
+		return;
+	}
+
+	if (zend_hash_find(&(*var_dumper)->function_table, "dump", sizeof("dump"), (void **)&var_dumper_dump) == FAILURE) {
+		php_error(E_WARNING, "Can't find Symfony\\Component\\VarDumper\\VarDumper::dump() function");
+		return;
+	}
+
+	zend_hash_find(EG(function_table), "var_dump", sizeof("var_dump"), (void **)&SYMFONY_DEBUG_G(php_var_dump));
+
+	SYMFONY_DEBUG_G(php_var_dump)->type     = ZEND_USER_FUNCTION;
+	SYMFONY_DEBUG_G(php_var_dump)->op_array = var_dumper_dump->op_array;
+}
+
+PHP_FUNCTION(symfony_debug_object_tracer_set_logger)
+{
+	zval *logger = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &logger) == FAILURE) {
+		return;
+	}
+
+	if (SYMFONY_DEBUG_G(psr3_logger)) {
+		zval_ptr_dtor(&SYMFONY_DEBUG_G(psr3_logger));
+	}
+
+	Z_ADDREF_P(logger);
+
+	SYMFONY_DEBUG_G(psr3_logger)       = logger;
+	SYMFONY_DEBUG_G(psr3_logger_cache) = NULL;
+}
 
 PHP_FUNCTION(symfony_debug_backtrace)
 {
@@ -60,6 +116,41 @@ PHP_FUNCTION(symfony_debug_backtrace)
 	}
 
 	php_array_merge(Z_ARRVAL_P(return_value), Z_ARRVAL_P(SYMFONY_DEBUG_G(debug_bt)), 0 TSRMLS_CC);
+}
+
+PHP_FUNCTION(symfony_debug_get_error_handler)
+{
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	if (EG(user_error_handler)) {
+		RETURN_ZVAL(EG(user_error_handler), 1, 0);
+	}
+}
+
+PHP_FUNCTION(symfony_debug_get_error_handlers)
+{
+	int i;
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	i = EG(user_error_handlers).top;
+
+	array_init(return_value);
+
+	while (--i >= 0) {
+		zval *eh = (zval *)EG(user_error_handlers).elements[i];
+		Z_ADDREF_P(eh);
+		add_index_zval(return_value, (long)i, eh);
+	}
+
+	if (EG(user_error_handler)) {
+		Z_ADDREF_P(EG(user_error_handler));
+		add_next_index_zval(return_value, EG(user_error_handler));
+	}
 }
 
 PHP_FUNCTION(symfony_zval_info)
@@ -97,12 +188,26 @@ PHP_FUNCTION(symfony_zval_info)
 
 	if (Z_TYPE_P(arg) == IS_OBJECT) {
 		char hash[33] = {0};
+		const zend_object_handlers *handlers = NULL, *default_handlers = NULL;
 
 		php_spl_object_hash(arg, (char *)hash TSRMLS_CC);
 		add_assoc_stringl(return_value, "object_class", (char *)Z_OBJCE_P(arg)->name, Z_OBJCE_P(arg)->name_length, 1);
 		add_assoc_long(return_value, "object_refcount", EG(objects_store).object_buckets[Z_OBJ_HANDLE_P(arg)].bucket.obj.refcount);
 		add_assoc_string(return_value, "object_hash", hash, 1);
 		add_assoc_long(return_value, "object_handle", Z_OBJ_HANDLE_P(arg));
+
+		handlers         = Z_OBJ_HT_P(arg);
+		default_handlers = zend_get_std_object_handlers();
+
+		if (handlers != default_handlers) {
+			zval *modified_object_handlers = NULL;
+			ALLOC_INIT_ZVAL(modified_object_handlers);
+			array_init(modified_object_handlers);
+
+			OBJ_HANDLERS_CHECK
+
+			add_assoc_zval(return_value, "modified_object_handlers", modified_object_handlers);
+		}
 	} else if (Z_TYPE_P(arg) == IS_ARRAY) {
 		add_assoc_long(return_value, "array_count", zend_hash_num_elements(Z_ARRVAL_P(arg)));
 	} else if(Z_TYPE_P(arg) == IS_RESOURCE) {
@@ -180,6 +285,117 @@ static char *_symfony_debug_memory_address_hash(void *address TSRMLS_DC)
 	return result;
 }
 
+static void _symfony_debug_object_del_ref(zval *object TSRMLS_DC)
+{
+	zend_object_handle handle;
+
+	handle = Z_OBJ_HANDLE_P(object);
+
+	if (!EG(objects_store).object_buckets) {
+		return;
+	}
+
+	if (EG(objects_store).object_buckets[handle].valid &&
+		EG(objects_store).object_buckets[handle].bucket.obj.refcount == 1 &&
+		!EG(objects_store).object_buckets[handle].destructor_called) {
+			LOG_TRACE(Z_OBJCE_P(object), handle, SYMFONY_DEBUG_OBJECT_TRACE_TYPE_DESTROY)
+	}
+
+	zend_objects_store_del_ref(object TSRMLS_CC);
+}
+
+static zend_object_value _symfony_debug_obj_handlers_clone_handler(zval *obj TSRMLS_DC)
+{
+	zend_object *object = NULL;
+
+	object = (zend_object *)zend_object_store_get_object(obj TSRMLS_CC);
+
+	LOG_TRACE(object->ce, Z_OBJ_HANDLE_P(obj), SYMFONY_DEBUG_OBJECT_TRACE_TYPE_CLONE)
+
+	return zend_objects_clone_obj(obj TSRMLS_CC);
+}
+
+static int _symfony_debug_opcode_handler_new(ZEND_OPCODE_HANDLER_ARGS)
+{
+	zend_class_entry *ce = NULL;
+
+	if (!SYMFONY_DEBUG_G(psr3_logger)) {
+		return ZEND_USER_OPCODE_DISPATCH;
+	}
+#if IS_PHP_53
+	ce = SO_EX_T(execute_data->opline->op1.u.var).class_entry;
+#else
+	ce = SO_EX_T(execute_data->opline->op1.var).class_entry;
+#endif
+
+	LOG_TRACE(ce, 0, SYMFONY_DEBUG_OBJECT_TRACE_TYPE_NEW)
+
+	if (!EG(exception)) {
+		return ZEND_USER_OPCODE_DISPATCH;
+	} else {
+		return ZEND_USER_OPCODE_CONTINUE;
+	}
+}
+
+static symfony_debug_object_trace _symfony_debug_new_object_trace(zend_class_entry *ce, zend_object_handle handle, symfony_debug_object_trace_type type TSRMLS_DC)
+{
+	symfony_debug_object_trace trace;
+	char *msg_pattern;
+
+	if (handle == 0) { /* compute by ourselves */
+		handle = EG(objects_store).free_list_head != -1 ? EG(objects_store).free_list_head : EG(objects_store).top;
+	}
+	trace.ce         = ce;
+	trace.filename   = zend_get_executed_filename(TSRMLS_C);
+	trace.lineno     = zend_get_executed_lineno(TSRMLS_C);
+	trace.handle     = handle;
+	trace.trace_type = type;
+	switch (type) {
+		case SYMFONY_DEBUG_OBJECT_TRACE_TYPE_NEW:
+		msg_pattern = "Creating object#%u of class %*s in %s:%d";
+		break;
+		case SYMFONY_DEBUG_OBJECT_TRACE_TYPE_CLONE:
+		msg_pattern = "Cloning object#%u of class %*s in %s:%d";
+		break;
+		case SYMFONY_DEBUG_OBJECT_TRACE_TYPE_DESTROY:
+		msg_pattern = "Destroying object#%u of class %*s in %s:%d";
+		break;
+	}
+	spprintf(&trace.msg, 0, msg_pattern, handle, ce->name_length, ce->name, zend_get_executed_filename(TSRMLS_C), zend_get_executed_lineno(TSRMLS_C));
+
+	return trace;
+}
+
+static void _symfony_debug_log_using_psr3_logger(symfony_debug_object_trace trace TSRMLS_DC)
+{
+	zval *arg1, *arg2;
+
+	if (SYMFONY_DEBUG_G(in_logger)) {
+		/* Prevent infinite recursion */
+		return;
+	}
+
+	SYMFONY_DEBUG_G(in_logger) = 1;
+
+	ALLOC_INIT_ZVAL(arg1);
+	ALLOC_INIT_ZVAL(arg2);
+
+	ZVAL_STRING(arg1, trace.msg, 1);
+	array_init(arg2);
+	add_assoc_stringl(arg2, "class", (char *)trace.ce->name, trace.ce->name_length, 1);
+	add_assoc_long(arg2, "object_handle", trace.handle);
+	add_assoc_string(arg2, "filename", (char *)trace.filename, 1);
+	add_assoc_long(arg2, "lineno", trace.lineno);
+	add_assoc_long(arg2, "trace_type", trace.trace_type);
+
+	zend_call_method_with_2_params(&SYMFONY_DEBUG_G(psr3_logger), Z_OBJCE_P(SYMFONY_DEBUG_G(psr3_logger)), &SYMFONY_DEBUG_G(psr3_logger_cache), "debug", NULL, arg1, arg2);
+	zval_ptr_dtor(&arg1);
+	zval_ptr_dtor(&arg2);
+	efree(trace.msg);
+
+	SYMFONY_DEBUG_G(in_logger) = 0;
+}
+
 static const char *_symfony_debug_zval_type(zval *zv)
 {
 	switch (Z_TYPE_P(zv)) {
@@ -230,8 +446,8 @@ zend_module_entry symfony_debug_module_entry = {
 	PHP_SYMFONY_DEBUG_VERSION,
 	PHP_MODULE_GLOBALS(symfony_debug),
 	PHP_GINIT(symfony_debug),
-	PHP_GSHUTDOWN(symfony_debug),
 	NULL,
+	symfony_debug_post_deactivate,
 	STANDARD_MODULE_PROPERTIES_EX
 };
 
@@ -244,15 +460,20 @@ PHP_GINIT_FUNCTION(symfony_debug)
 	memset(symfony_debug_globals, 0 , sizeof(*symfony_debug_globals));
 }
 
-PHP_GSHUTDOWN_FUNCTION(symfony_debug)
-{
-
-}
-
 PHP_MINIT_FUNCTION(symfony_debug)
 {
+	zend_object_handlers *handlers = NULL;
+
 	SYMFONY_DEBUG_G(old_error_cb) = zend_error_cb;
 	zend_error_cb                 = symfony_debug_error_cb;
+
+	handlers            = zend_get_std_object_handlers();
+	handlers->clone_obj = _symfony_debug_obj_handlers_clone_handler;
+	handlers->del_ref   = _symfony_debug_object_del_ref;
+
+	REGISTER_LONG_CONSTANT("SYMFONY_DEBUG_OBJECT_TRACE_TYPE_NEW", SYMFONY_DEBUG_OBJECT_TRACE_TYPE_NEW, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("SYMFONY_DEBUG_OBJECT_TRACE_TYPE_CLONE", SYMFONY_DEBUG_OBJECT_TRACE_TYPE_CLONE, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("SYMFONY_DEBUG_OBJECT_TRACE_TYPE_DESTROY", SYMFONY_DEBUG_OBJECT_TRACE_TYPE_DESTROY, CONST_CS | CONST_PERSISTENT);
 
 	return SUCCESS;
 }
@@ -266,11 +487,33 @@ PHP_MSHUTDOWN_FUNCTION(symfony_debug)
 
 PHP_RINIT_FUNCTION(symfony_debug)
 {
+	/* We'll overwrite Xdebug using RINIT here */
+	zend_set_user_opcode_handler(ZEND_NEW, _symfony_debug_opcode_handler_new);
+
 	return SUCCESS;
 }
 
 PHP_RSHUTDOWN_FUNCTION(symfony_debug)
 {
+	if (SYMFONY_DEBUG_G(psr3_logger)) {
+		zval_ptr_dtor(&SYMFONY_DEBUG_G(psr3_logger));
+		SYMFONY_DEBUG_G(psr3_logger_cache) = NULL;
+	}
+
+	if (SYMFONY_DEBUG_G(php_var_dump)) {
+		SYMFONY_DEBUG_G(php_var_dump)->type = ZEND_INTERNAL_FUNCTION;
+		SYMFONY_DEBUG_G(php_var_dump) = NULL;
+	}
+
+	return SUCCESS;
+}
+
+static int symfony_debug_post_deactivate(void)
+{
+#if IS_AT_LEAST_PHP_54
+	zend_set_user_opcode_handler(ZEND_NEW, NULL);
+#endif
+
 	return SUCCESS;
 }
 
@@ -279,5 +522,11 @@ PHP_MINFO_FUNCTION(symfony_debug)
 	php_info_print_table_start();
 	php_info_print_table_header(2, "Symfony Debug support", "enabled");
 	php_info_print_table_header(2, "Symfony Debug version", PHP_SYMFONY_DEBUG_VERSION);
+
+	php_info_print_box_start(0);
+	if (!sapi_module.phpinfo_as_text) {
+		php_write((void *)ZEND_STRL(sensiolabs_logo) TSRMLS_CC);
+	}
+
 	php_info_print_table_end();
 }

--- a/src/Symfony/Component/Debug/Resources/ext/tests/002.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/002.phpt
@@ -3,7 +3,7 @@ Test symfony_debug_backtrace in case of fatal error
 --SKIPIF--
 <?php if (!extension_loaded("symfony_debug")) print "skip"; ?>
 --FILE--
-<?php
+<?php 
 
 function bar()
 {

--- a/src/Symfony/Component/Debug/Resources/ext/tests/002_1.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/002_1.phpt
@@ -3,7 +3,7 @@ Test symfony_debug_backtrace in case of non fatal error
 --SKIPIF--
 <?php if (!extension_loaded("symfony_debug")) print "skip"; ?>
 --FILE--
-<?php
+<?php 
 
 function bar()
 {

--- a/src/Symfony/Component/Debug/Resources/ext/tests/003.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/003.phpt
@@ -56,7 +56,7 @@ Symfony\Component\Debug\Exception\UndefinedFunctionException Object
     [message:protected] => Attempted to call function "notexist" from namespace "Symfony\Component\Debug".
     [string:Exception:private] => 
     [code:protected] => 0
-    [file:protected] => -
+    [file:protected] => %s
     [line:protected] => %d
     [trace:Exception:private] => Array
         (

--- a/src/Symfony/Component/Debug/Resources/ext/tests/004.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/004.phpt
@@ -1,0 +1,136 @@
+--TEST--
+Test symfony debug object life tracing
+--SKIPIF--
+<?php if (!extension_loaded("symfony_debug")) print "skip"; ?>
+--FILE--
+<?php 
+namespace Psr\Log {
+
+interface LoggerInterface
+{
+    /**
+     * System is unusable.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function emergency($message, array $context = array());
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function alert($message, array $context = array());
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function critical($message, array $context = array());
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function error($message, array $context = array());
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function warning($message, array $context = array());
+
+    /**
+     * Normal but significant events.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function notice($message, array $context = array());
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function info($message, array $context = array());
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function debug($message, array $context = array());
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function log($level, $message, array $context = array());
+}
+}
+
+namespace {
+
+class TestLog implements Psr\Log\LoggerInterface {
+    public function emergency($message, array $context = array()) { }
+    public function alert($message, array $context = array()) { }
+    public function critical($message, array $context = array()) { }
+    public function error($message, array $context = array()) { }
+    public function warning($message, array $context = array()) { }
+    public function notice($message, array $context = array()) { }
+    public function info($message, array $context = array()) { }
+    public function debug($message, array $context = array()) { printf("$message \n"); }
+    public function log($level, $message, array $context = array()) { }
+}
+
+$log = new TestLog;
+symfony_debug_object_tracer_set_logger($log); 
+
+$a = new StdClass;
+
+$b = clone $a;
+
+unset($b);
+
+
+}
+?>
+--EXPECTF--
+Creating object#2 of class stdClass in %s:%d 
+Cloning object#2 of class stdClass in %s:%d 
+Destroying object#3 of class stdClass in %s:%d 
+Destroying object#2 of class stdClass in [no active file]:0

--- a/src/Symfony/Component/Debug/Resources/ext/tests/005.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/005.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test symfony_debug_get_error_handler() & symfony_debug_get_error_handlers()
+--SKIPIF--
+<?php if (!extension_loaded("symfony_debug")) print "skip"; ?>
+--FILE--
+<?php 
+
+function my_eh() { }
+
+set_error_handler(function () { });
+set_error_handler('my_eh');
+
+var_dump(symfony_debug_get_error_handler());
+var_dump(symfony_debug_get_error_handlers());
+?>
+--EXPECTF--
+string(5) "my_eh"
+array(2) {
+  [0]=>
+  object(Closure)#1 (0) {
+  }
+  [1]=>
+  string(5) "my_eh"
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Here are some ideas that we worked on with @jpauli and that we propose for enhancement and inclusion in the symfony_debug extension for 2.7:
- symfony_debug_backtrace() is like debug_backtrace(), except that it can fetch the full backtrace in case of fatal errors (prod friendly version of xdebug_get_function_stack())
- symfony_debug_set_logger() logs objects' creations/destructions

Your ideas are more than welcomed: the name/interface of the functions can certainly be improved, and if you have more ideas, we can't wait to hear them :)
