### PR TITLE
[Validator] add deprecation log to class ApcCache (#12665)

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
+++ b/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
@@ -23,6 +23,8 @@ class ApcCache implements CacheInterface
 
     public function __construct($prefix)
     {
+        trigger_error('The Symfony\Component\Validator\Mapping\Cache\ApcCache class is deprecated since version 2.5 and will be removed in 3.0. Use DoctrineCache with Doctrine\Common\Cache\ApcCache instead.', E_USER_DEPRECATED);
+
         if (!extension_loaded('apc')) {
             throw new \RuntimeException('Unable to use ApcCache to cache validator mappings as APC is not enabled.');
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12665 |
| License | MIT |
| Doc PR |  |

This adds depreciation note for the Symfony\Component\Validator\Mapping\Cache\ApcCache class.
