### PR TITLE
[HttpFoundation] fix checkip6

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -39,7 +39,7 @@ class IpUtils
             $ips = array($ips);
         }
 
-        $method = false !== strpos($requestIp, ':') ? 'checkIp6' : 'checkIp4';
+        $method = substr_count($requestIp, ':') > 1 ? 'checkIp6' : 'checkIp4';
 
         foreach ($ips as $ip) {
             if (self::$method($requestIp, $ip)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I have this error ContextErrorException: Warning: inet_pton(): Unrecognized address X.X.X.X:X
in IpUtils.php line 110

X.X.X.X:X is detected as a ipv6 because HTTP_X_FORWARDED_FOR have a port.
