### PR TITLE
Add machine readable events

### DIFF
--- a/src/Symfony/Component/Console/ConsoleEvents.php
+++ b/src/Symfony/Component/Console/ConsoleEvents.php
@@ -26,6 +26,8 @@ final class ConsoleEvents
      * The event listener method receives a Symfony\Component\Console\Event\ConsoleCommandEvent
      * instance.
      *
+     * @Event
+     *
      * @var string
      */
     const COMMAND = 'console.command';
@@ -36,6 +38,8 @@ final class ConsoleEvents
      *
      * The event listener method receives a Symfony\Component\Console\Event\ConsoleTerminateEvent
      * instance.
+     *
+     * @Event
      *
      * @var string
      */
@@ -48,6 +52,8 @@ final class ConsoleEvents
      * to modify the thrown exception. The event listener method receives
      * a Symfony\Component\Console\Event\ConsoleExceptionEvent
      * instance.
+     *
+     * @Event
      *
      * @var string
      */

--- a/src/Symfony/Component/Form/FormEvents.php
+++ b/src/Symfony/Component/Form/FormEvents.php
@@ -15,31 +15,52 @@ namespace Symfony\Component\Form;
  */
 final class FormEvents
 {
+    /**
+     * @Event
+     */
     const PRE_SUBMIT = 'form.pre_bind';
 
+    /**
+     * @Event
+     */
     const SUBMIT = 'form.bind';
 
+    /**
+     * @Event
+     */
     const POST_SUBMIT = 'form.post_bind';
 
+    /**
+     * @Event
+     */
     const PRE_SET_DATA = 'form.pre_set_data';
 
+    /**
+     * @Event
+     */
     const POST_SET_DATA = 'form.post_set_data';
 
     /**
      * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
      *             {@link PRE_SUBMIT} instead.
+     *
+     * @Event
      */
     const PRE_BIND = 'form.pre_bind';
 
     /**
      * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
      *             {@link SUBMIT} instead.
+     *
+     * @Event
      */
     const BIND = 'form.bind';
 
     /**
      * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
      *             {@link POST_SUBMIT} instead.
+     *
+     * @Event
      */
     const POST_BIND = 'form.post_bind';
 

--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -29,6 +29,8 @@ final class KernelEvents
      * receives a Symfony\Component\HttpKernel\Event\GetResponseEvent
      * instance.
      *
+     * @Event
+     *
      * @var string
      *
      * @api
@@ -42,6 +44,8 @@ final class KernelEvents
      * to modify the thrown exception. The event listener method receives
      * a Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent
      * instance.
+     *
+     * @Event
      *
      * @var string
      *
@@ -58,6 +62,8 @@ final class KernelEvents
      * Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent
      * instance.
      *
+     * @Event
+     *
      * @var string
      *
      * @api
@@ -71,6 +77,8 @@ final class KernelEvents
      * This event allows you to change the controller that will handle the
      * request. The event listener method receives a
      * Symfony\Component\HttpKernel\Event\FilterControllerEvent instance.
+     *
+     * @Event
      *
      * @var string
      *
@@ -86,6 +94,8 @@ final class KernelEvents
      * replied. The event listener method receives a
      * Symfony\Component\HttpKernel\Event\FilterResponseEvent instance.
      *
+     * @Event
+     *
      * @var string
      *
      * @api
@@ -99,6 +109,8 @@ final class KernelEvents
      * The event listener method receives a
      * Symfony\Component\HttpKernel\Event\PostResponseEvent instance.
      *
+     * @Event
+     *
      * @var string
      */
     const TERMINATE = 'kernel.terminate';
@@ -108,6 +120,8 @@ final class KernelEvents
      *
      * This event allows you to reset the global and environmental state of
      * the application, when it was changed during the request.
+     *
+     * @Event
      *
      * @var string
      */

--- a/src/Symfony/Component/Security/Http/SecurityEvents.php
+++ b/src/Symfony/Component/Security/Http/SecurityEvents.php
@@ -20,6 +20,8 @@ final class SecurityEvents
      * The event listener method receives a
      * Symfony\Component\Security\Http\Event\InteractiveLoginEvent instance.
      *
+     * @Event
+     *
      * @var string
      */
     const INTERACTIVE_LOGIN = 'security.interactive_login';
@@ -30,6 +32,8 @@ final class SecurityEvents
      *
      * The event listener method receives a
      * Symfony\Component\Security\Http\Event\SwitchUserEvent instance.
+     *
+     * @Event
      *
      * @var string
      */


### PR DESCRIPTION
As discussed in [#11878] it would be great to have some simple machine readable way to find events

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11878 |
| License | MIT |
