### PR TITLE
Improved error message

### DIFF
--- a/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
@@ -34,7 +34,7 @@ class UndefinedMethodFatalErrorHandler implements FatalErrorHandlerInterface
         $className = $matches[1];
         $methodName = $matches[2];
 
-        $message = sprintf('Attempted to call method "%s" on class "%s".', $methodName, $className);
+        $message = sprintf('Attempted to call an undefined method named "%s" of class "%s".', $methodName, $className);
 
         $candidates = array();
         foreach (get_class_methods($className) as $definedMethodName) {


### PR DESCRIPTION
If no alternatives could be found, the error message is: "Attempted to call method "getContents" on class "SebastianBergmann\Diff\Diff"." This doesn't point out any error, as it doesn't tell you that the method does not exists. This PR tries to fix this.
