### PR TITLE
Remove all calls to call_user_func()

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
@@ -51,7 +51,7 @@ class RuntimeInstantiator implements InstantiatorInterface
         return $this->factory->createProxy(
             $definition->getClass(),
             function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($realInstantiator) {
-                $wrappedInstance = call_user_func($realInstantiator);
+                $wrappedInstance = $realInstantiator();
 
                 $proxy->setProxyInitializer(null);
 

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -75,7 +75,7 @@ class XmlUtils
             $e = null;
             if (is_callable($schemaOrCallable)) {
                 try {
-                    $valid = call_user_func($schemaOrCallable, $dom, $internalErrors);
+                    $valid = $schemaOrCallable($dom, $internalErrors);
                 } catch (\Exception $e) {
                     $valid = false;
                 }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -246,8 +246,8 @@ class Command
 
         $input->validate();
 
-        if ($this->code) {
-            $statusCode = call_user_func($this->code, $input, $output);
+        if ($code = $this->code) {
+            $statusCode = $code($input, $output);
         } else {
             $statusCode = $this->execute($input, $output);
         }

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -467,7 +467,7 @@ class DialogHelper extends InputAwareHelper
             }
 
             try {
-                return call_user_func($validator, $interviewer());
+                return $validator($interviewer());
             } catch (\Exception $error) {
             }
         }

--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -117,7 +117,7 @@ class ProcessHelper extends Helper
             $output->write($formatter->progress(spl_object_hash($process), $that->escapeString($buffer), Process::ERR === $type));
 
             if (null !== $callback) {
-                call_user_func($callback, $type, $buffer);
+                $callback($type, $buffer);
             }
         };
     }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -438,7 +438,7 @@ class ProgressBar
         $messages = $this->messages;
         $this->overwrite(preg_replace_callback("{%([a-z\-_]+)(?:\:([^%]+))?%}i", function ($matches) use ($self, $output, $messages) {
             if ($formatter = $self::getPlaceholderFormatterDefinition($matches[1])) {
-                $text = call_user_func($formatter, $self, $output);
+                $text = $formatter($self, $output);
             } elseif (isset($messages[$matches[1]])) {
                 $text = $messages[$matches[1]];
             } else {

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -353,13 +353,14 @@ class QuestionHelper extends Helper
     {
         $error = null;
         $attempts = $question->getMaxAttempts();
+        $validator = $question->getValidator();
         while (null === $attempts || $attempts--) {
             if (null !== $error) {
                 $output->writeln($this->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
             }
 
             try {
-                return call_user_func($question->getValidator(), $interviewer());
+                return $validator($interviewer());
             } catch (\Exception $error) {
             }
         }

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -205,7 +205,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Node "%s" not supported.', $node->getNodeName()));
         }
 
-        return call_user_func($this->nodeTranslators[$node->getNodeName()], $node, $this);
+        return $this->nodeTranslators[$node->getNodeName()]($node, $this);
     }
 
     /**
@@ -223,7 +223,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Combiner "%s" not supported.', $combiner));
         }
 
-        return call_user_func($this->combinationTranslators[$combiner], $this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
+        return $this->combinationTranslators[$combiner]($this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
     }
 
     /**
@@ -240,7 +240,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Function "%s" not supported.', $function->getName()));
         }
 
-        return call_user_func($this->functionTranslators[$function->getName()], $xpath, $function);
+        return $this->functionTranslators[$function->getName()]($xpath, $function);
     }
 
     /**
@@ -257,7 +257,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Pseudo-class "%s" not supported.', $pseudoClass));
         }
 
-        return call_user_func($this->pseudoClassTranslators[$pseudoClass], $xpath);
+        return $this->pseudoClassTranslators[$pseudoClass]($xpath);
     }
 
     /**
@@ -276,7 +276,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Attribute matcher operator "%s" not supported.', $operator));
         }
 
-        return call_user_func($this->attributeMatchingTranslators[$operator], $xpath, $attribute, $value);
+        return $this->attributeMatchingTranslators[$operator]($xpath, $attribute, $value);
     }
 
     /**

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -150,12 +150,13 @@ class DebugClassLoader
         ErrorHandler::stackErrors();
 
         try {
+            $classLoader = $this->classLoader;
             if ($this->isFinder) {
-                if ($file = $this->classLoader[0]->findFile($class)) {
+                if ($file = $classLoader[0]->findFile($class)) {
                     require $file;
                 }
             } else {
-                call_user_func($this->classLoader, $class);
+                $classLoader($class);
                 $file = false;
             }
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -466,11 +466,11 @@ class ErrorHandler
                 }
             }
         }
-        if (empty($this->exceptionHandler)) {
+        if (!$exceptionHandler = $this->exceptionHandler) {
             throw $exception; // Give back $exception to the native handler
         }
         try {
-            call_user_func($this->exceptionHandler, $exception);
+            $exceptionHandler($exception);
         } catch (\Exception $handlerException) {
             $this->exceptionHandler = null;
             $this->handleException($handlerException);

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -104,7 +104,7 @@ class ExceptionHandler
      */
     public function handle(\Exception $exception)
     {
-        if (null === $this->handler || $exception instanceof OutOfMemoryException) {
+        if ($exception instanceof OutOfMemoryException || null === $handler = $this->handler) {
             $this->failSafeHandle($exception);
 
             return;
@@ -125,7 +125,7 @@ class ExceptionHandler
         $this->caughtBuffer = null;
 
         try {
-            call_user_func($this->handler, $exception);
+            $handler($exception);
             $this->caughtLength = $caughtLength;
         } catch (\Exception $e) {
             if (!$caughtLength) {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -992,7 +992,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 throw new InvalidArgumentException(sprintf('The configure callable for class "%s" is not a callable.', get_class($service)));
             }
 
-            call_user_func($callable, $service);
+            $callable($service);
         }
 
         return $service;

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
@@ -28,6 +28,6 @@ class RealServiceInstantiator implements InstantiatorInterface
      */
     public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
     {
-        return call_user_func($realInstantiator);
+        return $realInstantiator();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
@@ -40,7 +40,7 @@ class ClosureLoader extends Loader
      */
     public function load($resource, $type = null)
     {
-        call_user_func($resource, $this->container);
+        $resource($this->container);
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -56,7 +56,8 @@ class WrappedListener
 
         $e = $this->stopwatch->start($this->name, 'event_listener');
 
-        call_user_func($this->listener, $event, $eventName, $dispatcher);
+        $listener = $this->listener;
+        $listener($event, $eventName, $dispatcher);
 
         if ($e->isStarted()) {
             $e->stop();

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -161,7 +161,7 @@ class EventDispatcher implements EventDispatcherInterface
     protected function doDispatch($listeners, $eventName, Event $event)
     {
         foreach ($listeners as $listener) {
-            call_user_func($listener, $event, $eventName, $this);
+            $listener($event, $eventName, $this);
             if ($event->isPropagationStopped()) {
                 break;
             }

--- a/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
@@ -53,7 +53,7 @@ class CustomFilterIterator extends FilterIterator
         $fileinfo = $this->current();
 
         foreach ($this->filters as $filter) {
-            if (false === call_user_func($filter, $fileinfo)) {
+            if (false === $filter($fileinfo)) {
                 return false;
             }
         }

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -61,7 +61,9 @@ class CallbackTransformer implements DataTransformerInterface
      */
     public function transform($data)
     {
-        return call_user_func($this->transform, $data);
+        $t = $this->transform;
+
+        return $t($data);
     }
 
     /**
@@ -77,6 +79,8 @@ class CallbackTransformer implements DataTransformerInterface
      */
     public function reverseTransform($data)
     {
-        return call_user_func($this->reverseTransform, $data);
+        $r = $this->reverseTransform;
+
+        return $r($data);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -198,7 +198,7 @@ class FormValidator extends ConstraintValidator
     private static function resolveValidationGroups($groups, FormInterface $form)
     {
         if (!is_string($groups) && is_callable($groups)) {
-            $groups = call_user_func($groups, $form);
+            $groups = $groups($form);
         }
 
         return (array) $groups;

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -95,14 +95,13 @@ class JsonResponse extends Response
      */
     public function setData($data = array())
     {
-        $errorHandler = null;
-        $errorHandler = set_error_handler(function () use (&$errorHandler) {
+        $errorHandler = set_error_handler(function ($type, $msg, $file, $line, $context) use (&$errorHandler) {
             if (JSON_ERROR_NONE !== json_last_error()) {
                 return;
             }
 
             if ($errorHandler) {
-                call_user_func_array($errorHandler, func_get_args());
+                $errorHandler($type, $msg, $file, $line, $context);
             }
         });
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1874,8 +1874,8 @@ class Request
 
     private static function createRequestFromFactory(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null)
     {
-        if (self::$requestFactory) {
-            $request = call_user_func(self::$requestFactory, $query, $request, $attributes, $cookies, $files, $server, $content);
+        if ($requestFactory = self::$requestFactory) {
+            $request = $requestFactory($query, $request, $attributes, $cookies, $files, $server, $content);
 
             if (!$request instanceof Request) {
                 throw new \LogicException('The Request factory must return an instance of Symfony\Component\HttpFoundation\Request.');

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -92,11 +92,11 @@ class StreamedResponse extends Response
 
         $this->streamed = true;
 
-        if (null === $this->callback) {
+        if (null === $callback = $this->callback) {
             throw new \LogicException('The Response callback must not be null.');
         }
 
-        call_user_func($this->callback);
+        $callback();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -348,9 +348,9 @@ class MockPdo extends \PDO
 
     public function prepare($statement, $driverOptions = array())
     {
-        return is_callable($this->prepareResult)
-            ? call_user_func($this->prepareResult, $statement, $driverOptions)
-            : $this->prepareResult;
+        return is_callable($prepareResult = $this->prepareResult)
+            ? $prepareResult($statement, $driverOptions)
+            : $prepareResult;
     }
 
     public function beginTransaction()

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1289,7 +1289,7 @@ class Process
             }
 
             if (null !== $callback) {
-                call_user_func($callback, $type, $data);
+                $callback($type, $data);
             }
         };
 
@@ -1369,6 +1369,7 @@ class Process
     private function readPipes($blocking, $close)
     {
         $result = $this->processPipes->readAndWrite($blocking, $close);
+        $callback = $this->callback;
 
         foreach ($result as $type => $data) {
             if (3 == $type) {

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -138,8 +138,8 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
             if ($context['circular_reference_limit'][$objectHash] >= $this->circularReferenceLimit) {
                 unset($context['circular_reference_limit'][$objectHash]);
 
-                if ($this->circularReferenceHandler) {
-                    return call_user_func($this->circularReferenceHandler, $object);
+                if ($circularReferenceHandler = $this->circularReferenceHandler) {
+                    return $circularReferenceHandler($object);
                 }
 
                 throw new CircularReferenceException(sprintf('A circular reference has been detected (configured limit: %d).', $this->circularReferenceLimit));
@@ -164,7 +164,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
 
                 $attributeValue = $method->invoke($object);
                 if (array_key_exists($attributeName, $this->callbacks)) {
-                    $attributeValue = call_user_func($this->callbacks[$attributeName], $attributeValue);
+                    $attributeValue = $this->callbacks[$attributeName]($attributeValue);
                 }
                 if (null !== $attributeValue && !is_scalar($attributeValue)) {
                     if (!$this->serializer instanceof NormalizerInterface) {

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -97,7 +97,7 @@ class PropertyNormalizer extends SerializerAwareNormalizer implements Normalizer
             $attributeValue = $property->getValue($object);
 
             if (array_key_exists($property->name, $this->callbacks)) {
-                $attributeValue = call_user_func($this->callbacks[$property->name], $attributeValue);
+                $attributeValue = $this->callbacks[$property->name]($attributeValue);
             }
             if (null !== $attributeValue && !is_scalar($attributeValue)) {
                 $attributeValue = $this->serializer->normalize($attributeValue, $format);

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -340,17 +340,19 @@ class PhpEngine implements EngineInterface, \ArrayAccess
             return $value;
         }
 
+        $escaper = $this->getEscaper($context);
+
         // If we deal with a scalar value, we can cache the result to increase
         // the performance when the same value is escaped multiple times (e.g. loops)
         if (is_scalar($value)) {
             if (!isset(self::$escaperCache[$context][$value])) {
-                self::$escaperCache[$context][$value] = call_user_func($this->getEscaper($context), $value);
+                self::$escaperCache[$context][$value] = $escaper($value);
             }
 
             return self::$escaperCache[$context][$value];
         }
 
-        return call_user_func($this->getEscaper($context), $value);
+        return $escaper($value);
     }
 
     /**

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -40,7 +40,7 @@ class PluralizationRules
         }
 
         if (isset(self::$rules[$locale])) {
-            $return = call_user_func(self::$rules[$locale], $number);
+            $return = self::$rules[$locale]($number);
 
             if (!is_int($return) || $return < 0) {
                 return 0;

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -55,7 +55,7 @@ class CallbackValidator extends ConstraintValidator
                     throw new ConstraintDefinitionException(sprintf('"%s::%s" targeted by Callback constraint is not a valid callable', $method[0], $method[1]));
                 }
 
-                call_user_func($method, $object, $this->context);
+                $method($object, $this->context);
 
                 continue;
             }

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -49,13 +49,12 @@ class ChoiceValidator extends ConstraintValidator
         }
 
         if ($constraint->callback) {
-            if (is_callable(array($this->context->getClassName(), $constraint->callback))) {
-                $choices = call_user_func(array($this->context->getClassName(), $constraint->callback));
-            } elseif (is_callable($constraint->callback)) {
-                $choices = call_user_func($constraint->callback);
-            } else {
+            if (!is_callable($choices = array($this->context->getClassName(), $constraint->callback))
+                || !is_callable($choices = $constraint->callback)
+            ) {
                 throw new ConstraintDefinitionException('The Choice constraint expects a valid callback');
             }
+            $choices = $choices();
         } else {
             $choices = $constraint->choices;
         }

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -257,7 +257,7 @@ abstract class AbstractCloner implements ClonerInterface
     private function callCaster($callback, $obj, $a, $stub, $isNested)
     {
         try {
-            $cast = call_user_func($callback, $obj, $a, $stub, $isNested);
+            $cast = $callback($obj, $a, $stub, $isNested);
 
             if (is_array($cast)) {
                 $a = $cast;
@@ -281,8 +281,8 @@ abstract class AbstractCloner implements ClonerInterface
             throw new \ErrorException($msg, 0, $type, $file, $line);
         }
 
-        if ($this->prevErrorHandler) {
-            return call_user_func($this->prevErrorHandler, $type, $msg, $file, $line, $context);
+        if ($eh = $this->prevErrorHandler) {
+            return $eh($type, $msg, $file, $line, $context);
         }
 
         return false;

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -115,7 +115,8 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
      */
     protected function dumpLine($depth)
     {
-        call_user_func($this->lineDumper, $this->line, $depth, $this->indentPad);
+        $lineDumper = $this->lineDumper;
+        $lineDumper($this->line, $depth, $this->indentPad);
         $this->line = '';
     }
 

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -27,15 +27,15 @@ class VarDumper
 
     public static function dump($var)
     {
-        if (null === self::$handler) {
+        if (null === $h = self::$handler) {
             $cloner = new VarCloner();
             $dumper = 'cli' === PHP_SAPI ? new CliDumper() : new HtmlDumper();
-            self::$handler = function ($var) use ($cloner, $dumper) {
+            $h = self::$handler = function ($var) use ($cloner, $dumper) {
                 $dumper->dump($cloner->cloneVar($var));
             };
         }
 
-        return call_user_func(self::$handler, $var);
+        return $h($var);
     }
 
     public static function setHandler($callable)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | lets see |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR proposes to replace all occurences of `call_user_func()` by plain PHP. This is one less function call, and one less depth level in the stack. With it, I also propose that we agree on never using `call_user_func()` in Sf 3.0, since there is always an equivalent faster PHP syntax.
