### PR TITLE
[FrameworkBundle] remove deprecated method 'createEsi'

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -369,6 +369,8 @@ UPGRADE FROM 2.x to 3.0
 
  * The `RouterApacheDumperCommand` was removed.
 
+ * The `createEsi` method of `Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache` was removed. Use `createSurrogate` instead.
+
 ### HttpKernel
 
  * The `Symfony\Component\HttpKernel\Log\LoggerInterface` has been removed in

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -72,18 +72,6 @@ abstract class HttpCache extends BaseHttpCache
 
     protected function createSurrogate()
     {
-        return $this->createEsi();
-    }
-
-    /**
-     * Creates new ESI instance
-     *
-     * @return Esi
-     *
-     * @deprecated Deprecated since version 2.6, to be removed in 3.0. Use createSurrogate() instead
-     */
-    protected function createEsi()
-    {
         return new Esi();
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | -- |
