### PR TITLE
[CssSelector] don't raise warnings when exception is thrown

### DIFF
--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -123,17 +123,15 @@ class Translator implements TranslatorInterface
         $selectors = $this->parseSelectors($cssExpr);
 
         /** @var SelectorNode $selector */
-        foreach ($selectors as $selector) {
+        foreach ($selectors as $index => $selector) {
             if (null !== $selector->getPseudoElement()) {
                 throw new ExpressionErrorException('Pseudo-elements are not supported.');
             }
+
+            $selectors[$index] = $this->selectorToXPath($selector, $prefix);
         }
 
-        $translator = $this;
-
-        return implode(' | ', array_map(function (SelectorNode $selector) use ($translator, $prefix) {
-            return $translator->selectorToXPath($selector, $prefix);
-        }, $selectors));
+        return implode(' | ', $selectors);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11947 |
| License | MIT |
| Doc PR |  |

`array_map()` raises a warning when an exception is thrown inside the
callback (see https://bugs.php.net/bug.php?id=55416). To avoid these
warnings, `selectorToXPath()` is applied inside the loop.
