### PR TITLE
[Form] Deprecated "cascade_validation"

### DIFF
--- a/UPGRADE-2.6.md
+++ b/UPGRADE-2.6.md
@@ -55,6 +55,45 @@ Form
        ...
    {% endif %}
    ```
+   
+ * The "cascade_validation" option was deprecated. Use the "constraints"
+   option together with the `Valid` constraint instead. Contrary to
+   "cascade_validation", "constraints" must be set on the respective child forms,
+   not the parent form.
+   
+   Before:
+   
+   ```php
+   $form = $this->createForm('form', $article, array('cascade_validation' => true))
+       ->add('author', new AuthorType())
+       ->getForm();
+   ```
+   
+   After:
+   
+   ```php
+   use Symfony\Component\Validator\Constraints\Valid;
+   
+   $form = $this->createForm('form', $article)
+       ->add('author', new AuthorType(), array(
+           'constraints' => new Valid(),
+       ))
+       ->getForm();
+   ```
+   
+   Alternatively, you can set the `Valid` constraint in the model itself:
+   
+   ```php
+   use Symfony\Component\Validator\Constraints as Assert;
+   
+   class Article
+   {
+       /**
+        * @Assert\Valid
+        */
+       private $author;
+   }
+   ```
 
 Validator
 ---------

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -176,6 +176,11 @@
     {{ block('form_widget_simple') }}
 {%- endblock email_widget -%}
 
+{%- block range_widget -%}
+    {% set type = type|default('range') %}
+    {{- block('form_widget_simple') -}}
+{%- endblock range_widget %}
+
 {%- block button_widget -%}
     {%- if label is empty -%}
         {%- if label_format is not empty -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -113,6 +113,9 @@
         <service id="form.type.radio" class="Symfony\Component\Form\Extension\Core\Type\RadioType">
             <tag name="form.type" alias="radio" />
         </service>
+        <service id="form.type.range" class="Symfony\Component\Form\Extension\Core\Type\RangeType">
+            <tag name="form.type" alias="range" />
+        </service>
         <service id="form.type.repeated" class="Symfony\Component\Form\Extension\Core\Type\RepeatedType">
             <tag name="form.type" alias="repeated" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/range_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/range_widget.html.php
@@ -1,0 +1,1 @@
+<?php echo $view['form']->block($form, 'form_widget_simple', array('type' => isset($type) ? $type : 'range'));

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -57,6 +57,14 @@
 {% endblock %}
 
 {% block panelContent %}
+    {% set filter = request.query.get('state', '-1') %}
+    {% set filterOptions = {
+        '-1': '',
+        (constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_DEFINED')): 'Defined messages',
+        (constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_MISSING')): 'Missing messages',
+        (constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK')): 'Fallback messages',
+    } %}
+
     <h2>Translation Stats</h2>
     <table>
         <tbody>
@@ -72,6 +80,22 @@
                 <th>Missing messages</th>
                 <td><pre>{{ collector.countMissings }}</pre></td>
             </tr>
+            <tr>
+                <th>Filter</th>
+                <td>
+                    <form id="filter-form" action="" method="get" style="display: inline">
+                        <input type="hidden" name="panel" value="translation">
+                        <select id="filter" name="state" onchange="document.getElementById('filter-form').submit(); ">
+                            {% for key,option in filterOptions %}
+                                <option value="{{ key }}"{{ filter == key ? ' selected' : '' }}>{{ option }}</option>
+                            {% endfor %}
+                        </select>
+                        <noscript>
+                            <input type="submit" value="refresh">
+                        </noscript>
+                    </form>
+                </td>
+            </tr>
         </tbody>
     </table>
 
@@ -83,7 +107,7 @@
             <th>Id</th>
             <th>Message Preview</th>
         </tr>
-        {% for message in collector.messages %}
+        {% for message in collector.messages if message.state == filter or filter == '-1' %}
             <tr>
                 <td><code>{{ translator.state(message) }}</code></td>
                 <td><code>{{ message.locale }}</code></td>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * deprecated option "read_only" in favor of "attr['readonly']"
+ * added the html5 "range" FormType
 
 2.7.0
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * deprecated option "read_only" in favor of "attr['readonly']"
  * added the html5 "range" FormType
+ * deprecated the "cascade_validation" option in favor of setting "constraints"
+   with the Valid constraint
 
 2.7.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -63,6 +63,7 @@ class CoreExtension extends AbstractExtension
             new Type\PasswordType(),
             new Type\PercentType(),
             new Type\RadioType(),
+            new Type\RangeType(),
             new Type\RepeatedType(),
             new Type\SearchType(),
             new Type\TextareaType(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+
+class RangeType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'text';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'range';
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Extension\Validator\Constraints;
 
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -63,6 +64,20 @@ class FormValidator extends ConstraintValidator
             // in the form
             $constraints = $config->getOption('constraints');
             foreach ($constraints as $constraint) {
+                // For the "Valid" constraint, validate the data in all groups
+                if ($constraint instanceof Valid) {
+                    if ($validator) {
+                        $validator->atPath('data')->validate($form->getData(), $constraint, $groups);
+                    } else {
+                        // 2.4 API
+                        $this->context->validateValue($form->getData(), $constraint, 'data', $groups);
+                    }
+
+                    continue;
+                }
+
+                // Otherwise validate a constraint only once for the first
+                // matching group
                 foreach ($groups as $group) {
                     if (in_array($group, $constraint->groups)) {
                         if ($validator) {

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -70,7 +70,7 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
         $resolver->setDefaults(array(
             'error_mapping' => array(),
             'constraints' => array(),
-            'cascade_validation' => false,
+            'cascade_validation' => false, // deprecated
             'invalid_message' => 'This value is not valid.',
             'invalid_message_parameters' => array(),
             'allow_extra_fields' => false,

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -1597,6 +1597,37 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    public function testRange()
+    {
+        $form = $this->factory->createNamed('name', 'range', 42, array('attr' => array('min' => 5)));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
+'/input
+    [@type="range"]
+    [@name="name"]
+    [@value="42"]
+    [@min="5"]
+    [@class="my&class form-control"]
+'
+        );
+    }
+
+    public function testRangeWithMinMaxValues()
+    {
+        $form = $this->factory->createNamed('name', 'range', 42, array('attr' => array('min' => 5, 'max' => 57)));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
+'/input
+    [@type="range"]
+    [@name="name"]
+    [@value="42"]
+    [@min="5"]
+    [@max="57"]
+    [@class="my&class form-control"]
+'
+        );
+    }
+
     public function testTextarea()
     {
         $form = $this->factory->createNamed('name', 'textarea', 'foo&bar', array(

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1712,6 +1712,35 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
+    public function testRange()
+    {
+        $form = $this->factory->createNamed('name', 'range', 42, array('attr' => array('min' => 5)));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/input
+    [@type="range"]
+    [@name="name"]
+    [@value="42"]
+    [@min="5"]
+'
+        );
+    }
+
+    public function testRangeWithMinMaxValues()
+    {
+        $form = $this->factory->createNamed('name', 'range', 42, array('attr' => array('min' => 5, 'max' => 57)));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/input
+    [@type="range"]
+    [@name="name"]
+    [@value="42"]
+    [@min="5"]
+    [@max="57"]
+'
+        );
+    }
+
     public function testTextarea()
     {
         $form = $this->factory->createNamed('name', 'textarea', 'foo&bar', array(

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\SubmitButtonBuilder;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest;
 use Symfony\Component\Validator\Validation;
 
@@ -103,6 +104,52 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         // Then custom constraints
         $this->expectValidateValueAt(2, 'data', $object, $constraint1, 'group1');
         $this->expectValidateValueAt(3, 'data', $object, $constraint2, 'group2');
+
+        $this->validator->validate($form, new Form());
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidateIfParentWithCascadeValidation()
+    {
+        $object = $this->getMock('\stdClass');
+
+        $parent = $this->getBuilder('parent', null, array('cascade_validation' => true))
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->getForm();
+        $options = array('validation_groups' => array('group1', 'group2'));
+        $form = $this->getBuilder('name', '\stdClass', $options)->getForm();
+        $parent->add($form);
+
+        $form->setData($object);
+
+        $this->expectValidateAt(0, 'data', $object, 'group1');
+        $this->expectValidateAt(1, 'data', $object, 'group2');
+
+        $this->validator->validate($form, new Form());
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidateIfChildWithValidConstraint()
+    {
+        $object = $this->getMock('\stdClass');
+
+        $parent = $this->getBuilder('parent')
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->getForm();
+        $options = array(
+            'validation_groups' => array('group1', 'group2'),
+            'constraints' => array(new Valid()),
+        );
+        $form = $this->getBuilder('name', '\stdClass', $options)->getForm();
+        $parent->add($form);
+
+        $form->setData($object);
+
+        $this->expectValidateAt(0, 'data', $object, array('group1', 'group2'));
 
         $this->validator->validate($form, new Form());
 
@@ -387,12 +434,13 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
     {
         $object = $this->getMock('\stdClass');
 
-        $parent = $this->getBuilder('parent', null, array('cascade_validation' => true))
+        $parent = $this->getBuilder('parent')
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->getForm();
         $form = $this->getForm('name', '\stdClass', array(
             'validation_groups' => 'form_group',
+            'constraints' => array(new Valid()),
         ));
 
         $parent->add($form);
@@ -402,7 +450,7 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
         $parent->submit(array('name' => $object, 'submit' => ''));
 
-        $this->expectValidateAt(0, 'data', $object, 'button_group');
+        $this->expectValidateAt(0, 'data', $object, array('button_group'));
 
         $this->validator->validate($form, new Form());
 
@@ -413,12 +461,13 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
     {
         $object = $this->getMock('\stdClass');
 
-        $parent = $this->getBuilder('parent', null, array('cascade_validation' => true))
+        $parent = $this->getBuilder('parent')
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->getForm();
         $form = $this->getForm('name', '\stdClass', array(
             'validation_groups' => 'form_group',
+            'constraints' => array(new Valid()),
         ));
 
         $parent->add($form);
@@ -428,7 +477,7 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
         $form->setData($object);
 
-        $this->expectValidateAt(0, 'data', $object, 'form_group');
+        $this->expectValidateAt(0, 'data', $object, array('form_group'));
 
         $this->validator->validate($form, new Form());
 
@@ -439,20 +488,18 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
     {
         $object = $this->getMock('\stdClass');
 
-        $parentOptions = array(
-            'validation_groups' => 'group',
-            'cascade_validation' => true,
-        );
+        $parentOptions = array('validation_groups' => 'group');
         $parent = $this->getBuilder('parent', null, $parentOptions)
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->getForm();
-        $form = $this->getBuilder('name', '\stdClass')->getForm();
+        $formOptions = array('constraints' => array(new Valid()));
+        $form = $this->getBuilder('name', '\stdClass', $formOptions)->getForm();
         $parent->add($form);
 
         $form->setData($object);
 
-        $this->expectValidateAt(0, 'data', $object, 'group');
+        $this->expectValidateAt(0, 'data', $object, array('group'));
 
         $this->validator->validate($form, new Form());
 
@@ -463,21 +510,18 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
     {
         $object = $this->getMock('\stdClass');
 
-        $parentOptions = array(
-            'validation_groups' => array($this, 'getValidationGroups'),
-            'cascade_validation' => true,
-        );
+        $parentOptions = array('validation_groups' => array($this, 'getValidationGroups'));
         $parent = $this->getBuilder('parent', null, $parentOptions)
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->getForm();
-        $form = $this->getBuilder('name', '\stdClass')->getForm();
+        $formOptions = array('constraints' => array(new Valid()));
+        $form = $this->getBuilder('name', '\stdClass', $formOptions)->getForm();
         $parent->add($form);
 
         $form->setData($object);
 
-        $this->expectValidateAt(0, 'data', $object, 'group1');
-        $this->expectValidateAt(1, 'data', $object, 'group2');
+        $this->expectValidateAt(0, 'data', $object, array('group1', 'group2'));
 
         $this->validator->validate($form, new Form());
 
@@ -492,19 +536,18 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
             'validation_groups' => function (FormInterface $form) {
                 return array('group1', 'group2');
             },
-            'cascade_validation' => true,
         );
         $parent = $this->getBuilder('parent', null, $parentOptions)
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->getForm();
-        $form = $this->getBuilder('name', '\stdClass')->getForm();
+        $formOptions = array('constraints' => array(new Valid()));
+        $form = $this->getBuilder('name', '\stdClass', $formOptions)->getForm();
         $parent->add($form);
 
         $form->setData($object);
 
-        $this->expectValidateAt(0, 'data', $object, 'group1');
-        $this->expectValidateAt(1, 'data', $object, 'group2');
+        $this->expectValidateAt(0, 'data', $object, array('group1', 'group2'));
 
         $this->validator->validate($form, new Form());
 

--- a/src/Symfony/Component/Translation/Loader/JsonFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/JsonFileLoader.php
@@ -25,14 +25,6 @@ class JsonFileLoader extends FileLoader
      */
     protected function loadResource($resource)
     {
-        if (!stream_is_local($resource)) {
-            throw new InvalidResourceException(sprintf('This is not a local file "%s".', $resource));
-        }
-
-        if (!file_exists($resource)) {
-            throw new NotFoundResourceException(sprintf('File "%s" not found.', $resource));
-        }
-
         $messages = array();
         if ($data = file_get_contents($resource)) {
             $messages = json_decode($data, true);

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -220,14 +220,24 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
 
     protected function expectValidateAt($i, $propertyPath, $value, $group)
     {
-        $validator = $this->context->getValidator()->inContext($this->context);
-        $validator->expects($this->at(2 * $i))
-            ->method('atPath')
-            ->with($propertyPath)
-            ->will($this->returnValue($validator));
-        $validator->expects($this->at(2 * $i + 1))
-            ->method('validate')
-            ->with($value, $this->logicalOr(null, array()), $group);
+        switch ($this->getApiVersion()) {
+            case Validation::API_VERSION_2_4:
+                $this->context->expects($this->at($i))
+                    ->method('validate')
+                    ->with($value, $propertyPath, $group);
+                break;
+            case Validation::API_VERSION_2_5:
+            case Validation::API_VERSION_2_5_BC:
+                $validator = $this->context->getValidator()->inContext($this->context);
+                $validator->expects($this->at(2 * $i))
+                    ->method('atPath')
+                    ->with($propertyPath)
+                    ->will($this->returnValue($validator));
+                $validator->expects($this->at(2 * $i + 1))
+                    ->method('validate')
+                    ->with($value, $this->logicalOr(null, array(), $this->isInstanceOf('\Symfony\Component\Validator\Constraints\Valid')), $group);
+                break;
+        }
     }
 
     protected function expectValidateValueAt($i, $propertyPath, $value, $constraints, $group = null)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #11268 (requires explicit work though) |
| License | MIT |
| Doc PR | TODO |

The "cascade_validation" option was designed for a 1% use case and comparatively used way too often when the `Valid` constraint should have been used instead. Also, there seem to be bugs with that option (#5204).

The option is now deprecated. When using the 2.5 Validator API, you can set the "constraints" option of the respective child to a `Valid` constraint instead. Alternatively, set the constraint in the model (as most people hopefully do).
