### PR TITLE
[Form] Add "prototype_data" option to collection type

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -29,7 +29,9 @@ class CollectionType extends AbstractType
         if ($options['allow_add'] && $options['prototype']) {
             $prototype = $builder->create($options['prototype_name'], $options['type'], array_replace(array(
                 'label' => $options['prototype_name'].'label__',
-            ), $options['options']));
+            ), $options['options'], array(
+                'data' => $options['prototype_data'],
+            )));
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 
@@ -55,12 +57,7 @@ class CollectionType extends AbstractType
         ));
 
         if ($form->getConfig()->hasAttribute('prototype')) {
-            $view->vars['prototype'] = $form
-                ->getConfig()
-                ->getAttribute('prototype')
-                ->setData($options['prototype_data'])
-                ->createView($view)
-            ;
+            $view->vars['prototype'] = $form->getConfig()->getAttribute('prototype')->createView($view);
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -55,7 +55,12 @@ class CollectionType extends AbstractType
         ));
 
         if ($form->getConfig()->hasAttribute('prototype')) {
-            $view->vars['prototype'] = $form->getConfig()->getAttribute('prototype')->createView($view);
+            $view->vars['prototype'] = $form
+                ->getConfig()
+                ->getAttribute('prototype')
+                ->setData($options['prototype_data'])
+                ->createView($view)
+            ;
         }
     }
 
@@ -84,6 +89,7 @@ class CollectionType extends AbstractType
             'allow_add' => false,
             'allow_delete' => false,
             'prototype' => true,
+            'prototype_data' => null,
             'prototype_name' => '__name__',
             'type' => 'text',
             'options' => array(),

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -282,6 +282,9 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'allow_add'      => true,
             'prototype'      => true,
             'prototype_data' => 'foo',
+            'options'        => array(
+                'data' => 'bar',
+            ),
         ));
 
         $this->assertSame('foo', $form->createView()->vars['prototype']->vars['value']);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -278,11 +278,11 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPrototypeData()
     {
         $form = $this->factory->create('collection', array(), array(
-            'type'           => 'text',
-            'allow_add'      => true,
-            'prototype'      => true,
+            'type' => 'text',
+            'allow_add' => true,
+            'prototype' => true,
             'prototype_data' => 'foo',
-            'options'        => array(
+            'options' => array(
                 'data' => 'bar',
             ),
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -274,4 +274,16 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertSame('__test__label__', $form->createView()->vars['prototype']->vars['label']);
     }
+
+    public function testPrototypeData()
+    {
+        $form = $this->factory->create('collection', array(), array(
+            'type'           => 'text',
+            'allow_add'      => true,
+            'prototype'      => true,
+            'prototype_data' => 'foo',
+        ));
+
+        $this->assertSame('foo', $form->createView()->vars['prototype']->vars['value']);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5095 |
| License | MIT |
| Doc PR | symfony/symfony-docs#4367 |

Makes it possible to have default data for collection prototypes.
