### PR TITLE
[Security][listener] change priority of switchuser

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -338,13 +338,13 @@ class SecurityExtension extends Extension
 
         $listeners = array_merge($listeners, $authListeners);
 
-        // Access listener
-        $listeners[] = new Reference('security.access_listener');
-
         // Switch user listener
         if (isset($firewall['switch_user'])) {
             $listeners[] = new Reference($this->createSwitchUserListener($container, $id, $firewall['switch_user'], $defaultProvider));
         }
+
+        // Access listener
+        $listeners[] = new Reference('security.access_listener');
 
         // Determine default entry point
         if (isset($firewall['entry_point'])) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Reference;
-
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
@@ -82,8 +81,8 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
                 'security.authentication.listener.basic.secure',
                 'security.authentication.listener.digest.secure',
                 'security.authentication.listener.anonymous.secure',
-                'security.access_listener',
                 'security.authentication.switchuser_listener.secure',
+                'security.access_listener',
             ),
         ), $listeners);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Hi,
I have the following users:
- Manager: Allowed to access to (/admin) and has a role ROLE_ALLOWED_TO_SWITCH
- Partner: Allowed to access to (/partner)

When I attempt to switch to partner user I get "Access denied", well I think the switchuser listener must be registred before access listener.
