### PR TITLE
[Form] ViolationMapper - Make form submission requirement optional

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -30,6 +30,11 @@ class ViolationMapper implements ViolationMapperInterface
     private $allowNonSynchronized;
 
     /**
+     * @var bool
+     */
+    private $formSubmissionRequired = true;
+
+    /**
      * {@inheritdoc}
      */
     public function mapViolation(ConstraintViolation $violation, FormInterface $form, $allowNonSynchronized = false)
@@ -292,9 +297,29 @@ class ViolationMapper implements ViolationMapperInterface
      */
     private function acceptsErrors(FormInterface $form)
     {
-        // Ignore non-submitted forms. This happens, for example, in PATCH
-        // requests.
-        // https://github.com/symfony/symfony/pull/10567
-        return $form->isSubmitted() && ($this->allowNonSynchronized || $form->isSynchronized());
+        if ($this->isFormSubmissionRequired()) {
+            // Ignore non-submitted forms. This happens, for example, in PATCH
+            // requests.
+            // https://github.com/symfony/symfony/pull/10567
+            return $form->isSubmitted() && ($this->allowNonSynchronized || $form->isSynchronized());
+        }
+
+        return $this->allowNonSynchronized || $form->isSynchronized();
+    }
+
+    /**
+     * @param bool $formSubmissionRequired
+     */
+    public function setFormSubmissionRequired($formSubmissionRequired)
+    {
+        $this->formSubmissionRequired = (bool) $formSubmissionRequired;
+    }
+
+    /**
+     * @return bool
+     */
+    private function isFormSubmissionRequired()
+    {
+        return $this->formSubmissionRequired;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

It would be useful to have the ability to decide if the form will accept errors.  We have found that in certain use cases this functionality would be needed.  
For example, we have a use case where a user is uploading a large amount of product data via spreadsheet.  We present validation errors for individual products using the form component.  In this case, since the data is "submitted" via the file upload, it is no longer possible to use form to present errors as the form has not been submitted in the conventional sense.  

Related:
https://github.com/symfony/symfony/pull/10567
