### PR TITLE
No call_user_func()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -45,7 +45,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -36,7 +36,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -32,7 +32,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
@@ -51,7 +51,7 @@ class RuntimeInstantiator implements InstantiatorInterface
         return $this->factory->createProxy(
             $definition->getClass(),
             function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($realInstantiator) {
-                $wrappedInstance = call_user_func($realInstantiator);
+                $wrappedInstance = $realInstantiator();
 
                 $proxy->setProxyInitializer(null);
 

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -32,7 +32,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -54,7 +54,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -36,7 +36,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -74,10 +74,6 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
-    public function init()
-    {
-    }
-
     public function getRootDir()
     {
         return __DIR__;

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -58,7 +58,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -74,10 +74,6 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
-    public function init()
-    {
-    }
-
     public function getRootDir()
     {
         return __DIR__;

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -39,7 +39,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -37,7 +37,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -34,7 +34,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -33,7 +33,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -28,7 +28,7 @@
     "target-dir": "Symfony/Component/ClassLoader",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -225,8 +225,10 @@ class ExprBuilder
     {
         foreach ($expressions as $k => $expr) {
             if ($expr instanceof ExprBuilder) {
-                $expressions[$k] = function ($v) use ($expr) {
-                    return call_user_func($expr->ifPart, $v) ? call_user_func($expr->thenPart, $v) : $v;
+                $ifPart = $expr->ifPart;
+                $thenPart = $expr->thenPart;
+                $expressions[$k] = function ($v) use ($ifPart, $thenPart) {
+                    return $ifPart($v) ? $thenPart($v) : $v;
                 };
             }
         }

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -49,7 +49,9 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
      */
     public function getDefaultValue()
     {
-        return $this->defaultValue instanceof \Closure ? call_user_func($this->defaultValue) : $this->defaultValue;
+        $v = $this->defaultValue;
+
+        return $v instanceof \Closure ? $v() : $v;
     }
 
     /**

--- a/src/Symfony/Component/Config/Exception/FileLoaderImportCircularReferenceException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderImportCircularReferenceException.php
@@ -22,6 +22,6 @@ class FileLoaderImportCircularReferenceException extends FileLoaderLoadException
     {
         $message = sprintf('Circular reference detected in "%s" ("%s" > "%s").', $this->varToString($resources[0]), implode('" > "', $resources), $resources[0]);
 
-        call_user_func('Exception::__construct', $message, $code, $previous);
+        \Exception::__construct($message, $code, $previous);
     }
 }

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -75,7 +75,7 @@ class XmlUtils
             $e = null;
             if (is_callable($schemaOrCallable)) {
                 try {
-                    $valid = call_user_func($schemaOrCallable, $dom, $internalErrors);
+                    $valid = $schemaOrCallable($dom, $internalErrors);
                 } catch (\Exception $e) {
                     $valid = false;
                 }

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -246,8 +246,8 @@ class Command
 
         $input->validate();
 
-        if ($this->code) {
-            $statusCode = call_user_func($this->code, $input, $output);
+        if ($code = $this->code) {
+            $statusCode = $code($input, $output);
         } else {
             $statusCode = $this->execute($input, $output);
         }

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -467,7 +467,7 @@ class DialogHelper extends InputAwareHelper
             }
 
             try {
-                return call_user_func($validator, $interviewer());
+                return $validator($interviewer());
             } catch (\Exception $error) {
             }
         }

--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -117,7 +117,7 @@ class ProcessHelper extends Helper
             $output->write($formatter->progress(spl_object_hash($process), $that->escapeString($buffer), Process::ERR === $type));
 
             if (null !== $callback) {
-                call_user_func($callback, $type, $buffer);
+                $callback($type, $buffer);
             }
         };
     }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -438,7 +438,7 @@ class ProgressBar
         $messages = $this->messages;
         $this->overwrite(preg_replace_callback("{%([a-z\-_]+)(?:\:([^%]+))?%}i", function ($matches) use ($self, $output, $messages) {
             if ($formatter = $self::getPlaceholderFormatterDefinition($matches[1])) {
-                $text = call_user_func($formatter, $self, $output);
+                $text = $formatter($self, $output);
             } elseif (isset($messages[$matches[1]])) {
                 $text = $messages[$matches[1]];
             } else {

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -353,13 +353,14 @@ class QuestionHelper extends Helper
     {
         $error = null;
         $attempts = $question->getMaxAttempts();
+        $validator = $question->getValidator();
         while (null === $attempts || $attempts--) {
             if (null !== $error) {
                 $output->writeln($this->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
             }
 
             try {
-                return call_user_func($question->getValidator(), $interviewer());
+                return $validator($interviewer());
             } catch (\Exception $error) {
             }
         }

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -35,7 +35,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -205,7 +205,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Node "%s" not supported.', $node->getNodeName()));
         }
 
-        return call_user_func($this->nodeTranslators[$node->getNodeName()], $node, $this);
+        return $this->nodeTranslators[$node->getNodeName()]($node, $this);
     }
 
     /**
@@ -223,7 +223,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Combiner "%s" not supported.', $combiner));
         }
 
-        return call_user_func($this->combinationTranslators[$combiner], $this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
+        return $this->combinationTranslators[$combiner]($this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
     }
 
     /**
@@ -240,7 +240,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Function "%s" not supported.', $function->getName()));
         }
 
-        return call_user_func($this->functionTranslators[$function->getName()], $xpath, $function);
+        return $this->functionTranslators[$function->getName()]($xpath, $function);
     }
 
     /**
@@ -257,7 +257,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Pseudo-class "%s" not supported.', $pseudoClass));
         }
 
-        return call_user_func($this->pseudoClassTranslators[$pseudoClass], $xpath);
+        return $this->pseudoClassTranslators[$pseudoClass]($xpath);
     }
 
     /**
@@ -276,7 +276,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Attribute matcher operator "%s" not supported.', $operator));
         }
 
-        return call_user_func($this->attributeMatchingTranslators[$operator], $xpath, $attribute, $value);
+        return $this->attributeMatchingTranslators[$operator]($xpath, $attribute, $value);
     }
 
     /**

--- a/src/Symfony/Component/CssSelector/composer.json
+++ b/src/Symfony/Component/CssSelector/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -150,12 +150,13 @@ class DebugClassLoader
         ErrorHandler::stackErrors();
 
         try {
+            $classLoader = $this->classLoader;
             if ($this->isFinder) {
-                if ($file = $this->classLoader[0]->findFile($class)) {
+                if ($file = $classLoader[0]->findFile($class)) {
                     require $file;
                 }
             } else {
-                call_user_func($this->classLoader, $class);
+                $classLoader($class);
                 $file = false;
             }
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -466,11 +466,11 @@ class ErrorHandler
                 }
             }
         }
-        if (empty($this->exceptionHandler)) {
+        if (!$exceptionHandler = $this->exceptionHandler) {
             throw $exception; // Give back $exception to the native handler
         }
         try {
-            call_user_func($this->exceptionHandler, $exception);
+            $exceptionHandler($exception);
         } catch (\Exception $handlerException) {
             $this->exceptionHandler = null;
             $this->handleException($handlerException);

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -108,7 +108,7 @@ class ExceptionHandler
      */
     public function handle(\Exception $exception)
     {
-        if (null === $this->handler || $exception instanceof OutOfMemoryException) {
+        if (null === $handler = $this->handler || $exception instanceof OutOfMemoryException) {
             $this->failSafeHandle($exception);
 
             return;
@@ -129,7 +129,7 @@ class ExceptionHandler
         $this->caughtBuffer = null;
 
         try {
-            call_user_func($this->handler, $exception);
+            $handler($exception);
             $this->caughtLength = $caughtLength;
         } catch (\Exception $e) {
             if (!$caughtLength) {

--- a/src/Symfony/Component/Debug/composer.json
+++ b/src/Symfony/Component/Debug/composer.json
@@ -34,7 +34,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -992,7 +992,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 throw new InvalidArgumentException(sprintf('The configure callable for class "%s" is not a callable.', get_class($service)));
             }
 
-            call_user_func($callable, $service);
+            $callable($service);
         }
 
         return $service;

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
@@ -28,6 +28,6 @@ class RealServiceInstantiator implements InstantiatorInterface
      */
     public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
     {
-        return call_user_func($realInstantiator);
+        return $realInstantiator();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
@@ -40,7 +40,7 @@ class ClosureLoader extends Loader
      */
     public function load($resource, $type = null)
     {
-        call_user_func($resource, $this->container);
+        $resource($this->container);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -42,7 +42,9 @@ class ProjectServiceContainer extends Container
      */
     protected function getServiceFromAnonymousFactoryService()
     {
-        return $this->services['service_from_anonymous_factory'] = call_user_func(array(new \Bar\FooClass(), 'getInstance'));
+        $foo = new \Bar\FooClass();
+
+        return $this->services['service_from_anonymous_factory'] = $foo->getInstance();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -211,9 +211,11 @@ class ProjectServiceContainer extends Container
      */
     protected function getFoo_BazService()
     {
-        $this->services['foo.baz'] = $instance = call_user_func(array($this->getParameter('baz_class'), 'getInstance'));
+        $baz = array($this->getParameter('baz_class'), 'getInstance');
+        $this->services['foo.baz'] = $instance = $baz();
 
-        call_user_func(array($this->getParameter('baz_class'), 'configureStatic1'), $instance);
+        $baz[1] = 'configureStatic1';
+        $baz($instance);
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -35,7 +35,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -56,7 +56,8 @@ class WrappedListener
 
         $e = $this->stopwatch->start($this->name, 'event_listener');
 
-        call_user_func($this->listener, $event, $eventName, $dispatcher);
+        $listener = $this->listener;
+        $listener($event, $eventName, $dispatcher);
 
         if ($e->isStarted()) {
             $e->stop();

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -161,7 +161,7 @@ class EventDispatcher implements EventDispatcherInterface
     protected function doDispatch($listeners, $eventName, Event $event)
     {
         foreach ($listeners as $listener) {
-            call_user_func($listener, $event, $eventName, $this);
+            $listener($event, $eventName, $this);
             if ($event->isPropagationStopped()) {
                 break;
             }

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -36,7 +36,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -88,10 +88,10 @@ class BinaryNode extends Node
             $right = $this->nodes['right']->evaluate($functions, $values);
 
             if ('not in' == $operator) {
-                return !call_user_func('in_array', $left, $right);
+                return !in_array($left, $right);
             }
 
-            return call_user_func(self::$functions[$operator], $left, $right);
+            return self::$functions[$operator]($left, $right);
         }
 
         switch ($operator) {

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
@@ -53,7 +53,7 @@ class CustomFilterIterator extends FilterIterator
         $fileinfo = $this->current();
 
         foreach ($this->filters as $filter) {
-            if (false === call_user_func($filter, $fileinfo)) {
+            if (false === $filter($fileinfo)) {
                 return false;
             }
         }

--- a/src/Symfony/Component/Finder/Shell/Command.php
+++ b/src/Symfony/Component/Finder/Shell/Command.php
@@ -246,14 +246,14 @@ class Command
      */
     public function execute()
     {
-        if (null === $this->errorHandler) {
+        if (null === $errorHandler = $this->errorHandler) {
             exec($this->join(), $output);
         } else {
             $process = proc_open($this->join(), array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => array('pipe', 'w')), $pipes);
             $output = preg_split('~(\r\n|\r|\n)~', stream_get_contents($pipes[1]), -1, PREG_SPLIT_NO_EMPTY);
 
             if ($error = stream_get_contents($pipes[2])) {
-                call_user_func($this->errorHandler, $error);
+                $errorHandler($error);
             }
 
             proc_close($process);

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -61,7 +61,9 @@ class CallbackTransformer implements DataTransformerInterface
      */
     public function transform($data)
     {
-        return call_user_func($this->transform, $data);
+        $t = $this->transform;
+
+        return $t($data);
     }
 
     /**
@@ -77,6 +79,8 @@ class CallbackTransformer implements DataTransformerInterface
      */
     public function reverseTransform($data)
     {
-        return call_user_func($this->reverseTransform, $data);
+        $r = $this->reverseTransform;
+
+        return $r($data);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -198,7 +198,7 @@ class FormValidator extends ConstraintValidator
     private static function resolveValidationGroups($groups, FormInterface $form)
     {
         if (!is_string($groups) && is_callable($groups)) {
-            $groups = call_user_func($groups, $form);
+            $groups = $groups($form);
         }
 
         return (array) $groups;

--- a/src/Symfony/Component/Form/README.md
+++ b/src/Symfony/Component/Form/README.md
@@ -14,7 +14,7 @@ https://github.com/fabpot/Silex/blob/master/src/Silex/Provider/FormServiceProvid
 
 Documentation:
 
-http://symfony.com/doc/2.7/book/forms.html
+http://symfony.com/doc/3.0/book/forms.html
 
 Resources
 ---------

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -42,7 +42,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1874,8 +1874,8 @@ class Request
 
     private static function createRequestFromFactory(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null)
     {
-        if (self::$requestFactory) {
-            $request = call_user_func(self::$requestFactory, $query, $request, $attributes, $cookies, $files, $server, $content);
+        if ($requestFactory = self::$requestFactory) {
+            $request = $requestFactory($query, $request, $attributes, $cookies, $files, $server, $content);
 
             if (!$request instanceof Request) {
                 throw new \LogicException('The Request factory must return an instance of Symfony\Component\HttpFoundation\Request.');

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -92,11 +92,11 @@ class StreamedResponse extends Response
 
         $this->streamed = true;
 
-        if (null === $this->callback) {
+        if (null === $callback = $this->callback) {
             throw new \LogicException('The Response callback must not be null.');
         }
 
-        call_user_func($this->callback);
+        $callback();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -348,9 +348,9 @@ class MockPdo extends \PDO
 
     public function prepare($statement, $driverOptions = array())
     {
-        return is_callable($this->prepareResult)
-            ? call_user_func($this->prepareResult, $statement, $driverOptions)
-            : $this->prepareResult;
+        return is_callable($prepareResult = $this->prepareResult)
+            ? $prepareResult($statement, $driverOptions)
+            : $prepareResult;
     }
 
     public function beginTransaction()

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.0.0
+-----
+
+* Removed `Symfony\Component\HttpKernel\Kernel::init()`
+
 2.6.0
 -----
 
@@ -24,7 +29,7 @@ CHANGELOG
  * [BC BREAK] renamed `Symfony\Component\HttpKernel\EventListener\DeprecationLoggerListener` to `Symfony\Component\HttpKernel\EventListener\ErrorsLoggerListener` and changed its constructor
  * deprecated `Symfony\Component\HttpKernel\Debug\ErrorHandler`, `Symfony\Component\HttpKernel\Debug\ExceptionHandler`,
    `Symfony\Component\HttpKernel\Exception\FatalErrorException`, and `Symfony\Component\HttpKernel\Exception\FlattenException`
- * deprecated `Symfony\Component\HttpKernel\Kernel::init()``
+ * deprecated `Symfony\Component\HttpKernel\Kernel::init()`
  * added the possibility to specify an id an extra attributes to hinclude tags
  * added the collect of data if a controller is a Closure in the Request collector
  * pass exceptions from the ExceptionListener to the logger using the logging context to allow for more

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,10 +59,10 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.0-DEV';
-    const VERSION_ID = '20700';
-    const MAJOR_VERSION = '2';
-    const MINOR_VERSION = '7';
+    const VERSION = '3.0.0-DEV';
+    const VERSION_ID = '30000';
+    const MAJOR_VERSION = '3';
+    const MINOR_VERSION = '0';
     const RELEASE_VERSION = '0';
     const EXTRA_VERSION = 'DEV';
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -84,15 +84,6 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         if ($this->debug) {
             $this->startTime = microtime(true);
         }
-
-        $this->init();
-    }
-
-    /**
-     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Move your logic in the constructor instead.
-     */
-    public function init()
-    {
     }
 
     public function __clone()

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -69,10 +69,6 @@ class KernelForTest extends Kernel
     {
     }
 
-    public function init()
-    {
-    }
-
     public function getBundles()
     {
         return array();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -72,8 +72,8 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
 
         $response = new Response($this->body, $this->status, $this->headers);
 
-        if (null !== $this->customizer) {
-            call_user_func($this->customizer, $request, $response);
+        if (null !== $customizer = $this->customizer) {
+            $customizer($request, $response);
         }
 
         return $response;

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -53,7 +53,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Intl/README.md
+++ b/src/Symfony/Component/Intl/README.md
@@ -22,4 +22,4 @@ You can run the unit tests with the following command:
     $ phpunit
 
 [0]: http://www.php.net/manual/en/intl.setup.php
-[1]: http://symfony.com/doc/2.7/components/intl.html
+[1]: http://symfony.com/doc/3.0/components/intl.html

--- a/src/Symfony/Component/Intl/composer.json
+++ b/src/Symfony/Component/Intl/composer.json
@@ -41,7 +41,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -833,7 +833,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             // BEGIN
             $this->calling[$option] = true;
             foreach ($this->lazy[$option] as $closure) {
-                $value = call_user_func($closure, $this, $value);
+                $value = $closure($this, $value);
             }
             unset($this->calling[$option]);
             // END
@@ -929,7 +929,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             // dependency
             // BEGIN
             $this->calling[$option] = true;
-            $value = call_user_func($normalizer, $this, $value);
+            $value = $normalizer($this, $value);
             unset($this->calling[$option]);
             // END
         }

--- a/src/Symfony/Component/OptionsResolver/composer.json
+++ b/src/Symfony/Component/OptionsResolver/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1289,7 +1289,7 @@ class Process
             }
 
             if (null !== $callback) {
-                call_user_func($callback, $type, $data);
+                $callback($type, $data);
             }
         };
 
@@ -1369,12 +1369,13 @@ class Process
     private function readPipes($blocking, $close)
     {
         $result = $this->processPipes->readAndWrite($blocking, $close);
+        $callback = $this->callback;
 
         foreach ($result as $type => $data) {
             if (3 == $type) {
                 $this->fallbackExitcode = (int) $data;
             } else {
-                call_user_func($this->callback, $type === self::STDOUT ? self::OUT : self::ERR, $data);
+                $callback($type === self::STDOUT ? self::OUT : self::ERR, $data);
             }
         }
     }

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -865,7 +865,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     {
         $process = $this->getProcess('php -m');
         $this->setExpectedException('Symfony\Component\Process\Exception\LogicException', sprintf('Process must be started before calling %s.', $method));
-        call_user_func(array($process, $method));
+        $process->{$method}();
     }
 
     public function provideMethodsThatNeedARunningProcess()
@@ -887,7 +887,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $process = $this->getProcess('php -r "sleep(1);"');
         $process->start();
         try {
-            call_user_func(array($process, $method));
+            $process->{$method}();
             $process->stop(0);
             $this->fail('A LogicException must have been thrown');
         } catch (\Exception $e) {
@@ -1013,7 +1013,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $p = $this->getProcess('php -r "usleep(500000);"');
         $p->disableOutput();
         $this->setExpectedException($exception, $exceptionMessage);
-        call_user_func(array($p, $startMethod), function () {});
+        $p->{$startMethod}(function () {});
     }
 
     public function provideStartMethods()
@@ -1034,7 +1034,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $p->disableOutput();
         $p->start();
         $this->setExpectedException('Symfony\Component\Process\Exception\LogicException', 'Output has been disabled.');
-        call_user_func(array($p, $fetchMethod));
+        $p->{$fetchMethod}();
     }
 
     public function provideOutputFetchingMethods()

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -505,11 +505,11 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         foreach ($itemToRemove as $item) {
-            call_user_func(array($object, $removeMethod), $item);
+            $object->{$removeMethod}($item);
         }
 
         foreach ($itemsToAdd as $item) {
-            call_user_func(array($object, $addMethod), $item);
+            $object->{$addMethod}($item);
         }
     }
 

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Routing/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ClosureLoader.php
@@ -37,7 +37,7 @@ class ClosureLoader extends Loader
      */
     public function load($closure, $type = null)
     {
-        return call_user_func($closure);
+        return $closure();
     }
 
     /**

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -39,7 +39,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Security/Acl/README.md
+++ b/src/Symfony/Component/Security/Acl/README.md
@@ -11,7 +11,7 @@ Resources
 
 Documentation:
 
-http://symfony.com/doc/2.7/book/security.html
+http://symfony.com/doc/3.0/book/security.html
 
 Tests
 -----

--- a/src/Symfony/Component/Security/Acl/composer.json
+++ b/src/Symfony/Component/Security/Acl/composer.json
@@ -36,7 +36,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Security/Core/README.md
+++ b/src/Symfony/Component/Security/Core/README.md
@@ -11,7 +11,7 @@ Resources
 
 Documentation:
 
-http://symfony.com/doc/2.7/book/security.html
+http://symfony.com/doc/3.0/book/security.html
 
 Tests
 -----

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -40,7 +40,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Security/Csrf/README.md
+++ b/src/Symfony/Component/Security/Csrf/README.md
@@ -9,7 +9,7 @@ Resources
 
 Documentation:
 
-http://symfony.com/doc/2.7/book/security.html
+http://symfony.com/doc/3.0/book/security.html
 
 Tests
 -----

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -32,7 +32,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/README.md
+++ b/src/Symfony/Component/Security/Http/README.md
@@ -11,7 +11,7 @@ Resources
 
 Documentation:
 
-http://symfony.com/doc/2.7/book/security.html
+http://symfony.com/doc/3.0/book/security.html
 
 Tests
 -----

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -38,7 +38,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Security/README.md
+++ b/src/Symfony/Component/Security/README.md
@@ -11,7 +11,7 @@ Resources
 
 Documentation:
 
-http://symfony.com/doc/2.7/book/security.html
+http://symfony.com/doc/3.0/book/security.html
 
 Tests
 -----

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -52,7 +52,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -138,8 +138,8 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
             if ($context['circular_reference_limit'][$objectHash] >= $this->circularReferenceLimit) {
                 unset($context['circular_reference_limit'][$objectHash]);
 
-                if ($this->circularReferenceHandler) {
-                    return call_user_func($this->circularReferenceHandler, $object);
+                if ($circularReferenceHandler = $this->circularReferenceHandler) {
+                    return $circularReferenceHandler($object);
                 }
 
                 throw new CircularReferenceException(sprintf('A circular reference has been detected (configured limit: %d).', $this->circularReferenceLimit));
@@ -164,7 +164,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
 
                 $attributeValue = $method->invoke($object);
                 if (array_key_exists($attributeName, $this->callbacks)) {
-                    $attributeValue = call_user_func($this->callbacks[$attributeName], $attributeValue);
+                    $attributeValue = $this->callbacks[$attributeName]($attributeValue);
                 }
                 if (null !== $attributeValue && !is_scalar($attributeValue)) {
                     if (!$this->serializer instanceof NormalizerInterface) {

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -97,7 +97,7 @@ class PropertyNormalizer extends SerializerAwareNormalizer implements Normalizer
             $attributeValue = $property->getValue($object);
 
             if (array_key_exists($property->name, $this->callbacks)) {
-                $attributeValue = call_user_func($this->callbacks[$property->name], $attributeValue);
+                $attributeValue = $this->callbacks[$property->name]($attributeValue);
             }
             if (null !== $attributeValue && !is_scalar($attributeValue)) {
                 $attributeValue = $this->serializer->normalize($attributeValue, $format);

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -344,17 +344,19 @@ class PhpEngine implements EngineInterface, \ArrayAccess
             return $value;
         }
 
+        $escaper = $this->getEscaper($context);
+
         // If we deal with a scalar value, we can cache the result to increase
         // the performance when the same value is escaped multiple times (e.g. loops)
         if (is_scalar($value)) {
             if (!isset(self::$escaperCache[$context][$value])) {
-                self::$escaperCache[$context][$value] = call_user_func($this->getEscaper($context), $value);
+                self::$escaperCache[$context][$value] = $escaper($value);
             }
 
             return self::$escaperCache[$context][$value];
         }
 
-        return call_user_func($this->getEscaper($context), $value);
+        return $escaper($value);
     }
 
     /**

--- a/src/Symfony/Component/Templating/composer.json
+++ b/src/Symfony/Component/Templating/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -40,7 +40,7 @@ class PluralizationRules
         }
 
         if (isset(self::$rules[$locale])) {
-            $return = call_user_func(self::$rules[$locale], $number);
+            $return = self::$rules[$locale]($number);
 
             if (!is_int($return) || $return < 0) {
                 return 0;

--- a/src/Symfony/Component/Translation/README.md
+++ b/src/Symfony/Component/Translation/README.md
@@ -28,7 +28,7 @@ https://github.com/fabpot/Silex/blob/master/src/Silex/Provider/TranslationServic
 
 Documentation:
 
-http://symfony.com/doc/2.7/book/translation.html
+http://symfony.com/doc/3.0/book/translation.html
 
 You can run the unit tests with the following command:
 

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -36,7 +36,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -55,7 +55,7 @@ class CallbackValidator extends ConstraintValidator
                     throw new ConstraintDefinitionException(sprintf('"%s::%s" targeted by Callback constraint is not a valid callable', $method[0], $method[1]));
                 }
 
-                call_user_func($method, $object, $this->context);
+                $method($object, $this->context);
 
                 continue;
             }

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -49,13 +49,12 @@ class ChoiceValidator extends ConstraintValidator
         }
 
         if ($constraint->callback) {
-            if (is_callable(array($this->context->getClassName(), $constraint->callback))) {
-                $choices = call_user_func(array($this->context->getClassName(), $constraint->callback));
-            } elseif (is_callable($constraint->callback)) {
-                $choices = call_user_func($constraint->callback);
-            } else {
+            if (!is_callable($choices = array($this->context->getClassName(), $constraint->callback))
+                && !is_callable($choices = $constraint->callback)
+            ) {
                 throw new ConstraintDefinitionException('The Choice constraint expects a valid callback');
             }
+            $choices = $choices();
         } else {
             $choices = $constraint->choices;
         }

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -40,9 +40,9 @@ class TypeValidator extends ConstraintValidator
         $isFunction = 'is_'.$type;
         $ctypeFunction = 'ctype_'.$type;
 
-        if (function_exists($isFunction) && call_user_func($isFunction, $value)) {
+        if (function_exists($isFunction) && $isFunction($value)) {
             return;
-        } elseif (function_exists($ctypeFunction) && call_user_func($ctypeFunction, $value)) {
+        } elseif (function_exists($ctypeFunction) && $ctypeFunction($value)) {
             return;
         } elseif ($value instanceof $constraint->type) {
             return;

--- a/src/Symfony/Component/Validator/README.md
+++ b/src/Symfony/Component/Validator/README.md
@@ -113,7 +113,7 @@ https://github.com/fabpot/Silex/blob/master/src/Silex/Provider/ValidatorServiceP
 
 Documentation:
 
-http://symfony.com/doc/2.7/book/validation.html
+http://symfony.com/doc/3.0/book/validation.html
 
 JSR-303 Specification:
 

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -49,7 +49,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -257,7 +257,7 @@ abstract class AbstractCloner implements ClonerInterface
     private function callCaster($callback, $obj, $a, $stub, $isNested)
     {
         try {
-            $cast = call_user_func($callback, $obj, $a, $stub, $isNested);
+            $cast = $callback($obj, $a, $stub, $isNested);
 
             if (is_array($cast)) {
                 $a = $cast;
@@ -281,8 +281,8 @@ abstract class AbstractCloner implements ClonerInterface
             throw new \ErrorException($msg, 0, $type, $file, $line);
         }
 
-        if ($this->prevErrorHandler) {
-            return call_user_func($this->prevErrorHandler, $type, $msg, $file, $line, $context);
+        if ($eh = $this->prevErrorHandler) {
+            return $eh($type, $msg, $file, $line, $context);
         }
 
         return false;

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -115,7 +115,8 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
      */
     protected function dumpLine($depth)
     {
-        call_user_func($this->lineDumper, $this->line, $depth);
+        $lineDumper = $this->lineDumper;
+        $lineDumper($this->line, $depth, $this->indentPad);
         $this->line = '';
     }
 

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -27,15 +27,15 @@ class VarDumper
 
     public static function dump($var)
     {
-        if (null === self::$handler) {
+        if (null === $h = self::$handler) {
             $cloner = new VarCloner();
             $dumper = 'cli' === PHP_SAPI ? new CliDumper() : new HtmlDumper();
-            self::$handler = function ($var) use ($cloner, $dumper) {
+            $h = self::$handler = function ($var) use ($cloner, $dumper) {
                 $dumper->dump($cloner->cloneVar($var));
             };
         }
 
-        return call_user_func(self::$handler, $var);
+        return $h($var);
     }
 
     public static function setHandler($callable)

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | lets see |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR proposes to replace all occurences of `call_user_func()` by plain PHP. This is one less function call, and one less depth level in the stack. With it, I also propose that we agree on never using `call_user_func()` in Sf 3.0, since there is always an equivalent faster PHP syntax.
