### PR TITLE
[PropertyAccess] Simplified code

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
@@ -19,7 +19,7 @@ class TestClass
 
     private $publicAccessor;
     private $publicMethodAccessor;
-    private $publicMethodMutator;
+    private $publicGetSetter;
     private $publicAccessorWithDefaultValue;
     private $publicAccessorWithRequiredAndDefaultValue;
     private $publicAccessorWithMoreRequiredParameters;
@@ -31,7 +31,7 @@ class TestClass
         $this->publicProperty = $value;
         $this->publicAccessor = $value;
         $this->publicMethodAccessor = $value;
-        $this->publicMethodMutator = $value;
+        $this->publicGetSetter = $value;
         $this->publicAccessorWithDefaultValue = $value;
         $this->publicAccessorWithRequiredAndDefaultValue = $value;
         $this->publicAccessorWithMoreRequiredParameters = $value;
@@ -99,19 +99,18 @@ class TestClass
         return $this->publicHasAccessor;
     }
 
-    public function publicMethodAccessor()
+    public function publicGetSetter($value = null)
     {
-        return $this->publicMethodAccessor;
-    }
+        if (null !== $value) {
+            $this->publicGetSetter = $value;
+        }
 
-    public function publicMethodMutator($value)
-    {
-        $this->publicMethodMutator = $value;
+        return $this->publicGetSetter;
     }
 
     public function getPublicMethodMutator()
     {
-        return $this->publicMethodMutator;
+        return $this->publicGetSetter;
     }
 
     protected function setProtectedAccessor($value)

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -28,26 +28,6 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->propertyAccessor = new PropertyAccessor();
     }
 
-    public function getValidGetPropertyPaths()
-    {
-        return array_merge(
-            array(
-                array(new TestClass('Bernhard'), 'publicMethodAccessor', 'Bernhard', 'Bernhard'),
-            ),
-            $this->getValidPropertyPaths()
-        );
-    }
-
-    public function getValidSetPropertyPaths()
-    {
-        return array_merge(
-            array(
-                array(new TestClass('Bernhard'), 'publicMethodMutator', 'Bernhard', 'Bernhard'),
-            ),
-            $this->getValidPropertyPaths()
-        );
-    }
-
     public function getPathsWithMissingProperty()
     {
         return array(
@@ -80,7 +60,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getValidGetPropertyPaths
+     * @dataProvider getValidPropertyPaths
      */
     public function testGetValue($objectOrArray, $path, $value)
     {
@@ -181,7 +161,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getValidSetPropertyPaths
+     * @dataProvider getValidPropertyPaths
      */
     public function testSetValue($objectOrArray, $path)
     {
@@ -297,7 +277,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getValidGetPropertyPaths
+     * @dataProvider getValidPropertyPaths
      */
     public function testIsReadable($objectOrArray, $path)
     {
@@ -365,11 +345,11 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getValidSetPropertyPaths
+     * @dataProvider getValidPropertyPaths
      */
     public function testIsWritable($objectOrArray, $path)
     {
-        $this->assertTrue($this->propertyAccessor->isWritable($objectOrArray, $path, 'Updated'));
+        $this->assertTrue($this->propertyAccessor->isWritable($objectOrArray, $path));
     }
 
     /**
@@ -377,7 +357,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsWritableReturnsFalseIfPropertyNotFound($objectOrArray, $path)
     {
-        $this->assertFalse($this->propertyAccessor->isWritable($objectOrArray, $path, 'Updated'));
+        $this->assertFalse($this->propertyAccessor->isWritable($objectOrArray, $path));
     }
 
     /**
@@ -386,7 +366,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     public function testIsWritableReturnsTrueIfIndexNotFound($objectOrArray, $path)
     {
         // Non-existing indices can be written. Arrays are created on-demand.
-        $this->assertTrue($this->propertyAccessor->isWritable($objectOrArray, $path, 'Updated'));
+        $this->assertTrue($this->propertyAccessor->isWritable($objectOrArray, $path));
     }
 
     /**
@@ -397,42 +377,42 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->propertyAccessor = new PropertyAccessor(false, true);
 
         // Non-existing indices can be written even if exceptions are enabled
-        $this->assertTrue($this->propertyAccessor->isWritable($objectOrArray, $path, 'Updated'));
+        $this->assertTrue($this->propertyAccessor->isWritable($objectOrArray, $path));
     }
 
     public function testIsWritableRecognizesMagicSet()
     {
-        $this->assertTrue($this->propertyAccessor->isWritable(new TestClassMagicGet('Bernhard'), 'magicProperty', 'Updated'));
+        $this->assertTrue($this->propertyAccessor->isWritable(new TestClassMagicGet('Bernhard'), 'magicProperty'));
     }
 
     public function testIsWritableDoesNotRecognizeMagicCallByDefault()
     {
-        $this->assertFalse($this->propertyAccessor->isWritable(new TestClassMagicCall('Bernhard'), 'magicCallProperty', 'Updated'));
+        $this->assertFalse($this->propertyAccessor->isWritable(new TestClassMagicCall('Bernhard'), 'magicCallProperty'));
     }
 
     public function testIsWritableRecognizesMagicCallIfEnabled()
     {
         $this->propertyAccessor = new PropertyAccessor(true);
 
-        $this->assertTrue($this->propertyAccessor->isWritable(new TestClassMagicCall('Bernhard'), 'magicCallProperty', 'Updated'));
+        $this->assertTrue($this->propertyAccessor->isWritable(new TestClassMagicCall('Bernhard'), 'magicCallProperty'));
     }
 
-    public function testIsWritableThrowsExceptionIfNotObjectOrArray()
+    public function testNotObjectOrArrayIsNotWritable()
     {
-        $this->assertFalse($this->propertyAccessor->isWritable('baz', 'foobar', 'Updated'));
+        $this->assertFalse($this->propertyAccessor->isWritable('baz', 'foobar'));
     }
 
-    public function testIsWritableThrowsExceptionIfNull()
+    public function testNullIsNotWritable()
     {
-        $this->assertFalse($this->propertyAccessor->isWritable(null, 'foobar', 'Updated'));
+        $this->assertFalse($this->propertyAccessor->isWritable(null, 'foobar'));
     }
 
-    public function testIsWritableThrowsExceptionIfEmpty()
+    public function testEmptyIsNotWritable()
     {
-        $this->assertFalse($this->propertyAccessor->isWritable('', 'foobar', 'Updated'));
+        $this->assertFalse($this->propertyAccessor->isWritable('', 'foobar'));
     }
 
-    private function getValidPropertyPaths()
+    public function getValidPropertyPaths()
     {
         return array(
             array(array('Bernhard', 'Schussek'), '[0]', 'Bernhard'),
@@ -451,9 +431,11 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
             array(new TestClass('Bernhard'), 'publicAccessorWithRequiredAndDefaultValue', 'Bernhard'),
             array(new TestClass('Bernhard'), 'publicIsAccessor', 'Bernhard'),
             array(new TestClass('Bernhard'), 'publicHasAccessor', 'Bernhard'),
+            array(new TestClass('Bernhard'), 'publicGetSetter', 'Bernhard'),
 
             // Methods are camelized
             array(new TestClass('Bernhard'), 'public_accessor', 'Bernhard'),
+            array(new TestClass('Bernhard'), '_public_accessor', 'Bernhard'),
 
             // Missing indices
             array(array('index' => array()), '[index][firstName]', null),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12275 |
| License | MIT |
| Doc PR | - |

Makes implementation of #10882 more readable.

Simplifies `camelize()` as pointed out in #12275.
