### PR TITLE
[HttpKernel] Fix UriSigner::check when _hash is not at the end of the uri

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -33,5 +33,7 @@ class UriSignerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo')));
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar')));
+
+        $this->assertTrue($signer->sign('http://example.com/foo?foo=bar&bar=foo') === $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
     }
 }

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -91,7 +91,7 @@ class UriSigner
 
     private function buildUrl(array $url, array $params = array())
     {
-        ksort($params, SORT_NATURAL);
+        ksort($params);
         $url['query'] = http_build_query($params);
 
         $scheme   = isset($url['scheme']) ? $url['scheme'].'://' : '';

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -74,8 +74,8 @@ class UriSigner
 
         $url['query'] = http_build_query($params);
 
-        $scheme   = isset($url['scheme']) ? $url['scheme'].'://' : ''; 
-        $host     = isset($url['host']) ? $url['host'] : ''; 
+        $scheme   = isset($url['scheme']) ? $url['scheme'].'://' : '';
+        $host     = isset($url['host']) ? $url['host'] : '';
         $port     = isset($url['port']) ? ':'.$url['port'] : '';
         $user     = isset($url['user']) ? $url['user'] : '';
         $pass     = isset($url['pass']) ? ':'.$url['pass']  : '';

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -59,21 +59,21 @@ class UriSigner
     public function check($uri)
     {
         $url = parse_url($uri);
-		if (isset($url['query'])) {
-			parse_str($url['query'], $params);
-		} else {
-			$params = array();
-		}
-        
+        if (isset($url['query'])) {
+            parse_str($url['query'], $params);
+        } else {
+            $params = array();
+        }
+
         if (!isset($params['_hash']) || !$params['_hash']) {
             return false;
         }
-        
+
         $hash = urlencode($params['_hash']);
         unset($params['_hash']);
-        
+
         $url['query'] = http_build_query($params);
-        
+
         $scheme   = isset($url['scheme']) ? $url['scheme'] . '://' : ''; 
         $host     = isset($url['host']) ? $url['host'] : ''; 
         $port     = isset($url['port']) ? ':' . $url['port'] : ''; 
@@ -84,7 +84,7 @@ class UriSigner
         $query    = isset($url['query']) && $url['query'] ? '?' . $url['query'] : ''; 
         $fragment = isset($url['fragment']) ? '#' . $url['fragment'] : ''; 
         $testUrl  = $scheme.$user.$pass.$host.$port.$path.$query.$fragment;
-		
+
         return $this->computeHash($testUrl) === $hash;
     }
 

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -48,9 +48,9 @@ class UriSigner
         } else {
             $params = array();
         }
-        
+
         $uri = $this->buildUrl($url, $params);
-        
+
         return $uri.(false === (strpos($uri, '?')) ? '?' : '&').'_hash='.$this->computeHash($uri);
     }
 
@@ -103,7 +103,7 @@ class UriSigner
         $path     = isset($url['path']) ? $url['path'] : '';
         $query    = isset($url['query']) && $url['query'] ? '?'.$url['query'] : '';
         $fragment = isset($url['fragment']) ? '#'.$url['fragment'] : '';
-        
+
         return $scheme.$user.$pass.$host.$port.$path.$query.$fragment;
     }
 

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -88,7 +88,7 @@ class UriSigner
     {
         return urlencode(base64_encode(hash_hmac('sha256', $uri, $this->secret, true)));
     }
-    
+
     private function buildUrl(array $url, array $params = array())
     {
         ksort($params);
@@ -106,5 +106,4 @@ class UriSigner
 
         return $scheme.$user.$pass.$host.$port.$path.$query.$fragment;
     }
-
 }

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -74,15 +74,15 @@ class UriSigner
 
         $url['query'] = http_build_query($params);
 
-        $scheme   = isset($url['scheme']) ? $url['scheme'] . '://' : ''; 
+        $scheme   = isset($url['scheme']) ? $url['scheme'].'://' : ''; 
         $host     = isset($url['host']) ? $url['host'] : ''; 
-        $port     = isset($url['port']) ? ':' . $url['port'] : ''; 
-        $user     = isset($url['user']) ? $url['user'] : ''; 
-        $pass     = isset($url['pass']) ? ':' . $url['pass']  : ''; 
-        $pass     = ($user || $pass) ? "$pass@" : ''; 
-        $path     = isset($url['path']) ? $url['path'] : ''; 
-        $query    = isset($url['query']) && $url['query'] ? '?' . $url['query'] : ''; 
-        $fragment = isset($url['fragment']) ? '#' . $url['fragment'] : ''; 
+        $port     = isset($url['port']) ? ':'.$url['port'] : '';
+        $user     = isset($url['user']) ? $url['user'] : '';
+        $pass     = isset($url['pass']) ? ':'.$url['pass']  : '';
+        $pass     = ($user || $pass) ? "$pass@" : '';
+        $path     = isset($url['path']) ? $url['path'] : '';
+        $query    = isset($url['query']) && $url['query'] ? '?'.$url['query'] : '';
+        $fragment = isset($url['fragment']) ? '#'.$url['fragment'] : '';
         $testUrl  = $scheme.$user.$pass.$host.$port.$path.$query.$fragment;
 
         return $this->computeHash($testUrl) === $hash;

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -91,7 +91,7 @@ class UriSigner
 
     private function buildUrl(array $url, array $params = array())
     {
-        ksort($params);
+        ksort($params, SORT_NATURAL);
         $url['query'] = http_build_query($params);
 
         $scheme   = isset($url['scheme']) ? $url['scheme'].'://' : '';

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -65,7 +65,7 @@ class UriSigner
             $params = array();
         }
 
-        if (!isset($params['_hash']) || !$params['_hash']) {
+        if (empty($params['_hash'])) {
             return false;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I have a weird server installation behind Varnish that rewrite the signed URL to add the _hash at the end of the url queries.
Exemple : 
URL called: http://exemple.com/page?foo=bar&_hash=123
URL received by PHP: http://exemple.com/page?_hash=123&foo=bar

When the _hash is not at the end of the URL, the UriSigner fail to verify it even if the _hash is correct.

The fix rewrites the check function to use parse_url and parse_str to analyse the URI and check the signature.
