### PR TITLE
[RFC][TwigBridge] Add option to prevent html escaping for translations

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -27,8 +27,9 @@ class TranslationExtension extends \Twig_Extension
 {
     private $translator;
     private $translationNodeVisitor;
+    private $safeHtml;
 
-    public function __construct(TranslatorInterface $translator, \Twig_NodeVisitorInterface $translationNodeVisitor = null)
+    public function __construct(TranslatorInterface $translator, \Twig_NodeVisitorInterface $translationNodeVisitor = null, $safeHtml = false)
     {
         if (!$translationNodeVisitor) {
             $translationNodeVisitor = new TranslationNodeVisitor();
@@ -36,6 +37,7 @@ class TranslationExtension extends \Twig_Extension
 
         $this->translator = $translator;
         $this->translationNodeVisitor = $translationNodeVisitor;
+        $this->safeHtml = $safeHtml;
     }
 
     public function getTranslator()
@@ -48,9 +50,11 @@ class TranslationExtension extends \Twig_Extension
      */
     public function getFilters()
     {
+        $options = $this->safeHtml ? array('is_safe' => array('html')) : array();
+
         return array(
-            new \Twig_SimpleFilter('trans', array($this, 'trans')),
-            new \Twig_SimpleFilter('transchoice', array($this, 'transchoice')),
+            new \Twig_SimpleFilter('trans', array($this, 'trans'), $options),
+            new \Twig_SimpleFilter('transchoice', array($this, 'transchoice'), $options),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (todo: new tests) |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | todo |

I find for almost every project I extend this class to enable this.  Maybe there is an alternate solution I am not seeing.  I almost always have bits of html in my translations for button icons and such.  Is this a bad idea?  If so, then of course this PR is probably invalid.

If we want to add this feature, where should it be configured?

Thoughts?
