### PR TITLE
[DX] [Form] [WebProfiler] Added abbrs with type classes

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -420,7 +420,7 @@
             {% else %}
                 <div class="toggle-icon empty"></div>
             {% endif %}
-            {{ name }}
+            {{ name }} {% if data.type is not empty %}[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]{% endif %}
             {% if data.errors is defined and data.errors|length > 0 %}
             <div class="badge-error">{{ data.errors|length }}</div>
             {% endif %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

This adds an `<abbr/>` element having a descriptive title that displays the form element's type class name. Everyone wants to know what's the type behind a form child, yes?

Looks like this:
![screenshot 2014-10-21 00 22 09](https://cloud.githubusercontent.com/assets/345754/4706604/32cf2d7a-5886-11e4-9fae-b9bff7a419ac.png)
