### PR TITLE
[Form] Added option type checks in some FormTypes

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -307,6 +307,8 @@ UPGRADE FROM 2.x to 3.0
    ```php
    echo $form->getErrors(true, false);
    ```
+  * The array type hints for `ChoiceList::initialize()` method's `$labels` and
+    `$preferredChoices` parameters were removed.
 
 ### FrameworkBundle
 

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -87,7 +87,7 @@ class ChoiceList implements ChoiceListInterface
      *
      * @throws UnexpectedTypeException If the choices are not an array or \Traversable.
      */
-    public function __construct($choices, array $labels, array $preferredChoices = array())
+    public function __construct($choices, $labels, $preferredChoices = array())
     {
         if (!is_array($choices) && !$choices instanceof \Traversable) {
             throw new UnexpectedTypeException($choices, 'array or \Traversable');
@@ -105,7 +105,7 @@ class ChoiceList implements ChoiceListInterface
      * @param array              $labels           The labels belonging to the choices.
      * @param array              $preferredChoices The choices to display with priority.
      */
-    protected function initialize($choices, array $labels, array $preferredChoices)
+    protected function initialize($choices, $labels, $preferredChoices)
     {
         $this->choices = array();
         $this->values = array();
@@ -271,7 +271,7 @@ class ChoiceList implements ChoiceListInterface
      * @throws InvalidArgumentException      If the structures of the choices and labels array do not match.
      * @throws InvalidConfigurationException If no valid value or index could be created for a choice.
      */
-    protected function addChoices(array &$bucketForPreferred, array &$bucketForRemaining, $choices, array $labels, array $preferredChoices)
+    protected function addChoices(array &$bucketForPreferred, array &$bucketForRemaining, $choices, $labels, $preferredChoices)
     {
         // Add choices to the nested buckets
         foreach ($choices as $group => $choice) {

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -90,7 +90,7 @@ class ObjectChoiceList extends ChoiceList
      *                                                    are generated instead.
      * @param PropertyAccessorInterface $propertyAccessor The reflection graph for reading property paths.
      */
-    public function __construct($choices, $labelPath = null, array $preferredChoices = array(), $groupPath = null, $valuePath = null, PropertyAccessorInterface $propertyAccessor = null)
+    public function __construct($choices, $labelPath = null, $preferredChoices = array(), $groupPath = null, $valuePath = null, PropertyAccessorInterface $propertyAccessor = null)
     {
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
         $this->labelPath = null !== $labelPath ? new PropertyPath($labelPath) : null;
@@ -112,7 +112,7 @@ class ObjectChoiceList extends ChoiceList
      * @throws InvalidArgumentException When passing a hierarchy of choices and using
      *                                  the "groupPath" option at the same time.
      */
-    protected function initialize($choices, array $labels, array $preferredChoices)
+    protected function initialize($choices, $labels, $preferredChoices)
     {
         if (null !== $this->groupPath) {
             $groupedChoices = array();

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
@@ -91,7 +91,7 @@ class SimpleChoiceList extends ChoiceList
      * @param array              $labels             Ignored.
      * @param array              $preferredChoices   The preferred choices.
      */
-    protected function addChoices(array &$bucketForPreferred, array &$bucketForRemaining, $choices, array $labels, array $preferredChoices)
+    protected function addChoices(array &$bucketForPreferred, array &$bucketForRemaining, $choices, $labels, $preferredChoices)
     {
         // Add choices to the nested buckets
         foreach ($choices as $choice => $label) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -90,6 +90,8 @@ class CollectionType extends AbstractType
             'delete_empty' => false,
         ));
 
+        $resolver->setAllowedTypes('options', 'array');
+
         $resolver->setNormalizer('options', $optionsNormalizer);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1671,4 +1671,21 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         // Trigger data initialization
         $form->getViewData();
     }
+
+    public function testChoicesOptionSupportsTraversable()
+    {
+        $this->factory->create('choice', null, array(
+            'choices' => new \ArrayObject($this->choices),
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidPreferredChoicesOption()
+    {
+        $this->factory->create('choice', null, array(
+            'preferred_choices' => 'bad value',
+        ));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -274,4 +274,14 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertSame('__test__label__', $form->createView()->vars['prototype']->vars['label']);
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidOptions()
+    {
+        $this->factory->create('collection', null, array(
+            'options' => 'bad value',
+        ));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -50,4 +50,14 @@ class CountryTypeTest extends TestCase
             }
         }
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidChoices()
+    {
+        $this->factory->create('country', null, array(
+            'choices' => 'bad value',
+        ));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -34,4 +34,14 @@ class CurrencyTypeTest extends TestCase
         $this->assertContains(new ChoiceView('USD', 'USD', 'US Dollar'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('SIT', 'SIT', 'Slovenian Tolar'), $choices, '', false, false);
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidChoices()
+    {
+        $this->factory->create('currency', null, array(
+            'choices' => 'bad value',
+        ));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -45,4 +45,14 @@ class LanguageTypeTest extends TestCase
 
         $this->assertNotContains(new ChoiceView('mul', 'mul', 'Mehrsprachig'), $choices, '', false, false);
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidChoices()
+    {
+        $this->factory->create('language', null, array(
+            'choices' => 'bad value',
+        ));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -34,4 +34,14 @@ class LocaleTypeTest extends TestCase
         $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'English (United Kingdom)'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'Chinese (Traditional, Macau SAR China)'), $choices, '', false, false);
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidChoices()
+    {
+        $this->factory->create('locale', null, array(
+            'choices' => 'bad value',
+        ));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -731,4 +731,14 @@ class TimeTypeTest extends TestCase
             'seconds' => 'bad value',
         ));
     }
+    
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testThrowExceptionIfEmptyValueIsInvalid()
+    {
+        $this->factory->create('time', null, array(
+            'empty_value' => array(),
+        ));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -27,4 +27,14 @@ class TimezoneTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertArrayHasKey('America', $choices);
         $this->assertContains(new ChoiceView('America/New_York', 'America/New_York', 'New York'), $choices['America'], '', false, false);
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testSetInvalidChoices()
+    {
+        $this->factory->create('timezone', null, array(
+            'choices' => 'bad value',
+        ));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Follow-up to #11696. Some of the built-in form types allowed passing invalid options, which lead to errors that were not so easy to understand. This PR adds needed checks where applicable.

Allowed types in `TimeType`'s `empty_value` option were taken from the documentation.
