### PR TITLE
[Security] More accurate docblocks for AbstractVoter

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
@@ -85,7 +85,7 @@ abstract class AbstractVoter implements VoterInterface
     /**
      * Return an array of supported classes. This will be called by supportsClass
      *
-     * @return array    an array of supported classes, i.e. ['\Acme\DemoBundle\Model\Product']
+     * @return array    an array of supported classes, i.e. ['Acme\DemoBundle\Model\Product']
      */
     abstract protected function getSupportedClasses();
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
@@ -85,14 +85,14 @@ abstract class AbstractVoter implements VoterInterface
     /**
      * Return an array of supported classes. This will be called by supportsClass
      *
-     * @return array    an array of supported classes, i.e. ['Acme\DemoBundle\Model\Product']
+     * @return array    an array of supported classes, i.e. array('Acme\DemoBundle\Model\Product')
      */
     abstract protected function getSupportedClasses();
 
     /**
      * Return an array of supported attributes. This will be called by supportsAttribute
      *
-     * @return array    an array of supported attributes, i.e. ['CREATE', 'READ']
+     * @return array    an array of supported attributes, i.e. array('CREATE', 'READ')
      */
     abstract protected function getSupportedAttributes();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | none |
| License | MIT |

Two fixes for docblocks in AbstractVoter:
1. Previously the example return value for a few methods used PHP's short array syntax (>= PHP 5.4). Symfony minimum PHP is 5.3 so the docblock examples should be compatible with that.
2. Previously getSupportedClasses() docblock had an example return value showing a FQCN using a leading slash. AbstractVoter looks for `get_class($object)` in the array of getSupportedClasses() returned values, and `get_class()` returns the FQCN without a leading slash.
