### PR TITLE
[Hackday] - trigger errors for deprecated classes

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
+++ b/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\ClassLoader;
 
-if (PHP_VERSION_ID >= 50400) {
-    define('SYMFONY_TRAIT', T_TRAIT);
-} else {
-    define('SYMFONY_TRAIT', 0);
+if (!defined('SYMFONY_TRAIT')) {
+    if (PHP_VERSION_ID >= 50400) {
+        define('SYMFONY_TRAIT', T_TRAIT);
+    } else {
+        define('SYMFONY_TRAIT', 0);
+    }
 }
 
 /**
@@ -32,8 +34,8 @@ class ClassMapGenerator
      */
     public static function dump($dirs, $file)
     {
-        $dirs = (array) $dirs;
-        $maps = array();
+        $dirs = (array)$dirs;
+        $maps = [];
 
         foreach ($dirs as $dir) {
             $maps = array_merge($maps, static::createMap($dir));
@@ -55,7 +57,7 @@ class ClassMapGenerator
             $dir = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
         }
 
-        $map = array();
+        $map = [];
 
         foreach ($dir as $file) {
             if (!$file->isFile()) {
@@ -90,7 +92,7 @@ class ClassMapGenerator
         $contents = file_get_contents($path);
         $tokens = token_get_all($contents);
 
-        $classes = array();
+        $classes = [];
 
         $namespace = '';
         for ($i = 0, $max = count($tokens); $i < $max; $i++) {
@@ -107,7 +109,7 @@ class ClassMapGenerator
                     $namespace = '';
                     // If there is a namespace, extract it
                     while (($t = $tokens[++$i]) && is_array($t)) {
-                        if (in_array($t[0], array(T_STRING, T_NS_SEPARATOR))) {
+                        if (in_array($t[0], [T_STRING, T_NS_SEPARATOR])) {
                             $namespace .= $t[1];
                         }
                     }

--- a/src/Symfony/Component/Validator/Constraints/Collection/Optional.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection/Optional.php
@@ -24,4 +24,13 @@ use Symfony\Component\Validator\Constraints\Optional as BaseOptional;
  */
 class Optional extends BaseOptional
 {
+    public function __construct($options = null)
+    {
+        trigger_error(
+            'The Symfony\Component\Validator\Constraints\Collection\Optional is deprecated. '.
+            'You should use Symfony\Component\Validator\Constraints\Optional.',
+            E_USER_DEPRECATED
+        );
+        parent::__construct($options);
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Collection/Optional.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection/Optional.php
@@ -27,8 +27,7 @@ class Optional extends BaseOptional
     public function __construct($options = null)
     {
         trigger_error(
-            'The Symfony\Component\Validator\Constraints\Collection\Optional is deprecated. '.
-            'You should use Symfony\Component\Validator\Constraints\Optional.',
+            'The Symfony\Component\Validator\Constraints\Collection\Optional is deprecated. You should use Symfony\Component\Validator\Constraints\Optional.',
             E_USER_DEPRECATED
         );
         parent::__construct($options);

--- a/src/Symfony/Component/Validator/Constraints/Collection/Optional.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection/Optional.php
@@ -26,10 +26,7 @@ class Optional extends BaseOptional
 {
     public function __construct($options = null)
     {
-        trigger_error(
-            'The Symfony\Component\Validator\Constraints\Collection\Optional is deprecated. You should use Symfony\Component\Validator\Constraints\Optional.',
-            E_USER_DEPRECATED
-        );
+        trigger_error('The Symfony\Component\Validator\Constraints\Collection\Optional is deprecated. You should use Symfony\Component\Validator\Constraints\Optional.', E_USER_DEPRECATED);
         parent::__construct($options);
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Collection/Required.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection/Required.php
@@ -26,10 +26,7 @@ class Required extends BaseRequired
 {
     public function __construct($options = null)
     {
-        trigger_error(
-            'The Symfony\Component\Validator\Constraints\Collection\Required is deprecated. You should use Symfony\Component\Validator\Constraints\Required.',
-            E_USER_DEPRECATED
-        );
+        trigger_error('The Symfony\Component\Validator\Constraints\Collection\Required is deprecated. You should use Symfony\Component\Validator\Constraints\Required.', E_USER_DEPRECATED);
         parent::__construct($options);
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Collection/Required.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection/Required.php
@@ -27,8 +27,7 @@ class Required extends BaseRequired
     public function __construct($options = null)
     {
         trigger_error(
-            'The Symfony\Component\Validator\Constraints\Collection\Required is deprecated. '.
-            'You should use Symfony\Component\Validator\Constraints\Required.',
+            'The Symfony\Component\Validator\Constraints\Collection\Required is deprecated. You should use Symfony\Component\Validator\Constraints\Required.',
             E_USER_DEPRECATED
         );
         parent::__construct($options);

--- a/src/Symfony/Component/Validator/Constraints/Collection/Required.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection/Required.php
@@ -24,4 +24,13 @@ use Symfony\Component\Validator\Constraints\Required as BaseRequired;
  */
 class Required extends BaseRequired
 {
+    public function __construct($options = null)
+    {
+        trigger_error(
+            'The Symfony\Component\Validator\Constraints\Collection\Required is deprecated. '.
+            'You should use Symfony\Component\Validator\Constraints\Required.',
+            E_USER_DEPRECATED
+        );
+        parent::__construct($options);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12669 |
| License | MIT |
| Doc PR | - |

trigger errors for deprecated classes Symfony\Component\Validator\Constraints\Required and Symfony\Component\Validator\Constraints\Optional

Whould I create a UPGRADE-2.7.md and explain this?
