### PR TITLE
Improved the phpdoc for security token classes

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -88,7 +88,7 @@ abstract class AbstractToken implements TokenInterface
      * The user can be a UserInterface instance, or an object implementing
      * a __toString method or the username as a regular string.
      *
-     * @param mixed $user The user
+     * @param string|object $user The user
      * @throws \InvalidArgumentException
      */
     public function setUser($user)

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -26,10 +26,10 @@ class UsernamePasswordToken extends AbstractToken
     /**
      * Constructor.
      *
-     * @param string          $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method.
-     * @param string          $credentials This usually is the password of the user
-     * @param string          $providerKey The provider key
-     * @param RoleInterface[] $roles       An array of roles
+     * @param string|object            $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method.
+     * @param string                   $credentials This usually is the password of the user
+     * @param string                   $providerKey The provider key
+     * @param RoleInterface[]|string[] $roles       An array of roles
      *
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This will avoid to have Scrutinizer complaining that we pass an array of string rather than an array of RoleInterface for instance.
