### PR TITLE
[EventDispatcher] Fixed RegisterListenersPass (ContainerAwareEventDispatcher)

### DIFF
--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -56,6 +56,12 @@ class RegisterListenersPass implements CompilerPassInterface
 
         $definition = $container->findDefinition($this->dispatcherService);
 
+        $definitionRefClass = new \ReflectionClass($definition->getClass());
+        $eventDispatcherClass = 'Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher';
+        if ($definition->getClass() != $eventDispatcherClass && !$definitionRefClass->isSubclassOf($eventDispatcherClass)) {
+            throw new \RuntimeException(sprintf('RegisterListenersPass requires class "%s" for the "%s" dispatcher.', $eventDispatcherClass, $this->dispatcherService));
+        }
+
         foreach ($container->findTaggedServiceIds($this->listenerTag) as $id => $events) {
             $def = $container->getDefinition($id);
             if (!$def->isPublic()) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | sort of, minor |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I use Symfony components as standalone libraries, so it wasn't obvious for me that `RegisterListenersPass` requires `ContainerAwareEventDispatcher`:

```
PHP Fatal error:  Call to undefined method Symfony\Component\EventDispatcher\EventDispatcher::addListenerService()
```
