### PR TITLE
[DependencyInjection] inlined factory not referenced

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -114,6 +114,10 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
                 $this->processArguments($argument->getArguments());
                 $this->processArguments($argument->getMethodCalls());
                 $this->processArguments($argument->getProperties());
+
+                if ($argument->getFactoryService()) {
+                    $this->processArguments(array(new Reference($argument->getFactoryService())));
+                }
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -144,6 +144,10 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             return false;
         }
 
+        if (count($ids) > 1 && $definition->getFactoryService()) {
+            return false;
+        }
+
         return $container->getDefinition(reset($ids))->getScope() === $definition->getScope();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
@@ -79,6 +79,28 @@ class AnalyzeServiceReferencesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($ref, $refs[0]->getValue());
     }
 
+    public function testProcessDetectsReferencesFromInlinedFactoryDefinitions()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('a')
+        ;
+
+        $factory = new Definition();
+        $factory->setFactoryService('a');
+
+        $container
+            ->register('b')
+            ->addArgument($factory)
+        ;
+
+        $graph = $this->process($container);
+
+        $this->assertTrue($graph->hasNode('a'));
+        $this->assertCount(1, $refs = $graph->getNode('a')->getInEdges());
+    }
+
     public function testProcessDoesNotSaveDuplicateReferences()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

While working with the DI I encountered a `You have requested a non-existent service "xxxxx"` exception. 
Research it seems that a private reference was inlined but the private factory that was also referencing to the service was ignored.

A example of the problem:

``` XML
        <service id="manager"
                 class="\stdClass"
                 factory-method="getX"
                 factory-service="factory"
                 public="false">
            <argument>X</argument>
        </service>
        <service id="repository"
                 class="\stdClass"
                 factory-method="getRepository"
                 factory-service="manager"
                 public="false">
            <argument>X</argument>
        </service>
        <service id="storage" class="\stdClass" public="false">
            <argument type="service" id="manager"/>
            <argument type="service" id="repository"/>
        </service>
```

What happens before the patch:
1. repository get's inlined
2. manager get's inlined for the first argument
3. manager get's removed since there was no reference.

After the first commit the following will happen:
1. repository get's inlined 
2. manager get's inlined for the first argument 
3. manager will not be removed since the inlined repository still references manager

This introduced a smell since InlineServiceDefinitionsPass was still inlining the manager for the first argument. 

To fix this I have chosen that not inline factories if they are used more then once by the same definition.

So after the second commit the following will happen:
1. repository get's inlined 

Personally I feel that the InlineServiceDefinitionsPass patch isn't the best possible one but that a different fix would probably mean breaking BC so it's probably a good idea to look at this for Symfony 3.0.
