### PR TITLE
Fix misleading TokenInterface docblock

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -47,8 +47,8 @@ interface TokenInterface extends \Serializable
     /**
      * Returns a user representation.
      *
-     * @return mixed either returns an object which implements __toString(), or
-     *                  a primitive string is returned.
+     * @return mixed either returns an object which implements Symfony\Component\Security\Core\User\UserInterface,
+     *                  or a primitive string is returned.
      */
     public function getUser();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I've found the docblock for `TokenInterface::getUser` misleading. By reading it I've written something like:

``` php
$username = (string) $token->getUser();
```

This actually doesn't work, since `UserInterface` doesn't implements `__toString` and I have some instance of `AdvancedUser` (coming from InMemory provider).

If the token always return a `UserInterface` or string, then my fix is ok.
