### PR TITLE
[FrameworkBundle] [DX] Displays friendly message if the event does not have any registered listeners

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -58,13 +58,27 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $dispatcher = $this->getEventDispatcher();
+
         if ($event = $input->getArgument('event')) {
+            if (!$dispatcher->hasListeners($event)) {
+                $formatter = $this->getHelperSet()->get('formatter');
+
+                $formattedBlock = $formatter->formatBlock(
+                    sprintf('[NOTE] The event "%s" does not have any registered listeners.', $event),
+                    'fg=yellow',
+                    true
+                );
+
+                $output->writeln($formattedBlock);
+
+                return;
+            }
+
             $options = array('event' => $event);
         } else {
             $options = array();
         }
-
-        $dispatcher = $this->getEventDispatcher();
 
         $helper = new DescriptorHelper();
         $options['format'] = $input->getOption('format');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

Currently if you run debug:event-dispatcher on an event without registered listeners, the output looks like this

![capture d ecran de 2014-10-13 00 43 26](https://cloud.githubusercontent.com/assets/1172099/4607814/486213e4-5261-11e4-93b3-6ef009c19a05.png)

This PR just add a friendly message like debug:container or debug:router :

![capture d ecran de 2014-10-13 00 44 38](https://cloud.githubusercontent.com/assets/1172099/4607819/7a28a01e-5261-11e4-9b07-d0ca36725da2.png)
