### PR TITLE
[Session] remove invalid hack in session regenerate

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -206,23 +206,7 @@ class NativeSessionStorage implements SessionStorageInterface
             $this->metadataBag->stampNew();
         }
 
-        $ret = session_regenerate_id($destroy);
-
-        // workaround for https://bugs.php.net/bug.php?id=61470 as suggested by David Grudl
-        if ('files' === $this->getSaveHandler()->getSaveHandlerName()) {
-            session_write_close();
-            if (isset($_SESSION)) {
-                $backup = $_SESSION;
-                session_start();
-                $_SESSION = $backup;
-            } else {
-                session_start();
-            }
-
-            $this->loadSession();
-        }
-
-        return $ret;
+        return session_regenerate_id($destroy);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
@@ -88,6 +88,14 @@ interface SessionStorageInterface
      * Note regenerate+destroy should not clear the session data in memory
      * only delete the session data from persistent storage.
      *
+     * Care: When regenerating the session ID no locking is involved in PHPs
+     * session design. See https://bugs.php.net/bug.php?id=61470 for a discussion.
+     * So you must make sure the regenerated session is saved BEFORE sending the
+     * headers with the new ID. Symfonys HttpKernel offers a listener for this.
+     * See Symfony\Component\HttpKernel\EventListener\SaveSessionListener.
+     * Otherwise session data could get lost again for concurrent requests with the
+     * new ID. One result could be that you get logged out after just logging in.
+     *
      * @param bool    $destroy  Destroy session when regenerating?
      * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
      *                          will leave the system settings unchanged, 0 sets the cookie


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The original issue #7380 was just caused because the developer missed to save the session before doing the redirect. That's all. Such mistakes won't happen anymore with #12341

This reverts #8270 and following. Also it makes absolutely no sense to do this only for the `files` save handler which creates huge inconsistencies. All save handlers are affected and it's more a documentation thing.
