### PR TITLE
use meta charset in layouts without legacy http-equiv

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Resources/views/base.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Resources/views/base.html.twig
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta charset="UTF-8" />
         <title>{% block title %}Welcome!{% endblock %}</title>
         {% block stylesheets %}{% endblock %}
         <link rel="shortcut icon" href="{{ asset('favicon.ico') }}" />

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta charset="UTF-8" />
         <title>An Error Occurred: {{ status_text }}</title>
     </head>
     <body>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset={{ _charset }}"/>
+        <meta charset="{{ _charset }}" />
         <meta name="robots" content="noindex,nofollow" />
         <title>{% block title %}{% endblock %}</title>
-        <link href="{{ asset('bundles/framework/css/structure.css') }}" rel="stylesheet" type="text/css" media="all" />
-        <link href="{{ asset('bundles/framework/css/body.css') }}" rel="stylesheet" type="text/css" media="all" />
+        <link href="{{ asset('bundles/framework/css/structure.css') }}" rel="stylesheet" />
+        <link href="{{ asset('bundles/framework/css/body.css') }}" rel="stylesheet" />
         {% block head %}{% endblock %}
     </head>
     <body>

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -257,7 +257,7 @@ EOF;
 <!DOCTYPE html>
 <html>
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta charset="UTF-8" />
         <meta name="robots" content="noindex,nofollow" />
         <style>
             /* Copyright (c) 2010, Yahoo! Inc. All rights reserved. Code licensed under the BSD License: http://developer.yahoo.com/yui/license.html */

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -89,7 +89,7 @@ class RedirectResponse extends Response
             sprintf('<!DOCTYPE html>
 <html>
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta charset="UTF-8" />
         <meta http-equiv="refresh" content="1;url=%1$s" />
 
         <title>Redirecting to %1$s</title>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

`<meta charset="UTF-8" />` is now the recommended approach
