### PR TITLE
[FrameworkBundle] Update redirection status

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -74,7 +74,7 @@ class Controller extends ContainerAware
      *
      * @return RedirectResponse
      */
-    public function redirect($url, $status = 302)
+    public function redirect($url, $status = 301)
     {
         return new RedirectResponse($url, $status);
     }

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -26,7 +26,7 @@ class RedirectResponse extends Response
      * Creates a redirect response so that it conforms to the rules defined for a redirect status code.
      *
      * @param string  $url     The URL to redirect to
-     * @param int     $status  The status code (302 by default)
+     * @param int     $status  The status code (301 by default)
      * @param array   $headers The headers (Location is always set to the given URL)
      *
      * @throws \InvalidArgumentException
@@ -35,7 +35,7 @@ class RedirectResponse extends Response
      *
      * @api
      */
-    public function __construct($url, $status = 302, $headers = array())
+    public function __construct($url, $status = 301, $headers = array())
     {
         if (empty($url)) {
             throw new \InvalidArgumentException('Cannot redirect to an empty URL.');


### PR DESCRIPTION
IMO, we should use the `301` status code in redirection as a default value instead of `302` status, since it's `SEO` friendly (302 is not) and because most of the web redirection are `permanent` and not `temporarily`. In this case the user can chose  to use a `302` status for `temporarily` redirection if he want.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | NA |
| License | MIT |
| Doc PR | NA |
