### PR TITLE
[DX] [HttpKernel] Use "context" argument when logging route in RouterListener

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -128,7 +128,7 @@ class RouterListener implements EventSubscriberInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
+                $this->logger->info(sprintf('Matched route "%s"', $parameters['_route']), $parameters);
             }
 
             $request->attributes->add($parameters);
@@ -148,16 +148,6 @@ class RouterListener implements EventSubscriberInterface
 
             throw new MethodNotAllowedHttpException($e->getAllowedMethods(), $message, $e);
         }
-    }
-
-    private function parametersToString(array $parameters)
-    {
-        $pieces = array();
-        foreach ($parameters as $key => $val) {
-            $pieces[] = sprintf('"%s": "%s"', $key, (is_string($val) ? $val : json_encode($val)));
-        }
-
-        return implode(', ', $pieces);
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

When using the "fingers_crossed" option, I only log stuff when a certain level is reached. I found the matched route with parameters to be extremely useful. The only problem was, that it gets dumped in a string, which reduces readability significantly when having multiple parameters. 

I've used the context argument to provide the additional information so it becomes easier to read. Especially for formatters that use the context, such as the HtmlFormatter, can really use this.

_I've done a quick check and noticed that almost always the information is dumped in the message, while I think it should be in the context. Is this something that should be changed in general?_
