### PR TITLE
[3.0] Rename Symfony2 to Symfony

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing
 ------------
 
-Symfony2 is an open source, community-driven project.
+Symfony is an open source, community-driven project.
 
 If you'd like to contribute, please read the following documents:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,7 @@
 CONTRIBUTORS
 ============
 
-Symfony2 is the result of the work of many people who made the code better
+Symfony is the result of the work of many people who made the code better
 (see http://symfony.com/contributors for more information):
 
  - Fabien Potencier (fabpot)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 README
 ======
 
-What is Symfony2?
+What is Symfony?
 -----------------
 
-Symfony2 is a PHP 5.3 full-stack web framework. It is written with speed and
+Symfony is a PHP 5.3 full-stack web framework. It is written with speed and
 flexibility in mind. It allows developers to build better and easy to maintain
 websites with PHP.
 
@@ -14,7 +14,7 @@ to high traffic ones like Dailymotion or Yahoo! Answers.
 Requirements
 ------------
 
-Symfony2 is only supported on PHP 5.3.3 and up.
+Symfony is only supported on PHP 5.3.3 and up.
 
 Be warned that PHP versions before 5.3.8 are known to be buggy and might not
 work for you:
@@ -28,35 +28,35 @@ work for you:
    known PHP bug (see https://bugs.php.net/bug.php?id=55156).
 
  * PHP 5.3.16 has a major bug in the Reflection subsystem and is not suitable to
-   run Symfony2 (https://bugs.php.net/bug.php?id=62715)
+   run Symfony (https://bugs.php.net/bug.php?id=62715)
 
 Installation
 ------------
 
-The best way to install Symfony2 is to download the Symfony Standard Edition
+The best way to install Symfony is to download the Symfony Standard Edition
 available at [http://symfony.com/download][1].
 
 Documentation
 -------------
 
 The "[Quick Tour][2]" tutorial gives you a first feeling of the framework. If,
-like us, you think that Symfony2 can help speed up your development and take
+like us, you think that Symfony can help speed up your development and take
 the quality of your work to the next level, read the official
-[Symfony2 documentation][3].
+[Symfony documentation][3].
 
 Contributing
 ------------
 
-Symfony2 is an open source, community-driven project. If you'd like to contribute,
+Symfony is an open source, community-driven project. If you'd like to contribute,
 please read the [Contributing Code][4] part of the documentation. If you're submitting
 a pull request, please follow the guidelines in the [Submitting a Patch][5] section
 and use [Pull Request Template][6].
 
-Running Symfony2 Tests
+Running Symfony Tests
 ----------------------
 
-Information on how to run the Symfony2 test suite can be found in the
-[Running Symfony2 Tests][7] section.
+Information on how to run the Symfony test suite can be found in the
+[Running Symfony Tests][7] section.
 
 [1]: http://symfony.com/download
 [2]: http://symfony.com/get_started

--- a/src/Symfony/Bridge/Doctrine/README.md
+++ b/src/Symfony/Bridge/Doctrine/README.md
@@ -2,7 +2,7 @@ Doctrine Bridge
 ===============
 
 Provides integration for [Doctrine](http://www.doctrine-project.org/) with
-various Symfony2 components.
+various Symfony components.
 
 Resources
 ---------

--- a/src/Symfony/Bridge/Monolog/README.md
+++ b/src/Symfony/Bridge/Monolog/README.md
@@ -1,7 +1,7 @@
 Monolog Bridge
 ==============
 
-Provides integration for Monolog with various Symfony2 components.
+Provides integration for Monolog with various Symfony components.
 
 Resources
 ---------

--- a/src/Symfony/Bridge/Propel1/README.md
+++ b/src/Symfony/Bridge/Propel1/README.md
@@ -1,7 +1,7 @@
 Propel Bridge
 =============
 
-Provides integration for Propel with various Symfony2 components.
+Provides integration for Propel with various Symfony components.
 
 Resources
 ---------

--- a/src/Symfony/Bridge/ProxyManager/README.md
+++ b/src/Symfony/Bridge/ProxyManager/README.md
@@ -1,7 +1,7 @@
 ProxyManager Bridge
 ===================
 
-Provides integration for [ProxyManager][1] with various Symfony2 components.
+Provides integration for [ProxyManager][1] with various Symfony components.
 
 Resources
 ---------

--- a/src/Symfony/Bridge/Twig/README.md
+++ b/src/Symfony/Bridge/Twig/README.md
@@ -2,7 +2,7 @@ Twig Bridge
 ===========
 
 Provides integration for [Twig](http://twig.sensiolabs.org/) with various
-Symfony2 components.
+Symfony components.
 
 Resources
 ---------

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -42,7 +42,7 @@ class StopwatchExtensionTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('{% stopwatch "foo" %}something{% endstopwatch %}', 'foo'),
-            array('{% stopwatch "foo" %}symfony2 is fun{% endstopwatch %}{% stopwatch "bar" %}something{% endstopwatch %}', array('foo', 'bar')),
+            array('{% stopwatch "foo" %}symfony is fun{% endstopwatch %}{% stopwatch "bar" %}something{% endstopwatch %}', array('foo', 'bar')),
             array('{% set foo = "foo" %}{% stopwatch foo %}something{% endstopwatch %}', 'foo'),
             array('{% set foo = "foo" %}{% stopwatch foo %}something {% set foo = "bar" %}{% endstopwatch %}', 'foo'),
             array('{% stopwatch "foo.bar" %}something{% endstopwatch %}', 'foo.bar'),

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -75,13 +75,13 @@ class TranslationExtensionTest extends \PHPUnit_Framework_TestCase
         return array(
             // trans tag
             array('{% trans %}Hello{% endtrans %}', 'Hello'),
-            array('{% trans %}%name%{% endtrans %}', 'Symfony2', array('name' => 'Symfony2')),
+            array('{% trans %}%name%{% endtrans %}', 'Symfony', array('name' => 'Symfony')),
 
             array('{% trans from elsewhere %}Hello{% endtrans %}', 'Hello'),
 
-            array('{% trans %}Hello %name%{% endtrans %}', 'Hello Symfony2', array('name' => 'Symfony2')),
-            array('{% trans with { \'%name%\': \'Symfony2\' } %}Hello %name%{% endtrans %}', 'Hello Symfony2'),
-            array('{% set vars = { \'%name%\': \'Symfony2\' } %}{% trans with vars %}Hello %name%{% endtrans %}', 'Hello Symfony2'),
+            array('{% trans %}Hello %name%{% endtrans %}', 'Hello Symfony', array('name' => 'Symfony')),
+            array('{% trans with { \'%name%\': \'Symfony\' } %}Hello %name%{% endtrans %}', 'Hello Symfony'),
+            array('{% set vars = { \'%name%\': \'Symfony\' } %}{% trans with vars %}Hello %name%{% endtrans %}', 'Hello Symfony'),
 
             array('{% trans into "fr"%}Hello{% endtrans %}', 'Hello'),
 
@@ -91,9 +91,9 @@ class TranslationExtensionTest extends \PHPUnit_Framework_TestCase
             array('{% transchoice count %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
                 'There is 5 apples', array('count' => 5),),
             array('{% transchoice count %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
-                'There is 5 apples (Symfony2)', array('count' => 5, 'name' => 'Symfony2'),),
-            array('{% transchoice count with { \'%name%\': \'Symfony2\' } %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
-                'There is 5 apples (Symfony2)', array('count' => 5),),
+                'There is 5 apples (Symfony)', array('count' => 5, 'name' => 'Symfony'),),
+            array('{% transchoice count with { \'%name%\': \'Symfony\' } %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
+                'There is 5 apples (Symfony)', array('count' => 5),),
             array('{% transchoice count into "fr"%}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
                 'There is no apples', array('count' => 0),),
             array('{% transchoice 5 into "fr"%}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
@@ -101,14 +101,14 @@ class TranslationExtensionTest extends \PHPUnit_Framework_TestCase
 
             // trans filter
             array('{{ "Hello"|trans }}', 'Hello'),
-            array('{{ name|trans }}', 'Symfony2', array('name' => 'Symfony2')),
-            array('{{ hello|trans({ \'%name%\': \'Symfony2\' }) }}', 'Hello Symfony2', array('hello' => 'Hello %name%')),
-            array('{% set vars = { \'%name%\': \'Symfony2\' } %}{{ hello|trans(vars) }}', 'Hello Symfony2', array('hello' => 'Hello %name%')),
+            array('{{ name|trans }}', 'Symfony', array('name' => 'Symfony')),
+            array('{{ hello|trans({ \'%name%\': \'Symfony\' }) }}', 'Hello Symfony', array('hello' => 'Hello %name%')),
+            array('{% set vars = { \'%name%\': \'Symfony\' } %}{{ hello|trans(vars) }}', 'Hello Symfony', array('hello' => 'Hello %name%')),
             array('{{ "Hello"|trans({}, "messages", "fr") }}', 'Hello'),
 
             // transchoice filter
             array('{{ "{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples"|transchoice(count) }}', 'There is 5 apples', array('count' => 5)),
-            array('{{ text|transchoice(5, {\'%name%\': \'Symfony2\'}) }}', 'There is 5 apples (Symfony2)', array('text' => '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%)')),
+            array('{{ text|transchoice(5, {\'%name%\': \'Symfony\'}) }}', 'There is 5 apples (Symfony)', array('text' => '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%)')),
             array('{{ "{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples"|transchoice(count, {}, "messages", "fr") }}', 'There is 5 apples', array('count' => 5)),
         );
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
 
 /**
- * Runs Symfony2 application using PHP built-in web server.
+ * Runs Symfony application using PHP built-in web server.
  *
  * @author Michał Pipa <michal.pipa.xsolve@gmail.com>
  */

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -17,7 +17,7 @@ use Symfony\Component\Templating\TemplateReferenceInterface;
 
 /**
  * FilesystemLoader extends the default Twig filesystem loader
- * to work with the Symfony2 paths and template references.
+ * to work with the Symfony paths and template references.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,4 +1,4 @@
-<!-- START of Symfony2 Web Debug Toolbar -->
+<!-- START of Symfony Web Debug Toolbar -->
 {% if 'normal' != position %}
     <div id="sfMiniToolbar-{{ token }}" class="sf-minitoolbar" data-no-turbolink>
         <a href="javascript:void(0);" title="Show Symfony toolbar" onclick="
@@ -45,4 +45,4 @@
         "></a>
     {% endif %}
 </div>
-<!-- END of Symfony2 Web Debug Toolbar -->
+<!-- END of Symfony Web Debug Toolbar -->

--- a/src/Symfony/Component/EventDispatcher/README.md
+++ b/src/Symfony/Component/EventDispatcher/README.md
@@ -1,7 +1,7 @@
 EventDispatcher Component
 =========================
 
-The Symfony2 EventDispatcher component implements the Mediator pattern in a
+The Symfony EventDispatcher component implements the Mediator pattern in a
 simple and effective way to make your projects truly extensible.
 
 ```php

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilePathsIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilePathsIteratorTest.php
@@ -31,7 +31,7 @@ class FilePathsIteratorTest extends RealIteratorTestCase
 
     public function getSubPathData()
     {
-        $tmpDir = sys_get_temp_dir().'/symfony2_finder';
+        $tmpDir = sys_get_temp_dir().'/symfony_finder';
 
         return array(
             array(

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -18,7 +18,7 @@ abstract class RealIteratorTestCase extends IteratorTestCase
 
     public static function setUpBeforeClass()
     {
-        self::$tmpDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'symfony2_finder';
+        self::$tmpDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'symfony_finder';
 
         self::$files = array(
             '.git/',
@@ -74,7 +74,7 @@ abstract class RealIteratorTestCase extends IteratorTestCase
          * Without the call to setUpBeforeClass() property can be null.
          */
         if (!self::$tmpDir) {
-            self::$tmpDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'symfony2_finder';
+            self::$tmpDir = realpath(sys_get_temp_dir()).DIRECTORY_SEPARATOR.'symfony_finder';
         }
 
         if (is_array($files)) {

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/SessionCsrfProvider.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/SessionCsrfProvider.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Extension\Csrf\CsrfProvider;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
- * This provider uses a Symfony2 Session object to retrieve the user's
+ * This provider uses a Symfony Session object to retrieve the user's
  * session ID.
  *
  * @see DefaultCsrfProvider

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
- * Extension supporting the Symfony2 Validator component in forms.
+ * Extension supporting the Symfony Validator component in forms.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */

--- a/src/Symfony/Component/Form/Tests/FormConfigTest.php
+++ b/src/Symfony/Component/Form/Tests/FormConfigTest.php
@@ -49,7 +49,7 @@ class FormConfigTest extends \PHPUnit_Framework_TestCase
             array('9', true),
             // Contrary to the HTML4 spec, we allow names starting with an
             // underscore, since this is already a widely used practice in
-            // Symfony2.
+            // Symfony.
             // For root forms, leading underscores will be stripped from the
             // "id" attribute to produce valid HTML4.
             array('_', true),

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler;
 
 /**
- * Allows session to be started by PHP and managed by Symfony2
+ * Allows session to be started by PHP and managed by Symfony
  *
  * @author Drak <drak@zikula.org>
  */

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -136,7 +136,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         return array(
             array('foo', 'bar', array('foo' => 'bar')),
             array('foo.bar', 'too much beer', array('foo.bar' => 'too much beer')),
-            array('great', 'symfony2 is great', array('great' => 'symfony2 is great')),
+            array('great', 'symfony is great', array('great' => 'symfony is great')),
         );
     }
 
@@ -195,7 +195,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetIterator()
     {
-        $attributes = array('hello' => 'world', 'symfony2' => 'rocks');
+        $attributes = array('hello' => 'world', 'symfony' => 'rocks');
         foreach ($attributes as $key => $val) {
             $this->session->set($key, $val);
         }
@@ -215,7 +215,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     public function testGetCount()
     {
         $this->session->set('hello', 'world');
-        $this->session->set('symfony2', 'rocks');
+        $this->session->set('symfony', 'rocks');
 
         $this->assertCount(2, $this->session);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -137,7 +137,7 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
         $options = array(
             'cookie_lifetime' => 123456,
             'cookie_path' => '/my/cookie/path',
-            'cookie_domain' => 'symfony2.example.com',
+            'cookie_domain' => 'symfony.example.com',
             'cookie_secure' => true,
             'cookie_httponly' => false,
         );

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -69,7 +69,7 @@ class Ssi implements SurrogateInterface
     public function addSurrogateCapability(Request $request)
     {
         $current = $request->headers->get('Surrogate-Capability');
-        $new = 'symfony2="SSI/1.0"';
+        $new = 'symfony="SSI/1.0"';
 
         $request->headers->set('Surrogate-Capability', $current ? $current.', '.$new : $new);
     }

--- a/src/Symfony/Component/HttpKernel/README.md
+++ b/src/Symfony/Component/HttpKernel/README.md
@@ -4,7 +4,7 @@ HttpKernel Component
 HttpKernel provides the building blocks to create flexible and fast HTTP-based
 frameworks.
 
-``HttpKernelInterface`` is the core interface of the Symfony2 full-stack
+``HttpKernelInterface`` is the core interface of the Symfony full-stack
 framework:
 
 ```php
@@ -23,11 +23,11 @@ interface HttpKernelInterface
 
 It takes a ``Request`` as an input and should return a ``Response`` as an
 output. Using this interface makes your code compatible with all frameworks
-using the Symfony2 components. And this will give you many cool features for
+using the Symfony components. And this will give you many cool features for
 free.
 
-Creating a framework based on the Symfony2 components is really easy. Here is
-a very simple, but fully-featured framework based on the Symfony2 components:
+Creating a framework based on the Symfony components is really easy. Here is
+a very simple, but fully-featured framework based on the Symfony components:
 
 ```php
 $routes = new RouteCollection();
@@ -54,7 +54,7 @@ $kernel = new HttpKernel($dispatcher, $resolver);
 $kernel->handle($request)->send();
 ```
 
-This is all you need to create a flexible framework with the Symfony2
+This is all you need to create a flexible framework with the Symfony
 components.
 
 Want to add an HTTP reverse proxy and benefit from HTTP caching and Edge Side

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -39,10 +39,10 @@ class SsiTest extends \PHPUnit_Framework_TestCase
 
         $request = Request::create('/');
         $ssi->addSurrogateCapability($request);
-        $this->assertEquals('symfony2="SSI/1.0"', $request->headers->get('Surrogate-Capability'));
+        $this->assertEquals('symfony="SSI/1.0"', $request->headers->get('Surrogate-Capability'));
 
         $ssi->addSurrogateCapability($request);
-        $this->assertEquals('symfony2="SSI/1.0", symfony2="SSI/1.0"', $request->headers->get('Surrogate-Capability'));
+        $this->assertEquals('symfony="SSI/1.0", symfony="SSI/1.0"', $request->headers->get('Surrogate-Capability'));
     }
 
     public function testAddSurrogateControl()

--- a/src/Symfony/Component/Intl/CONTRIBUTING.md
+++ b/src/Symfony/Component/Intl/CONTRIBUTING.md
@@ -88,4 +88,4 @@ Once it is, the following steps have to be followed to build the .dat-file:
 
    $ rm -rf build packagelist.txt
 
-3. You can now move region.dat to replace the version bundled with Symfony2.
+3. You can now move region.dat to replace the version bundled with Symfony.

--- a/src/Symfony/Component/Intl/Resources/bin/update-data.php
+++ b/src/Symfony/Component/Intl/Resources/bin/update-data.php
@@ -38,7 +38,7 @@ if ($argc > 3 || 2 === $argc && '-h' === $argv[1]) {
     bailout(<<<MESSAGE
 Usage: php update-icu-component.php <path/to/icu/source> <path/to/icu/build>
 
-Updates the ICU data for Symfony2 to the latest version of ICU.
+Updates the ICU data for Symfony to the latest version of ICU.
 
 If you downloaded the SVN repository before, you can pass the path to the
 repository source in the first optional argument.

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorage.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
 
 /**
- * Token storage that uses a Symfony2 Session object.
+ * Token storage that uses a Symfony Session object.
  *
  * @since  2.4
  * @author Bernhard Schussek <bschussek@gmail.com>

--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -74,8 +74,8 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
     public function getTransTests()
     {
         return array(
-            array('Symfony2 is great!', 'Symfony2 is great!', array()),
-            array('Symfony2 is awesome!', 'Symfony2 is %what%!', array('%what%' => 'awesome')),
+            array('Symfony is great!', 'Symfony is great!', array()),
+            array('Symfony is awesome!', 'Symfony is %what%!', array('%what%' => 'awesome')),
         );
     }
 

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -356,18 +356,18 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     public function getTransTests()
     {
         return array(
-            array('Symfony2 est super !', 'Symfony2 is great!', 'Symfony2 est super !', array(), 'fr', ''),
-            array('Symfony2 est awesome !', 'Symfony2 is %what%!', 'Symfony2 est %what% !', array('%what%' => 'awesome'), 'fr', ''),
-            array('Symfony2 est super !', new String('Symfony2 is great!'), 'Symfony2 est super !', array(), 'fr', ''),
+            array('Symfony est super !', 'Symfony is great!', 'Symfony est super !', array(), 'fr', ''),
+            array('Symfony est awesome !', 'Symfony is %what%!', 'Symfony est %what% !', array('%what%' => 'awesome'), 'fr', ''),
+            array('Symfony est super !', new String('Symfony is great!'), 'Symfony est super !', array(), 'fr', ''),
         );
     }
 
     public function getFlattenedTransTests()
     {
         $messages = array(
-            'symfony2' => array(
+            'symfony' => array(
                 'is' => array(
-                    'great' => 'Symfony2 est super!',
+                    'great' => 'Symfony est super!',
                 ),
             ),
             'foo' => array(
@@ -379,7 +379,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         );
 
         return array(
-            array('Symfony2 est super!', $messages, 'symfony2.is.great'),
+            array('Symfony est super!', $messages, 'symfony.is.great'),
             array('Foo Bar Baz', $messages, 'foo.bar.baz'),
             array('Foo Baz', $messages, 'foo.baz'),
         );

--- a/src/Symfony/Component/Translation/Tests/fixtures/resourcebundle/dat/en.txt
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resourcebundle/dat/en.txt
@@ -1,3 +1,3 @@
 en{
-    symfony{"Symfony 2 is great"}
+    symfony{"Symfony is great"}
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/resourcebundle/dat/fr.txt
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resourcebundle/dat/fr.txt
@@ -1,3 +1,3 @@
 fr{
-    symfony{"Symfony 2 est génial"}
+    symfony{"Symfony est génial"}
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

I did not rename Symfony BrowserKit HTTP user agent as it might break BC.
