### PR TITLE
[Hackday] [Toolbar] Fix info position and icons on small screens

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -139,10 +139,6 @@
     border-radius: 4px 4px 0 0;
 }
 
-.sf-toolbarreset > div:last-of-type .sf-toolbar-info {
-    right: -1px;
-}
-
 .sf-toolbar-block .sf-toolbar-info:empty {
     visibility: hidden;
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -30,7 +30,6 @@
     background-color: #f7f7f7;
     left: 0;
     right: 0;
-    height: 38px;
     margin: 0;
     padding: 0 40px 0 0;
     z-index: 6000000;
@@ -77,6 +76,7 @@
     color: #2f2f2f;
     display: block;
     min-height: 28px;
+    border-bottom: 1px solid #e4e4e4;
     border-right: 1px solid #e4e4e4;
     padding: 0;
     float: left;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -42,6 +42,10 @@
                         var leftValue = (elementWidth + this.offsetLeft) - pageWidth;
                         var rightValue = (elementWidth + (pageWidth - this.offsetLeft)) - pageWidth;
 
+                        /* Reset right and left value, useful on window resize */
+                        toolbarInfo.style.right = '';
+                        toolbarInfo.style.left = '';
+
                         if (leftValue > 0 && rightValue > 0) {
                             toolbarInfo.style.right = (rightValue * -1) + 'px';
                         } else if (leftValue < 0) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -31,6 +31,26 @@
                 }
 
                 Sfjs.renderAjaxRequests();
+
+                /* Handle toolbar-info position */
+                var toolbarBlocks = document.getElementsByClassName('sf-toolbar-block');
+                for (var i = 0; i < toolbarBlocks.length; i += 1) {
+                    toolbarBlocks[i].onmouseover = function () {
+                        var toolbarInfo = this.getElementsByClassName('sf-toolbar-info')[0];
+                        var pageWidth = document.body.clientWidth;
+                        var elementWidth = toolbarInfo.offsetWidth;
+                        var leftValue = (elementWidth + this.offsetLeft) - pageWidth;
+                        var rightValue = (elementWidth + (pageWidth - this.offsetLeft)) - pageWidth;
+
+                        if (leftValue > 0 && rightValue > 0) {
+                            toolbarInfo.style.right = (rightValue * -1) + 'px';
+                        } else if (leftValue < 0) {
+                            toolbarInfo.style.left = 0;
+                        } else {
+                            toolbarInfo.style.right = '-1px';
+                        }
+                    };
+                }
             },
             function(xhr) {
                 if (xhr.status !== 0) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12582 |
| License | MIT |
| Doc PR | - |

I changed a bit the order of profiles, IMO the dump goes closer to request data. Then I tweaked a bit the toolbar to show more icons even on smaller screen. I tested everything with Chrome and IE9 and it seems to work smoothly.

Here are some explanatory screenshots:

![](http://cl.ly/image/3E2e360Y0a15/Screen%20Shot%202014-11-29%20at%2011.56.17.png)
![](http://cl.ly/image/1d073v2v2U2J/Screen%20Shot%202014-11-29%20at%2011.56.42.png)
