### PR TITLE
[Important] Don't override dump() when DebugBundle isn't enabled

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class DumpExtension extends \Twig_Extension
+class DumpExtension extends \Twig_Extension_Debug
 {
     public function __construct(ClonerInterface $cloner = null)
     {
@@ -30,8 +30,8 @@ class DumpExtension extends \Twig_Extension
     public function getFunctions()
     {
         if (!$this->cloner) {
-            // don't override the dump() function if it can't produce output due to missing components
-            return array();
+            // use native dump function, as the DebugBundle is not registered
+            return parent::getFunctions();
         }
 
         return array(

--- a/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
@@ -29,6 +29,11 @@ class DumpExtension extends \Twig_Extension
 
     public function getFunctions()
     {
+        if (!$this->cloner) {
+            // don't override the dump() function if it can't produce output due to missing components
+            return array();
+        }
+
         return array(
             new \Twig_SimpleFunction('dump', array($this, 'dump'), array('is_safe' => array('html'), 'needs_context' => true, 'needs_environment' => true)),
         );


### PR DESCRIPTION
A lot of people have this problem already: Updating your 2.x (x<6) Symfony app to a 2.6 app results in no output when using `dump()`. The problem is that the native Twig `dump()` function is overriden by the TwigBundle, but if the DebugBundle isn't enabled the function will simply stop the execution of the function and no output is produced.

This PR fixes this by only overriding the `dump()` function if the DebugBundle was registered, otherwise the native twig `dump()` function will be used.

The Symfony 2.6 release notes should explain that people should register this bundle in their AppKernel if they want to have output.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
