### PR TITLE
[FrameworkBundle] improve server commands feedback

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php
@@ -27,10 +27,6 @@ abstract class ServerCommand extends ContainerAwareCommand
             return false;
         }
 
-        if (!extension_loaded('pcntl')) {
-            return false;
-        }
-
         return parent::isEnabled();
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -97,6 +97,7 @@ EOF
         }
 
         $output->writeln(sprintf("Server running on <info>http://%s</info>\n", $input->getArgument('address')));
+        $output->writeln('Quit the server with CONTROL-C.');
 
         $builder = $this->createPhpProcessBuilder($input, $output, $env);
         $builder->setWorkingDirectory($documentRoot);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -70,6 +70,13 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!extension_loaded('pcntl')) {
+            $output->writeln('<error>This command needs the pcntl extension to run.</error>');
+            $output->writeln('You can either install it or use the <info>server:run</info> command instead to run the built-in web server.');
+
+            return 1;
+        }
+
         $env = $this->getContainer()->getParameter('kernel.environment');
 
         if ('prod' === $env) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | kind of |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12153 |
| License | MIT |
| Doc PR |  |
- display a message when `server:start` is executed and the PCNTL
  extension is not loaded
- print instructions about how to terminate the `server:run` command
