### PR TITLE
[Security] added a timing attack resistant string comparison that resists length leaking

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Util/StringUtilsTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Util/StringUtilsTest.php
@@ -24,8 +24,8 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->string = new StringUtils(new SecureRandom);
-        $this->utils = new StringUtils(new SecureRandom);
+        $this->string = new StringUtils(new SecureRandom());
+        $this->utils = new StringUtils(new SecureRandom());
     }
 
     public function dataProviderTrue()
@@ -96,7 +96,7 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         return array(
             array(-1),
             array(0),
-            array(new \stdClass),
+            array(new \stdClass()),
             array(-150),
             array(''),
             array('-42'),
@@ -170,6 +170,4 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
     {
         $this->utils->setKeySize($size);
     }
-
-
 }

--- a/src/Symfony/Component/Security/Core/Tests/Util/StringUtilsTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Util/StringUtilsTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Tests\Util;
 
+use Symfony\Component\Security\Core\Util\SecureRandom;
 use Symfony\Component\Security\Core\Util\StringUtils;
 
 /**
@@ -18,6 +19,15 @@ use Symfony\Component\Security\Core\Util\StringUtils;
  */
 class StringUtilsTest extends \PHPUnit_Framework_TestCase
 {
+    protected $string;
+    protected $utils;
+
+    public function setUp()
+    {
+        $this->string = new StringUtils(new SecureRandom);
+        $this->utils = new StringUtils(new SecureRandom);
+    }
+
     public function dataProviderTrue()
     {
         return array(
@@ -43,6 +53,57 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function dataProviderValidAlgos()
+    {
+        return array(
+            array('sha1'),
+            array('sha256'),
+            array('sha512'),
+            array('ripemd160'),
+        );
+    }
+
+    public function dataProviderInvalidAlgos()
+    {
+        return array(
+            array('pebkac'),
+            array('pebcak'),
+            array('invalid algo'),
+            array(0),
+            array(15.8),
+            array(''),
+            array(null),
+        );
+    }
+
+    public function dataProviderValidKeySizes()
+    {
+        return array(
+            array(10),
+            array(1),
+            array(52),
+            array(25000),
+            array(1024),
+            array(PHP_INT_MAX),
+            array('16'),
+            array(15.0),
+            array('17.0'),
+        );
+    }
+
+    public function dataProviderInvalidKeySizes()
+    {
+        return array(
+            array(-1),
+            array(0),
+            array(new \stdClass),
+            array(-150),
+            array(''),
+            array('-42'),
+            array(null),
+        );
+    }
+
     /**
      * @dataProvider dataProviderTrue
      */
@@ -58,4 +119,57 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse(StringUtils::equals($known, $user));
     }
+
+    /**
+     * @dataProvider dataProviderTrue
+     */
+    public function testEqualsHashTrue($known, $user)
+    {
+        $this->assertTrue($this->string->equalsHash($known, $user));
+    }
+
+    /**
+     * @dataProvider dataProviderFalse
+     */
+    public function testEqualsHashFalse($known, $user)
+    {
+        $this->assertFalse($this->string->equalsHash($known, $user));
+    }
+
+    /**
+     * @dataProvider dataProviderInvalidAlgos
+     * @expectedException \Symfony\Component\Security\Core\Exception\InvalidArgumentException
+     */
+    public function testInvalidHashAlgo($algo)
+    {
+        $this->utils->setAlgo($algo);
+    }
+
+    /**
+     * @dataProvider dataProviderValidAlgos
+     */
+    public function testValidHashAlgo($algo)
+    {
+        $this->utils->setAlgo($algo);
+    }
+
+    /**
+     * @dataProvider dataProviderValidKeySizes
+     */
+    public function testValidKeySize($size)
+    {
+        $this->utils->setKeySize($size);
+        $this->assertTrue((int) $size === $this->utils->getKeySize());
+    }
+
+    /**
+     * @dataProvider dataProviderInvalidKeySizes
+     * @expectedException \Symfony\Component\Security\Core\Exception\InvalidArgumentException
+     */
+    public function testInvalidKeySize($size)
+    {
+        $this->utils->setKeySize($size);
+    }
+
+
 }

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -20,7 +20,6 @@ use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
  */
 class StringUtils
 {
-
     /**
      * A class to provide random data for hmac keys.
      *
@@ -133,8 +132,9 @@ class StringUtils
      */
     public function setKeySize($keySize)
     {
-        if ( ! is_numeric($keySize) or ((int) $keySize <= 0))
+        if (! is_numeric($keySize) or ((int) $keySize <= 0)) {
             throw new InvalidArgumentException("Key size should be an integer > 0");
+        }
 
         // We want to avoid casting to int in the event that $keySize
         // is an object or a resource-like handle as it will return
@@ -161,8 +161,9 @@ class StringUtils
     {
         $algo = (string) $algo;
 
-        if ( ! in_array($algo, hash_algos()))
+        if (! in_array($algo, hash_algos())) {
             throw new InvalidArgumentException("$algo is not a supported algorithm");
+        }
 
         $this->algo = $algo;
     }

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Util;
 
+use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
+
 /**
  * String utility functions.
  *
@@ -18,11 +20,38 @@ namespace Symfony\Component\Security\Core\Util;
  */
 class StringUtils
 {
+
     /**
-     * This class should not be instantiated
+     * A class to provide random data for hmac keys.
+     *
+     * @var SecureRandomInterface
      */
-    private function __construct()
+    protected $random;
+
+    /**
+     * Key size used for hash_hmac keys, in bytes.
+     *
+     * @var int
+     */
+    protected $keySize = 16;
+
+    /**
+     * The algorithm to use with hash_hmac
+     *
+     * @var string
+     */
+    protected $algo = "sha512";
+
+    /**
+     * This class can be instantiated with a SecureRandomInterface to provide
+     * additional security in the form of stronger timing attack resistance
+     * when comparing strings by masking length.
+     *
+     * @param SecureRandomInterface $random
+     */
+    public function __construct(SecureRandomInterface $random)
     {
+        $this->random = $random;
     }
 
     /**
@@ -62,5 +91,79 @@ class StringUtils
 
         // They are only identical strings if $result is exactly 0...
         return 0 === $result;
+    }
+
+    /**
+     * Compares two strings using a random source and hash_hmac.
+     *
+     * This method implements a constant-time algorithm to compare strings;
+     * this method will mask length information about the known string.
+     *
+     * @param string $knownString The string of known length to compare against
+     * @param string $userInput   The string that the user can control
+     *
+     * @return bool    true if the two strings are the same, false otherwise
+     */
+    public function equalsHash($knownString, $userInput)
+    {
+        $key = $this->random->nextBytes($this->keySize);
+
+        // Here we hash_hmac the input using the same randomly generated key.
+        // This also generates a random offset useful for masking length.
+        $knownHash = hash_hmac($this->algo, $knownString, $key);
+        $userHash = hash_hmac($this->algo, $userInput, $key);
+
+        // length here will always be constant due to hash_hmac
+        $length = strlen($userHash);
+
+        // We can safely iterate over the length because the computed
+        // length is constant in both cases.
+        for ($i = 0, $result = 0; $i < $length; $i++) {
+            $result |= (ord($knownHash[$i]) ^ ord($userHash[$i]));
+        }
+
+        // They are only identical strings if $result is exactly 0...
+        return 0 === $result;
+    }
+
+    /**
+     * Set a key size to use for comparison.
+     *
+     * @param int $keySize The length to use for key size, in bytes.
+     */
+    public function setKeySize($keySize)
+    {
+        if ( ! is_numeric($keySize) or ((int) $keySize <= 0))
+            throw new InvalidArgumentException("Key size should be an integer > 0");
+
+        // We want to avoid casting to int in the event that $keySize
+        // is an object or a resource-like handle as it will return
+        // an integer unrelated to the object/resource.
+        $this->keySize = (int) $keySize;
+    }
+
+    /**
+     * Get the random key size for this instance.
+     *
+     * @return int The key size (in bytes) used for hash keys.
+     */
+    public function getKeySize()
+    {
+        return $this->keySize;
+    }
+
+    /**
+     * Set the algorithm used to hash_hmac compare two strings.
+     *
+     * @param string $algo The algorithm to use for hashing strings.
+     */
+    public function setAlgo($algo)
+    {
+        $algo = (string) $algo;
+
+        if ( ! in_array($algo, hash_algos()))
+            throw new InvalidArgumentException("$algo is not a supported algorithm");
+
+        $this->algo = $algo;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The current PHP implementation ([hash_equals](https://github.com/php/php-src/blob/PHP-5.6/ext/hash/hash.c#L734-L768), below) and the implementation in `StringUtils::equals` will leak length difference information:

``` c
/* This is security sensitive code. Do not optimize this for speed. */
for (j = 0; j < Z_STRLEN_P(known_zval); j++) {
    result |= known_str[j] ^ user_str[j];
}
```

This implementation gets around the issue by first hashing both inputs (known and user) with hmac-sha512 with a 128bit (16 byte) random key by default.

This is an optional, backwards compatible change that requires instantiating the StringUtils class with a `SecureRandomInterface` implementation to make use of. Previously, the constructor was private due to only static methods being available, but I do not believe this breaks backwards compatibility. `StringUtils::equals()` is still as-is. Coverage report is 100% for all methods added (tested in PHP 5.6).

Usage:

``` php
$string = new StringUtils(new SecureRandom);
$known = "pebkac";
$user = "asbasdfasdf";

$equal = $string->equalsHash($known, $user);
```
