### PR TITLE
[Form] Improve exception message in config builder when data class is invalid

### DIFF
--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -193,7 +193,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         self::validateName($name);
 
         if (null !== $dataClass && !class_exists($dataClass)) {
-            throw new InvalidArgumentException(sprintf('The data class "%s" is not a valid class.', $dataClass));
+            throw new InvalidArgumentException(sprintf('Error while building form configuration. The data class "%s" was not found, are you sure it exists?', $dataClass));
         }
 
         $this->name = (string) $name;


### PR DESCRIPTION
[Form] Improve exception message in config builder when data class is invalid

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12359 |
| License | MIT |
| Doc PR |  |
