### PR TITLE
[Form] Remove timezone options from DateType and TimeType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -33,6 +33,7 @@ CHANGELOG
  * fixed CSRF error message to be translated
  * custom CSRF error messages can now be set through the "csrf_message" option
  * fixed: expanded single-choice fields now show a radio button for the empty value
+ * [BC BREAK] drop support for model_timezone and view_timezone options in TimeType and DateType
 
 2.2.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -57,8 +57,8 @@ class DateType extends AbstractType
 
         if ('single_text' === $options['widget']) {
             $builder->addViewTransformer(new DateTimeToLocalizedStringTransformer(
-                $options['model_timezone'],
-                $options['view_timezone'],
+                'UTC',
+                'UTC',
                 $dateFormat,
                 $timeFormat,
                 $calendar,
@@ -105,7 +105,7 @@ class DateType extends AbstractType
                 ->add('month', $options['widget'], $monthOptions)
                 ->add('day', $options['widget'], $dayOptions)
                 ->addViewTransformer(new DateTimeToArrayTransformer(
-                    $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day')
+                    'UTC', 'UTC', array('year', 'month', 'day')
                 ))
                 ->setAttribute('formatter', $formatter)
             ;
@@ -113,15 +113,15 @@ class DateType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'Y-m-d')
+                new DateTimeToStringTransformer('UTC', 'UTC', 'Y-m-d')
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer($options['model_timezone'], $options['model_timezone'])
+                new DateTimeToTimestampTransformer('UTC', 'UTC')
             ));
         } elseif ('array' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], array('year', 'month', 'day'))
+                new DateTimeToArrayTransformer('UTC', 'UTC', array('year', 'month', 'day'))
             ));
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -48,7 +48,7 @@ class TimeType extends AbstractType
         }
 
         if ('single_text' === $options['widget']) {
-            $builder->addViewTransformer(new DateTimeToStringTransformer($options['model_timezone'], $options['view_timezone'], $format));
+            $builder->addViewTransformer(new DateTimeToStringTransformer('UTC', 'UTC', $format));
         } else {
             $hourOptions = $minuteOptions = $secondOptions = array(
                 'error_bubbling' => true,
@@ -109,20 +109,20 @@ class TimeType extends AbstractType
                 $builder->add('second', $options['widget'], $secondOptions);
             }
 
-            $builder->addViewTransformer(new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts, 'text' === $options['widget']));
+            $builder->addViewTransformer(new DateTimeToArrayTransformer('UTC', 'UTC', $parts, 'text' === $options['widget']));
         }
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'H:i:s')
+                new DateTimeToStringTransformer('UTC', 'UTC', 'H:i:s')
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer($options['model_timezone'], $options['model_timezone'])
+                new DateTimeToTimestampTransformer('UTC', 'UTC')
             ));
         } elseif ('array' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], $parts)
+                new DateTimeToArrayTransformer('UTC', 'UTC', $parts)
             ));
         }
     }
@@ -189,8 +189,6 @@ class TimeType extends AbstractType
             'input' => 'datetime',
             'with_minutes' => true,
             'with_seconds' => false,
-            'model_timezone' => null,
-            'view_timezone' => null,
             'empty_value' => $emptyValue,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class DateTypeTest extends TypeTestCase
 {
+    private $defaultTimezone;
+
     protected function setUp()
     {
         parent::setUp();
@@ -25,6 +27,13 @@ class DateTypeTest extends TypeTestCase
         IntlTestHelper::requireFullIntl($this);
 
         \Locale::setDefault('de_AT');
+
+        $this->defaultTimezone = date_default_timezone_get();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->defaultTimezone);
     }
 
     /**
@@ -50,8 +59,6 @@ class DateTypeTest extends TypeTestCase
     public function testSubmitFromSingleTextDateTimeWithDefaultFormat()
     {
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'datetime',
         ));
@@ -66,8 +73,6 @@ class DateTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'datetime',
         ));
@@ -82,8 +87,6 @@ class DateTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'string',
         ));
@@ -98,8 +101,6 @@ class DateTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'timestamp',
         ));
@@ -116,8 +117,6 @@ class DateTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'array',
         ));
@@ -137,8 +136,6 @@ class DateTypeTest extends TypeTestCase
     public function testSubmitFromText()
     {
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'text',
         ));
 
@@ -159,8 +156,6 @@ class DateTypeTest extends TypeTestCase
     public function testSubmitFromChoice()
     {
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -181,8 +176,6 @@ class DateTypeTest extends TypeTestCase
     public function testSubmitFromChoiceEmpty()
     {
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'choice',
             'required' => false,
         ));
@@ -202,8 +195,6 @@ class DateTypeTest extends TypeTestCase
     public function testSubmitFromInputDateTimeDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'datetime',
@@ -218,8 +209,6 @@ class DateTypeTest extends TypeTestCase
     public function testSubmitFromInputStringDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'string',
@@ -234,8 +223,6 @@ class DateTypeTest extends TypeTestCase
     public function testSubmitFromInputTimestampDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'timestamp',
@@ -252,8 +239,6 @@ class DateTypeTest extends TypeTestCase
     public function testSubmitFromInputRawDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'array',
@@ -370,27 +355,12 @@ class DateTypeTest extends TypeTestCase
         ));
     }
 
-    public function testSetDataWithDifferentTimezones()
+    public function testSetDataWithDifferentTimezoneDateTime()
     {
+        date_default_timezone_set('Pacific/Tahiti');
+
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'model_timezone' => 'America/New_York',
-            'view_timezone' => 'Pacific/Tahiti',
-            'input' => 'string',
-            'widget' => 'single_text',
-        ));
-
-        $form->setData('2010-06-02');
-
-        $this->assertEquals('01.06.2010', $form->getViewData());
-    }
-
-    public function testSetDataWithDifferentTimezonesDateTime()
-    {
-        $form = $this->factory->create('date', null, array(
-            'format' => \IntlDateFormatter::MEDIUM,
-            'model_timezone' => 'America/New_York',
-            'view_timezone' => 'Pacific/Tahiti',
             'input' => 'datetime',
             'widget' => 'single_text',
         ));
@@ -400,7 +370,7 @@ class DateTypeTest extends TypeTestCase
         $form->setData($dateTime);
 
         $this->assertDateTimeEquals($dateTime, $form->getData());
-        $this->assertEquals('01.06.2010', $form->getViewData());
+        $this->assertEquals('02.06.2010', $form->getViewData());
     }
 
     public function testYearsOption()
@@ -495,8 +465,6 @@ class DateTypeTest extends TypeTestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'single_text',
         ));
 
@@ -510,8 +478,6 @@ class DateTypeTest extends TypeTestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -529,8 +495,6 @@ class DateTypeTest extends TypeTestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -548,8 +512,6 @@ class DateTypeTest extends TypeTestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -17,18 +17,25 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class TimeTypeTest extends TypeTestCase
 {
+    private $defaultTimezone;
+
     protected function setUp()
     {
         IntlTestHelper::requireIntl($this);
 
         parent::setUp();
+
+        $this->defaultTimezone = date_default_timezone_get();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->defaultTimezone);
     }
 
     public function testSubmitDateTime()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'datetime',
         ));
 
@@ -48,8 +55,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitString()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'string',
         ));
 
@@ -67,8 +72,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitTimestamp()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'timestamp',
         ));
 
@@ -88,8 +91,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitArray()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'array',
         ));
 
@@ -107,8 +108,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitDatetimeSingleText()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'widget' => 'single_text',
         ));
@@ -122,8 +121,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitDatetimeSingleTextWithoutMinutes()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'widget' => 'single_text',
             'with_minutes' => false,
@@ -138,8 +135,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitArraySingleText()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'array',
             'widget' => 'single_text',
         ));
@@ -158,8 +153,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitArraySingleTextWithoutMinutes()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'array',
             'widget' => 'single_text',
             'with_minutes' => false,
@@ -178,8 +171,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitArraySingleTextWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'array',
             'widget' => 'single_text',
             'with_seconds' => true,
@@ -200,8 +191,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitStringSingleText()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -215,8 +204,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSubmitStringSingleTextWithoutMinutes()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'string',
             'widget' => 'single_text',
             'with_minutes' => false,
@@ -231,8 +218,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSetDataWithoutMinutes()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'with_minutes' => false,
         ));
@@ -245,8 +230,6 @@ class TimeTypeTest extends TypeTestCase
     public function testSetDataWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'with_seconds' => true,
         ));
@@ -256,53 +239,23 @@ class TimeTypeTest extends TypeTestCase
         $this->assertEquals(array('hour' => 3, 'minute' => 4, 'second' => 5), $form->getViewData());
     }
 
-    public function testSetDataDifferentTimezones()
+    public function testSetDataWithTimezoneDateTime()
     {
+        date_default_timezone_set('Asia/Hong_Kong');
+
         $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'America/New_York',
-            'view_timezone' => 'Asia/Hong_Kong',
-            'input' => 'string',
-            'with_seconds' => true,
-        ));
-
-        $dateTime = new \DateTime('2013-01-01 12:04:05');
-        $dateTime->setTimezone(new \DateTimeZone('America/New_York'));
-
-        $form->setData($dateTime->format('H:i:s'));
-
-        $outputTime = clone $dateTime;
-        $outputTime->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
-
-        $displayedData = array(
-            'hour' => (int) $outputTime->format('H'),
-            'minute' => (int) $outputTime->format('i'),
-            'second' => (int) $outputTime->format('s'),
-        );
-
-        $this->assertEquals($displayedData, $form->getViewData());
-    }
-
-    public function testSetDataDifferentTimezonesDateTime()
-    {
-        $form = $this->factory->create('time', null, array(
-            'model_timezone' => 'America/New_York',
-            'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'datetime',
             'with_seconds' => true,
         ));
 
-        $dateTime = new \DateTime('12:04:05');
-        $dateTime->setTimezone(new \DateTimeZone('America/New_York'));
+        $dateTime = new \DateTime('12:04:05', new \DateTimeZone('America/New_York'));
 
         $form->setData($dateTime);
 
-        $outputTime = clone $dateTime;
-        $outputTime->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
-
         $displayedData = array(
-            'hour' => (int) $outputTime->format('H'),
-            'minute' => (int) $outputTime->format('i'),
-            'second' => (int) $outputTime->format('s'),
+            'hour' => 12,
+            'minute' => 4,
+            'second' => 5,
         );
 
         $this->assertDateTimeEquals($dateTime, $form->getData());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12239 |
| License | MIT |
| Doc PR | todo |

I'm not sure if this should actually go to 2.3.
