### PR TITLE
Fixed whitespace control for password form widget

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -162,7 +162,7 @@
 
 {% block password_widget -%}
     {% set type = type|default('password') %}
-    {{ block('form_widget_simple') }}
+    {{- block('form_widget_simple') -}}
 {%- endblock password_widget %}
 
 {% block hidden_widget -%}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When removing the spaceless tags the additional needed `-` has been forgotten for the password widget.

By the way, is in the {% tags the - at the end of the starting and at the beginning of the ending tag sufficient?
This does not correspond to the twig documentation where it is always documented on the beginning and at the end.

``` php
{% block hidden_widget -%}
    {% set type = type|default('hidden') %}
    {{- block('form_widget_simple') -}}
{%- endblock hidden_widget -%}
```
