### PR TITLE
[SecurityBundle] Firewall providers building - code cleaning

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -533,17 +533,20 @@ class SecurityExtension extends Extension
         }
 
         // Chain provider
-        $providers = array();
-        foreach ($provider['chain']['providers'] as $providerName) {
-            $providers[] = new Reference($this->getUserProviderId(strtolower($providerName)));
+        if (isset($provider['chain'])) {
+            $providers = array();
+            foreach ($provider['chain']['providers'] as $providerName) {
+                $providers[] = new Reference($this->getUserProviderId(strtolower($providerName)));
+            }
+
+            $container
+                ->setDefinition($name, new DefinitionDecorator('security.user.provider.chain'))
+                ->addArgument($providers);
+
+            return $name;
         }
 
-        $container
-            ->setDefinition($name, new DefinitionDecorator('security.user.provider.chain'))
-            ->addArgument($providers)
-        ;
-
-        return $name;
+        throw new InvalidConfigurationException(sprintf('Unable to create definition for "%s" user provider', $name));
     }
 
     private function getUserProviderId($name)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/UserProvider/DummyProvider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/UserProvider/DummyProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider;
+
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DummyProvider implements UserProviderFactoryInterface
+{
+    public function create(ContainerBuilder $container, $id, $config)
+    {
+        
+    }
+
+    public function getKey()
+    {
+        return 'foo';
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\DummyProvider;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
@@ -59,6 +60,33 @@ class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
             'firewalls' => array(
                 'some_firewall' => array(
                     'pattern' => '/.*',
+                ),
+            ),
+        ));
+
+        $container->compile();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Unable to create definition for "security.user.provider.concrete.my_foo" user provider
+     */
+    public function testFirewallWithInvalidUserProvider()
+    {
+        $container = $this->getRawContainer();
+
+        $extension = $container->getExtension('security');
+        $extension->addUserProviderFactory(new DummyProvider());
+
+        $container->loadFromExtension('security', array(
+            'providers' => array(
+                'my_foo' => array('foo' => []),
+            ),
+
+            'firewalls' => array(
+                'some_firewall' => array(
+                    'pattern' => '/.*',
+                    'http_basic' => [],
                 ),
             ),
         ));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony-fr/symfony-docs-fr/pull/609 |

It seems old code to build firewall provider still exist in the SecurityExtension. The `In-Memory` and `Entity` providers are handled in their own factories.
