### PR TITLE
[Form][WebProfiler] Empty form names fix

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -420,7 +420,7 @@
             {% else %}
                 <div class="toggle-icon empty"></div>
             {% endif %}
-            {{ name }}
+            {{ name|default('(no name)') }}
             {% if data.errors is defined and data.errors|length > 0 %}
             <div class="badge-error">{{ data.errors|length }}</div>
             {% endif %}
@@ -437,9 +437,9 @@
 {% endmacro %}
 
 {% macro form_tree_details(name, data, forms_by_hash) %}
-    <div class="tree-details" id="{{ data.id }}-details">
+    <div class="tree-details" {% if data.id is defined %} id="{{ data.id }}-details"{% endif %}>
         <h2>
-            {{ name }}
+            {{ name|default('(no name)') }}
             {% if data.type_class is defined %}
             <span class="form-type">[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]</span>
             {% endif %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

When a Form had no name, the markup was broken in the profiler, making the form tree ugly. This pull request changes the output so that `(no name)` string is displayed when no form name was available.

Before:
![screenshot 2014-10-21 00 06 23](https://cloud.githubusercontent.com/assets/345754/4706329/d596a3ec-5883-11e4-8c67-44a7f357f3e1.png)

After:
![screenshot 2014-10-21 00 08 02](https://cloud.githubusercontent.com/assets/345754/4706359/122674c2-5884-11e4-8237-0177a590f2a0.png)
