### PR TITLE
[TwigBundle] remove unused email placeholder from error page

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.atom.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.atom.twig
@@ -1,1 +1,1 @@
-{% include 'TwigBundle:Exception:error.xml.twig' with { 'exception': exception } %}
+{% include 'TwigBundle:Exception:error.xml.twig' %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
@@ -9,9 +9,8 @@
         <h2>The server returned a "{{ status_code }} {{ status_text }}".</h2>
 
         <div>
-            Something is broken. Please e-mail us at [email] and let us know
-            what you were doing when this error occurred. We will fix it as soon
-            as possible. Sorry for any inconvenience caused.
+            Something is broken. Please let us know what you were doing when this error occurred.
+            We will fix it as soon as possible. Sorry for any inconvenience caused.
         </div>
     </body>
 </html>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.rdf.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.rdf.twig
@@ -1,1 +1,1 @@
-{% include 'TwigBundle:Exception:error.xml.twig' with { 'exception': exception } %}
+{% include 'TwigBundle:Exception:error.xml.twig' %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.txt.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.txt.twig
@@ -3,6 +3,5 @@ Oops! An Error Occurred
 
 The server returned a "{{ status_code }} {{ status_text }}".
 
-Please e-mail us at [email] and let us know what you were doing when this
-error occurred. We will fix it as soon as possible. Sorry for any
-inconvenience caused.
+Something is broken. Please let us know what you were doing when this error occurred.
+We will fix it as soon as possible. Sorry for any inconvenience caused.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

remove unused email placeholder from error page
