### PR TITLE
Correctly transmit response code when working within HHVM

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -333,9 +333,6 @@ class Response
             return $this;
         }
 
-        //response code
-        http_response_code($this->statusCode);
-
         // headers
         foreach ($this->headers->allPreserveCase() as $name => $values) {
             foreach ($values as $value) {

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -333,8 +333,8 @@ class Response
             return $this;
         }
 
-        // status
-        header(sprintf('HTTP/%s %s %s', $this->version, $this->statusCode, $this->statusText), true, $this->statusCode);
+        //response code
+        http_response_code($this->statusCode);
 
         // headers
         foreach ($this->headers->allPreserveCase() as $name => $values) {
@@ -342,6 +342,9 @@ class Response
                 header($name.': '.$value, false, $this->statusCode);
             }
         }
+
+        // status
+        header(sprintf('HTTP/%s %s %s', $this->version, $this->statusCode, $this->statusText), true, $this->statusCode);
 
         // cookies
         foreach ($this->headers->getCookies() as $cookie) {


### PR DESCRIPTION
to stop response codes coming through with text as explicit_header_response_code

Ref https://github.com/facebook/hhvm/issues/3945
