### PR TITLE
[HttpKernel] Removed deprecated Kernel::init() method

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -74,10 +74,6 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
-    public function init()
-    {
-    }
-
     public function getRootDir()
     {
         return __DIR__;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -74,10 +74,6 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
-    public function init()
-    {
-    }
-
     public function getRootDir()
     {
         return __DIR__;

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.0.0
+-----
+
+* Removed `Symfony\Component\HttpKernel\Kernel::init()`
+
 2.6.0
 -----
 
@@ -24,7 +29,7 @@ CHANGELOG
  * [BC BREAK] renamed `Symfony\Component\HttpKernel\EventListener\DeprecationLoggerListener` to `Symfony\Component\HttpKernel\EventListener\ErrorsLoggerListener` and changed its constructor
  * deprecated `Symfony\Component\HttpKernel\Debug\ErrorHandler`, `Symfony\Component\HttpKernel\Debug\ExceptionHandler`,
    `Symfony\Component\HttpKernel\Exception\FatalErrorException`, and `Symfony\Component\HttpKernel\Exception\FlattenException`
- * deprecated `Symfony\Component\HttpKernel\Kernel::init()``
+ * deprecated `Symfony\Component\HttpKernel\Kernel::init()`
  * added the possibility to specify an id an extra attributes to hinclude tags
  * added the collect of data if a controller is a Closure in the Request collector
  * pass exceptions from the ExceptionListener to the logger using the logging context to allow for more

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -84,15 +84,6 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         if ($this->debug) {
             $this->startTime = microtime(true);
         }
-
-        $this->init();
-    }
-
-    /**
-     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Move your logic in the constructor instead.
-     */
-    public function init()
-    {
     }
 
     public function __clone()

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -69,10 +69,6 @@ class KernelForTest extends Kernel
     {
     }
 
-    public function init()
-    {
-    }
-
     public function getBundles()
     {
         return array();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | maybe |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
