### PR TITLE
[HttpFoundation] MongoDbSessionHandler::read() now checks for valid session age

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -159,8 +159,11 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function read($sessionId)
     {
+        $timeoutThreshold = new \MongoDate(time() - (int) ini_get('session.gc_maxlifetime'));
+
         $dbData = $this->getCollection()->findOne(array(
-            $this->options['id_field'] => $sessionId,
+            $this->options['id_field']   => $sessionId,
+            $this->options['time_field'] => array('$gt' => $timeoutThreshold),
         ));
 
         return null === $dbData ? '' : $dbData[$this->options['data_field']]->bin;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -42,6 +42,24 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      *  * id_field: The field name for storing the session id [default: _id]
      *  * data_field: The field name for storing the session data [default: data]
      *  * time_field: The field name for storing the timestamp [default: time]
+     *  * expiry_field: The field name for storing the expiry-timestamp [default: expires_at]
+     *
+     * It is strongly recommended to put an index on the `expiry_field` for
+     * garbage-collection. Alternatively it's possible to automatically expire
+     * the sessions in the database as described below:
+     *
+     * A TTL collections can be used on MongoDB 2.2+ to cleanup expired sessions
+     * automatically. Such an index can for example look like this:
+     *
+     *     db.<session-collection>.ensureIndex(
+     *         { "<expiry-field>": 1 },
+     *         { "expireAfterSeconds": 0 }
+     *     )
+     *
+     * More details on: http://docs.mongodb.org/manual/tutorial/expire-data/
+     *
+     * If you use such an index, you can drop `gc_probability` to 0 since
+     * no garbage-collection is required.
      *
      * @param \Mongo|\MongoClient $mongo   A MongoClient or Mongo instance
      * @param array               $options An associative array of field options
@@ -65,7 +83,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
             'id_field' => '_id',
             'data_field' => 'data',
             'time_field' => 'time',
-            'expiry_field' => false,
+            'expiry_field' => 'expires_at',
         ), $options);
     }
 
@@ -102,21 +120,8 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function gc($maxlifetime)
     {
-        /* Note: MongoDB 2.2+ supports TTL collections, which may be used in
-         * place of this method by indexing the "time_field" field with an
-         * "expireAfterSeconds" option. Regardless of whether TTL collections
-         * are used, consider indexing this field to make the remove query more
-         * efficient.
-         *
-         * See: http://docs.mongodb.org/manual/tutorial/expire-data/
-         */
-        if (false !== $this->options['expiry_field']) {
-            return true;
-        }
-        $time = new \MongoDate(time() - $maxlifetime);
-
         $this->getCollection()->remove(array(
-            $this->options['time_field'] => array('$lt' => $time),
+            $this->options['expiry_field'] => array('$lt' => new \MongoDate()),
         ));
 
         return true;
@@ -127,23 +132,13 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function write($sessionId, $data)
     {
+        $expiry = new \MongoDate(time() + (int) ini_get('session.gc_maxlifetime'));
+
         $fields = array(
             $this->options['data_field'] => new \MongoBinData($data, \MongoBinData::BYTE_ARRAY),
             $this->options['time_field'] => new \MongoDate(),
+            $this->options['expiry_field'] => $expiry,
         );
-
-        /* Note: As discussed in the gc method of this class. You can utilise
-         * TTL collections in MongoDB 2.2+
-         * We are setting the "expiry_field" as part of the write operation here
-         * You will need to create the index on your collection that expires documents
-         * at that time
-         * e.g.
-         * db.MySessionCollection.ensureIndex( { "expireAt": 1 }, { expireAfterSeconds: 0 } )
-         */
-        if (false !== $this->options['expiry_field']) {
-            $expiry = new \MongoDate(time() + (int) ini_get('session.gc_maxlifetime'));
-            $fields[$this->options['expiry_field']] = $expiry;
-        }
 
         $this->getCollection()->update(
             array($this->options['id_field'] => $sessionId),
@@ -159,11 +154,9 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function read($sessionId)
     {
-        $timeoutThreshold = new \MongoDate(time() - (int) ini_get('session.gc_maxlifetime'));
-
         $dbData = $this->getCollection()->findOne(array(
             $this->options['id_field']   => $sessionId,
-            $this->options['time_field'] => array('$gt' => $timeoutThreshold),
+            $this->options['expiry_field'] => array('$gte' => new \MongoDate()),
         ));
 
         return null === $dbData ? '' : $dbData[$this->options['data_field']]->bin;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -40,6 +40,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             'id_field' => '_id',
             'data_field' => 'data',
             'time_field' => 'time',
+            'expiry_field' => 'expires_at',
             'database' => 'sf2-test',
             'collection' => 'session-test',
         );
@@ -86,7 +87,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
         // defining the timeout before the actual method call
         // allows to test for "greater than" values in the $criteria
-        $testTimeout = time() - (int) ini_get('session.gc_maxlifetime');
+        $testTimeout = time();
 
         $collection->expects($this->once())
             ->method('findOne')
@@ -94,10 +95,10 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
                 $that->assertArrayHasKey($that->options['id_field'], $criteria);
                 $that->assertEquals($criteria[$that->options['id_field']], 'foo');
 
-                $that->assertArrayHasKey($that->options['time_field'], $criteria);
-                $that->assertArrayHasKey('$gt', $criteria[$that->options['time_field']]);
-                $that->assertInstanceOf('MongoDate', $criteria[$that->options['time_field']]['$gt']);
-                $that->assertGreaterThanOrEqual($criteria[$that->options['time_field']]['$gt']->sec, $testTimeout);
+                $that->assertArrayHasKey($that->options['expiry_field'], $criteria);
+                $that->assertArrayHasKey('$gte', $criteria[$that->options['expiry_field']]);
+                $that->assertInstanceOf('MongoDate', $criteria[$that->options['expiry_field']]['$gte']);
+                $that->assertGreaterThanOrEqual($criteria[$that->options['expiry_field']]['$gte']->sec, $testTimeout);
 
                 return array(
                     $that->options['id_field'] => 'foo',
@@ -130,49 +131,13 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
                 $data = $updateData['$set'];
             }));
 
+        $expectedExpiry = time() + (int) ini_get('session.gc_maxlifetime');
         $this->assertTrue($this->storage->write('foo', 'bar'));
 
         $this->assertEquals('bar', $data[$this->options['data_field']]->bin);
         $that->assertInstanceOf('MongoDate', $data[$this->options['time_field']]);
-    }
-
-    public function testWriteWhenUsingExpiresField()
-    {
-        $this->options = array(
-            'id_field' => '_id',
-            'data_field' => 'data',
-            'time_field' => 'time',
-            'database' => 'sf2-test',
-            'collection' => 'session-test',
-            'expiry_field' => 'expiresAt',
-        );
-
-        $this->storage = new MongoDbSessionHandler($this->mongo, $this->options);
-
-        $collection = $this->createMongoCollectionMock();
-
-        $this->mongo->expects($this->once())
-            ->method('selectCollection')
-            ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
-
-        $that = $this;
-        $data = array();
-
-        $collection->expects($this->once())
-            ->method('update')
-            ->will($this->returnCallback(function ($criteria, $updateData, $options) use ($that, &$data) {
-                $that->assertEquals(array($that->options['id_field'] => 'foo'), $criteria);
-                $that->assertEquals(array('upsert' => true, 'multiple' => false), $options);
-
-                $data = $updateData['$set'];
-            }));
-
-        $this->assertTrue($this->storage->write('foo', 'bar'));
-
-        $this->assertEquals('bar', $data[$this->options['data_field']]->bin);
-        $that->assertInstanceOf('MongoDate', $data[$this->options['time_field']]);
-        $that->assertInstanceOf('MongoDate', $data[$this->options['expiry_field']]);
+        $this->assertInstanceOf('MongoDate', $data[$this->options['expiry_field']]);
+        $this->assertGreaterThanOrEqual($expectedExpiry, $data[$this->options['expiry_field']]->sec);
     }
 
     public function testReplaceSessionData()
@@ -228,35 +193,9 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $collection->expects($this->once())
             ->method('remove')
             ->will($this->returnCallback(function ($criteria) use ($that) {
-                $that->assertInstanceOf('MongoDate', $criteria[$that->options['time_field']]['$lt']);
-                $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['time_field']]['$lt']->sec);
+                $that->assertInstanceOf('MongoDate', $criteria[$that->options['expiry_field']]['$lt']);
+                $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['expiry_field']]['$lt']->sec);
             }));
-
-        $this->assertTrue($this->storage->gc(1));
-    }
-
-    public function testGcWhenUsingExpiresField()
-    {
-        $this->options = array(
-            'id_field' => '_id',
-            'data_field' => 'data',
-            'time_field' => 'time',
-            'database' => 'sf2-test',
-            'collection' => 'session-test',
-            'expiry_field' => 'expiresAt',
-        );
-
-        $this->storage = new MongoDbSessionHandler($this->mongo, $this->options);
-
-        $collection = $this->createMongoCollectionMock();
-
-        $this->mongo->expects($this->never())
-            ->method('selectCollection');
-
-        $that = $this;
-
-        $collection->expects($this->never())
-            ->method('remove');
 
         $this->assertTrue($this->storage->gc(1));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

As discussed with @jmikola: 
- It's a bugfix - expired sessions should never be read
- Therefore should be merged into 2.3 LTS
- TODO: Modify the behavior to match the PDO adapter
- TODO: Add a precise description of the behavior to the manual

-- old description below --

This patch can be seen as either bugfix or feature, though it's probably more on the feature-side. 

Currently a session will be returned by `read()` even if it's already older than `gc_maxlifetime`. If `gc_maxlifetime` is used for timing out sessions and a low gc-ratio is in place there is a high chance the session stays alive for a longer time than wanted. The manual describes the current limitations of `gc_maxlifetime` correctly at http://symfony.com/doc/current/components/http_foundation/session_configuration.html#session-lifetime.

But since the modification timestamp is stored in MongoDB anway, we can actually use it to only return "valid" session-data as does the [PdoSessionHandler](https://github.com/symfony/HttpFoundation/blob/2.7/Session/Storage/Handler/PdoSessionHandler.php#L518)
