### PR TITLE
fix 'Undefined Property' error for charset in HttpFoundation/Response.php

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -282,7 +282,7 @@ class Response
             }
 
             // Fix Content-Type
-            $charset = $this->charset ?: 'UTF-8';
+            $charset = empty($this->charset) ? 'UTF-8' : $this->charset;
             if (!$headers->has('Content-Type')) {
                 $headers->set('Content-Type', 'text/html; charset='.$charset);
             } elseif (0 === stripos($headers->get('Content-Type'), 'text/') && false === stripos($headers->get('Content-Type'), 'charset')) {


### PR DESCRIPTION
This fixes an issue of getting a 500 response due to an undefined property (charset).

The error message I was receiving follows:

```
500 json.message:"exception 'ErrorException' with message 'Undefined property

Illuminate\Http\Response::$charset' in /var/app/current/vendor/symfony/http-foundation/Symfony/Component/HttpFoundation/Response.php:285

Stack trace:#0 /var/app/current/vendor/symfony/http-foundation/Symfony/Component/HttpFoundation/Response.php(285)

Illuminate\Exception\Handler->handleError(8, 'Undefined prope...', '/var/app/curren...', 285, Array)#1 /var/app/current/vendor/laravel/framework/src/Illuminate/Routing/Router.php(1501)

Symfony\Component\HttpFoundation\Response->prepare(Object(Illuminate\Http\Request))#2 /var/app/current/vendor/laravel/framework/src/Illuminate/Routing/Router.php(1031)

Illuminate\Routing\Router->prepareResponse(Object(Illuminate\Http\Request), Object(Illuminate\View\View))#3 /var/app/current/vendor/laravel/framework/src/Illuminate/Routing/Router.php(996)

Illuminate\Routing\Router->dispatchToRoute(Object(Illuminate\Http\Request))#4 /var/app/current/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(777)

Illuminate\Routing\Router->dispatch(Object(Illuminate\Http\Request))#5 /var/app/current/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(747)

Illuminate\Foundation\Application->dispatch(Object(Illuminate\Http\Request))#6 /var/app/current/vendor/laravel/framework/src/Illuminate/Session/Middleware.php(72)

Illuminate\Foundation\Application->handle(Object(Illuminate\Http\Request), 1, true)#7 /var/app/current/vendor/laravel/framework/src/Illuminate/Cookie/Queue.php(47)

Illuminate\Session\Middleware->handle(Object(Illuminate\Http\Request), 1, true)#8 /var/app/current/vendor/laravel/framework/src/Illuminate/Cookie/Guard.php(51)

Illuminate\Cookie\Queue->handle(Object(Illuminate\Http\Request), 1, true)#9 /var/app/current/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23)

Illuminate\Cookie\Guard->handle(Object(Illuminate\Http\Request), 1, true)#10 /var/app/current/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(643)

Stack\StackedHttpKernel->handle(Object(Illuminate\Http\Request))#11 /var/app/current/public/index.php(49)

Illuminate\Foundation\Application->run()#12 {main}"
```
