### PR TITLE
Add type aliases for allowed types in OptionsResolver

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -843,7 +843,15 @@ class OptionsResolver implements Options, OptionsResolverInterface
         if (isset($this->allowedTypes[$option])) {
             $valid = false;
 
+            $typeAliases = array(
+                'boolean' => 'bool',
+                'integer' => 'int',
+                'double' => 'float',
+            );
+
             foreach ($this->allowedTypes[$option] as $type) {
+                $type = isset($typeAliases[$type]) ? $typeAliases[$type] : $type;
+
                 if (function_exists($isFunction = 'is_'.$type)) {
                     if ($isFunction($value)) {
                         $valid = true;

--- a/src/Symfony/Component/OptionsResolver/Tests/Issue12586Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/Issue12586Test.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Symfony\Component\OptionsResolver\Tests;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class Issue12586Test extends \PHPUnit_Framework_TestCase
+{
+    public function testBooleanIsAliasedAsBool()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
+            'force' => false,
+        ));
+
+        $resolver->setAllowedTypes(array(
+            'force' => 'boolean',
+        ));
+
+        $resolver->resolve(array(
+            'force' => true,
+        ));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [#12586] |
| License | MIT |

same as #12602 but for 2.6

Improves DX by allowing type names that does not correspond 1 to 1
with php is_ functions.

integer => int
boolean => bool
double => float
