### PR TITLE
[Security] Don't send remember cookie for sub request

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/ResponseListener.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/ResponseListener.php
@@ -27,6 +27,10 @@ class ResponseListener implements EventSubscriberInterface
      */
     public function onKernelResponse(FilterResponseEvent $event)
     {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
         $request = $event->getRequest();
         $response = $event->getResponse();
 

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Tests\RememberMe;
 
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,6 +33,21 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new ResponseListener();
         $listener->onKernelResponse($this->getEvent($request, $response));
+    }
+
+    public function testRememberMeCookieIsNotSendWithResponseForSubRequests()
+    {
+        $cookie = new Cookie('rememberme');
+
+        $request = $this->getRequest(array(
+            RememberMeServicesInterface::COOKIE_ATTR_NAME => $cookie,
+        ));
+
+        $response = $this->getResponse();
+        $response->headers->expects($this->never())->method('setCookie');
+
+        $listener = new ResponseListener();
+        $listener->onKernelResponse($this->getEvent($request, $response, HttpKernelInterface::SUB_REQUEST));
     }
 
     public function testRememberMeCookieIsNotSendWithResponse()
@@ -71,13 +87,15 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
         return $response;
     }
 
-    private function getEvent($request, $response)
+    private function getEvent($request, $response, $type = HttpKernelInterface::MASTER_REQUEST)
     {
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\FilterResponseEvent')
             ->disableOriginalConstructor()
             ->getMock();
 
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
+        $event->expects($this->any())->method('getRequestType')->will($this->returnValue($type));
+        $event->expects($this->any())->method('isMasterRequest')->will($this->returnValue($type === HttpKernelInterface::MASTER_REQUEST));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
 
         return $event;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Remember cookie shouldn't be sent for sub request
