### PR TITLE
[FrameworkBundle] register `TranslatorListener` service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -40,5 +40,11 @@
             <argument type="service" id="router" on-invalid="ignore" />
             <argument type="service" id="request_stack" />
         </service>
+
+        <service id="translator_listener" class="Symfony\Component\HttpKernel\EventListener\TranslatorListener">
+            <argument type="service" id="translator" />
+            <argument type="service" id="request_stack" />
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12167 |
| License | MIT |
| Doc PR |  |

Since the `TranslatorListener` was not registered as a service, the
proper locale would never have been passed from the current request
to the translator.
