### PR TITLE
[ExpressionLanguage] Simplify use by adding expression contexts

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/AbstractExpressionContext.php
+++ b/src/Symfony/Component/ExpressionLanguage/AbstractExpressionContext.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage;
+
+/**
+ * An implementation of ExpressionContextInterface that does most
+ * of the heavy lifting.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+abstract class AbstractExpressionContext implements ExpressionContextInterface
+{
+    private $expressionLanguage;
+    private $values;
+
+    public function __construct(ExpressionLanguage $expressionLanguage = null)
+    {
+        $this->expressionLanguage = $expressionLanguage ?: new ExpressionLanguage();
+
+        static::registerFunctions($this->expressionLanguage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function parse($expression, ExpressionLanguage $expressionLanguage = null)
+    {
+        $expressionLanguage = $expressionLanguage ?: new ExpressionLanguage();
+        static::registerFunctions($expressionLanguage);
+
+        return $expressionLanguage->parse($expression, static::getNames());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function compile($expression, ExpressionLanguage $expressionLanguage = null)
+    {
+        $expressionLanguage = $expressionLanguage ?: new ExpressionLanguage();
+        static::registerFunctions($expressionLanguage);
+
+        return $expressionLanguage->compile($expression, static::getNames());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function evaluate($expression)
+    {
+        return $this->expressionLanguage->evaluate($expression, $this->getValues());
+    }
+
+    /**
+     * Build the values to be used within this context.
+     *
+     * @return array
+     */
+    abstract protected function buildValues();
+
+    /**
+     * Get and cache the values to be used within this context.
+     *
+     * @return array
+     */
+    private function getValues()
+    {
+        if ($this->values) {
+            return $this->values;
+        }
+
+        return $this->values = $this->buildValues();
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionContextInterface.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionContextInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage;
+
+/**
+ * Allows to compile and evaluate expressions within a specific context.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface ExpressionContextInterface
+{
+    /**
+     * The variable names used.
+     *
+     * @return array
+     */
+    public static function getNames();
+
+    /**
+     * Register functions to ExpressionLanguage.
+     *
+     * @param ExpressionLanguage $expressionLanguage
+     */
+    public static function registerFunctions(ExpressionLanguage $expressionLanguage);
+
+    /**
+     * Parses an expression.
+     *
+     * @param Expression|string       $expression         The expression to parse
+     * @param ExpressionLanguage|null $expressionLanguage Optional instance of ExpressionLanguage to use
+     *
+     * @return ParsedExpression A ParsedExpression instance
+     */
+    public static function parse($expression, ExpressionLanguage $expressionLanguage = null);
+
+    /**
+     * Compiles an expression source code.
+     *
+     * @param Expression|string       $expression         The expression to compile
+     * @param ExpressionLanguage|null $expressionLanguage Optional instance of ExpressionLanguage to use
+     *
+     * @return string The compiled PHP source code
+     */
+    public static function compile($expression, ExpressionLanguage $expressionLanguage = null);
+
+    /**
+     * Evaluate an expression.
+     *
+     * @param Expression|string $expression The expression to compile
+     *
+     * @return string The result of the evaluation of the expression
+     */
+    public function evaluate($expression);
+}

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionContextTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionContextTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Tests;
+
+use Symfony\Component\ExpressionLanguage\AbstractExpressionContext;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class ExpressionContextTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEvaluate()
+    {
+        $context = new ExpressionContextFixture1();
+
+        $this->assertSame(2, $context->evaluate('1+1'));
+        $this->assertSame('Hello bar', $context->evaluate("hello()~' '~foo"));
+    }
+
+    public function testParse()
+    {
+        $this->assertInstanceOf(
+            'Symfony\Component\ExpressionLanguage\ParsedExpression',
+            ExpressionContextFixture1::parse("hello()~' '~foo")
+        );
+    }
+
+    public function testCompile()
+    {
+        $this->assertSame('(($helloer->sayHello() . " ") . $foo)', ExpressionContextFixture1::compile("hello()~' '~foo"));
+    }
+}
+
+class ExpressionContextFixture1 extends AbstractExpressionContext
+{
+    protected function buildValues()
+    {
+        return array(
+            'foo' => 'bar',
+            'helloer' => new ExpressionContextFixture2(),
+        );
+    }
+
+    public static function getNames()
+    {
+        return array('foo', 'helloer');
+    }
+
+    public static function registerFunctions(ExpressionLanguage $expressionLanguage)
+    {
+        $expressionLanguage->register(
+            'hello',
+            function () {
+                return sprintf('$helloer->sayHello()');
+            },
+            function ($variables) {
+                return $variables['helloer']->sayHello();
+            }
+        );
+    }
+}
+
+class ExpressionContextFixture2
+{
+    public function sayHello()
+    {
+        return 'Hello';
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | _TODO_ |

I find the ExpressionLanguage awkward to use. You define your functions in one place and your variables in another. This PR adds the ability to implement an `ExpressionContextInterface` so you can define your functions and variables in one place. Making the `compile` and `parse` functions static allows you to pre-parse/pre-compile your expressions without instantiating the class and its possible dependencies.

I'm not sure `Context` is the best name for this.
