### PR TITLE
[HttpFoundation] Allow Cache-Control headers on StreamedResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -84,8 +84,6 @@ class StreamedResponse extends Response
      */
     public function prepare(Request $request)
     {
-        $this->headers->set('Cache-Control', 'no-cache');
-
         return parent::prepare($request);
     }
 

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -81,14 +81,6 @@ class StreamedResponse extends Response
 
     /**
      * {@inheritdoc}
-     */
-    public function prepare(Request $request)
-    {
-        return parent::prepare($request);
-    }
-
-    /**
-     * {@inheritdoc}
      *
      * This method only sends the content once.
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -34,7 +34,6 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('1.1', $response->getProtocolVersion());
         $this->assertNotEquals('chunked', $response->headers->get('Transfer-Encoding'), 'Apache assumes responses with a Transfer-Encoding header set to chunked to already be encoded.');
-        $this->assertEquals('no-cache, private', $response->headers->get('Cache-Control'));
     }
 
     public function testPrepareWith10Protocol()
@@ -47,7 +46,6 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('1.0', $response->getProtocolVersion());
         $this->assertNull($response->headers->get('Transfer-Encoding'));
-        $this->assertEquals('no-cache, private', $response->headers->get('Cache-Control'));
     }
 
     public function testPrepareWithHeadRequest()
@@ -56,6 +54,15 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/', 'HEAD');
 
         $response->prepare($request);
+    }
+
+    public function testPrepareWithCacheHeaders()
+    {
+        $response = new StreamedResponse(function () { echo 'foo'; }, 200, array('Cache-Control' => 'max-age=600, public'));
+        $request = Request::create('/', 'GET');
+
+        $response->prepare($request);
+        $this->assertEquals('max-age=600, public', $response->headers->get('Cache-Control'));
     }
 
     public function testSendContent()


### PR DESCRIPTION
StreamedResponse currently always sets `Cache-Control: no-cache` headers, which prevents all caching of streamed responses.

This change removes this limitation to allow normal cache control response behaviour.

Some caching proxies support caching streamed responses using chunked encoding, most notably AWS CloudFront:
http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#ResponseCustomTransferEncoding

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/6530 |
| License | MIT |
| Doc PR |  |
