### PR TITLE
[VarDumper] polymorphic and stateless output selection

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -22,7 +22,7 @@ use Symfony\Component\VarDumper\Cloner\Cursor;
 class CliDumper extends AbstractDumper
 {
     public static $defaultColors;
-    public static $defaultOutputStream = 'php://stdout';
+    public static $defaultOutput = 'php://stdout';
 
     protected $colors;
     protected $maxStringWidth = 0;
@@ -335,7 +335,7 @@ class CliDumper extends AbstractDumper
      */
     protected function supportsColors()
     {
-        if ($this->outputStream !== static::$defaultOutputStream) {
+        if ($this->outputStream !== static::$defaultOutput) {
             return @(is_resource($this->outputStream) && function_exists('posix_isatty') && posix_isatty($this->outputStream));
         }
         if (null !== static::$defaultColors) {

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -21,7 +21,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
  */
 class HtmlDumper extends CliDumper
 {
-    public static $defaultOutputStream = 'php://output';
+    public static $defaultOutput = 'php://output';
 
     protected $dumpHeader;
     protected $dumpPrefix = '<pre class=sf-dump id=%s data-indent-pad="%s">';
@@ -47,11 +47,11 @@ class HtmlDumper extends CliDumper
     /**
      * {@inheritdoc}
      */
-    public function setLineDumper($callback)
+    public function setOutput($output)
     {
         $this->headerIsDumped = false;
 
-        return parent::setLineDumper($callback);
+        return parent::setOutput($output);
     }
 
     /**
@@ -88,10 +88,10 @@ class HtmlDumper extends CliDumper
     /**
      * {@inheritdoc}
      */
-    public function dump(Data $data, $lineDumper = null)
+    public function dump(Data $data, $output = null)
     {
         $this->dumpId = 'sf-dump-'.mt_rand();
-        parent::dump($data, $lineDumper);
+        parent::dump($data, $output);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/4243 |

While writing the documentation for the VarDumper component, it came to me that selecting the output destination was a state-full process for streams.
This PR fixes that by allowing not only callbacks but also streams on the second argument of `AbstractDumper::dump()`.
I also updated some interfaces to make the feature/names more straightforward.

See https://github.com/symfony/symfony-docs/commit/c578fe79627054a35db556ead758f1ea7f82f172 for the related documentation update.
