### PR TITLE
Hackday deprecated 12621

### DIFF
--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -27,6 +27,8 @@ class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
      */
     public function emerg($message, array $context = array())
     {
+        trigger_error('The emerg() method of the Monolog Logger was removed. You should use the new method emergency() instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+
         return parent::addRecord(BaseLogger::EMERGENCY, $message, $context);
     }
 
@@ -35,6 +37,8 @@ class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
      */
     public function crit($message, array $context = array())
     {
+        trigger_error('The crit() method of the Monolog Logger was removed. You should use the new method critical() instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+
         return parent::addRecord(BaseLogger::CRITICAL, $message, $context);
     }
 
@@ -43,6 +47,8 @@ class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
      */
     public function err($message, array $context = array())
     {
+        trigger_error('The err() method of the Monolog Logger was removed. You should use the new method error() instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+
         return parent::addRecord(BaseLogger::ERROR, $message, $context);
     }
 
@@ -51,6 +57,8 @@ class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
      */
     public function warn($message, array $context = array())
     {
+        trigger_error('The warn() method of the Monolog Logger was removed. You should use the new method warning() instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+
         return parent::addRecord(BaseLogger::WARNING, $message, $context);
     }
 

--- a/src/Symfony/Component/HttpKernel/Log/NullLogger.php
+++ b/src/Symfony/Component/HttpKernel/Log/NullLogger.php
@@ -28,6 +28,7 @@ class NullLogger extends PsrNullLogger implements LoggerInterface
      */
     public function emerg($message, array $context = array())
     {
+        trigger_error('The emerg() method of the NullLogger was removed. You should use the new method emergency() instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
     }
 
     /**
@@ -36,6 +37,7 @@ class NullLogger extends PsrNullLogger implements LoggerInterface
      */
     public function crit($message, array $context = array())
     {
+        trigger_error('The crit() method of the NullLogger was removed. You should use the new method critical() instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
     }
 
     /**
@@ -44,6 +46,7 @@ class NullLogger extends PsrNullLogger implements LoggerInterface
      */
     public function err($message, array $context = array())
     {
+        trigger_error('The err() method of the NullLogger was removed. You should use the new method error() instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
     }
 
     /**
@@ -52,5 +55,6 @@ class NullLogger extends PsrNullLogger implements LoggerInterface
      */
     public function warn($message, array $context = array())
     {
+        trigger_error('The warn() method of the NullLogger was removed. You should use the new method warning() instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12621 |
| License | MIT |
| Doc PR | - |

[MonologBridge] added the deprecated error trigger in the monolog logger emerg(), crit(), err() and warn() methods
[HttpKernel] added the deprecated error trigger in the NullLogger emerg(), crit(), err() and warn() methods
