### PR TITLE
Prevent an empty choice list being passed in debug:container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -110,15 +110,8 @@ EOF
             $options = array('tag' => $tag, 'show_private' => $input->getOption('show-private'));
         } elseif ($name = $input->getArgument('name')) {
             $object = $this->getContainerBuilder();
-            $matchedId = $this->findProperServiceName($input, $output, $object, $name);
-            // check to see if nothing was matched
-            if (false === $matchedId) {
-                $output->writeln(sprintf('<error>No services found that match "%s".</error>', $name));
-
-                return;
-            }
-
-            $options = array('id' => $matchedId);
+            $name = $this->findProperServiceName($input, $output, $object, $name);
+            $options = array('id' => $name);
         } else {
             $object = $this->getContainerBuilder();
             $options = array('show_private' => $input->getOption('show-private'));
@@ -193,7 +186,7 @@ EOF
 
         $matchingServices = $this->findServiceIdsContaining($builder, $name);
         if (empty($matchingServices)) {
-            return false;
+            throw new \InvalidArgumentException(sprintf('No services found that match "%s".', $name));
         }
 
         $question = new ChoiceQuestion('Choose a number for more information on the service', $matchingServices);


### PR DESCRIPTION
Hi guys!

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | n/a |

Currently, there is a "bug" where if you pass an empty array to ChoiceList, then you get this following warning from `QuestionHelper::doAsk()`:

> Warning: max(): Array must contain at least one element

That should probably be fixed too, but it would go on an earlier version, so I didn't want to mix fixes for different branches.

Thanks!
