### PR TITLE
[Translation] [2.6] Upgrade information for LoggingTranslator

### DIFF
--- a/UPGRADE-2.6.md
+++ b/UPGRADE-2.6.md
@@ -364,3 +364,43 @@ $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
 Then enjoy dumping variables by calling `dump($var)` anywhere in your PHP
 and `{% dump var %}` or `{{ dump(var) }}` in Twig. Dumps are displayed
 **in the web debug toolbar**.
+
+Translation
+-----------
+
+With `LoggingTranslator`, a new translator class is introduced with Symfony
+2.6. By default, the `@translator` service is referring to this class in the
+debug environment.
+
+If you have own services that depend on the `@translator` service and expect
+this service to be an instance of either
+`Symfony\Component\Translation\Translator` or
+`Symfony\Bundle\FrameworkBundle\Translation\Translator`, e.g. by type-hinting
+for either of these classes, you will need to change that type hint. You can
+use the `TranslatorInterface` to be on the safe side for future changes.
+
+Before:
+
+```php
+use Symfony\Component\Translation\Translator;
+
+class MyService {
+    public function __construct(Translator $translator)
+    {
+        ...
+    }
+}
+```
+
+After:
+
+```php
+use Symfony\Component\Translation\TranslatorInterface;
+
+class MyService {
+    public function __construct(TranslatorInterface $translator)
+    {
+        ...
+    }
+}
+```


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

When upgrading a Symfony 2.5 project to the 2.6 branch, I noticed that the `@translator` service was changed. In the affected project, we've had a service that depends on the `@translator` service and uses a type hint to ensure that a `Translator` instance is passed to the constructor. With the introduction of the `LoggingTranslator` class (PR #10887), this type hint now fails.

I have added a small note to `UPGRADE-2.6.md` in case more people stumble across this changed behavior.
