### PR TITLE
[TwigBundle] do not pass a template reference to twig

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Exception\FlattenException;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\TemplateReferenceInterface;
 
 /**
  * ExceptionController.
@@ -51,7 +52,7 @@ class ExceptionController
         $code = $exception->getStatusCode();
 
         return new Response($this->twig->render(
-            $this->findTemplate($request, $request->getRequestFormat(), $code, $this->debug),
+            (string) $this->findTemplate($request, $request->getRequestFormat(), $code, $this->debug),
             array(
                 'status_code'    => $code,
                 'status_text'    => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
@@ -88,7 +89,7 @@ class ExceptionController
      * @param int     $code       An HTTP response status code
      * @param bool    $debug
      *
-     * @return TemplateReference
+     * @return TemplateReferenceInterface
      */
     protected function findTemplate(Request $request, $format, $code, $debug)
     {

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -43,21 +43,12 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
 
     /**
      * {@inheritdoc}
+     *
+     * The name parameter might also be a TemplateReferenceInterface.
      */
-    public function exists($template)
+    public function exists($name)
     {
-        if (parent::exists($template)) {
-            return true;
-        }
-
-        // same logic as findTemplate below for the fallback
-        try {
-            $this->cache[(string) $template] = $this->locator->locate($this->parser->parse($template));
-        } catch (\Exception $e) {
-            return false;
-        }
-
-        return true;
+        return parent::exists((string) $name);
     }
 
     /**
@@ -84,18 +75,14 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         $file = null;
         $previous = null;
         try {
-            $file = parent::findTemplate($template);
+            $file = parent::findTemplate($logicalName);
         } catch (\Twig_Error_Loader $e) {
             $previous = $e;
 
             // for BC
             try {
                 $template = $this->parser->parse($template);
-                try {
-                    $file = $this->locator->locate($template);
-                } catch (\InvalidArgumentException $e) {
-                    $previous = $e;
-                }
+                $file = $this->locator->locate($template);
             } catch (\Exception $e) {
                 $previous = $e;
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

twig does not know about template references and only expects a string.
this commit also fixes that name parsing and locating was called twice for nonexistent templates.
