### PR TITLE
[Filesystem] Keep executable permission when a file is copied

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -69,6 +69,11 @@ class Filesystem
                 throw new IOException(sprintf('Failed to copy "%s" to "%s".', $originFile, $targetFile), 0, null, $originFile);
             }
 
+            if (is_executable($originFile)) {
+                // User Executable | Group Executable | Other Executable
+                chmod($targetFile, fileperms($targetFile) | 0x0040 | 0x0008 | 0x0001);
+            }
+
             if (stream_is_local($originFile) && $bytesCopied !== filesize($originFile)) {
                 throw new IOException(sprintf('Failed to copy the whole content of "%s" to "%s %g bytes copied".', $originFile, $targetFile, $bytesCopied), 0, null, $originFile);
             }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -967,4 +967,30 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($filename);
         $this->assertSame('bar', file_get_contents($filename));
     }
+
+    public function testCopyShouldKeepExecutionPermission()
+    {
+        $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';
+        $targetFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_target_file';
+
+        file_put_contents($sourceFilePath, 'SOURCE FILE');
+        chmod($sourceFilePath, 0755);
+
+        $this->filesystem->copy($sourceFilePath, $targetFilePath);
+
+        $this->assertFilePermissions(755, $targetFilePath);
+    }
+
+    public function testCopyShouldNotKeepWritePermissionOtherThanCurrentUser()
+    {
+        $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';
+        $targetFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_target_file';
+
+        file_put_contents($sourceFilePath, 'SOURCE FILE');
+        chmod($sourceFilePath, 0777);
+
+        $this->filesystem->copy($sourceFilePath, $targetFilePath);
+
+        $this->assertFilePermissions(755, $targetFilePath);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | / |
| License | MIT |
| Doc PR | / |

I made this PR in order to have the same behavior as the default `cp` unix command: permissions are not keep when copying a file at the exception of the execution flag (unless `-p` is passed to the command).
