### PR TITLE
[Twig translation bridge] Improve error reporting of twig markup problems

### DIFF
--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -61,8 +61,8 @@ class TwigExtractor implements ExtractorInterface
             try {
                 $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
             } catch (\Twig_Error $e) {
-				$e->setTemplateFile($file->getPathname());
-				throw $e;
+                $e->setTemplateFile($file->getPathname());
+                throw $e;
             }
         }
     }

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -58,11 +58,11 @@ class TwigExtractor implements ExtractorInterface
         $finder = new Finder();
         $files = $finder->files()->name('*.twig')->sortByName()->in($directory);
         foreach ($files as $file) {
-			try {
-				$this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
-			} catch (\Exception $e) {
-				throw new \Exception(sprintf('Error parsing template "%s"', $file), $e->getCode(), $e);
-			}
+            try {
+                $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
+            } catch (\Exception $e) {
+                throw new \Exception(sprintf('Error parsing template "%s"', $file), $e->getCode(), $e);
+            }
         }
     }
 

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -58,7 +58,11 @@ class TwigExtractor implements ExtractorInterface
         $finder = new Finder();
         $files = $finder->files()->name('*.twig')->sortByName()->in($directory);
         foreach ($files as $file) {
-            $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
+			try {
+				$this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
+			} catch (\Exception $e) {
+				throw new \Exception(sprintf('Error parsing template "%s"', $file), $e->getCode(), $e);
+			}
         }
     }
 

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -60,8 +60,9 @@ class TwigExtractor implements ExtractorInterface
         foreach ($files as $file) {
             try {
                 $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
-            } catch (\Exception $e) {
-                throw new \Exception(sprintf('Error parsing template "%s"', $file), $e->getCode(), $e);
+            } catch (\Twig_Error $e) {
+				$e->setTemplateFile($file->getPathname());
+				throw $e;
             }
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Indicate which file was being parsed if an exception is thrown while running translation:debug

When running the translation:debug command, if a template contains invalid twig markup,
an exception is thrown. This patch rethrows a new exception that includes the filename
being parsed in the message to aid debuging.
