### PR TITLE
[HttpKernel][2.6] Adding support for invokable controllers in the RequestDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -153,7 +153,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                     'class' => $r->getName(),
                     'method' => null,
                     'file' => $r->getFileName(),
-                    'line' => $r->getStartLine()
+                    'line' => $r->getStartLine(),
                 );
             } else {
                 $this->data['controller'] = (string) $controller ?: 'n/a';

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -148,7 +148,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                     'line' => $r->getStartLine(),
                 );
             } elseif (is_object($controller)) {
-                $r = new \ReflectionClass(get_class($controller));
+                $r = new \ReflectionClass($controller);
                 $this->data['controller'] = array(
                     'class' => $r->getName(),
                     'method' => null,

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -147,6 +147,14 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                     'file' => $r->getFilename(),
                     'line' => $r->getStartLine(),
                 );
+            } elseif (is_object($controller)) {
+                $r = new \ReflectionClass(get_class($controller));
+                $this->data['controller'] = array(
+                    'class' => $r->getName(),
+                    'method' => null,
+                    'file' => $r->getFileName(),
+                    'line' => $r->getStartLine()
+                );
             } else {
                 $this->data['controller'] = (string) $controller ?: 'n/a';
             }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -59,6 +59,7 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         // make sure we always match the line number
         $r1 = new \ReflectionMethod($this, 'testControllerInspection');
         $r2 = new \ReflectionMethod($this, 'staticControllerMethod');
+        $r3 = new \ReflectionClass($this);
         // test name, callable, expected
         $controllerTests = array(
             array(
@@ -132,6 +133,17 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
                     'line' => 'n/a',
                 ),
             ),
+
+            array(
+                'Invokable controller',
+                $this,
+                array(
+                    'class' => 'Symfony\Component\HttpKernel\Tests\DataCollector\RequestDataCollectorTest',
+                    'method' => null,
+                    'file' => __FILE__,
+                    'line' => $r3->getStartLine(),
+                )
+            )
         );
 
         $c = new RequestDataCollector();
@@ -199,6 +211,11 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
      * Magic method to allow non existing methods to be called and delegated.
      */
     public static function __callStatic($method, $args)
+    {
+        throw new \LogicException('Unexpected method call');
+    }
+
+    public function __invoke()
     {
         throw new \LogicException('Unexpected method call');
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -142,8 +142,8 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
                     'method' => null,
                     'file' => __FILE__,
                     'line' => $r3->getStartLine(),
-                )
-            )
+                ),
+            ),
         );
 
         $c = new RequestDataCollector();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

As part of https://github.com/symfony/symfony/pull/11193 support for controllers using `__invoke()` was added.

The `RequestDataCollector` did not support controllers that were defined in the routing as...

``` php
route_name:
    path: /{id}
    defaults: { _controller: acme_app.page.controller.page }
    requirements:
        id: \d+
```

Where the controller was defined as...

``` php
class PageController
{
    public function __invoke()
    {
        //
    }
}
```

This PR adds that support. Tests have been updated.
