### PR TITLE
[Routing] fix type inconsistencies in RequestContext

### DIFF
--- a/src/Symfony/Component/Routing/Tests/RequestContextTest.php
+++ b/src/Symfony/Component/Routing/Tests/RequestContextTest.php
@@ -98,4 +98,46 @@ class RequestContextTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('bar', $requestContext->getParameter('foo'));
     }
+
+    public function testMethod()
+    {
+        $requestContext = new RequestContext();
+        $requestContext->setMethod('post');
+
+        $this->assertSame('POST', $requestContext->getMethod());
+    }
+
+    public function testScheme()
+    {
+        $requestContext = new RequestContext();
+        $requestContext->setScheme('HTTPS');
+
+        $this->assertSame('https', $requestContext->getScheme());
+    }
+
+    public function testHost()
+    {
+        $requestContext = new RequestContext();
+        $requestContext->setHost('eXampLe.com');
+
+        $this->assertSame('example.com', $requestContext->getHost());
+    }
+
+    public function testQueryString()
+    {
+        $requestContext = new RequestContext();
+        $requestContext->setQueryString(null);
+
+        $this->assertSame('', $requestContext->getQueryString());
+    }
+
+    public function testPort()
+    {
+        $requestContext = new RequestContext();
+        $requestContext->setHttpPort('123');
+        $requestContext->setHttpsPort('456');
+
+        $this->assertSame(123, $requestContext->getHttpPort());
+        $this->assertSame(456, $requestContext->getHttpsPort());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Fixed inconsistencies in RequestContext:
- [x] port setters and getters inconsistent with constructor (string vs int)
- [x] host should be lowercased for easier case-insensitivity, see #9072
- [x] fix setQueryString with null
- [x] fix return phpdoc typehint
