### PR TITLE
[RFC] [DebugBundle] [HttpKernel] Avoid using container as dependency for DumpListener

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -18,8 +18,8 @@
 
         <service id="debug.dump_listener" class="Symfony\Component\HttpKernel\EventListener\DumpListener">
             <tag name="kernel.event_subscriber" />
-            <argument type="service" id="service_container" />
-            <argument>data_collector.dump</argument>
+            <argument type="service" id="var_dumper.cloner" />
+            <argument type="service" id="data_collector.dump" />
         </service>
 
         <service id="var_dumper.cloner" class="Symfony\Component\VarDumper\Cloner\VarCloner" />

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 use Symfony\Component\VarDumper\VarDumper;
 
 /**
@@ -27,30 +28,27 @@ class DumpListener implements EventSubscriberInterface
     private $dumper;
 
     /**
-     * @param ContainerInterface $container Service container, for lazy loading.
-     * @param string             $dumper    var_dumper dumper service to use.
+     * @param ClonerInterface      $cloner    Cloner service.
+     * @param DataDumperInterface  $dumper    Dumper service.
      */
-    public function __construct(ContainerInterface $container, $dumper)
+    public function __construct(ClonerInterface $cloner, DataDumperInterface $dumper)
     {
-        $this->container = $container;
+        $this->cloner = $cloner;
         $this->dumper = $dumper;
     }
 
     public function configure()
     {
-        if ($this->container) {
-            $container = $this->container;
-            $dumper = $this->dumper;
-            $this->container = null;
+        $cloner = $this->cloner;
+        $dumper = $this->dumper;
 
-            VarDumper::setHandler(function ($var) use ($container, $dumper) {
-                $dumper = $container->get($dumper);
-                $cloner = $container->get('var_dumper.cloner');
-                $handler = function ($var) use ($dumper, $cloner) {$dumper->dump($cloner->cloneVar($var));};
-                VarDumper::setHandler($handler);
-                $handler($var);
-            });
-        }
+        VarDumper::setHandler(function ($var) use ($cloner, $dumper) {
+            $handler = function ($var) use ($dumper, $cloner) {
+                $dumper->dump($cloner->cloneVar($var));
+            };
+            VarDumper::setHandler($handler);
+            $handler($var);
+        });
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -43,11 +43,7 @@ class DumpListener implements EventSubscriberInterface
         $dumper = $this->dumper;
 
         VarDumper::setHandler(function ($var) use ($cloner, $dumper) {
-            $handler = function ($var) use ($dumper, $cloner) {
-                $dumper->dump($cloner->cloneVar($var));
-            };
-            VarDumper::setHandler($handler);
-            $handler($var);
+            $dumper->dump($cloner->cloneVar($var));
         });
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
@@ -35,7 +35,8 @@ class DumpListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigure()
     {
-        $prevDumper = $this->getDumpHandler();
+        $prevDumper = VarDumper::setHandler('var_dump');
+        VarDumper::setHandler($prevDumper);
 
         $cloner = new MockCloner();
         $dumper = new MockDumper();
@@ -47,21 +48,10 @@ class DumpListenerTest extends \PHPUnit_Framework_TestCase
         try {
             $listener->configure();
 
-            $lazyDumper = $this->getDumpHandler();
             VarDumper::dump('foo');
-
-            $loadedDumper = $this->getDumpHandler();
             VarDumper::dump('bar');
 
             $this->assertSame('+foo-+bar-', ob_get_clean());
-
-            $listenerReflector = new \ReflectionClass($listener);
-            $lazyReflector = new \ReflectionFunction($lazyDumper);
-            $loadedReflector = new \ReflectionFunction($loadedDumper);
-
-            $this->assertSame($listenerReflector->getFilename(), $lazyReflector->getFilename());
-            $this->assertSame($listenerReflector->getFilename(), $loadedReflector->getFilename());
-            $this->assertGreaterThan($lazyReflector->getStartLine(), $loadedReflector->getStartLine());
         } catch (\Exception $exception) {
         }
 
@@ -70,14 +60,6 @@ class DumpListenerTest extends \PHPUnit_Framework_TestCase
         if (null !== $exception) {
             throw $exception;
         }
-    }
-
-    private function getDumpHandler()
-    {
-        $prevDumper = VarDumper::setHandler('var_dump');
-        VarDumper::setHandler($prevDumper);
-
-        return $prevDumper;
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
@@ -11,10 +11,11 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\EventListener\DumpListener;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 use Symfony\Component\VarDumper\VarDumper;
 
 /**
@@ -36,13 +37,12 @@ class DumpListenerTest extends \PHPUnit_Framework_TestCase
     {
         $prevDumper = $this->getDumpHandler();
 
-        $container = new ContainerBuilder();
-        $container->setDefinition('var_dumper.cloner', new Definition('Symfony\Component\HttpKernel\Tests\EventListener\MockCloner'));
-        $container->setDefinition('mock_dumper', new Definition('Symfony\Component\HttpKernel\Tests\EventListener\MockDumper'));
+        $cloner = new MockCloner();
+        $dumper = new MockDumper();
 
         ob_start();
         $exception = null;
-        $listener = new DumpListener($container, 'mock_dumper');
+        $listener = new DumpListener($cloner, $dumper);
 
         try {
             $listener->configure();
@@ -75,24 +75,26 @@ class DumpListenerTest extends \PHPUnit_Framework_TestCase
     private function getDumpHandler()
     {
         $prevDumper = VarDumper::setHandler('var_dump');
-        VarDumper::setHandler($prevDumper );
+        VarDumper::setHandler($prevDumper);
 
         return $prevDumper;
     }
 }
 
-class MockCloner
+class MockCloner implements ClonerInterface
 {
     public function cloneVar($var)
     {
-        return $var.'-';
+        return new Data(array($var.'-'));
     }
 }
 
-class MockDumper
+class MockDumper implements DataDumperInterface
 {
-    public function dump($var)
+    public function dump(Data $data)
     {
-        echo '+'.$var;
+        $rawData = $data->getRawData();
+
+        echo '+'.$rawData[0];
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kinda |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Usage of the `container` service as dependency avoid using the listener outside of a Symfony project.

I don't know if the lazy loading of the dumper service is really required. We should only use the `DebugBundle` in `dev` environment.
If it break performance, maybe we can consider using the `lazy="true"` parameter in services definition.

I currently working on a Silex [`DebugServiceProvider`](https://github.com/jeromemacias/Silex-Debug) which use the `DebugBundle` to avoid duplicating the dump profiler view (like it's done by the `WebProfilerServiceProvider`).
Those modifications are required by the provider to be usable.
