### PR TITLE
[WIP][Process] Add commandline parameter binding support

### DIFF
--- a/src/Symfony/Component/Process/CommandLine.php
+++ b/src/Symfony/Component/Process/CommandLine.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process;
+
+use Symfony\Component\Process\Exception\InvalidArgumentException;
+
+/**
+ * @author Romain Neutron <imprec@gmail.com>
+ *
+ * @api
+ */
+class CommandLine
+{
+    const DEFAULT_PLACEHOLDER = '{}';
+    private $commandLine;
+    private $placeholder;
+    private $disabled = false;
+
+    public function __construct($commandLine, $placeholder = self::DEFAULT_PLACEHOLDER)
+    {
+        $this->commandLine = (string) $commandLine;
+        $this->setPlaceholder($placeholder);
+    }
+
+    /**
+     * @return string
+     *
+     * @api
+     */
+    public function getCommandLine()
+    {
+        return $this->commandLine;
+    }
+
+    /**
+     * @param string $commandLine
+     *
+     * @return CommandLine
+     *
+     * @api
+     */
+    public function setCommandLine($commandLine)
+    {
+        $this->commandLine = $commandLine;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     *
+     * @api
+     */
+    public function getPlaceholder()
+    {
+        return $this->placeholder;
+    }
+
+    /**
+     * @param string $placeholder
+     *
+     * @return CommandLine
+     *
+     * @throws InvalidArgumentException
+     *
+     * @api
+     */
+    public function setPlaceholder($placeholder)
+    {
+        if (null !== $placeholder && 0 === strlen($placeholder)) {
+            throw new InvalidArgumentException('Invalid placeholder');
+        }
+
+        $this->placeholder = $placeholder;
+
+        return $this;
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     *
+     * @api
+     */
+    public function prepare(array $parameters)
+    {
+        if ($this->disabled) {
+            return $this->commandLine;
+        }
+
+        $placeholders = $this->countPlaceholders(array_filter(array_keys($parameters), function ($value) { return !is_numeric($value); }));
+
+        if (count($parameters) !== $placeholders) {
+            throw new InvalidArgumentException('Invalid number of bound parameters');
+        }
+
+        if (0 === $placeholders) {
+            return $this->commandLine;
+        }
+
+        $command = '';
+        $offset = 0;
+
+        foreach ($parameters as $key => $value) {
+            $placeholder = is_numeric($key) ? $this->placeholder : $key;
+
+            $pos = strpos($this->commandLine, $placeholder, $offset);
+            $command .= substr($this->commandLine, $offset, $pos - $offset);
+            $offset = $pos + strlen($placeholder);
+            $command .= $this->escape($value);
+        }
+        $command .= substr($this->commandLine, $offset);
+
+        return $command;
+    }
+
+    /**
+     * @internal
+     */
+    public function disableArguments()
+    {
+        $this->disabled = true;
+    }
+
+    /**
+     * @param array $placeholders
+     *
+     * @return int
+     */
+    private function countPlaceholders(array $placeholders)
+    {
+        if (null === $this->placeholder && 0 === count($placeholders)) {
+            return 0;
+        }
+
+        $total = preg_match_all('#' . preg_quote($this->placeholder, '#') . '#', $this->commandLine, $matches);
+
+        foreach ($placeholders as $placeholder) {
+            $total += preg_match_all('#' . preg_quote($placeholder, '#') . '#', $this->commandLine, $matches);
+        }
+
+        return $total;
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    private function escape($string)
+    {
+        return ProcessUtils::escapeArgument($string);
+    }
+}

--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -59,15 +59,15 @@ class PhpProcess extends Process
     /**
      * {@inheritdoc}
      */
-    public function start($callback = null)
+    public function start($callback = null, array $parameters = array())
     {
-        if (null === $this->getCommandLine()) {
+        if ('' === $this->getCommandLine()) {
             if (false === $php = $this->executableFinder->find()) {
                 throw new RuntimeException('Unable to find the PHP executable.');
             }
             $this->setCommandLine($php);
         }
 
-        parent::start($callback);
+        parent::start($callback, $parameters);
     }
 }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -46,6 +46,7 @@ class Process
     const TIMEOUT_PRECISION = 0.2;
 
     private $callback;
+    /** @var CommandLine */
     private $commandline;
     private $cwd;
     private $env;
@@ -148,7 +149,7 @@ class Process
             throw new RuntimeException('The Process class relies on proc_open, which is not available on your PHP installation.');
         }
 
-        $this->commandline = $commandline;
+        $this->setCommandLine($commandline);
         $this->cwd = $cwd;
 
         // on Windows, if the cwd changed via chdir(), proc_open defaults to the dir where PHP was started
@@ -194,18 +195,20 @@ class Process
      *
      * @param callable|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR
+     * @param array         $parameters
      *
      * @return int     The exit status code
      *
      * @throws RuntimeException When process can't be launched
      * @throws RuntimeException When process stopped after receiving signal
      * @throws LogicException   In case a callback is provided and output has been disabled
+     * @throws InvalidArgumentException
      *
      * @api
      */
-    public function run($callback = null)
+    public function run($callback = null, array $parameters = array())
     {
-        $this->start($callback);
+        $this->start($callback, $parameters);
 
         return $this->wait();
     }
@@ -253,14 +256,16 @@ class Process
      *
      * @param callable|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR
+     * @param array         $parameters
      *
      * @return Process The process itself
      *
      * @throws RuntimeException When process can't be launched
      * @throws RuntimeException When process is already running
      * @throws LogicException   In case a callback is provided and output has been disabled
+     * @throws InvalidArgurmentException
      */
-    public function start($callback = null)
+    public function start($callback = null, array $parameters = array())
     {
         if ($this->isRunning()) {
             throw new RuntimeException('Process is already running');
@@ -272,9 +277,8 @@ class Process
         $this->resetProcessData();
         $this->starttime = $this->lastOutputTime = microtime(true);
         $this->callback = $this->buildCallback($callback);
-        $descriptors = $this->getDescriptors();
-
-        $commandline = $this->commandline;
+        $commandline = $this->commandline->prepare($parameters);
+        list($descriptors, $commandline) = $this->getDescriptors($commandline);
 
         if (defined('PHP_WINDOWS_VERSION_BUILD') && $this->enhanceWindowsCompatibility) {
             $commandline = 'cmd /V:ON /E:ON /C "('.$commandline.')';
@@ -310,22 +314,24 @@ class Process
      *
      * @param callable|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR
+     * @param array         $parameters
      *
      * @return Process The new process
      *
      * @throws RuntimeException When process can't be launched
      * @throws RuntimeException When process is already running
+     * @throws InvalidArgumentException
      *
      * @see start()
      */
-    public function restart($callback = null)
+    public function restart($callback = null, array $parameters = array())
     {
         if ($this->isRunning()) {
             throw new RuntimeException('Process is already running');
         }
 
         $process = clone $this;
-        $process->start($callback);
+        $process->start($callback, $parameters);
 
         return $process;
     }
@@ -843,11 +849,13 @@ class Process
     /**
      * Gets the command line to be executed.
      *
-     * @return string The command to execute
+     * @param bool $asObject
+     *
+     * @return string|CommandLine The command to execute
      */
-    public function getCommandLine()
+    public function getCommandLine($asObject = false)
     {
-        return $this->commandline;
+        return $asObject ? $this->commandline : $this->commandline->getCommandLine();
     }
 
     /**
@@ -859,6 +867,9 @@ class Process
      */
     public function setCommandLine($commandline)
     {
+        if (!$commandline instanceof CommandLine) {
+            $commandline = new CommandLine($commandline);
+        }
         $this->commandline = $commandline;
 
         return $this;
@@ -1245,9 +1256,11 @@ class Process
     /**
      * Creates the descriptors needed by the proc_open.
      *
+     * @param string $commandline
+     *
      * @return array
      */
-    private function getDescriptors()
+    private function getDescriptors($commandline)
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->processPipes = WindowsPipes::create($this, $this->input);
@@ -1260,10 +1273,10 @@ class Process
             // last exit code is output on the fourth pipe and caught to work around --enable-sigchild
             $descriptors = array_merge($descriptors, array(array('pipe', 'w')));
 
-            $this->commandline = '('.$this->commandline.') 3>/dev/null; code=$?; echo $code >&3; exit $code';
+            $commandline = '('.$commandline.') 3>/dev/null; code=$?; echo $code >&3; exit $code';
         }
 
-        return $descriptors;
+        return array($descriptors, $commandline);
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -641,7 +641,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $termSignal = defined('SIGKILL') ? SIGKILL : 9;
 
-        $process = $this->getProcess('exec php -r "while (true) {}"');
+        $process = $this->getProcess('exec php -r "while (true) { }"');
         $process->start();
         posix_kill($process->getPid(), $termSignal);
 

--- a/src/Symfony/Component/Process/Tests/CommandLineTest.php
+++ b/src/Symfony/Component/Process/Tests/CommandLineTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Component\Process\Tests;
+
+use Symfony\Component\Process\CommandLine;
+
+class CommandLineTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideVariousCommandsAndParameters
+     */
+    public function testCommandLinePrepare($commandLine, $placeholder, $parameters, $expected)
+    {
+        $commandLine = new CommandLine($commandLine, $placeholder);
+        $this->assertSame($expected, $commandLine->prepare($parameters));
+    }
+
+    public function provideVariousCommandsAndParameters()
+    {
+        return array(
+            array("{} | grep {}", CommandLine::DEFAULT_PLACEHOLDER, array('/usr/bin/ls', 'symfony'), "'/usr/bin/ls' | grep 'symfony'"),
+            array("## | grep ##", '##', array('/usr/bin/ls', 'symfony'), "'/usr/bin/ls' | grep 'symfony'"),
+            array("{ } | grep {}", CommandLine::DEFAULT_PLACEHOLDER, array('symfony'), "{ } | grep 'symfony'"),
+            array("exec {} | grep {} > symfony.log", CommandLine::DEFAULT_PLACEHOLDER, array('/usr/bin/ls', 'symfony'), "exec '/usr/bin/ls' | grep 'symfony' > symfony.log"),
+            array("exec ## | grep ## > symfony.log", '##', array('/usr/bin/ls', 'symfony'), "exec '/usr/bin/ls' | grep 'symfony' > symfony.log"),
+            array("exec Ê™ | grep Ê™ > symfony.log", 'Ê™', array('/usr/bin/ls', 'symfony'), "exec '/usr/bin/ls' | grep 'symfony' > symfony.log"),
+            array("exec {} | grep {} > symfony.log", CommandLine::DEFAULT_PLACEHOLDER, array('i\'m', 'symfony'), "exec 'i'\\''m' | grep 'symfony' > symfony.log"),
+            array("{} | grep {}", CommandLine::DEFAULT_PLACEHOLDER, array('/usr/bin/ls', 'symfony'), "'/usr/bin/ls' | grep 'symfony'"),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | Not yet |

Hello, 

this is an alternative proposal to #11972.
Let me summarise which issues we have and what I propose:

We need to enforce our strategy to prevent command line injections as it's already done for SQL. At the moment, the ProcessBuilder we provide lacks of support for many use case, especially:
- pipe `|`
- redirections `>>`, `<`, `>`, etc... 
- `exec` functionality (it's not a command, it must not be escaped) rel #5759, #11335

In these cases, users do not use the `ProcessBuilder` as this one does not fit their needs ; they build the commandline by themselves.
In #11972, I proposed to add a fluent command builder. However, thinking more about it, it will be a mess to write and maintain, it's mostly writing a bash parser and I think it's a big work to do in order to solve something that should be easy. Moreover, writing such commandline builder would not be easy to use (just read the few comment of this PR, think about explicit precedence).

Discussing about this topic with @nicolas-grekas brought us to this proposal that is fully BC and provides an easy way for developers to prepare and run commands just as in SQL.

What do you think about it? 

Here's a sample of code that allows to build a safe and complex command:

``` php
$process = new Process('ls ## | grep ## > data.log && curl -XPOST ## 2>&1 --data-binary "@data.log" >/dev/null');
$process->run(null, array('.', '\'', 'http://localhost/endpoint'));
```

would run: 

```
ls '.' | grep ''\''' > data.log && curl -XPOST 'http://localhost/endpoint' 2>&1 --data-binary "@data.log" >/dev/null
```

It also can be used with named parameters:

``` php
$process = new Process('ls :dir: | grep :filter: > data.log && curl -XPOST :url: 2>&1 --data-binary "@data.log" >/dev/null');
$process->run(null, array(
    ':dir:' => '.',
    ':filter:' => '\'',
    ':url:' => 'http://localhost/endpoint',
));
```

would run: 

```
ls '.' | grep ''\''' > data.log && curl -XPOST 'http://localhost/endpoint' 2>&1 --data-binary "@data.log" >/dev/null
```

It's currently working, let me know what you think about it.
I currently propose to be straight on parameters: If parameters mismatch (missing, unused), the components throws an exception.
I also propose to use `{}` as default placeholder, it might be wrong, let me know if you have comments on this.

Last but not least, this PR still requires:
- [ ] more tests, especially for exceptions and named parameters
- [ ] documentation
- [ ] better integration with `ProcessBuilder` 
