### PR TITLE
[Form] Allow NumberToLocalizedStringTransformer::reverseTransform to accept int/float

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -159,6 +159,10 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
      */
     public function reverseTransform($value)
     {
+        if (is_int($value) || is_float($value)) {
+            return $this->round($value);
+        }
+
         if (!is_string($value)) {
             throw new TransformationFailedException('Expected a string.');
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -334,6 +334,20 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($output, $transformer->reverseTransform($input));
     }
 
+    public function testReverseTransformWithInt()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->assertEquals(10, $transformer->reverseTransform(10));
+    }
+
+    public function testReverseTransformWithRoundingFloat()
+    {
+        $transformer = new NumberToLocalizedStringTransformer(1, null, NumberToLocalizedStringTransformer::ROUND_DOWN);
+
+        $this->assertEquals(10.3, $transformer->reverseTransform(10.35));
+    }
+
     public function testReverseTransformDoesNotRoundIfNoPrecision()
     {
         $transformer = new NumberToLocalizedStringTransformer(null, null, NumberToLocalizedStringTransformer::ROUND_DOWN);
@@ -437,16 +451,6 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->transform('foo');
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
-    public function testReverseTransformExpectsString()
-    {
-        $transformer = new NumberToLocalizedStringTransformer();
-
-        $transformer->reverseTransform(1);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | not sure |
| New feature? | not sure |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12499 |
| License | MIT |
| Doc PR | - |

When adding a form type `integer` with a `empty_data => 0` (aka with a int or float value) the form field will never validate correctly because the `NumberToLocalizedStringTransformer` will throw a `TransformationFailedException` because the value is not a string.

This PR fixes this problem by allowing int and float types as values in `reverseTransform`. Because the string only behavior was enforced by the transformer tests this is a BC change. (Personally I think that this is not a BC break that would cause problems).

Another possible fix is to add a normalizer for the `empty_data` option and transform a int or float to a LocalizedString but that looks/feels like a bad patch job.

I hope this PR will have less people going through there validation schema just to figure out that it's the `NumberToLocalizedStringTransformer` causing the problem.
