### PR TITLE
[Bridge][Doctrine][Form] Add entity manager instance support for em option

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -143,6 +143,10 @@ abstract class DoctrineType extends AbstractType
         $emNormalizer = function (Options $options, $em) use ($registry) {
             /* @var ManagerRegistry $registry */
             if (null !== $em) {
+                if ($em instanceof ObjectManager) {
+                    return $em;
+                }
+
                 return $registry->getManager($em);
             }
 
@@ -176,6 +180,7 @@ abstract class DoctrineType extends AbstractType
         ));
 
         $resolver->setAllowedTypes(array(
+            'em'     => array('null', 'string', 'Doctrine\Common\Persistence\ObjectManager'),
             'loader' => array('null', 'Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface'),
         ));
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -119,6 +119,16 @@ class EntityTypeTest extends TypeTestCase
         $this->factory->createNamed('name', 'entity');
     }
 
+    /**
+     * @expectedException Symfony\Component\Form\Exception\RuntimeException
+     */
+    public function testInvalidClassOption()
+    {
+        $this->factory->createNamed('name', 'entity', null, array(
+            'class' => 'foo',
+        ));
+    }
+
     public function testSetDataToUninitializedEntityWithNonRequired()
     {
         $entity1 = new SingleIntIdEntity(1, 'Foo');
@@ -754,6 +764,21 @@ class EntityTypeTest extends TypeTestCase
         $this->factory->createNamed('name', 'entity', null, array(
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
+            'property' => 'name',
+        ));
+    }
+
+    public function testExplicitEm()
+    {
+        $this->emRegistry->expects($this->never())
+            ->method('getManager');
+
+        $this->emRegistry->expects($this->never())
+            ->method('getManagerForClass');
+
+        $this->factory->createNamed('name', 'entity', null, array(
+            'em' => $this->em,
+            'class' => self::SINGLE_IDENT_CLASS,
             'property' => 'name',
         ));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10157 |
| License | MIT |
| Doc PR | symfony/symfony-docs#4336 |

This PR allows to pass an explicit entity manager instance as em option.
