### PR TITLE
[HttpKernel] Move the bundle booting into a separate kernel method

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -126,10 +126,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         // init container
         $this->initializeContainer();
 
-        foreach ($this->getBundles() as $bundle) {
-            $bundle->setContainer($this->container);
-            $bundle->boot();
-        }
+        // boot bundles
+        $this->bootBundles();
 
         $this->booted = true;
     }
@@ -569,6 +567,17 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
         if (!$fresh && $this->container->has('cache_warmer')) {
             $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'));
+        }
+    }
+
+    /**
+     * Boots the registered bundle instances.
+     */
+    protected function bootBundles()
+    {
+        foreach ($this->getBundles() as $bundle) {
+            $bundle->setContainer($this->container);
+            $bundle->boot();
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

We are currently working on using Symfony in the next [Contao](https://contao.org) major version. We need to extend the boot process, which is currently only possible by overriding the whole `boot()` method. With this change, we could simply extend the `bootBundles()` method:

``` php
// AppKernel.php
public function bootBundles()
{
    $this->doOurStuff();
    parent::bootBundles();
}
```
