### PR TITLE
remove an unneeded check

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -83,12 +83,6 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (defined('HHVM_VERSION')) {
-            $output->writeln('<error>This command is not supported on HHVM.</error>');
-
-            return 1;
-        }
-
         $documentRoot = $input->getOption('docroot');
 
         if (null === $documentRoot) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It is already checked in the `isEnabled()` method if the current PHP
build is HHVM and the `server:run` command is never enabled then.
Thus, it's not needed to check for HHVM on every command execution.
