### PR TITLE
File upload is broken when submitting a form...

### DIFF
--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -94,7 +94,7 @@ class FileBag extends ParameterBag
 
             if ($keys == self::$fileKeys) {
                 if (UPLOAD_ERR_NO_FILE == $file['error']) {
-                    $file = null;
+                    $file = array();
                 } else {
                     $file = new UploadedFile($file['tmp_name'], $file['name'], $file['type'], $file['size'], $file['error']);
                 }


### PR DESCRIPTION
...without selecting a file in Laravel 5! My tests revealed that with this tweek the problem described at this issue are resolved: laravel/framework#6189 

...in Symfony on the FileBag.php file, convertFileInformation() method returns NULL if no files was selected on the upload. In this case "FileBag->set('image', NULL)" receives NULL, and that is what is dispatching a throw!

I don't make unit tests, but this will no more break my code flow. I'm not sure if this is the real deal! If someone could look deeper into the problem, I appreciated! 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
