### PR TITLE
[Validator] Deprecated comparison constraints

### DIFF
--- a/UPGRADE-2.6.md
+++ b/UPGRADE-2.6.md
@@ -77,6 +77,43 @@ Validator
    ```
    value == null or (YOUR_EXPRESSION)
    ```
+   
+ * The basic comparison constraints were deprecated and will be removed in
+   Symfony 3.0:
+   
+   * `AbstractComparison` and `AbstractComparisonValidator`
+   * `Blank` and `BlankValidator`
+   * `EqualTo` and `EqualToValidator`
+   * `False` and `FalseValidator`
+   * `GreaterThan` and `GreaterThanValidator`
+   * `GreaterThanOrEqual` and `GreaterThanOrEqualValidator`
+   * `IdenticalTo` and `IdenticalToValidator`
+   * `LessThan` and `LessThanValidator`
+   * `LessThanOrEqual` and `LessThanOrEqualValidator`
+   * `NotEqualTo` and `NotEqualToValidator`
+   * `NotIdenticalTo` and `NotIdenticalToValidator`
+   * `Null` and `NullValidator`
+   * `True` and `TrueValidator`
+   
+   You should use the `Expression` constraint instead.
+   
+   Before:
+   
+   ```php
+   /**
+    * @GreaterThan(0, message="Please enter a positive number.")
+    */
+   private $age;
+   ```
+   
+   After:
+   
+   ```php
+   /**
+    * @Expression("value > 0", message="Please enter a positive number.")
+    */
+   private $age;
+   ```
 
 Security
 --------

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -15,6 +15,19 @@ CHANGELOG
  * [BC BREAK] added `Mapping\MetadataInterface::getConstraints()`
  * added generic "payload" option to all constraints for attaching domain-specific data
  * [BC BREAK] added `ConstraintViolationBuilderInterface::setCause()`
+ * deprecated `AbstractComparison` and `AbstractComparisonValidator`
+ * deprecated `Blank` and `BlankValidator`
+ * deprecated `EqualTo` and `EqualToValidator`
+ * deprecated `False` and `FalseValidator`
+ * deprecated `GreaterThan` and `GreaterThanValidator`
+ * deprecated `GreaterThanOrEqual` and `GreaterThanOrEqualValidator`
+ * deprecated `IdenticalTo` and `IdenticalToValidator`
+ * deprecated `LessThan` and `LessThanValidator`
+ * deprecated `LessThanOrEqual` and `LessThanOrEqualValidator`
+ * deprecated `NotEqualTo` and `NotEqualToValidator`
+ * deprecated `NotIdenticalTo` and `NotIdenticalToValidator`
+ * deprecated `Null` and `NullValidator`
+ * deprecated `True` and `TrueValidator`
 
 2.5.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -18,6 +18,9 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  * Used for the comparison of values.
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 abstract class AbstractComparison extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -20,6 +20,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 abstract class AbstractComparisonValidator extends ConstraintValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/Blank.php
+++ b/src/Symfony/Component/Validator/Constraints/Blank.php
@@ -20,6 +20,9 @@ use Symfony\Component\Validator\Constraint;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class Blank extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class BlankValidator extends ConstraintValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/EqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/EqualTo.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class EqualTo extends AbstractComparison
 {

--- a/src/Symfony/Component/Validator/Constraints/EqualToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EqualToValidator.php
@@ -15,6 +15,9 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are equal (==).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class EqualToValidator extends AbstractComparisonValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/False.php
+++ b/src/Symfony/Component/Validator/Constraints/False.php
@@ -20,6 +20,9 @@ use Symfony\Component\Validator\Constraint;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class False extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class FalseValidator extends ConstraintValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/GreaterThan.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThan.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class GreaterThan extends AbstractComparison
 {

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class GreaterThanOrEqual extends AbstractComparison
 {

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqualValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqualValidator.php
@@ -15,6 +15,9 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are greater than or equal to the previous (>=).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class GreaterThanOrEqualValidator extends AbstractComparisonValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanValidator.php
@@ -15,6 +15,9 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are greater than the previous (>).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class GreaterThanValidator extends AbstractComparisonValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class IdenticalTo extends AbstractComparison
 {

--- a/src/Symfony/Component/Validator/Constraints/IdenticalToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IdenticalToValidator.php
@@ -15,6 +15,9 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are identical (===).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class IdenticalToValidator extends AbstractComparisonValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/LessThan.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThan.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class LessThan extends AbstractComparison
 {

--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class LessThanOrEqual extends AbstractComparison
 {

--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqualValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqualValidator.php
@@ -15,6 +15,9 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are less than or equal to the previous (<=).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class LessThanOrEqualValidator extends AbstractComparisonValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/LessThanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanValidator.php
@@ -15,6 +15,9 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are less than the previous (<).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class LessThanValidator extends AbstractComparisonValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class NotEqualTo extends AbstractComparison
 {

--- a/src/Symfony/Component/Validator/Constraints/NotEqualToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotEqualToValidator.php
@@ -15,6 +15,9 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are all unequal (!=).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class NotEqualToValidator extends AbstractComparisonValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class NotIdenticalTo extends AbstractComparison
 {

--- a/src/Symfony/Component/Validator/Constraints/NotIdenticalToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotIdenticalToValidator.php
@@ -15,6 +15,9 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values aren't identical (!==).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class NotIdenticalToValidator extends AbstractComparisonValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/Null.php
+++ b/src/Symfony/Component/Validator/Constraints/Null.php
@@ -20,6 +20,9 @@ use Symfony\Component\Validator\Constraint;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class Null extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/NullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NullValidator.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class NullValidator extends ConstraintValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/True.php
+++ b/src/Symfony/Component/Validator/Constraints/True.php
@@ -20,6 +20,9 @@ use Symfony\Component\Validator\Constraint;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class True extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated as of Symfony 2.6, to be removed in version 3.0.
+ *             Use {@link Expression} instead.
  */
 class TrueValidator extends ConstraintValidator
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | partially #12300 |
| License | MIT |
| Doc PR | - |

I deprecated the constraints which can be easily replaced using the Expression constraint. Using just the Expression constraint means less constraints to learn while at the same time having more power, e.g. arithmetic or logical operators.
