### PR TITLE
[WebProfilerBundle] Remove usage of app.request in search bar template

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -249,6 +249,7 @@ class ProfilerController
             'start' => $start,
             'end' => $end,
             'limit' => $limit,
+            'request' => $request,
         )), 200, array('Content-Type' => 'text/html'));
     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -15,7 +15,7 @@
         </select>
         <div class="clear-fix"></div>
         <label for="url">URL</label>
-        <input type="url" name="url" id="url" value="{{ url }}" placeholder="e.g. {{ app.request.baseUrl }}">
+        <input type="url" name="url" id="url" value="{{ url }}" placeholder="e.g. {{ request.baseUrl }}">
         <div class="clear-fix"></div>
         <label for="token">Token</label>
         <input type="text" name="token" id="token" value="{{ token }}" placeholder="e.g. 1f321b">


### PR DESCRIPTION
This PR removes the last usage of the global Twig variable `app.request` in Symfony.

| Q | A |
| --- | --- |
| Bug fix? | kinda |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
