### PR TITLE
Translation debug improve error reporting

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -78,4 +78,17 @@ class TwigExtractorTest extends TestCase
             array('{{ "new key" | transchoice(domain="domain", count=1) }}', array('new key' => 'domain')),
         );
     }
+
+    /**
+     * @expectedException        \Twig_Error
+     * @expectedExceptionMessage Unclosed "block" in "extractor/syntax_error.twig" at line 1
+     */
+    public function testExtractSyntaxError()
+    {
+        $twig = new \Twig_Environment(new \Twig_Loader_Array(array()));
+        $twig->addExtension(new TranslationExtension($this->getMock('Symfony\Component\Translation\TranslatorInterface')));
+
+        $extractor = new TwigExtractor($twig);
+        $extractor->extract(__DIR__.'/../Fixtures', new MessageCatalogue('en'));
+    }
 }

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -61,7 +61,8 @@ class TwigExtractor implements ExtractorInterface
             try {
                 $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
             } catch (\Twig_Error $e) {
-                $e->setTemplateFile($file->getPathname());
+                $e->setTemplateFile($file->getRelativePathname());
+
                 throw $e;
             }
         }

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -58,7 +58,12 @@ class TwigExtractor implements ExtractorInterface
         $finder = new Finder();
         $files = $finder->files()->name('*.twig')->in($directory);
         foreach ($files as $file) {
-            $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
+            try {
+                $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
+            } catch (\Twig_Error $e) {
+                $e->setTemplateFile($file->getPathname());
+                throw $e;
+            }
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12252 |
| License | MIT |
| Doc PR |  |

Indicate which file was being parsed if an exception is thrown while running translation:debug

When running the translation:debug command, if a template contains invalid twig markup,
an exception is thrown. This patch rethrows a new exception that includes the filename
being parsed in the message to aid debugging.
