### PR TITLE
Return current object in SetContainer

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerAware.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAware.php
@@ -31,11 +31,12 @@ abstract class ContainerAware implements ContainerAwareInterface
      * Sets the Container associated with this Controller.
      *
      * @param ContainerInterface $container A ContainerInterface instance
-     *
+     * @return ContainerAwareInterface
      * @api
      */
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
+        return $this;
     }
 }


### PR DESCRIPTION
[Component] [DependencyInjection] $this is missing in the setContainer function.  It broke my code in the following example:

``` php
 $widgetType->setType($type)
            ->setCssDocument($this->getCSSDocument($location))
            ->setLocation($location)
            ->setEntity($widget)
            ->setWidgetManager($this)
            ->setContainer($this->getContainer())
            ->setSettings($this->getSettings($location, $id))
            ->initialize();
```

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |
