### PR TITLE
[Config] Improved FileLocator->isAbsolutePath()

### DIFF
--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -80,11 +80,11 @@ class FileLocator implements FileLocatorInterface
      */
     private function isAbsolutePath($file)
     {
-        if ($file[0] === '/' || $file[0] === '\\'
-            || (strlen($file) > 3 && ctype_alpha($file[0])
-                && $file[1] === ':'
-                && ($file[2] === '\\' || $file[2] === '/')
-            )
+        if (!is_string($file)) {
+            return false;
+        }
+
+        if (preg_match('~^(?:[a-z]:)?+[/\\\\]~i', $file)
             || null !== parse_url($file, PHP_URL_SCHEME)
         ) {
             return true;

--- a/src/Symfony/Component/Config/Tests/FileLocatorTest.php
+++ b/src/Symfony/Component/Config/Tests/FileLocatorTest.php
@@ -18,14 +18,18 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getIsAbsolutePathTests
      */
-    public function testIsAbsolutePath($path)
+    public function testIsAbsolutePath($path, $absolute = true)
     {
         $loader = new FileLocator(array());
         $r = new \ReflectionObject($loader);
         $m = $r->getMethod('isAbsolutePath');
         $m->setAccessible(true);
 
-        $this->assertTrue($m->invoke($loader, $path), '->isAbsolutePath() returns true for an absolute path');
+        if (true === $absolute) {
+            $this->assertTrue($m->invoke($loader, $path), '->isAbsolutePath() returns true for an absolute path');
+        } else {
+            $this->assertFalse($m->invoke($loader, $path), '->isAbsolutePath() returns false for anything that is not an absolute path');
+        }
     }
 
     public function getIsAbsolutePathTests()
@@ -37,6 +41,8 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
             array('\\server\\foo.xml'),
             array('https://server/foo.xml'),
             array('phar://server/foo.xml'),
+            array('', false),
+            array(array('/', 'foo.xml'), false),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `isAbsolutePath()` method used array notation to access string characters. Passing an empty string to it, would therefore generate an undefined offset error. Moreover, passing an array that had a slash or backslash in its first element would incorrectly pass as well, e.g. `array('/', 'what', 'ever')`.

Using a simple regular expression here seems like the way to go. It is shorter and easier to read.
