### PR TITLE
Remove block submit_widget

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -14,11 +14,6 @@
     {{- parent() -}}
 {%- endblock textarea_widget %}
 
-{% block submit_widget -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' btn')|trim}) %}
-    {{- parent() -}}
-{%- endblock %}
-
 {% block button_widget -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' btn')|trim}) %}
     {{- parent() -}}


### PR DESCRIPTION
submit_widget parent block already renders button_widget_block. btn is already added by button_widget_block. I propose to remove this block as it adds btn twice and has no other use.
