### PR TITLE
[TwigBridge] Replace default list style to icon

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -223,9 +223,13 @@
 {# Errors #}
 
 {% block form_errors -%}
-    {% if errors|length > 0 %}
+    {% if errors|length > 0 -%}
     {% if form.parent %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
-        {{- parent() -}}
+    <ul class="list-unstyled">
+        {%- for error in errors -%}
+            <li><span class="glyphicon glyphicon-exclamation-sign"></span> {{ error.message|trans({}, translation_domain) }}</li>
+        {%- endfor -%}
+    </ul>
     {% if form.parent %}</span>{% else %}</div>{% endif %}
-    {% endif %}
+    {%- endif %}
 {%- endblock form_errors %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Replaces default list style in **bootstrap_3_layout.html.twig** to icon.
Requires Glyphicons from Bootstrap 3.

Before:
![2014-10-07 11-55-50](https://cloud.githubusercontent.com/assets/1592053/4540807/d6f8eb46-4e0b-11e4-82bf-77b56fd1d17c.png)

After:
![2014-10-07 11-55-07](https://cloud.githubusercontent.com/assets/1592053/4540810/e02fe048-4e0b-11e4-9f3b-69902c0ae32b.png)
