### PR TITLE
compare version using PHP_VERSION_ID

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -1,6 +1,6 @@
 <?php
 
-if (version_compare(PHP_VERSION, '5.4', '>=') && gc_enabled()) {
+if (PHP_VERSION_ID >= 50400 && gc_enabled()) {
     // Disabling Zend Garbage Collection to prevent segfaults with PHP5.4+
     // https://bugs.php.net/bug.php?id=53976
     gc_disable();

--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -172,7 +172,7 @@ class CodeExtension extends \Twig_Extension
         $text = "$text at line $line";
 
         if (false !== $link = $this->getFileLink($file, $line)) {
-            if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            if (PHP_VERSION_ID >= 50400) {
                 $flags = ENT_QUOTES | ENT_SUBSTITUTE;
             } else {
                 $flags = ENT_QUOTES;

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -67,7 +67,7 @@ class FormThemeTest extends TestCase
 
     protected function getVariableGetter($name)
     {
-        if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -264,7 +264,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
     protected function getVariableGetter($name)
     {
-        if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -38,7 +38,7 @@ class TransNodeTest extends \PHPUnit_Framework_TestCase
     }
     protected function getVariableGetterWithoutStrictCheck($name)
     {
-        if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
         }
 
@@ -47,7 +47,7 @@ class TransNodeTest extends \PHPUnit_Framework_TestCase
 
     protected function getVariableGetterWithStrictCheck($name)
     {
-        if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             return sprintf('(isset($context["%s"]) ? $context["%s"] : $this->getContext($context, "%s"))', $name, $name, $name);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -29,7 +29,7 @@ class ServerRunCommand extends ContainerAwareCommand
      */
     public function isEnabled()
     {
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             return false;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -166,7 +166,7 @@ class CodeHelper extends Helper
         }
 
         if (false !== $link = $this->getFileLink($file, $line)) {
-            if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            if (PHP_VERSION_ID >= 50400) {
                 $flags = ENT_QUOTES | ENT_SUBSTITUTE;
             } else {
                 $flags = ENT_QUOTES;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
@@ -30,7 +30,7 @@ class SecurityRoutingIntegrationTest extends WebTestCase
      */
     public function testRoutingErrorIsExposedWhenNotProtected($config)
     {
-        if (strpos(PHP_OS, "WIN") === 0 && version_compare(phpversion(), "5.3.9", "<")) {
+        if (defined('PHP_WINDOWS_VERSION_BUILD') && PHP_VERSION_ID < 50309) {
             $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120 fixed in http://svn.php.net/viewvc?view=revision&revision=318366');
         }
 
@@ -46,7 +46,7 @@ class SecurityRoutingIntegrationTest extends WebTestCase
      */
     public function testRoutingErrorIsNotExposedForProtectedResourceWhenLoggedInWithInsufficientRights($config)
     {
-        if (strpos(PHP_OS, "WIN") === 0 && version_compare(phpversion(), "5.3.9", "<")) {
+        if (defined('PHP_WINDOWS_VERSION_BUILD') && PHP_VERSION_ID < 50309) {
             $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120 fixed in http://svn.php.net/viewvc?view=revision&revision=318366');
         }
 

--- a/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
+++ b/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\ClassLoader;
 
-if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+if (PHP_VERSION_ID >= 50400) {
     define('SYMFONY_TRAIT', T_TRAIT);
 } else {
     define('SYMFONY_TRAIT', 0);

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -22,7 +22,7 @@ class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
 {
     public function testTraitDependencies()
     {
-        if (version_compare(phpversion(), '5.4', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Requires PHP > 5.4');
 
             return;
@@ -100,7 +100,7 @@ class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testClassWithTraitsReordering(array $classes)
     {
-        if (version_compare(phpversion(), '5.4', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Requires PHP > 5.4');
 
             return;

--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -104,7 +104,7 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
             )),
         );
 
-        if (version_compare(PHP_VERSION, '5.4', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $data[] = array(__DIR__.'/Fixtures/php5.4', array(
                 'TFoo' => __DIR__.'/Fixtures/php5.4/traits.php',
                 'CFoo' => __DIR__.'/Fixtures/php5.4/traits.php',

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -186,7 +186,7 @@ class TextDescriptor extends Descriptor
      */
     private function formatDefaultValue($default)
     {
-        if (version_compare(PHP_VERSION, '5.4', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             return str_replace('\/', '/', json_encode($default));
         }
 

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -101,7 +101,7 @@ class ErrorHandler
 
         if ($level & (E_USER_DEPRECATED | E_DEPRECATED)) {
             if (isset(self::$loggers['deprecation'])) {
-                if (version_compare(PHP_VERSION, '5.4', '<')) {
+                if (PHP_VERSION_ID < 50400) {
                     $stack = array_map(
                         function ($row) {
                             unset($row['args']);

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -288,7 +288,7 @@ EOF;
      */
     private function formatArgs(array $args)
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $flags = ENT_QUOTES | ENT_SUBSTITUTE;
         } else {
             $flags = ENT_QUOTES;

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -530,7 +530,7 @@ class Crawler extends \SplObjectStorage
 
         $html = '';
         foreach ($this->getNode(0)->childNodes as $child) {
-            if (version_compare(PHP_VERSION, '5.3.6', '>=')) {
+            if (PHP_VERSION_ID >= 50306) {
                 // node parameter was added to the saveHTML() method in PHP 5.3.6
                 // @see http://php.net/manual/en/domdocument.savehtml.php
                 $html .= $child->ownerDocument->saveHTML($child);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -69,7 +69,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
         // The pipe in the parser pattern only works as of PHP 5.3.7
         // See http://bugs.php.net/54316
         $this->parseUsingPipe = null === $parseUsingPipe
-            ? version_compare(phpversion(), '5.3.7', '>=')
+            ? PHP_VERSION_ID >= 50307
             : $parseUsingPipe;
 
         // See http://php.net/manual/en/datetime.createfromformat.php

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php
@@ -65,7 +65,7 @@ class DefaultCsrfProvider implements CsrfProviderInterface
      */
     protected function getSessionId()
     {
-        if (version_compare(PHP_VERSION, '5.4', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             if (PHP_SESSION_NONE === session_status()) {
                 session_start();
             }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -60,7 +60,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         );
 
         // This test will fail < 5.3.9 - see https://bugs.php.net/51994
-        if (version_compare(phpversion(), '5.3.9', '>=')) {
+        if (PHP_VERSION_ID >= 50309) {
             $data[] = array('Y-z', '2010-33', '2010-02-03 00:00:00 UTC');
         }
 
@@ -111,7 +111,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
      */
     public function testReverseTransformUsingPipe($format, $input, $output)
     {
-        if (version_compare(phpversion(), '5.3.7', '<')) {
+        if (PHP_VERSION_ID < 50307) {
             $this->markTestSkipped('Pipe usage requires PHP 5.3.7 or newer.');
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/DefaultCsrfProviderTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/DefaultCsrfProviderTest.php
@@ -49,7 +49,7 @@ class DefaultCsrfProviderTest extends \PHPUnit_Framework_TestCase
     {
         session_id('touti');
 
-        if (!version_compare(PHP_VERSION, '5.4', '>=')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('This test requires PHP >= 5.4');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -324,7 +324,7 @@ class Response
             while (($level = ob_get_level()) > 0 && $level !== $previous) {
                 $previous = $level;
                 if ($obStatus[$level - 1]) {
-                    if (version_compare(PHP_VERSION, '5.4', '>=')) {
+                    if (PHP_VERSION_ID >= 50400) {
                         if (isset($obStatus[$level - 1]['flags']) && ($obStatus[$level - 1]['flags'] & PHP_OUTPUT_HANDLER_REMOVABLE)) {
                             ob_end_flush();
                         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  * @see http://php.net/sessionhandler
  */
 
-if (version_compare(phpversion(), '5.4.0', '>=')) {
+if (PHP_VERSION_ID >= 50400) {
     class NativeSessionHandler extends \SessionHandler
     {
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -100,7 +100,7 @@ class NativeSessionStorage implements SessionStorageInterface
         session_cache_limiter(''); // disable by default because it's managed by HeaderBag (if used)
         ini_set('session.use_cookies', 1);
 
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             session_register_shutdown();
         } else {
             register_shutdown_function('session_write_close');
@@ -130,11 +130,11 @@ class NativeSessionStorage implements SessionStorageInterface
             return true;
         }
 
-        if (version_compare(phpversion(), '5.4.0', '>=') && \PHP_SESSION_ACTIVE === session_status()) {
+        if (PHP_VERSION_ID >= 50400 && \PHP_SESSION_ACTIVE === session_status()) {
             throw new \RuntimeException('Failed to start the session: already started by PHP.');
         }
 
-        if (version_compare(phpversion(), '5.4.0', '<') && isset($_SESSION) && session_id()) {
+        if (PHP_VERSION_ID < 50400 && isset($_SESSION) && session_id()) {
             // not 100% fool-proof, but is the most reliable way to determine if a session is active in PHP 5.3
             throw new \RuntimeException('Failed to start the session: already started by PHP ($_SESSION is set).');
         }
@@ -366,13 +366,13 @@ class NativeSessionStorage implements SessionStorageInterface
         if (!$saveHandler instanceof AbstractProxy && $saveHandler instanceof \SessionHandlerInterface) {
             $saveHandler = new SessionHandlerProxy($saveHandler);
         } elseif (!$saveHandler instanceof AbstractProxy) {
-            $saveHandler = version_compare(phpversion(), '5.4.0', '>=') ?
+            $saveHandler = PHP_VERSION_ID >= 50400 ?
                 new SessionHandlerProxy(new \SessionHandler()) : new NativeProxy();
         }
         $this->saveHandler = $saveHandler;
 
         if ($this->saveHandler instanceof \SessionHandlerInterface) {
-            if (version_compare(phpversion(), '5.4.0', '>=')) {
+            if (PHP_VERSION_ID >= 50400) {
                 session_set_save_handler($this->saveHandler, false);
             } else {
                 session_set_save_handler(

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
@@ -72,7 +72,7 @@ abstract class AbstractProxy
      */
     public function isActive()
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             return $this->active = \PHP_SESSION_ACTIVE === session_status();
         }
 
@@ -93,7 +93,7 @@ abstract class AbstractProxy
      */
     public function setActive($flag)
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             throw new \LogicException('This method is disabled in PHP 5.4.0+');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -27,7 +27,7 @@ class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new NativeSessionStorage(array('name' => 'TESTING'), new NativeFileSessionHandler(sys_get_temp_dir()));
 
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->assertEquals('files', $storage->getSaveHandler()->getSaveHandlerName());
             $this->assertEquals('files', ini_get('session.save_handler'));
         } else {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeSessionHandlerTest.php
@@ -28,7 +28,7 @@ class NativeSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
         // note for PHPUnit optimisers - the use of assertTrue/False
         // here is deliberate since the tests do not require the classes to exist - drak
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->assertFalse($handler instanceof \SessionHandler);
             $this->assertTrue($handler instanceof NativeSessionHandler);
         } else {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -164,7 +164,7 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testSetSaveHandler53()
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
         }
 
@@ -186,7 +186,7 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testSetSaveHandler54()
     {
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
         }
 
@@ -211,7 +211,7 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
      */
     public function testStartedOutside53()
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
         }
 
@@ -234,7 +234,7 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
      */
     public function testCanStartOutside54()
     {
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -60,7 +60,7 @@ class PhpBridgeSessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testPhpSession53()
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
         }
 
@@ -84,7 +84,7 @@ class PhpBridgeSessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testPhpSession54()
     {
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -87,7 +87,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
 
     public function testIsActivePhp53()
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
         }
 
@@ -99,7 +99,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsActivePhp54()
     {
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
         }
 
@@ -110,7 +110,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
 
     public function testSetActivePhp53()
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
         }
 
@@ -126,7 +126,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetActivePhp54()
     {
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
         }
 
@@ -149,7 +149,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testNameExceptionPhp53()
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
         }
 
@@ -163,7 +163,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testNameExceptionPhp54()
     {
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
         }
 
@@ -187,7 +187,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testIdExceptionPhp53()
     {
-        if (version_compare(phpversion(), '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
         }
 
@@ -201,7 +201,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testIdExceptionPhp54()
     {
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -52,7 +52,7 @@ class SessionHandlerProxyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->proxy->isActive());
         $this->proxy->open('name', 'id');
-        if (version_compare(phpversion(), '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->assertTrue($this->proxy->isActive());
         } else {
             $this->assertFalse($this->proxy->isActive());

--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -107,7 +107,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
         }
         $renderedAttributes = '';
         if (count($attributes) > 0) {
-            if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            if (PHP_VERSION_ID >= 50400) {
                 $flags = ENT_QUOTES | ENT_SUBSTITUTE;
             } else {
                 $flags = ENT_QUOTES;

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -188,7 +188,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set('foobar', 'foobar');
         $controller = array(new self(), 'controllerMethod3');
 
-        if (version_compare(PHP_VERSION, '5.3.16', '==')) {
+        if (PHP_VERSION_ID === 50316) {
             $this->markTestSkipped('PHP 5.3.16 has a major bug in the Reflection sub-system');
         } else {
             try {

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/JsonBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/JsonBundleWriter.php
@@ -35,7 +35,7 @@ class JsonBundleWriter implements BundleWriterInterface
             }
         });
 
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             // Use JSON_PRETTY_PRINT so that we can see what changed in Git diffs
             file_put_contents(
                 $path.'/'.$locale.'.json',

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -200,7 +200,7 @@ class IntlDateFormatter
     {
         // intl allows timestamps to be passed as arrays - we don't
         if (is_array($timestamp)) {
-            $message = version_compare(PHP_VERSION, '5.3.4', '>=') ?
+            $message = PHP_VERSION_ID >= 50304 ?
                 'Only integer Unix timestamps and DateTime objects are supported' :
                 'Only integer Unix timestamps are supported';
 
@@ -209,11 +209,11 @@ class IntlDateFormatter
 
         // behave like the intl extension
         $argumentError = null;
-        if (version_compare(PHP_VERSION, '5.3.4', '<') && !is_int($timestamp)) {
+        if (PHP_VERSION_ID < 50304 && !is_int($timestamp)) {
             $argumentError = 'datefmt_format: takes either an array  or an integer timestamp value ';
-        } elseif (version_compare(PHP_VERSION, '5.3.4', '>=') && !is_int($timestamp) && !$timestamp instanceof \DateTime) {
+        } elseif (PHP_VERSION_ID >= 50304 && !is_int($timestamp) && !$timestamp instanceof \DateTime) {
             $argumentError = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object';
-            if (version_compare(PHP_VERSION, '5.5.0-dev', '>=') && !is_int($timestamp)) {
+            if (PHP_VERSION_ID >= 50500 && !is_int($timestamp)) {
                 $argumentError = sprintf('datefmt_format: string \'%s\' is not numeric, which would be required for it to be a valid date', $timestamp);
             }
         }
@@ -227,7 +227,7 @@ class IntlDateFormatter
         }
 
         // As of PHP 5.3.4, IntlDateFormatter::format() accepts DateTime instances
-        if (version_compare(PHP_VERSION, '5.3.4', '>=') && $timestamp instanceof \DateTime) {
+        if (PHP_VERSION_ID >= 50304 && $timestamp instanceof \DateTime) {
             $timestamp = $timestamp->getTimestamp();
         }
 
@@ -376,7 +376,7 @@ class IntlDateFormatter
         }
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID >= 50500) {
             return date_default_timezone_get();
         }
     }
@@ -541,7 +541,7 @@ class IntlDateFormatter
     {
         if (null === $timeZoneId) {
             // In PHP 5.5 if $timeZoneId is null it fallbacks to `date_default_timezone_get()` method
-            if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+            if (PHP_VERSION_ID >= 50500) {
                 $timeZoneId = date_default_timezone_get();
             } else {
                 // TODO: changes were made to ext/intl in PHP 5.4.4 release that need to be investigated since it will

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -816,10 +816,7 @@ class NumberFormatter
             // The negative PHP_INT_MAX was being converted to float
             if (
                 $value == self::$int32Range['negative'] &&
-                (
-                    (version_compare(PHP_VERSION, '5.4.0', '<') && version_compare(PHP_VERSION, '5.3.14', '>=')) ||
-                    version_compare(PHP_VERSION, '5.4.4', '>=')
-                )
+                ((PHP_VERSION_ID < 50400 && PHP_VERSION_ID >= 50314) || PHP_VERSION_ID >= 50404)
             ) {
                 return (int) $value;
             }
@@ -832,10 +829,7 @@ class NumberFormatter
             // A 32 bit integer was being generated instead of a 64 bit integer
             if (
                   ($value > self::$int32Range['positive'] || $value < self::$int32Range['negative']) &&
-                  (
-                      (version_compare(PHP_VERSION, '5.3.14', '<')) ||
-                      (version_compare(PHP_VERSION, '5.4.0', '>=') && version_compare(PHP_VERSION, '5.4.4', '<'))
-                  )
+                  (PHP_VERSION_ID < 50314 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404))
             ) {
                 $value = (-2147483648 - ($value % -2147483648)) * ($value / abs($value));
             }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
@@ -34,7 +34,7 @@ class JsonBundleWriterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('This test requires at least PHP 5.4.0.');
         }
 
@@ -47,7 +47,7 @@ class JsonBundleWriterTest extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+        if (PHP_VERSION_ID < 50400) {
             return;
         }
 

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -37,7 +37,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
         $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID >= 50500) {
             $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
         } else {
             $this->assertNull($formatter->getTimeZoneId());
@@ -238,7 +238,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
         );
 
         // As of PHP 5.3.4, IntlDateFormatter::format() accepts DateTime instances
-        if (version_compare(PHP_VERSION, '5.3.4', '>=')) {
+        if (PHP_VERSION_ID >= 50304) {
             $dateTime = new \DateTime('@0');
 
             /* general, DateTime */
@@ -269,7 +269,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     public function formatErrorProvider()
     {
         // With PHP 5.5 IntlDateFormatter accepts empty values ('0')
-        if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID >= 50500) {
             return array(
                 array('y-M-d', 'foobar', 'datefmt_format: string \'foobar\' is not numeric, which would be required for it to be a valid date: U_ILLEGAL_ARGUMENT_ERROR'),
             );
@@ -277,7 +277,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
         $message = 'datefmt_format: takes either an array  or an integer timestamp value : U_ILLEGAL_ARGUMENT_ERROR';
 
-        if (version_compare(PHP_VERSION, '5.3.4', '>=')) {
+        if (PHP_VERSION_ID >= 50304) {
             $message = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object: U_ILLEGAL_ARGUMENT_ERROR';
         }
 
@@ -326,7 +326,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
         );
 
         // As of PHP 5.5, intl ext no longer fallbacks invalid time zones to UTC
-        if (!version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID < 50500) {
             // When time zone not exists, uses UTC by default
             $data[] = array(0, 'Foo/Bar', '1970-01-01 00:00:00');
             $data[] = array(0, 'UTC+04:30', '1970-01-01 00:00:00');
@@ -340,7 +340,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID >= 50500) {
             $formatter->setTimeZone('GMT+03:00');
         } else {
             $formatter->setTimeZoneId('GMT+03:00');
@@ -353,7 +353,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID >= 50500) {
             $formatter->setTimeZone('GMT+00:30');
         } else {
             $formatter->setTimeZoneId('GMT+00:30');
@@ -366,7 +366,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID >= 50500) {
             $formatter->setTimeZone('Pacific/Fiji');
         } else {
             $formatter->setTimeZoneId('Pacific/Fiji');
@@ -388,7 +388,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatWithTimezoneFromEnvironmentVariable()
     {
-        if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID >= 50500) {
             $this->markTestSkipped('IntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
         }
 
@@ -411,7 +411,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatWithTimezoneFromPhp()
     {
-        if (!version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID < 50500) {
             $this->markTestSkipped('Only in PHP 5.5 IntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
         }
 
@@ -842,7 +842,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter();
 
-        if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
+        if (PHP_VERSION_ID >= 50500) {
             $formatter->setTimeZone($timeZoneId);
         } else {
             $formatter->setTimeZoneId($timeZoneId);

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -57,7 +57,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         } catch (\Exception $e) {
             $this->assertInstanceOf('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException', $e);
 
-            if (version_compare(PHP_VERSION, '5.3.4', '>=')) {
+            if (PHP_VERSION_ID >= 50304) {
                 $this->assertStringEndsWith('Only integer Unix timestamps and DateTime objects are supported.  Please install the "intl" extension for full localization capabilities.', $e->getMessage());
             } else {
                 $this->assertStringEndsWith('Only integer Unix timestamps are supported.  Please install the "intl" extension for full localization capabilities.', $e->getMessage());

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -593,10 +593,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
 
         // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
         // The negative PHP_INT_MAX was being converted to float
-        if (
-            (version_compare(PHP_VERSION, '5.4.0', '<') && version_compare(PHP_VERSION, '5.3.14', '>=')) ||
-            version_compare(PHP_VERSION, '5.4.4', '>=')
-        ) {
+        if ((PHP_VERSION_ID < 50400 && PHP_VERSION_ID >= 50314) || PHP_VERSION_ID >= 50404) {
             $this->assertInternalType('int', $parsedValue);
         } else {
             $this->assertInternalType('float', $parsedValue);
@@ -653,10 +650,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
 
         // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
         // A 32 bit integer was being generated instead of a 64 bit integer
-        if (
-            (version_compare(PHP_VERSION, '5.3.14', '<')) ||
-            (version_compare(PHP_VERSION, '5.4.0', '>=') && version_compare(PHP_VERSION, '5.4.4', '<'))
-        ) {
+        if (PHP_VERSION_ID < 50314 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404)) {
             $this->assertEquals(-2147483648, $parsedValue, '->parse() TYPE_INT64 does not use true 64 bit integers, using only the 32 bit range (PHP < 5.3.14 and PHP < 5.4.4).');
         } else {
             $this->assertEquals(2147483648, $parsedValue, '->parse() TYPE_INT64 uses true 64 bit integers (PHP >= 5.3.14 and PHP >= 5.4.4).');
@@ -667,10 +661,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
 
         // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
         // A 32 bit integer was being generated instead of a 64 bit integer
-        if (
-            (version_compare(PHP_VERSION, '5.3.14', '<')) ||
-            (version_compare(PHP_VERSION, '5.4.0', '>=') && version_compare(PHP_VERSION, '5.4.4', '<'))
-        ) {
+        if (PHP_VERSION_ID < 50314 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404)) {
             $this->assertEquals(2147483647, $parsedValue, '->parse() TYPE_INT64 does not use true 64 bit integers, using only the 32 bit range  (PHP < 5.3.14 and PHP < 5.4.4).');
         } else {
             $this->assertEquals(-2147483649, $parsedValue, '->parse() TYPE_INT64 uses true 64 bit integers (PHP >= 5.3.14 and PHP >= 5.4.4).');

--- a/src/Symfony/Component/Security/Core/Util/SecureRandom.php
+++ b/src/Symfony/Component/Security/Core/Util/SecureRandom.php
@@ -43,7 +43,7 @@ final class SecureRandom implements SecureRandomInterface
         $this->logger = $logger;
 
         // determine whether to use OpenSSL
-        if (defined('PHP_WINDOWS_VERSION_BUILD') && version_compare(PHP_VERSION, '5.3.4', '<')) {
+        if (defined('PHP_WINDOWS_VERSION_BUILD') && PHP_VERSION_ID < 50304) {
             $this->useOpenSsl = false;
         } elseif (!function_exists('openssl_random_pseudo_bytes')) {
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
@@ -66,7 +66,7 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     private function skipIfPhpVersionIsNotSupported()
     {
-        if (version_compare(phpversion(), '5.3.7', '<')) {
+        if (PHP_VERSION_ID < 50307) {
             $this->markTestSkipped('Requires PHP >= 5.3.7');
         }
     }

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -92,7 +92,7 @@ class JsonDecode implements DecoderInterface
         $recursionDepth = $context['json_decode_recursion_depth'];
         $options = $context['json_decode_options'];
 
-        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+        if (PHP_VERSION_ID >= 50400) {
             $decodedData = json_decode($data, $associative, $recursionDepth, $options);
         } else {
             $decodedData = json_decode($data, $associative, $recursionDepth);

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -462,7 +462,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     protected function initializeEscapers()
     {
         $that = $this;
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $flags = ENT_QUOTES | ENT_SUBSTITUTE;
         } else {
             $flags = ENT_QUOTES;

--- a/src/Symfony/Component/Yaml/Exception/ParseException.php
+++ b/src/Symfony/Component/Yaml/Exception/ParseException.php
@@ -125,7 +125,7 @@ class ParseException extends RuntimeException
         }
 
         if (null !== $this->parsedFile) {
-            if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            if (PHP_VERSION_ID >= 50400) {
                 $jsonOptions = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
             } else {
                 $jsonOptions = 0;

--- a/src/Symfony/Component/Yaml/Tests/ParseExceptionTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParseExceptionTest.php
@@ -19,7 +19,7 @@ class ParseExceptionTest extends \PHPUnit_Framework_TestCase
     public function testGetMessage()
     {
         $exception = new ParseException('Error message', 42, 'foo: bar', '/var/www/app/config.yml');
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $message = 'Error message in "/var/www/app/config.yml" at line 42 (near "foo: bar")';
         } else {
             $message = 'Error message in "\\/var\\/www\\/app\\/config.yml" at line 42 (near "foo: bar")';
@@ -31,7 +31,7 @@ class ParseExceptionTest extends \PHPUnit_Framework_TestCase
     public function testGetMessageWithUnicodeInFilename()
     {
         $exception = new ParseException('Error message', 42, 'foo: bar', 'äöü.yml');
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $message = 'Error message in "äöü.yml" at line 42 (near "foo: bar")';
         } else {
             $message = 'Error message in "\u00e4\u00f6\u00fc.yml" at line 42 (near "foo: bar")';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

To let opcode caches optimize cached code, the `PHP_VERSION_ID`
constant is used to detect the current PHP version instead of calling
`version_compare()` with `PHP_VERSION`.
