### PR TITLE
[FrameworkBundle] make GetSetMethodNormalizer available by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -15,6 +15,13 @@
             <argument type="collection" />
             <argument type="collection" />
         </service>
+
+        <!-- Normalizer -->
+        <service id="serializer.normalizer.get_set_method" class="Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer" public="false">
+            <!-- Run after all custom serializers -->
+            <tag name="serializer.normalizer" priority="-1000" />
+        </service>
+
         <!-- Encoders -->
         <service id="serializer.encoder.xml" class="%serializer.encoder.xml.class%" public="false" >
             <tag name="serializer.encoder" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | very limited |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | not yet |

The `GetSetMethodNormalizer` has not been enabled by default in #6815 because it was broken by design. Since #12098 has been merged, circular references are handled and that normalizer cannot breaks applications.
This PR makes that normalizer automatically available when the serializer is enabled. To keep BC, I've set a "high" priority for this service (higher than the default `0`).
