### PR TITLE
[TwigBundle] minor #12309 fix markup twbs inline radio button

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -147,8 +147,8 @@
 {%- endblock form_label %}
 
 {% block choice_label %}
-    {# remove the checkbox-inline, it's only use full for embed labels #}
-    {% set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': ''})|trim}) %}
+    {# remove the checkbox-inline and radio-inline class, it's only useful for embed labels #}
+    {% set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': '', 'radio-inline': ''})|trim}) %}
     {{- block('form_label') -}}
 {% endblock %}
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12309 |
| License | MIT |
| Doc PR | N/A |

This fixes a minor markup issue with the new bootstrap 3 form template.

**Before**
![before](https://cloud.githubusercontent.com/assets/930668/4767394/3c876d08-5b5d-11e4-9ab1-cbd93e2b5a70.png)

**After**
![after](https://cloud.githubusercontent.com/assets/930668/4767398/41213af6-5b5d-11e4-8156-302411ccf2ac.png)
