### PR TITLE
[Translation] Add a hasId method

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added TranslatorBagInterface
  * added LoggingTranslator
  * added Translator::getMessages() for retrieving the message catalogue as an array
+ * added Translator::hasId() for checking if a message ID has been registered
 
 2.5.0
 -----

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -197,6 +197,34 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     }
 
     /**
+     * Check if the specified message ID exists
+     *
+     * @param string      $id     The message id (may also be an object that can be cast to string)
+     * @param string|null $domain The domain for the message or null to use the default
+     * @param string|null $locale The locale or null to use the default
+     *
+     * @return bool true if the message has a translation, false otherwise
+     */
+    public function hasId($id, $domain = null, $locale = null)
+    {
+        if (null === $locale) {
+            $locale = $this->getLocale();
+        } else {
+            $this->assertValidLocale($locale);
+        }
+
+        if (null === $domain) {
+            $domain = 'messages';
+        }
+
+        if (!isset($this->catalogues[$locale])) {
+            $this->loadCatalogue($locale);
+        }
+
+        return $this->catalogues[$locale]->has((string) $id, $domain);
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @api


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/4404 |

TODO List:
- [x] submit changes to the documentation

This method can be utilized to check if a message ID exists in the message catalogue
