### PR TITLE
[Debug] DI controllable ErrorHandler::register()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -47,7 +47,7 @@ class FrameworkBundle extends Bundle
 {
     public function boot()
     {
-        ErrorHandler::register($this->container->getParameter('debug.error_handler.throw_at'));
+        ErrorHandler::register(null, false)->throwAt($this->container->getParameter('debug.error_handler.throw_at'), true);
 
         if ($trustedProxies = $this->container->getParameter('kernel.trusted_proxies')) {
             Request::setTrustedProxies($trustedProxies);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12327 |
| License | MIT |
| Doc PR | - |

This enhances the `ErrorHandler::register()` signature in a BC way, allowing greater control.

See https://github.com/symfony/symfony/pull/12330/files?w=1
