### PR TITLE
[Profiler] Flexible height for resume box (to accommodate long urls)

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -17,9 +17,9 @@
                             <strong>Profile for:</strong>
                             {{ profile.method|upper }}
                             {% if profile.method|upper in ['GET', 'HEAD'] %}
-                                <a href="{{ profile.url }}">{{ profile.url }}</a>
+                                <a href="{{ profile.url }}" id="resume-url">{{ profile.url }}</a>
                             {% else %}
-                                {{ profile.url }}
+                                <span id="resume-url">{{ profile.url }}</span>
                             {% endif %}
                             <span class="date">
                                 <em>by {{ profile.ip }}</em> at <em>{{ profile.time|date('r') }}</em>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -209,12 +209,13 @@ li {
 #resume {
     background-color: #f6f6f6;
     border-bottom: 1px solid #dfdfdf;
-    padding: 18px 10px 0px;
+    padding: 18px 10px 14px;
     margin-left: 250px;
-    height: 34px;
+    min-height: 20px;
     color: #313131;
     font-size: 12px;
     border-top-right-radius: 16px;
+    line-height: 18px;
 }
 a#resume-view-all {
     display: inline-block;
@@ -225,6 +226,11 @@ a#resume-view-all {
     color: white;
     font-weight: bold;
     text-decoration: none;
+    line-height: 14px;
+}
+#resume-url {
+    word-wrap: break-word;
+    word-break: break-all;
 }
 table th.value {
     width: 450px;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

There is an issue when the request url contains many parameters (eg. filter form values) - the url overflows the container.
My proposed solution would be to use ellipsis on it, and on mouseover display the complete url.
Tested it on IE9, Chromium 37 and Firefox 32.

Here is a preview of how it looks:

![profiler-url](https://cloud.githubusercontent.com/assets/886304/4548542/e985b718-4e55-11e4-9963-b97b59279a26.png)
