### PR TITLE
Various fixes

### DIFF
--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -76,21 +76,18 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     {
         $this->lazyLoad($eventName);
 
-        if (isset($this->listeners[$eventName])) {
-            foreach ($this->listeners[$eventName] as $key => $l) {
-                foreach ($this->listenerIds[$eventName] as $i => $args) {
-                    list($serviceId, $method, $priority) = $args;
-                    if ($key === $serviceId.'.'.$method) {
-                        if ($listener === array($l, $method)) {
-                            unset($this->listeners[$eventName][$key]);
-                            if (empty($this->listeners[$eventName])) {
-                                unset($this->listeners[$eventName]);
-                            }
-                            unset($this->listenerIds[$eventName][$i]);
-                            if (empty($this->listenerIds[$eventName])) {
-                                unset($this->listenerIds[$eventName]);
-                            }
-                        }
+        if (isset($this->listenerIds[$eventName])) {
+            foreach ($this->listenerIds[$eventName] as $i => $args) {
+                list($serviceId, $method, $priority) = $args;
+                $key = $serviceId.'.'.$method;
+                if (isset($this->listeners[$eventName][$key]) && $listener === array($this->listeners[$eventName][$key], $method)) {
+                    unset($this->listeners[$eventName][$key]);
+                    if (empty($this->listeners[$eventName])) {
+                        unset($this->listeners[$eventName]);
+                    }
+                    unset($this->listenerIds[$eventName][$i]);
+                    if (empty($this->listenerIds[$eventName])) {
+                        unset($this->listenerIds[$eventName]);
                     }
                 }
             }

--- a/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
@@ -232,8 +232,6 @@ class SubscriberService implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            'onEvent' => 'onEvent',
-            'onEvent' => array('onEvent', 10),
             'onEvent' => array('onEvent'),
         );
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -95,8 +95,6 @@ class DebugHandlersListenerTest extends \PHPUnit_Framework_TestCase
             throw $exception;
         }
 
-        $this->assertSame(array(), $dispatcher->getListeners());
-
         $xHandler = $eHandler->setExceptionHandler('var_dump');
         $this->assertInstanceOf('Closure', $xHandler);
 

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -41,7 +41,7 @@ class CliDumper extends AbstractDumper
         'meta'      => '38;5;27',
     );
 
-    protected static $controlCharsRx = "/\\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x7F/";
+    protected static $controlCharsRx = '/[\x00-\x1F\x7F]/';
 
     /**
      * Enables/disables colored output.
@@ -321,17 +321,13 @@ class CliDumper extends AbstractDumper
             $this->colors = $this->supportsColors($this->outputStream);
         }
 
-        if (!$this->colors || '' === $value) {
-            return $value;
-        }
-
         $style = $this->styles[$style];
-        $cchr = "\033[m\033[{$style};{$this->styles['cchr']}m%s\033[m\033[{$style}m";
+        $cchr = $this->colors ? "\033[m\033[{$style};{$this->styles['cchr']}m%s\033[m\033[{$style}m" : '%s';
         $value = preg_replace_callback(self::$controlCharsRx, function ($r) use ($cchr) {
             return sprintf($cchr, "\x7F" === $r[0] ? '?' : chr(64 + ord($r[0])));
         }, $value);
 
-        return sprintf("\033[%sm%s\033[m", $style, $value);
+        return $this->colors ? sprintf("\033[%sm%s\033[m", $style, $value) : $value;
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -57,7 +57,7 @@ array:25 [
   5 => -INF
   6 => {$intMax}
   "str" => "déjà"
-  7 => b"é"
+  7 => b"é@"
   "[]" => []
   "res" => :stream {@{$res1}
     wrapper_type: "plainfile"

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/dumb-var.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/dumb-var.php
@@ -19,7 +19,7 @@ fclose($h);
 $var = array(
     'number' => 1, null,
     'const' => 1.1, true, false, NAN, INF, -INF, PHP_INT_MAX,
-    'str' => "déjà", "\xE9",
+    'str' => "déjà", "\xE9\x00",
     '[]' => array(),
     'res' => $g,
     $h,

--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -62,7 +62,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   <span class=sf-dump-meta>5</span> => <span class=sf-dump-num>-INF</span>
   <span class=sf-dump-meta>6</span> => <span class=sf-dump-num>{$intMax}</span>
   "<span class=sf-dump-meta>str</span>" => "<span class=sf-dump-str title="4 characters">d&#233;j&#224;</span>"
-  <span class=sf-dump-meta>7</span> => b"<span class=sf-dump-str>&#233;</span>"
+  <span class=sf-dump-meta>7</span> => b"<span class=sf-dump-str title="2 binary or non-UTF-8 characters">&#233;<span class=sf-dump-cchr title=\\x00>@</span></span>"
   "<span class=sf-dump-meta>[]</span>" => []
   "<span class=sf-dump-meta>res</span>" => <abbr title="`stream` resource" class=sf-dump-note>:stream</abbr> {<a class=sf-dump-solo-ref>@{$res1}</a><samp>
     <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str title="9 characters">plainfile</span>"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12278 |
| License | MIT |
| Doc PR | - |

A 3 in one PR (diff is best viewed [with whitespaces ignored](https://github.com/symfony/symfony/pull/12285/files?w=1)):
- changed the way the DebugHandlerListeners desactivates itself
- reduced a N×N iteration to a N one in ContainerAwareEventListener::removeListener
- fixed an issue in VarDumper
