### PR TITLE
Make `\Request::get` more performant.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -723,7 +723,17 @@ class Request
      */
     public function get($key, $default = null, $deep = false)
     {
-        return $this->query->get($key, $this->attributes->get($key, $this->request->get($key, $default, $deep), $deep), $deep);
+        $result = $this->query($key, $this, $deep);
+        if ($result === $this) {
+            $result = $this->attributes->get($key, $this, $deep);
+        }
+        if ($result === $this) {
+            $result = $this->request->get($key, $this, $deep);
+        }
+        if ($result === $this) {
+            return $default;
+        }
+        return $result;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -723,7 +723,7 @@ class Request
      */
     public function get($key, $default = null, $deep = false)
     {
-        $result = $this->query($key, $this, $deep);
+        $result = $this->query->get($key, $this, $deep);
         if ($result === $this) {
             $result = $this->attributes->get($key, $this, $deep);
         }


### PR DESCRIPTION
Previously request get ran ALL searches regardless of whether a result was found. Now it only runs the ones required to find the value.
