### PR TITLE
[2.6] [Validator] make DateTime objects represented as strings in the violation message

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -35,7 +35,7 @@ class RangeValidator extends ConstraintValidator
 
         if (!is_numeric($value) && !$value instanceof \DateTime && !$value instanceof \DateTimeInterface) {
             $this->buildViolation($constraint->invalidMessage)
-                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
                 ->setCode(Range::INVALID_VALUE_ERROR)
                 ->addViolation();
 
@@ -61,7 +61,7 @@ class RangeValidator extends ConstraintValidator
 
         if (null !== $constraint->max && $value > $max) {
             $this->buildViolation($constraint->maxMessage)
-                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
                 ->setParameter('{{ limit }}', $this->formatValue($max, self::PRETTY_DATE))
                 ->setCode(Range::BEYOND_RANGE_ERROR)
                 ->addViolation();
@@ -71,7 +71,7 @@ class RangeValidator extends ConstraintValidator
 
         if (null !== $constraint->min && $value < $min) {
             $this->buildViolation($constraint->minMessage)
-                ->setParameter('{{ value }}', $value)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
                 ->setParameter('{{ limit }}', $this->formatValue($min, self::PRETTY_DATE))
                 ->setCode(Range::BELOW_RANGE_ERROR)
                 ->addViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -52,20 +52,20 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     public function getLessThanTen()
     {
         return array(
-            array(9.99999),
-            array('9.99999'),
-            array(5),
-            array(1.0),
+            array(9.99999, '9.99999'),
+            array('9.99999', '"9.99999"'),
+            array(5, '5'),
+            array(1.0, '1.0'),
         );
     }
 
     public function getMoreThanTwenty()
     {
         return array(
-            array(20.000001),
-            array('20.000001'),
-            array(21),
-            array(30.0),
+            array(20.000001, '20.000001'),
+            array('20.000001', '"20.000001"'),
+            array(21, '21'),
+            array(30.0, '30.0'),
         );
     }
 
@@ -105,7 +105,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getLessThanTen
      */
-    public function testInvalidValuesMin($value)
+    public function testInvalidValuesMin($value, $formattedValue)
     {
         $constraint = new Range(array(
             'min' => 10,
@@ -115,7 +115,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ value }}', $formattedValue)
             ->setParameter('{{ limit }}', 10)
             ->setCode(Range::BELOW_RANGE_ERROR)
             ->assertRaised();
@@ -124,7 +124,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getMoreThanTwenty
      */
-    public function testInvalidValuesMax($value)
+    public function testInvalidValuesMax($value, $formattedValue)
     {
         $constraint = new Range(array(
             'max' => 20,
@@ -134,7 +134,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ value }}', $formattedValue)
             ->setParameter('{{ limit }}', 20)
             ->setCode(Range::BEYOND_RANGE_ERROR)
             ->assertRaised();
@@ -143,7 +143,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getMoreThanTwenty
      */
-    public function testInvalidValuesCombinedMax($value)
+    public function testInvalidValuesCombinedMax($value, $formattedValue)
     {
         $constraint = new Range(array(
             'min' => 10,
@@ -155,7 +155,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMaxMessage')
-            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ value }}', $formattedValue)
             ->setParameter('{{ limit }}', 20)
             ->setCode(Range::BEYOND_RANGE_ERROR)
             ->assertRaised();
@@ -164,7 +164,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getLessThanTen
      */
-    public function testInvalidValuesCombinedMin($value)
+    public function testInvalidValuesCombinedMin($value, $formattedValue)
     {
         $constraint = new Range(array(
             'min' => 10,
@@ -176,7 +176,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMinMessage')
-            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ value }}', $formattedValue)
             ->setParameter('{{ limit }}', 10)
             ->setCode(Range::BELOW_RANGE_ERROR)
             ->assertRaised();
@@ -212,13 +212,13 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->setDefaultTimezone('UTC');
 
         $tests = array(
-            array(new \DateTime('March 20, 2013')),
-            array(new \DateTime('March 9, 2014')),
+            array(new \DateTime('March 20, 2013'), 'Mar 20, 2013, 12:00 AM'),
+            array(new \DateTime('March 9, 2014'), 'Mar 9, 2014, 12:00 AM'),
         );
 
         if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
-            $tests[] = array(new \DateTimeImmutable('March 20, 2013'));
-            $tests[] = array(new \DateTimeImmutable('March 9, 2014'));
+            $tests[] = array(new \DateTimeImmutable('March 20, 2013'), 'Mar 20, 2013, 12:00 AM');
+            $tests[] = array(new \DateTimeImmutable('March 9, 2014'), 'Mar 9, 2014, 12:00 AM');
         }
 
         $this->restoreDefaultTimezone();
@@ -233,13 +233,13 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->setDefaultTimezone('UTC');
 
         $tests = array(
-            array(new \DateTime('March 21, 2014')),
-            array(new \DateTime('March 9, 2015')),
+            array(new \DateTime('March 21, 2014'), 'Mar 21, 2014, 12:00 AM'),
+            array(new \DateTime('March 9, 2015'), 'Mar 9, 2015, 12:00 AM'),
         );
 
         if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
-            $tests[] = array(new \DateTimeImmutable('March 21, 2014'));
-            $tests[] = array(new \DateTimeImmutable('March 9, 2015'));
+            $tests[] = array(new \DateTimeImmutable('March 21, 2014'), 'Mar 21, 2014, 12:00 AM');
+            $tests[] = array(new \DateTimeImmutable('March 9, 2015'), 'Mar 9, 2015, 12:00 AM');
         }
 
         $this->restoreDefaultTimezone();
@@ -283,7 +283,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getSoonerThanTenthMarch2014
      */
-    public function testInvalidDatesMin($value)
+    public function testInvalidDatesMin($value, $dateTimeAsString)
     {
         // Conversion of dates to string differs between ICU versions
         // Make sure we have the correct version loaded
@@ -297,7 +297,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ value }}', $dateTimeAsString)
             ->setParameter('{{ limit }}', 'Mar 10, 2014, 12:00 AM')
             ->setCode(Range::BELOW_RANGE_ERROR)
             ->assertRaised();
@@ -306,7 +306,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getLaterThanTwentiethMarch2014
      */
-    public function testInvalidDatesMax($value)
+    public function testInvalidDatesMax($value, $dateTimeAsString)
     {
         // Conversion of dates to string differs between ICU versions
         // Make sure we have the correct version loaded
@@ -320,7 +320,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ value }}', $dateTimeAsString)
             ->setParameter('{{ limit }}', 'Mar 20, 2014, 12:00 AM')
             ->setCode(Range::BEYOND_RANGE_ERROR)
             ->assertRaised();
@@ -329,7 +329,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getLaterThanTwentiethMarch2014
      */
-    public function testInvalidDatesCombinedMax($value)
+    public function testInvalidDatesCombinedMax($value, $dateTimeAsString)
     {
         // Conversion of dates to string differs between ICU versions
         // Make sure we have the correct version loaded
@@ -345,7 +345,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMaxMessage')
-            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ value }}', $dateTimeAsString)
             ->setParameter('{{ limit }}', 'Mar 20, 2014, 12:00 AM')
             ->setCode(Range::BEYOND_RANGE_ERROR)
             ->assertRaised();
@@ -354,7 +354,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @dataProvider getSoonerThanTenthMarch2014
      */
-    public function testInvalidDatesCombinedMin($value)
+    public function testInvalidDatesCombinedMin($value, $dateTimeAsString)
     {
         // Conversion of dates to string differs between ICU versions
         // Make sure we have the correct version loaded
@@ -370,7 +370,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($value, $constraint);
 
         $this->buildViolation('myMinMessage')
-            ->setParameter('{{ value }}', $value)
+            ->setParameter('{{ value }}', $dateTimeAsString)
             ->setParameter('{{ limit }}', 'Mar 10, 2014, 12:00 AM')
             ->setCode(Range::BELOW_RANGE_ERROR)
             ->assertRaised();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
