### PR TITLE
[Debug] Show only unique class candidates

### DIFF
--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -119,7 +119,7 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
             }
         }
 
-        return $classes;
+        return array_unique($classes);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

```
PHPUnit 4.3.5 by Sebastian Bergmann.

Configuration read from .../symfony/phpunit.xml.dist

S....S.............................FFFS.......

Time: 2.29 seconds, Memory: 8.50Mb

There were 3 failures:

1) Symfony\Component\Debug\Tests\FatalErrorHandler\ClassNotFoundFatalErrorHandlerTest::testClassNotFound with data set #2 (array(1, 12, 'foo.php', 'Class \'UndefinedFunctionException\' not found'), 'Attempted to load class "UndefinedFunctionException" from the global namespace.
Did you forget a "use" statement for "Symfony\\Component\\Debug\\Exception\\UndefinedFunctionException"?')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 Attempted to load class "UndefinedFunctionException" from the global namespace.
-Did you forget a "use" statement for "Symfony\Component\Debug\Exception\UndefinedFunctionException"?
+Did you forget a "use" statement for e.g. "Symfony\Component\Debug\Exception\UndefinedFunctionException" or "Symfony\Component\Debug\Exception\UndefinedFunctionException"?

.../symfony/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php:28

2) Symfony\Component\Debug\Tests\FatalErrorHandler\ClassNotFoundFatalErrorHandlerTest::testClassNotFound with data set #3 (array(1, 12, 'foo.php', 'Class \'PEARClass\' not found'), 'Attempted to load class "PEARClass" from the global namespace.
Did you forget a "use" statement for "Symfony_Component_Debug_Tests_Fixtures_PEARClass"?')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 Attempted to load class "PEARClass" from the global namespace.
-Did you forget a "use" statement for "Symfony_Component_Debug_Tests_Fixtures_PEARClass"?
+Did you forget a "use" statement for e.g. "Symfony_Component_Debug_Tests_Fixtures_PEARClass" or "Symfony_Component_Debug_Tests_Fixtures_PEARClass"?

.../symfony/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php:28

3) Symfony\Component\Debug\Tests\FatalErrorHandler\ClassNotFoundFatalErrorHandlerTest::testClassNotFound with data set #4 (array(1, 12, 'foo.php', 'Class \'Foo\\Bar\\UndefinedFunctionException\' not found'), 'Attempted to load class "UndefinedFunctionException" from namespace "Foo\\Bar".
Did you forget a "use" statement for "Symfony\\Component\\Debug\\Exception\\UndefinedFunctionException"?')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 Attempted to load class "UndefinedFunctionException" from namespace "Foo\Bar".
-Did you forget a "use" statement for "Symfony\Component\Debug\Exception\UndefinedFunctionException"?
+Did you forget a "use" statement for e.g. "Symfony\Component\Debug\Exception\UndefinedFunctionException" or "Symfony\Component\Debug\Exception\UndefinedFunctionException"?

.../symfony/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php:28
```
