### PR TITLE
[DomCrawler] Added support for 'link' tags in the Link class

### DIFF
--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\DomCrawler;
 
 /**
- * Link represents an HTML link (an HTML a or area tag).
+ * Link represents an HTML link (an HTML a, area or link tag).
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
@@ -179,8 +179,8 @@ class Link
      */
     protected function setNode(\DOMElement $node)
     {
-        if ('a' !== $node->nodeName && 'area' !== $node->nodeName) {
-            throw new \LogicException(sprintf('Unable to click on a "%s" tag.', $node->nodeName));
+        if ('a' !== $node->nodeName && 'area' !== $node->nodeName && 'link' !== $node->nodeName) {
+            throw new \LogicException(sprintf('Unable to navigate from a "%s" tag.', $node->nodeName));
         }
 
         $this->node = $node;

--- a/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
@@ -86,6 +86,18 @@ class LinkTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $link->getUri());
     }
 
+    /**
+     * @dataProvider getGetUriTests
+     */
+    public function testGetUriOnLink($url, $currentUri, $expected)
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML(sprintf('<html><head><link href="%s" /></head></html>', $url));
+        $link = new Link($dom->getElementsByTagName('link')->item(0), $currentUri);
+
+        $this->assertEquals($expected, $link->getUri());
+    }
+
     public function getGetUriTests()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | No |
| New feature? | Not really |
| BC breaks? | No |
| Deprecations? | No |
| Tests pass? | Yes (at least those of DomCrawler) |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

My use case is that I crawl web pages for RSS links so I need to retrieve the 'href' attributes of 'link' elements.
I would like to use the Link class to resolve encountered 'href' relative URLs.

Please note that I did not replace `if ('a' !== $node->nodeName && 'area' !== $node->nodeName)` with `if (!$node->hasAttribute('href'))` to ensure backward compatibility.
Indeed, according to http://www.w3.org/TR/html5/links.html, the 'href' attribute is optional for 'a' and 'area' elements.
