### PR TITLE
[PhpProcess] Environment variables must be passed through to the child PHP process

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -362,7 +362,7 @@ abstract class Client
                      'TEMP' => sys_get_temp_dir());
         $env = array_replace($_ENV, $_SERVER, $env);
         $process = new PhpProcess($this->getScript($request), null, $env);
-	$process->run();
+        $process->run();
 
         if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {
             throw new \RuntimeException(sprintf('OUTPUT: %s ERROR OUTPUT: %s', $process->getOutput(), $process->getErrorOutput()));

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -358,8 +358,11 @@ abstract class Client
     protected function doRequestInProcess($request)
     {
         // We set the TMPDIR (for Macs) and TEMP (for Windows), because on these platforms the temp directory changes based on the user.
-        $process = new PhpProcess($this->getScript($request), null, array('TMPDIR' => sys_get_temp_dir(), 'TEMP' => sys_get_temp_dir()));
-        $process->run();
+        $env = array('TMPDIR' => sys_get_temp_dir(),
+                     'TEMP' => sys_get_temp_dir());
+        $env = array_replace($_ENV, $_SERVER, $env);
+        $process = new PhpProcess($this->getScript($request), null, $env);
+	$process->run();
 
         if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {
             throw new \RuntimeException(sprintf('OUTPUT: %s ERROR OUTPUT: %s', $process->getOutput(), $process->getErrorOutput()));

--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -39,7 +39,7 @@ class PhpProcess extends Process
      *
      * @api
      */
-    public function __construct($script, $cwd = null, array $env = array(), $timeout = 60, array $options = array())
+    public function __construct($script, $cwd = null, array $env = null, $timeout = 60, array $options = array())
     {
         parent::__construct(null, $cwd, $env, $script, $timeout, $options);
 

--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -39,7 +39,7 @@ class PhpProcess extends Process
      *
      * @api
      */
-    public function __construct($script, $cwd = null, array $env = null, $timeout = 60, array $options = array())
+    public function __construct($script, $cwd = null, array $env = array(), $timeout = 60, array $options = array())
     {
         parent::__construct(null, $cwd, $env, $script, $timeout, $options);
 


### PR DESCRIPTION
When a PhpProcess is instantiated from [BrowserKit][Client], the environment variables fail to reach the child process, causing the test to fail on HHVM.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |
