### PR TITLE
[HttpFoundation] [Hackday] #9942 test: Request::getContent() for null value

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -217,7 +217,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(80, $request->getPort());
         $this->assertEquals('test.com', $request->getHttpHost());
         $this->assertEquals('username', $request->getUser());
-        $this->assertSame('',$request->getPassword());
+        $this->assertSame('', $request->getPassword());
         $this->assertFalse($request->isSecure());
 
         $request = Request::create('http://test.com/?foo');
@@ -501,7 +501,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $request = new Request();
 
-        $request->initialize(array(), array(), array(), array(), array(),$server);
+        $request->initialize(array(), array(), array(), array(), array(), $server);
 
         $this->assertEquals('http://host:8080/index.php/some/path', $request->getUriForPath('/some/path'), '->getUriForPath() with non default port');
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -905,6 +905,18 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * [HttpFoundation] Request::getContent() behavior for null value #9942
+     *
+     * @see https://github.com/symfony/symfony/issues/9942
+     */
+    public function testEmptyStringContentReturns()
+    {
+        $req = Request::create('test');
+
+        $this->assertEquals("", $req->getContent());
+    }
+
+    /**
      * @expectedException \LogicException
      * @dataProvider getContentCantBeCalledTwiceWithResourcesProvider
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -904,16 +904,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(feof($retval));
     }
 
-    /**
-     * [HttpFoundation] Request::getContent() behavior for null value #9942
-     *
-     * @see https://github.com/symfony/symfony/issues/9942
-     */
     public function testEmptyStringContentReturns()
     {
         $req = Request::create('test');
 
-        $this->assertEquals("", $req->getContent());
+        $this->assertEquals('', $req->getContent());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9942 |
| License | MIT |
| Doc PR |  |

Implementing test for issue #9942 to confirm that the bug is already fixed. It's possibile to close the issue. 

Thanks also to @baiolo, @andyroid1978 for contributions at HackDay of the SymfonyConf 
