### PR TITLE
[FrameworkBundle] removed unneeded check

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -71,11 +71,6 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (defined('HHVM_VERSION')) {
-            $output->writeln('<error>This command is not supported on HHVM.</error>');
-
-            return 1;
-        }
         if (!extension_loaded('pcntl')) {
             $output->writeln('<error>This command needs the pcntl extension to run.</error>');
             $output->writeln('You can either install it or use the <info>server:run</info> command instead to run the built-in web server.');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It is already checked in the `isEnabled()` method of the parent
`ServerCommand` class if the current PHP build is HHVM and the
`server:start` command is never enabled then. Thus, it's not needed
to check for HHVM on every command execution.

This was pointed out by @stof in #12489 for the `server:run` command.
