### PR TITLE
[2.6] Remove possible call_user_func()

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -833,7 +833,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             // BEGIN
             $this->calling[$option] = true;
             foreach ($this->lazy[$option] as $closure) {
-                $value = call_user_func($closure, $this, $value);
+                $value = $closure($this, $value);
             }
             unset($this->calling[$option]);
             // END
@@ -929,7 +929,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             // dependency
             // BEGIN
             $this->calling[$option] = true;
-            $value = call_user_func($normalizer, $this, $value);
+            $value = $normalizer($this, $value);
             unset($this->calling[$option]);
             // END
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Remove possible call_user_func() introduced in 2.6
