### PR TITLE
[VarDumper] add meta-data on hover

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
@@ -97,7 +97,7 @@ class DumpExtensionTest extends \PHPUnit_Framework_TestCase
                 array('foo' => 'bar'),
                 array(),
                 "<pre class=sf-dump id=sf-dump data-indent-pad=\"  \"><span class=sf-dump-note>array:1</span> [<samp>\n"
-                ."  \"<span class=sf-dump-meta>foo</span>\" => \"<span class=sf-dump-str>bar</span>\"\n"
+                ."  \"<span class=sf-dump-meta>foo</span>\" => \"<span class=sf-dump-str title=\"3 characters\">bar</span>\"\n"
                 ."</samp>]\n"
                 ."</pre><script>Sfdump(\"sf-dump\")</script>\n",
             ),

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -49,7 +49,7 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($xDump, $dump);
 
         $this->assertStringStartsWith(
-            'a:1:{i:0;a:5:{s:4:"data";O:39:"Symfony\Component\VarDumper\Cloner\Data":3:{s:45:"Symfony\Component\VarDumper\Cloner\Datadata";a:1:{i:0;a:1:{i:0;i:123;}}s:49:"Symfony\Component\VarDumper\Cloner\DatamaxDepth";i:-1;s:57:"Symfony\Component\VarDumper\Cloner\DatamaxItemsPerDepth";i:-1;}s:4:"name";s:25:"DumpDataCollectorTest.php";s:4:"file";s:',
+            'a:1:{i:0;a:5:{s:4:"data";O:39:"Symfony\Component\VarDumper\Cloner\Data":4:{s:45:"Symfony\Component\VarDumper\Cloner\Datadata";a:1:{i:0;a:1:{i:0;i:123;}}s:49:"Symfony\Component\VarDumper\Cloner\DatamaxDepth";i:-1;s:57:"Symfony\Component\VarDumper\Cloner\DatamaxItemsPerDepth";i:-1;s:54:"Symfony\Component\VarDumper\Cloner\DatauseRefHandles";i:-1;}s:4:"name";s:25:"DumpDataCollectorTest.php";s:4:"file";s:',
             str_replace("\0", '', $collector->serialize())
         );
 

--- a/src/Symfony/Component/VarDumper/Caster/ConstStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ConstStub.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Represents a PHP constant and its value.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ConstStub extends Stub
+{
+    public function __construct($name, $value)
+    {
+        $this->class = $name;
+        $this->value = $value;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Caster/CutStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/CutStub.php
@@ -18,11 +18,10 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class CasterStub extends Stub
+class CutStub extends Stub
 {
-    public function __construct($value, $class = '')
+    public function __construct($value)
     {
-        $this->class = $class;
         $this->value = $value;
 
         switch (gettype($value)) {
@@ -47,12 +46,10 @@ class CasterStub extends Stub
                 break;
 
             case 'string':
-                if ('' === $class) {
-                    $this->type = self::TYPE_STRING;
-                    $this->class = preg_match('//u', $value) ? self::STRING_UTF8 : self::STRING_BINARY;
-                    $this->cut = self::STRING_BINARY === $this->class ? strlen($value) : (function_exists('iconv_strlen') ? iconv_strlen($value, 'UTF-8') : -1);
-                    $this->value = '';
-                }
+                $this->type = self::TYPE_STRING;
+                $this->class = preg_match('//u', $value) ? self::STRING_UTF8 : self::STRING_BINARY;
+                $this->cut = self::STRING_BINARY === $this->class ? strlen($value) : (function_exists('iconv_strlen') ? iconv_strlen($value, 'UTF-8') : -1);
+                $this->value = '';
                 break;
         }
     }

--- a/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
@@ -64,7 +64,7 @@ class DOMCaster
     public static function castException(\DOMException $e, array $a, Stub $stub, $isNested)
     {
         if (isset($a["\0*\0code"], self::$errorCodes[$a["\0*\0code"]])) {
-            $a["\0*\0code"] = new CasterStub(self::$errorCodes[$a["\0*\0code"]], 'const');
+            $a["\0*\0code"] = new ConstStub(self::$errorCodes[$a["\0*\0code"]], $a["\0*\0code"]);
         }
 
         return $a;
@@ -93,21 +93,21 @@ class DOMCaster
     {
         $a += array(
             'nodeName' => $dom->nodeName,
-            'nodeValue' => new CasterStub($dom->nodeValue),
-            'nodeType' => new CasterStub(self::$nodeTypes[$dom->nodeType], 'const'),
-            'parentNode' => new CasterStub($dom->parentNode),
+            'nodeValue' => new CutStub($dom->nodeValue),
+            'nodeType' => new ConstStub(self::$nodeTypes[$dom->nodeType], $dom->nodeType),
+            'parentNode' => new CutStub($dom->parentNode),
             'childNodes' => $dom->childNodes,
-            'firstChild' => new CasterStub($dom->firstChild),
-            'lastChild' => new CasterStub($dom->lastChild),
-            'previousSibling' => new CasterStub($dom->previousSibling),
-            'nextSibling' => new CasterStub($dom->nextSibling),
+            'firstChild' => new CutStub($dom->firstChild),
+            'lastChild' => new CutStub($dom->lastChild),
+            'previousSibling' => new CutStub($dom->previousSibling),
+            'nextSibling' => new CutStub($dom->nextSibling),
             'attributes' => $dom->attributes,
-            'ownerDocument' => new CasterStub($dom->ownerDocument),
+            'ownerDocument' => new CutStub($dom->ownerDocument),
             'namespaceURI' => $dom->namespaceURI,
             'prefix' => $dom->prefix,
             'localName' => $dom->localName,
             'baseURI' => $dom->baseURI,
-            'textContent' => new CasterStub($dom->textContent),
+            'textContent' => new CutStub($dom->textContent),
         );
 
         return $a;
@@ -119,13 +119,13 @@ class DOMCaster
 
         $a += array(
             'nodeName' => $dom->nodeName,
-            'nodeValue' => new CasterStub($dom->nodeValue),
-            'nodeType' => new CasterStub(self::$nodeTypes[$dom->nodeType], 'const'),
+            'nodeValue' => new CutStub($dom->nodeValue),
+            'nodeType' => new ConstStub(self::$nodeTypes[$dom->nodeType], $dom->nodeType),
             'prefix' => $dom->prefix,
             'localName' => $dom->localName,
             'namespaceURI' => $dom->namespaceURI,
-            'ownerDocument' => new CasterStub($dom->ownerDocument),
-            'parentNode' => new CasterStub($dom->parentNode),
+            'ownerDocument' => new CutStub($dom->ownerDocument),
+            'parentNode' => new CutStub($dom->parentNode),
         );
 
         return $a;
@@ -139,7 +139,7 @@ class DOMCaster
         $a += array(
             'doctype' => $dom->doctype,
             'implementation' => $dom->implementation,
-            'documentElement' => new CasterStub($dom->documentElement),
+            'documentElement' => new CutStub($dom->documentElement),
             'actualEncoding' => $dom->actualEncoding,
             'encoding' => $dom->encoding,
             'xmlEncoding' => $dom->xmlEncoding,

--- a/src/Symfony/Component/VarDumper/Caster/DoctrineCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DoctrineCaster.php
@@ -50,9 +50,9 @@ class DoctrineCaster
     {
         $prefix = "\0Doctrine\\ORM\\PersistentCollection\0";
 
-        $a[$prefix.'snapshot'] = new CasterStub($a[$prefix.'snapshot']);
-        $a[$prefix.'association'] = new CasterStub($a[$prefix.'association']);
-        $a[$prefix.'typeClass'] = new CasterStub($a[$prefix.'typeClass']);
+        $a[$prefix.'snapshot'] = new CutStub($a[$prefix.'snapshot']);
+        $a[$prefix.'association'] = new CutStub($a[$prefix.'association']);
+        $a[$prefix.'typeClass'] = new CutStub($a[$prefix.'typeClass']);
 
         return $a;
     }

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -61,7 +61,7 @@ class ExceptionCaster
     public static function castErrorException(\ErrorException $e, array $a, Stub $stub, $isNested)
     {
         if (isset($a[$s = "\0*\0severity"], self::$errorTypes[$a[$s]])) {
-            $a[$s] = new CasterStub(self::$errorTypes[$a[$s]], 'const');
+            $a[$s] = new ConstStub(self::$errorTypes[$a[$s]], $a[$s]);
         }
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Caster/PdoCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/PdoCaster.php
@@ -72,7 +72,7 @@ class PdoCaster
             try {
                 $a[$attr] = 'ERRMODE' === $attr ? $errmode : $c->getAttribute(constant("PDO::ATTR_{$attr}"));
                 if (isset($values[$a[$attr]])) {
-                    $a[$attr] = new CasterStub($values[$a[$attr]], 'const');
+                    $a[$attr] = new ConstStub($values[$a[$attr]], $a[$attr]);
                 }
             } catch (\Exception $m) {
             }

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -72,7 +72,7 @@ class SplCaster
         $c->setIteratorMode(\SplDoublyLinkedList::IT_MODE_KEEP | $mode & ~\SplDoublyLinkedList::IT_MODE_DELETE);
 
         $a += array(
-            "\0~\0mode" => new CasterStub((($mode & \SplDoublyLinkedList::IT_MODE_LIFO) ? 'IT_MODE_LIFO' : 'IT_MODE_FIFO').' | '.(($mode & \SplDoublyLinkedList::IT_MODE_KEEP) ? 'IT_MODE_KEEP' : 'IT_MODE_DELETE'), 'const'),
+            "\0~\0mode" => new ConstStub((($mode & \SplDoublyLinkedList::IT_MODE_LIFO) ? 'IT_MODE_LIFO' : 'IT_MODE_FIFO').' | '.(($mode & \SplDoublyLinkedList::IT_MODE_KEEP) ? 'IT_MODE_KEEP' : 'IT_MODE_DELETE'), $mode),
             "\0~\0dllist" => iterator_to_array($c),
         );
         $c->setIteratorMode($mode);

--- a/src/Symfony/Component/VarDumper/Caster/StubCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/StubCaster.php
@@ -14,13 +14,13 @@ namespace Symfony\Component\VarDumper\Caster;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
- * Casts a CasterStub.
+ * Casts a caster's Stub.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
 class StubCaster
 {
-    public static function castStub(CasterStub $c, array $a, Stub $stub, $isNested)
+    public static function castStub(Stub $c, array $a, Stub $stub, $isNested)
     {
         if ($isNested) {
             $stub->type = $c->type;
@@ -33,7 +33,7 @@ class StubCaster
         }
     }
 
-    public static function castNestedFat($obj, array $a, Stub $stub, $isNested)
+    public static function cutInternals($obj, array $a, Stub $stub, $isNested)
     {
         if ($isNested) {
             $stub->cut += count($a);

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -21,12 +21,13 @@ use Symfony\Component\VarDumper\Exception\ThrowingCasterException;
 abstract class AbstractCloner implements ClonerInterface
 {
     public static $defaultCasters = array(
-        'Symfony\Component\VarDumper\Caster\CasterStub' => 'Symfony\Component\VarDumper\Caster\StubCaster::castStub',
+        'Symfony\Component\VarDumper\Caster\CutStub' => 'Symfony\Component\VarDumper\Caster\StubCaster::castStub',
+        'Symfony\Component\VarDumper\Caster\ConstStub' => 'Symfony\Component\VarDumper\Caster\StubCaster::castStub',
 
         'Closure'        => 'Symfony\Component\VarDumper\Caster\ReflectionCaster::castClosure',
         'Reflector'      => 'Symfony\Component\VarDumper\Caster\ReflectionCaster::castReflector',
 
-        'Doctrine\Common\Persistence\ObjectManager' => 'Symfony\Component\VarDumper\Caster\StubCaster::castNestedFat',
+        'Doctrine\Common\Persistence\ObjectManager' => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
         'Doctrine\Common\Proxy\Proxy'               => 'Symfony\Component\VarDumper\Caster\DoctrineCaster::castCommonProxy',
         'Doctrine\ORM\Proxy\Proxy'                  => 'Symfony\Component\VarDumper\Caster\DoctrineCaster::castOrmProxy',
         'Doctrine\ORM\PersistentCollection'         => 'Symfony\Component\VarDumper\Caster\DoctrineCaster::castPersistentCollection',
@@ -57,7 +58,7 @@ abstract class AbstractCloner implements ClonerInterface
         'ErrorException' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castErrorException',
         'Exception'      => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castException',
         'Symfony\Component\DependencyInjection\ContainerInterface'
-                           => 'Symfony\Component\VarDumper\Caster\StubCaster::castNestedFat',
+                           => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
         'Symfony\Component\VarDumper\Exception\ThrowingCasterException'
                            => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castThrowingCasterException',
 

--- a/src/Symfony/Component/VarDumper/Cloner/Cursor.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Cursor.php
@@ -33,6 +33,7 @@ class Cursor
     public $hardRefHandle = 0;
     public $hashType;
     public $hashKey;
+    public $hashKeyIsBinary;
     public $hashIndex = 0;
     public $hashLength = 0;
     public $hashCut = 0;

--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -53,7 +53,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
             <<<EOTXT
 <foo></foo><bar><span class=sf-dump-note>array:25</span> [<samp>
   "<span class=sf-dump-meta>number</span>" => <span class=sf-dump-num>1</span>
-  <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref01>&amp;1</a> <span class=sf-dump-const>null</span>
+  <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref01 title="2 occurrences">&amp;1</a> <span class=sf-dump-const>null</span>
   "<span class=sf-dump-meta>const</span>" => <span class=sf-dump-num>1.1</span>
   <span class=sf-dump-meta>1</span> => <span class=sf-dump-const>true</span>
   <span class=sf-dump-meta>2</span> => <span class=sf-dump-const>false</span>
@@ -61,12 +61,12 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   <span class=sf-dump-meta>4</span> => <span class=sf-dump-num>INF</span>
   <span class=sf-dump-meta>5</span> => <span class=sf-dump-num>-INF</span>
   <span class=sf-dump-meta>6</span> => <span class=sf-dump-num>{$intMax}</span>
-  "<span class=sf-dump-meta>str</span>" => "<span class=sf-dump-str>d&#233;j&#224;</span>"
+  "<span class=sf-dump-meta>str</span>" => "<span class=sf-dump-str title="4 characters">d&#233;j&#224;</span>"
   <span class=sf-dump-meta>7</span> => b"<span class=sf-dump-str>&#233;</span>"
   "<span class=sf-dump-meta>[]</span>" => []
-  "<span class=sf-dump-meta>res</span>" => <abbr title="Resource of type `stream`" class=sf-dump-note>:stream</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref1{$res1}>@{$res1}</a><samp>
-    <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str>plainfile</span>"
-    <span class=sf-dump-meta>stream_type</span>: "<span class=sf-dump-str>STDIO</span>"
+  "<span class=sf-dump-meta>res</span>" => <abbr title="`stream` resource" class=sf-dump-note>:stream</abbr> {<a class=sf-dump-solo-ref>@{$res1}</a><samp>
+    <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str title="9 characters">plainfile</span>"
+    <span class=sf-dump-meta>stream_type</span>: "<span class=sf-dump-str title="5 characters">STDIO</span>"
     <span class=sf-dump-meta>mode</span>: "<span class=sf-dump-str>r</span>"
     <span class=sf-dump-meta>unread_bytes</span>: <span class=sf-dump-num>0</span>
     <span class=sf-dump-meta>seekable</span>: <span class=sf-dump-const>true</span>
@@ -75,35 +75,35 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
     <span class=sf-dump-meta>eof</span>: <span class=sf-dump-const>false</span>
     <span class=sf-dump-meta>options</span>: []
   </samp>}
-  <span class=sf-dump-meta>8</span> => <abbr title="Resource of type `Unknown`" class=sf-dump-note>:Unknown</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref1{$res2}>@{$res2}</a>}
-  "<span class=sf-dump-meta>obj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a><samp id={$dumpId}-ref2%d>
-    <span class=sf-dump-public>foo</span>: "<span class=sf-dump-str>foo</span>"
-    "<span class=sf-dump-public>bar</span>": "<span class=sf-dump-str>bar</span>"
+  <span class=sf-dump-meta>8</span> => <abbr title="`Unknown` resource" class=sf-dump-note>:Unknown</abbr> {<a class=sf-dump-solo-ref>@{$res2}</a>}
+  "<span class=sf-dump-meta>obj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="2 occurrences">#%d</a><samp id={$dumpId}-ref2%d>
+    <span class=sf-dump-public>foo</span>: "<span class=sf-dump-str title="3 characters">foo</span>"
+    "<span class=sf-dump-public title="Runtime added dynamic property">bar</span>": "<span class=sf-dump-str title="3 characters">bar</span>"
   </samp>}
   "<span class=sf-dump-meta>closure</span>" => <span class=sf-dump-note>Closure</span> {<a class=sf-dump-solo-ref>#%d</a><samp>
     <span class=sf-dump-meta>reflection</span>: """
-      <span class=sf-dump-str>Closure [ &lt;user&gt; {$closureLabel} Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {</span>
-      <span class=sf-dump-str>  @@ {$var['file']} {$var['line']} - {$var['line']}</span>
+      <span class=sf-dump-str title="%d characters">Closure [ &lt;user&gt; {$closureLabel} Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {</span>
+      <span class=sf-dump-str title="%d characters">  @@ {$var['file']} {$var['line']} - {$var['line']}</span>
 
-      <span class=sf-dump-str>  - Parameters [2] {</span>
-      <span class=sf-dump-str>    Parameter #0 [ &lt;required&gt; \$a ]</span>
-      <span class=sf-dump-str>    Parameter #1 [ &lt;optional&gt; PDO or NULL &amp;\$b = NULL ]</span>
-      <span class=sf-dump-str>  }</span>
-      <span class=sf-dump-str>}</span>
+      <span class=sf-dump-str title="%d characters">  - Parameters [2] {</span>
+      <span class=sf-dump-str title="%d characters">    Parameter #0 [ &lt;required&gt; \$a ]</span>
+      <span class=sf-dump-str title="%d characters">    Parameter #1 [ &lt;optional&gt; PDO or NULL &amp;\$b = NULL ]</span>
+      <span class=sf-dump-str title="%d characters">  }</span>
+      <span class=sf-dump-str title="%d characters">}</span>
       """
   </samp>}
   "<span class=sf-dump-meta>line</span>" => <span class=sf-dump-num>{$var['line']}</span>
   "<span class=sf-dump-meta>nobj</span>" => <span class=sf-dump-note>array:1</span> [<samp>
-    <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref03>&amp;3</a> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a>}
+    <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref03 title="2 occurrences">&amp;3</a> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="3 occurrences">#%d</a>}
   </samp>]
-  "<span class=sf-dump-meta>recurs</span>" => <a class=sf-dump-ref href=#{$dumpId}-ref04>&amp;4</a> <span class=sf-dump-note>array:1</span> [<samp id={$dumpId}-ref04>
-    <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref04>&amp;4</a> <span class=sf-dump-note>array:1</span> [<a class=sf-dump-ref href=#{$dumpId}-ref04>&amp;4</a>]
+  "<span class=sf-dump-meta>recurs</span>" => <a class=sf-dump-ref href=#{$dumpId}-ref04 title="2 occurrences">&amp;4</a> <span class=sf-dump-note>array:1</span> [<samp id={$dumpId}-ref04>
+    <span class=sf-dump-meta>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref04 title="2 occurrences">&amp;4</a> <span class=sf-dump-note>array:1</span> [<a class=sf-dump-ref href=#{$dumpId}-ref04 title="2 occurrences">&amp;4</a>]
   </samp>]
-  <span class=sf-dump-meta>9</span> => <a class=sf-dump-ref href=#{$dumpId}-ref01>&amp;1</a> <span class=sf-dump-const>null</span>
-  "<span class=sf-dump-meta>sobj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a>}
-  "<span class=sf-dump-meta>snobj</span>" => <a class=sf-dump-ref href=#{$dumpId}-ref03>&amp;3</a> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a>}
-  "<span class=sf-dump-meta>snobj2</span>" => {<a class=sf-dump-ref href=#{$dumpId}-ref2%d>#%d</a>}
-  "<span class=sf-dump-meta>file</span>" => "<span class=sf-dump-str>{$var['file']}</span>"
+  <span class=sf-dump-meta>9</span> => <a class=sf-dump-ref href=#{$dumpId}-ref01 title="2 occurrences">&amp;1</a> <span class=sf-dump-const>null</span>
+  "<span class=sf-dump-meta>sobj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="2 occurrences">#%d</a>}
+  "<span class=sf-dump-meta>snobj</span>" => <a class=sf-dump-ref href=#{$dumpId}-ref03 title="2 occurrences">&amp;3</a> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="3 occurrences">#%d</a>}
+  "<span class=sf-dump-meta>snobj2</span>" => {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="3 occurrences">#%d</a>}
+  "<span class=sf-dump-meta>file</span>" => "<span class=sf-dump-str title="%d characters">{$var['file']}</span>"
   b"<span class=sf-dump-meta>bin-key-&#233;</span>" => ""
 </samp>]
 </bar>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR adds meta-data on hover to HTML dumps:
- strings length
- constants value
- control chars code
- local refs count
