### PR TITLE
[Console] command list ordering, styles in command names bugfix #12051 

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -134,15 +134,17 @@ class ApplicationDescription
     private function sortCommands(array $commands)
     {
         $namespacedCommands = array();
+        $globalCommands = array();
         foreach ($commands as $name => $command) {
             $key = $this->application->extractNamespace($name, 1);
             if (!$key) {
-                $key = '_global';
+                $globalCommands['_global'][$name] = $command;
+            } else {
+                $namespacedCommands[$key][$name] = $command;
             }
-
-            $namespacedCommands[$key][$name] = $command;
         }
         ksort($namespacedCommands);
+        $namespacedCommands = array_merge($globalCommands, $namespacedCommands);
 
         foreach ($namespacedCommands as &$commands) {
             ksort($commands);

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -195,13 +195,15 @@ class TextDescriptor extends Descriptor
             // add commands by namespace
             foreach ($description->getNamespaces() as $namespace) {
                 if (!$describedNamespace && ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id']) {
-                    $this->writeText("\n");
-                    $this->writeText('<comment>'.$namespace['id'].'</comment>', $options);
+                    $this->writeText("\n<comment>", $options);
+                    $this->writeText($namespace['id'], array_merge($options, array('raw_output' => true)));
+                    $this->writeText("</comment>", $options);
                 }
 
                 foreach ($namespace['commands'] as $name) {
-                    $this->writeText("\n");
-                    $this->writeText(sprintf(" <info>%-${width}s</info> %s", $name, $description->getCommand($name)->getDescription()), $options);
+                    $this->writeText("\n <info>", $options);
+                    $this->writeText(sprintf("%-${width}s", $name), array_merge($options, array('raw_output' => true)));
+                    $this->writeText(sprintf("</info> %s", $description->getCommand($name)->getDescription()), $options);
                 }
             }
 

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -69,28 +69,9 @@ EOF;
         $application->add(new \Foo6Command());
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(array('command' => $command->getName()));
-        $output = <<<EOF
-Console Tool
 
-Usage:
- [options] command [arguments]
+        $regex = '/Available commands:\s*help\s*.*\s*list.*\s*<fg=blue>foo\s*<fg=blue>foo:bar<\/fg=blue>/';
 
-Options:
- --help (-h)           Display this help message.
- --quiet (-q)          Do not output any message.
- --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
- --version (-V)        Display this application version.
- --ansi                Force ANSI output.
- --no-ansi             Disable ANSI output.
- --no-interaction (-n) Do not ask any interactive question.
-
-Available commands:
- help                         Displays help for a command
- list                         Lists commands
-<fg=blue>foo
- <fg=blue>foo:bar</fg=blue>
-EOF;
-
-        $this->assertEquals($output, trim($commandTester->getDisplay(true)));
+        $this->assertRegExp($regex, $commandTester->getDisplay(true));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -61,4 +61,36 @@ EOF;
 
         $this->assertEquals($output, $commandTester->getDisplay(true));
     }
+
+    public function testExecuteListsCommandsNameAndNamespaceRaw()
+    {
+        require_once realpath(__DIR__.'/../Fixtures/Foo6Command.php');
+        $application = new Application();
+        $application->add(new \Foo6Command());
+        $commandTester = new CommandTester($command = $application->get('list'));
+        $commandTester->execute(array('command' => $command->getName()));
+        $output = <<<EOF
+Console Tool
+
+Usage:
+ [options] command [arguments]
+
+Options:
+ --help (-h)           Display this help message.
+ --quiet (-q)          Do not output any message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display this application version.
+ --ansi                Force ANSI output.
+ --no-ansi             Disable ANSI output.
+ --no-interaction (-n) Do not ask any interactive question.
+
+Available commands:
+ help                         Displays help for a command
+ list                         Lists commands
+<fg=blue>foo
+ <fg=blue>foo:bar</fg=blue>
+EOF;
+
+        $this->assertEquals($output, trim($commandTester->getDisplay(true)));
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo6Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo6Command.php
@@ -1,0 +1,13 @@
+<?php
+
+
+use Symfony\Component\Console\Command\Command;
+
+class Foo6Command extends Command
+{
+    protected function configure()
+    {
+        $this->setName('<fg=blue>foo:bar</fg=blue>');
+    }
+
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes? |
| Fixed tickets | #12051 |
| License | MIT |

This is my first pull request, hope everything is alright. 
- Fixes command ordering. Previously if you had a command with name `0name` it would show up before the global commands.
- Fixes command name looking different from the real one because of styling.
