### PR TITLE
[Form] fix form handling with OPTIONS request method

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form\Extension\HttpFoundation\EventListener;
 
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -49,12 +48,19 @@ class BindRequestListener implements EventSubscriberInterface
         $name = $form->getConfig()->getName();
         $default = $form->getConfig()->getCompound() ? array() : null;
 
-        // Store the bound data in case of a post request
+        // For request methods that must not have a request body we fetch data
+        // from the query string. Otherwise we look for data in the request body.
         switch ($request->getMethod()) {
-            case 'POST':
-            case 'PUT':
-            case 'DELETE':
-            case 'PATCH':
+            case 'GET':
+            case 'HEAD':
+            case 'TRACE':
+                $data = '' === $name
+                    ? $request->query->all()
+                    : $request->query->get($name, $default);
+
+                break;
+
+            default:
                 if ('' === $name) {
                     // Form bound without name
                     $params = $request->request->all();
@@ -71,19 +77,6 @@ class BindRequestListener implements EventSubscriberInterface
                 }
 
                 break;
-
-            case 'GET':
-                $data = '' === $name
-                    ? $request->query->all()
-                    : $request->query->get($name, $default);
-
-                break;
-
-            default:
-                throw new LogicException(sprintf(
-                    'The request method "%s" is not supported',
-                    $request->getMethod()
-                ));
         }
 
         $event->setData($data);

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -55,7 +55,9 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             return;
         }
 
-        if ('GET' === $method) {
+        // For request methods that must not have a request body we fetch data
+        // from the query string. Otherwise we look for data in the request body.
+        if ('GET' === $method || 'HEAD' === $method || 'TRACE' === $method) {
             if ('' === $name) {
                 $data = $request->query->all();
             } else {

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -63,7 +63,9 @@ class NativeRequestHandler implements RequestHandlerInterface
             return;
         }
 
-        if ('GET' === $method) {
+        // For request methods that must not have a request body we fetch data
+        // from the query string. Otherwise we look for data in the request body.
+        if ('GET' === $method || 'HEAD' === $method || 'TRACE' === $method) {
             if ('' === $name) {
                 $data = $_GET;
             } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8282 |
| License | MIT |
| Doc PR | - |

The OPTIONS request is just handled as any other request method. And accoring to the spec, an options request can also contain a request body like a POST. This only applied when using the deprecated form processing with `$form->submit($request)`. The change also makes the handling consistent with the `handleRequest` behavior via https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
