### PR TITLE
[VarDumper] Bug Fixed autoloading of var dumper's function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,10 @@
             "src/Symfony/Component/HttpFoundation/Resources/stubs",
             "src/Symfony/Component/Intl/Resources/stubs"
         ],
-        "files": [ "src/Symfony/Component/Intl/Resources/stubs/functions.php" ]
+        "files": [
+            "src/Symfony/Component/Intl/Resources/stubs/functions.php",
+            "src/Symfony/Component/VarDumper/Resources/functions/dump.php"
+        ]
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| License | MIT |
| Fixed tickets | - |

The `dump()` function provided by the component is autoloaded by the composer file in the component, but not in the composer file provided by symfony. This means you don't get this method when using `dump()` after you installed symfony using `symfony/symfony`.
