### PR TITLE
[TwigBridge] TwigExtractor tests require the Finder component

### DIFF
--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -20,6 +20,7 @@
         "twig/twig": "~1.12"
     },
     "require-dev": {
+        "symfony/finder": "~2.3",
         "symfony/form": "~2.2",
         "symfony/http-kernel": "~2.2",
         "symfony/routing": "~2.2",
@@ -29,6 +30,7 @@
         "symfony/security": "~2.0"
     },
     "suggest": {
+        "symfony/finder": "",
         "symfony/form": "",
         "symfony/http-kernel": "",
         "symfony/routing": "",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The tests for the `TwigExtractor`(as introduced in #12377) require the Finder component to be run properly.
