### PR TITLE
Add missing argument

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
@@ -39,7 +39,7 @@ class YamlExtension extends \Twig_Extension
             $dumper = new YamlDumper();
         }
 
-        return $dumper->dump($input, $inline, false, $dumpObjects);
+        return $dumper->dump($input, $inline, 0, false, $dumpObjects);
     }
 
     public function dump($value, $inline = 0, $dumpObjects = false)


### PR DESCRIPTION
`->dump` has 5 arguments (the 3th argument, the indent, was not provided in the twig extension).

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | let's see |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
