### PR TITLE
[TwigBundle] Add loader priority

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -40,9 +40,24 @@ class TwigLoaderPass implements CompilerPassInterface
             $container->setAlias('twig.loader', key($loaderIds));
         } else {
             $chainLoader = $container->getDefinition('twig.loader.chain');
-            foreach (array_keys($loaderIds) as $id) {
-                $chainLoader->addMethodCall('addLoader', array(new Reference($id)));
+
+            $prioritizedLoaders = array();
+
+            foreach ($loaderIds as $id => $tags) {
+                foreach ($tags as $tag) {
+                    $priority = isset($tag['priority']) ? $tag['priority'] : 0;
+                    $prioritizedLoaders[$priority][] = $id;
+                }
             }
+
+            krsort($prioritizedLoaders);
+
+            foreach ($prioritizedLoaders as $loaders) {
+                foreach ($loaders as $loader) {
+                    $chainLoader->addMethodCall('addLoader', array(new Reference($loader)));
+                }
+            }
+
             $container->setAlias('twig.loader', 'twig.loader.chain');
         }
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -43,6 +43,7 @@ class TwigLoaderPassTest extends \PHPUnit_Framework_TestCase
     {
         $serviceIds = array(
             'test_loader_1' => array(
+                array(),
             ),
         );
 
@@ -65,8 +66,10 @@ class TwigLoaderPassTest extends \PHPUnit_Framework_TestCase
     {
         $serviceIds = array(
             'test_loader_1' => array(
+                array(),
             ),
             'test_loader_2' => array(
+                array(),
             ),
         );
 
@@ -90,6 +93,45 @@ class TwigLoaderPassTest extends \PHPUnit_Framework_TestCase
         $calls = $this->chainLoader->getMethodCalls();
         $this->assertCount(2, $calls);
         $this->assertEquals('addLoader', $calls[0][0]);
+        $this->assertEquals('addLoader', $calls[1][0]);
+        $this->assertEquals('test_loader_1', (string) $calls[0][1][0]);
+        $this->assertEquals('test_loader_2', (string) $calls[1][1][0]);
+    }
+
+    public function testMapperPassWithTwoTaggedLoadersWithPriority()
+    {
+        $serviceIds = array(
+            'test_loader_1' => array(
+                array('priority' => 100),
+            ),
+            'test_loader_2' => array(
+                array('priority' => 200),
+            ),
+        );
+
+        $this->builder->expects($this->once())
+            ->method('hasDefinition')
+            ->with('twig')
+            ->will($this->returnValue(true));
+        $this->builder->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('twig.loader')
+            ->will($this->returnValue($serviceIds));
+        $this->builder->expects($this->once())
+            ->method('getDefinition')
+            ->with('twig.loader.chain')
+            ->will($this->returnValue($this->chainLoader));
+        $this->builder->expects($this->once())
+            ->method('setAlias')
+            ->with('twig.loader', 'twig.loader.chain');
+
+        $this->pass->process($this->builder);
+        $calls = $this->chainLoader->getMethodCalls();
+        $this->assertCount(2, $calls);
+        $this->assertEquals('addLoader', $calls[0][0]);
+        $this->assertEquals('addLoader', $calls[1][0]);
+        $this->assertEquals('test_loader_2', (string) $calls[0][1][0]);
+        $this->assertEquals('test_loader_1', (string) $calls[1][1][0]);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Add the ability to specify a priority to the tag of `twig.loader` services.

eg:

```
        <service id="twig.loader.filesystem" class="%twig.loader.filesystem.class%" public="false">
            <argument type="service" id="templating.locator" />
            <argument type="service" id="templating.name_parser" />
            <tag name="twig.loader" priority="100"/>
        </service>
```
