### PR TITLE
Add engine aware trait + interface

### DIFF
--- a/src/Symfony/Component/Templating/CHANGELOG.md
+++ b/src/Symfony/Component/Templating/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+
+ * added EngineAwareInterface
+ * added EngineAwareTrait to add default engine aware behavior to a class
+
 2.5.0
 -----
 

--- a/src/Symfony/Component/Templating/EngineAwareInterface.php
+++ b/src/Symfony/Component/Templating/EngineAwareInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Templating;
+
+/**
+ * EngineAwareTrait trait.
+ *
+ * @author Vincent Blanchon <blanchon.vincent@gmail.com>
+ */
+interface EngineAwareInterface
+{
+    /**
+     * Sets the Engine
+     *
+     * @param EngineInterface $engine A EngineInterface instance
+     */
+    public function setEngine(EngineInterface $engine = null);
+}

--- a/src/Symfony/Component/Templating/EngineAwareInterface.php
+++ b/src/Symfony/Component/Templating/EngineAwareInterface.php
@@ -21,7 +21,7 @@ interface EngineAwareInterface
     /**
      * Sets the Engine
      *
-     * @param EngineInterface $engine A EngineInterface instance
+     * @param EngineInterface $templateEngine A EngineInterface instance
      */
-    public function setEngine(EngineInterface $engine = null);
+    public function setTemplateEngine(EngineInterface $templateEngine = null);
 }

--- a/src/Symfony/Component/Templating/EngineAwareTrait.php
+++ b/src/Symfony/Component/Templating/EngineAwareTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Templating;
+
+/**
+ * EngineAwareTrait should be implemented by classes that depends on a template engine.
+ *
+ * @author Vincent Blanchon <blanchon.vincent@gmail.com>
+ */
+trait EngineAwareTrait
+{
+    /**
+     * @var EngineInterface
+     */
+    protected $engine;
+
+    /**
+     * Sets the Engine
+     *
+     * @param EngineInterface $engine A EngineInterface instance
+     */
+    public function setEngine(EngineInterface $engine = null)
+    {
+        $this->engine = $engine;
+    }
+}

--- a/src/Symfony/Component/Templating/EngineAwareTrait.php
+++ b/src/Symfony/Component/Templating/EngineAwareTrait.php
@@ -21,15 +21,15 @@ trait EngineAwareTrait
     /**
      * @var EngineInterface
      */
-    protected $engine;
+    protected $templateEngine;
 
     /**
      * Sets the Engine
      *
-     * @param EngineInterface $engine A EngineInterface instance
+     * @param EngineInterface $templateEngine A EngineInterface instance
      */
-    public function setEngine(EngineInterface $engine = null)
+    public function setTemplateEngine(EngineInterface $templateEngine = null)
     {
-        $this->engine = $engine;
+        $this->templateEngine = $templateEngine;
     }
 }

--- a/src/Symfony/Component/Templating/Tests/EngineAwareTraitTest.php
+++ b/src/Symfony/Component/Templating/Tests/EngineAwareTraitTest.php
@@ -18,19 +18,19 @@ class EngineAwareTraitTest extends \PHPUnit_Framework_TestCase
 {
     public function testCanSetAndRetrieveEngineFromEngineAwareClass()
     {
-        $engineAware = new EngineAwareClass();
-        $engineAware->setEngine($this->getMock('Symfony\Component\Templating\EngineInterface'));
-        
-        $this->assertInstanceOf('Symfony\Component\Templating\EngineInterface', $engineAware->getEngine());
+        $engineAware = new TemplateEngineAwareClass();
+        $engineAware->setTemplateEngine($this->getMock('Symfony\Component\Templating\EngineInterface'));
+
+        $this->assertInstanceOf('Symfony\Component\Templating\EngineInterface', $engineAware->getTemplateEngine());
     }
 }
 
-class EngineAwareClass implements EngineAwareInterface
+class TemplateEngineAwareClass implements EngineAwareInterface
 {
     use EngineAwareTrait;
 
-    public function getEngine()
+    public function getTemplateEngine()
     {
-        return $this->engine;
+        return $this->templateEngine;
     }
 }

--- a/src/Symfony/Component/Templating/Tests/EngineAwareTraitTest.php
+++ b/src/Symfony/Component/Templating/Tests/EngineAwareTraitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Templating\Tests;
+
+use Symfony\Component\Templating\EngineAwareInterface;
+use Symfony\Component\Templating\EngineAwareTrait;
+
+class EngineAwareTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanSetAndRetrieveEngineFromEngineAwareClass()
+    {
+        $engineAware = new EngineAwareClass();
+        $engineAware->setEngine($this->getMock('Symfony\Component\Templating\EngineInterface'));
+        
+        $this->assertInstanceOf('Symfony\Component\Templating\EngineInterface', $engineAware->getEngine());
+    }
+}
+
+class EngineAwareClass implements EngineAwareInterface
+{
+    use EngineAwareTrait;
+
+    public function getEngine()
+    {
+        return $this->engine;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Currently, when a service need the template engine, I have a code like this :

``` php
class MyAwesomeListener implements EventSubscriberInterface
{
    /**
     * @var EngineInterface
     */
    protected $renderer;

    /**
     * @param MyEvent $event
     */
    public function onMyAwesomeEvent(MyEvent $event)
    {
        // here I need to render a template
    }

    /**
     * @param $renderer
     */
    public function setRenderer(EngineInterface $renderer)
    {
        $this->renderer = $renderer;   
    }
}
```

With a trait, I just would like to reduce code to write and keep my classes skinny when a service need the template engine.
