### PR TITLE
[VarDumper] enhance dumping refs

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
@@ -86,20 +86,20 @@ class DumpExtensionTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(array(), array(), '', false),
-            array(array(), array(), "<pre class=sf-dump>[]\n</pre><script>Sfdump.instrument()</script>\n"),
+            array(array(), array(), "<pre class=sf-dump id=sf-dump data-indent-pad=\"  \">[]\n</pre><script>Sfdump(\"sf-dump\")</script>\n"),
             array(
                 array(),
                 array(123, 456),
-                "<pre class=sf-dump><span class=sf-dump-num>123</span>\n</pre><script>Sfdump.instrument()</script>\n"
-                ."<pre class=sf-dump><span class=sf-dump-num>456</span>\n</pre><script>Sfdump.instrument()</script>\n",
+                "<pre class=sf-dump id=sf-dump data-indent-pad=\"  \"><span class=sf-dump-num>123</span>\n</pre><script>Sfdump(\"sf-dump\")</script>\n"
+                ."<pre class=sf-dump id=sf-dump data-indent-pad=\"  \"><span class=sf-dump-num>456</span>\n</pre><script>Sfdump(\"sf-dump\")</script>\n",
             ),
             array(
                 array('foo' => 'bar'),
                 array(),
-                "<pre class=sf-dump><span class=sf-dump-note>array:1</span> [<span name=sf-dump-child>\n"
+                "<pre class=sf-dump id=sf-dump data-indent-pad=\"  \"><span class=sf-dump-note>array:1</span> [<samp>\n"
                 ."  \"<span class=sf-dump-meta>foo</span>\" => \"<span class=sf-dump-str>bar</span>\"\n"
-                ."</span>]\n"
-                ."</pre><script>Sfdump.instrument()</script>\n",
+                ."</samp>]\n"
+                ."</pre><script>Sfdump(\"sf-dump\")</script>\n",
             ),
         );
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -35,10 +35,11 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $dump = $collector->getDumps('html');
         $this->assertTrue(isset($dump[0]['data']));
         $dump[0]['data'] = preg_replace('/^.*?<pre/', '<pre', $dump[0]['data']);
+        $dump[0]['data'] = preg_replace('/sf-dump-\d+/', 'sf-dump', $dump[0]['data']);
 
         $xDump = array(
             array(
-                'data' => "<pre class=sf-dump><span class=sf-dump-num>123</span>\n</pre><script>Sfdump.instrument()</script>\n",
+                'data' => "<pre class=sf-dump id=sf-dump data-indent-pad=\"  \"><span class=sf-dump-num>123</span>\n</pre><script>Sfdump(\"sf-dump\")</script>\n",
                 'name' => 'DumpDataCollectorTest.php',
                 'file' => __FILE__,
                 'line' => $line,

--- a/src/Symfony/Component/VarDumper/Caster/CasterStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/CasterStub.php
@@ -41,6 +41,7 @@ class CasterStub extends Stub
             case 'resource':
             case 'unknown type':
                 $this->type = self::TYPE_RESOURCE;
+                $this->handle = (int) $value;
                 $this->class = @get_resource_type($value);
                 $this->cut = -1;
                 break;

--- a/src/Symfony/Component/VarDumper/Caster/StubCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/StubCaster.php
@@ -26,6 +26,7 @@ class StubCaster
             $stub->type = $c->type;
             $stub->class = $c->class;
             $stub->value = $c->value;
+            $stub->handle = $c->handle;
             $stub->cut = $c->cut;
 
             return array();

--- a/src/Symfony/Component/VarDumper/Cloner/Cursor.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Cursor.php
@@ -24,9 +24,13 @@ class Cursor
     const HASH_RESOURCE = Stub::TYPE_RESOURCE;
 
     public $depth = 0;
-    public $refIndex = false;
-    public $softRefTo = false;
-    public $hardRefTo = false;
+    public $refIndex = 0;
+    public $softRefTo = 0;
+    public $softRefCount = 0;
+    public $softRefHandle = 0;
+    public $hardRefTo = 0;
+    public $hardRefCount = 0;
+    public $hardRefHandle = 0;
     public $hashType;
     public $hashKey;
     public $hashIndex = 0;

--- a/src/Symfony/Component/VarDumper/Cloner/DumperInterface.php
+++ b/src/Symfony/Component/VarDumper/Cloner/DumperInterface.php
@@ -38,61 +38,23 @@ interface DumperInterface
     public function dumpString(Cursor $cursor, $str, $bin, $cut);
 
     /**
-     * Dumps while entering an array.
+     * Dumps while entering an hash.
      *
      * @param Cursor $cursor   The Cursor position in the dump.
-     * @param int    $count    The number of items in the original array.
-     * @param bool   $indexed  When the array is indexed or associative.
-     * @param bool   $hasChild When the dump of the array has child item.
+     * @param int    $type     A Cursor::HASH_* const for the type of hash.
+     * @param string $class    The object class, resource type or array count.
+     * @param bool   $hasChild When the dump of the hash has child item.
      */
-    public function enterArray(Cursor $cursor, $count, $indexed, $hasChild);
+    public function enterHash(Cursor $cursor, $type, $class, $hasChild);
 
     /**
-     * Dumps while leaving an array.
+     * Dumps while leaving an hash.
      *
      * @param Cursor $cursor   The Cursor position in the dump.
-     * @param int    $count    The number of items in the original array.
-     * @param bool   $indexed  Whether the array is indexed or associative.
-     * @param bool   $hasChild When the dump of the array has child item.
-     * @param int    $cut      The number of items the array has been cut by.
+     * @param int    $type     A Cursor::HASH_* const for the type of hash.
+     * @param string $class    The object class, resource type or array count.
+     * @param bool   $hasChild When the dump of the hash has child item.
+     * @param int    $cut      The number of items the hash has been cut by.
      */
-    public function leaveArray(Cursor $cursor, $count, $indexed, $hasChild, $cut);
-
-    /**
-     * Dumps while entering an object.
-     *
-     * @param Cursor $cursor   The Cursor position in the dump.
-     * @param string $class    The class of the object.
-     * @param bool   $hasChild When the dump of the object has child item.
-     */
-    public function enterObject(Cursor $cursor, $class, $hasChild);
-
-    /**
-     * Dumps while leaving an object.
-     *
-     * @param Cursor $cursor   The Cursor position in the dump.
-     * @param string $class    The class of the object.
-     * @param bool   $hasChild When the dump of the object has child item.
-     * @param int    $cut      The number of items the object has been cut by.
-     */
-    public function leaveObject(Cursor $cursor, $class, $hasChild, $cut);
-
-    /**
-     * Dumps while entering a resource.
-     *
-     * @param Cursor $cursor   The Cursor position in the dump.
-     * @param string $res      The resource type.
-     * @param bool   $hasChild When the dump of the resource has child item.
-     */
-    public function enterResource(Cursor $cursor, $res, $hasChild);
-
-    /**
-     * Dumps while leaving a resource.
-     *
-     * @param Cursor $cursor   The Cursor position in the dump.
-     * @param string $res      The resource type.
-     * @param bool   $hasChild When the dump of the resource has child item.
-     * @param int    $cut      The number of items the resource has been cut by.
-     */
-    public function leaveResource(Cursor $cursor, $res, $hasChild, $cut);
+    public function leaveHash(Cursor $cursor, $type, $class, $hasChild, $cut);
 }

--- a/src/Symfony/Component/VarDumper/Cloner/Stub.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Stub.php
@@ -34,6 +34,7 @@ class Stub
     public $class = '';
     public $value;
     public $cut = 0;
-    public $ref = 0;
+    public $handle = 0;
+    public $refCount = 0;
     public $position = 0;
 }

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -41,12 +41,14 @@ class CliDumperTest extends \PHPUnit_Framework_TestCase
         $closureLabel = PHP_VERSION_ID >= 50400 ? 'public method' : 'function';
         $out = preg_replace('/[ \t]+$/m', '', $out);
         $intMax = PHP_INT_MAX;
+        $res1 = (int) $var['res'];
+        $res2 = (int) $var[8];
 
-        $this->assertSame(
+        $this->assertStringMatchesFormat(
             <<<EOTXT
 array:25 [
   "number" => 1
-  0 => null #1
+  0 => &1 null
   "const" => 1.1
   1 => true
   2 => false
@@ -57,7 +59,7 @@ array:25 [
   "str" => "déjà"
   7 => b"é"
   "[]" => []
-  "res" => :stream {
+  "res" => :stream {@{$res1}
     wrapper_type: "plainfile"
     stream_type: "STDIO"
     mode: "r"
@@ -68,12 +70,12 @@ array:25 [
     eof: false
     options: []
   }
-  8 => :Unknown {}
-  "obj" => Symfony\Component\VarDumper\Tests\Fixture\DumbFoo { #2
+  8 => :Unknown {@{$res2}}
+  "obj" => Symfony\Component\VarDumper\Tests\Fixture\DumbFoo {#%d
     foo: "foo"
     "bar": "bar"
   }
-  "closure" => Closure {
+  "closure" => Closure {#%d
     reflection: """
       Closure [ <user> {$closureLabel} Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {
         @@ {$var['file']} {$var['line']} - {$var['line']}
@@ -87,15 +89,15 @@ array:25 [
   }
   "line" => {$var['line']}
   "nobj" => array:1 [
-    0 => {} #3
+    0 => &3 {#%d}
   ]
-  "recurs" => array:1 [ #4
-    0 => &4 array:1 [@4]
+  "recurs" => &4 array:1 [
+    0 => &4 array:1 [&4]
   ]
   9 => &1 null
-  "sobj" => Symfony\Component\VarDumper\Tests\Fixture\DumbFoo {@2}
-  "snobj" => &3 {@3}
-  "snobj2" => {@3}
+  "sobj" => Symfony\Component\VarDumper\Tests\Fixture\DumbFoo {#%d}
+  "snobj" => &3 {#%d}
+  "snobj2" => {#%d}
   "file" => "{$var['file']}"
   b"bin-key-é" => ""
 ]

--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -46,12 +46,14 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
         $intMax = PHP_INT_MAX;
         preg_match('/sf-dump-\d+/', $out, $dumpId);
         $dumpId = $dumpId[0];
+        $res1 = (int) $var['res'];
+        $res2 = (int) $var[8];
 
-        $this->assertSame(
+        $this->assertStringMatchesFormat(
             <<<EOTXT
-<foo></foo><bar><span class=sf-dump-note>array:25</span> [<span name=sf-dump-child>
+<foo></foo><bar><span class=sf-dump-note>array:25</span> [<samp>
   "<span class=sf-dump-meta>number</span>" => <span class=sf-dump-num>1</span>
-  <span class=sf-dump-meta>0</span> => <span class=sf-dump-const>null</span> <span class=sf-dump-ref name=sf-dump-ref id="{$dumpId}-ref1">#1</span>
+  <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref01>&amp;1</a> <span class=sf-dump-const>null</span>
   "<span class=sf-dump-meta>const</span>" => <span class=sf-dump-num>1.1</span>
   <span class=sf-dump-meta>1</span> => <span class=sf-dump-const>true</span>
   <span class=sf-dump-meta>2</span> => <span class=sf-dump-const>false</span>
@@ -62,7 +64,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   "<span class=sf-dump-meta>str</span>" => "<span class=sf-dump-str>d&#233;j&#224;</span>"
   <span class=sf-dump-meta>7</span> => b"<span class=sf-dump-str>&#233;</span>"
   "<span class=sf-dump-meta>[]</span>" => []
-  "<span class=sf-dump-meta>res</span>" => <abbr title="Resource of type `stream`" class=sf-dump-note>:stream</abbr> {<span name=sf-dump-child>
+  "<span class=sf-dump-meta>res</span>" => <abbr title="Resource of type `stream`" class=sf-dump-note>:stream</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref1{$res1}>@{$res1}</a><samp>
     <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str>plainfile</span>"
     <span class=sf-dump-meta>stream_type</span>: "<span class=sf-dump-str>STDIO</span>"
     <span class=sf-dump-meta>mode</span>: "<span class=sf-dump-str>r</span>"
@@ -72,13 +74,13 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
     <span class=sf-dump-meta>blocked</span>: <span class=sf-dump-const>true</span>
     <span class=sf-dump-meta>eof</span>: <span class=sf-dump-const>false</span>
     <span class=sf-dump-meta>options</span>: []
-  </span>}
-  <span class=sf-dump-meta>8</span> => <abbr title="Resource of type `Unknown`" class=sf-dump-note>:Unknown</abbr> {}
-  "<span class=sf-dump-meta>obj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<span name=sf-dump-child> <span class=sf-dump-ref name=sf-dump-ref id="{$dumpId}-ref2">#2</span>
+  </samp>}
+  <span class=sf-dump-meta>8</span> => <abbr title="Resource of type `Unknown`" class=sf-dump-note>:Unknown</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref1{$res2}>@{$res2}</a>}
+  "<span class=sf-dump-meta>obj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a><samp id={$dumpId}-ref2%d>
     <span class=sf-dump-public>foo</span>: "<span class=sf-dump-str>foo</span>"
     "<span class=sf-dump-public>bar</span>": "<span class=sf-dump-str>bar</span>"
-  </span>}
-  "<span class=sf-dump-meta>closure</span>" => <span class=sf-dump-note>Closure</span> {<span name=sf-dump-child>
+  </samp>}
+  "<span class=sf-dump-meta>closure</span>" => <span class=sf-dump-note>Closure</span> {<a class=sf-dump-solo-ref>#%d</a><samp>
     <span class=sf-dump-meta>reflection</span>: """
       <span class=sf-dump-str>Closure [ &lt;user&gt; {$closureLabel} Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {</span>
       <span class=sf-dump-str>  @@ {$var['file']} {$var['line']} - {$var['line']}</span>
@@ -89,21 +91,21 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
       <span class=sf-dump-str>  }</span>
       <span class=sf-dump-str>}</span>
       """
-  </span>}
+  </samp>}
   "<span class=sf-dump-meta>line</span>" => <span class=sf-dump-num>{$var['line']}</span>
-  "<span class=sf-dump-meta>nobj</span>" => <span class=sf-dump-note>array:1</span> [<span name=sf-dump-child>
-    <span class=sf-dump-meta>0</span> => {} <span class=sf-dump-ref name=sf-dump-ref id="{$dumpId}-ref3">#3</span>
-  </span>]
-  "<span class=sf-dump-meta>recurs</span>" => <span class=sf-dump-note>array:1</span> [<span name=sf-dump-child> <span class=sf-dump-ref name=sf-dump-ref id="{$dumpId}-ref4">#4</span>
-    <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref4">&4</a> <span class=sf-dump-note>array:1</span> [<a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref4">@4</a>]
-  </span>]
-  <span class=sf-dump-meta>9</span> => <a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref1">&1</a> <span class=sf-dump-const>null</span>
-  "<span class=sf-dump-meta>sobj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref2">@2</a>}
-  "<span class=sf-dump-meta>snobj</span>" => <a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref3">&3</a> {<a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref3">@3</a>}
-  "<span class=sf-dump-meta>snobj2</span>" => {<a class=sf-dump-ref name=sf-dump-ref href="#{$dumpId}-ref3">@3</a>}
+  "<span class=sf-dump-meta>nobj</span>" => <span class=sf-dump-note>array:1</span> [<samp>
+    <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref03>&amp;3</a> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a>}
+  </samp>]
+  "<span class=sf-dump-meta>recurs</span>" => <a class=sf-dump-ref href=#{$dumpId}-ref04>&amp;4</a> <span class=sf-dump-note>array:1</span> [<samp id={$dumpId}-ref04>
+    <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref04>&amp;4</a> <span class=sf-dump-note>array:1</span> [<a class=sf-dump-ref href=#{$dumpId}-ref04>&amp;4</a>]
+  </samp>]
+  <span class=sf-dump-meta>9</span> => <a class=sf-dump-ref href=#{$dumpId}-ref01>&amp;1</a> <span class=sf-dump-const>null</span>
+  "<span class=sf-dump-meta>sobj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a>}
+  "<span class=sf-dump-meta>snobj</span>" => <a class=sf-dump-ref href=#{$dumpId}-ref03>&amp;3</a> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a>}
+  "<span class=sf-dump-meta>snobj2</span>" => {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a>}
   "<span class=sf-dump-meta>file</span>" => "<span class=sf-dump-str>{$var['file']}</span>"
   b"<span class=sf-dump-meta>bin-key-&#233;</span>" => ""
-</span>]
+</samp>]
 </bar>
 
 EOTXT


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | nicolas-grekas/Patchwork-Dumper#39 |
| License | MIT |
| Doc PR | - |

This makes dumps prettier:
- VarCloner now exposes the "isref" state of a PHP variable
- on hard refs, `#n` suffix is replaced by `&n` prefix
- `#n`/`@n` (object/resource refs) are moved inside the `{ }`
- all repetitive dumps of the same object are toggle-able
- all repetitive dumps of the same object / hard ref are _visually_ identical
- dumps expose local ref counts and object's handle

I also simplified the `Cloner\DumperInterface`.

For the same (circumvoluted) variable:

Before:
![before](https://cloud.githubusercontent.com/assets/243674/4595026/f6b2a98c-5094-11e4-9fe0-dc6d24da3f14.png)

After:
![after](https://cloud.githubusercontent.com/assets/243674/4595035/07e04980-5095-11e4-9e45-54a1e7453547.png)
