### PR TITLE
Ensure that Twig form themes are always a list, not a hashmap

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -54,7 +54,7 @@ class Configuration implements ConfigurationInterface
                     return count($v['form']['resources']) > 0;
                 })
                 ->then(function ($v) {
-                    $v['form_themes'] = array_unique(array_merge($v['form']['resources'], $v['form_themes']));
+                    $v['form_themes'] = array_values(array_unique(array_merge($v['form']['resources'], $v['form_themes'])));
 
                     return $v;
                 })


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12305 |
| License | MIT |
| Doc PR | n/a |

array_unique does not reindex arrays when deleting keys.
