### PR TITLE
[hackday] Added tests trying to reproduce bug #11663, throwing AccessDeniedHttpException in kernel request listener

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,6 +42,32 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($logger, $_logger->getValue($l));
         $this->assertSame('foo', $_controller->getValue($l));
+    }
+
+    public function testHandleHttpExceptionThrownInListener()
+    {
+        // store the current error_log, and disable it temporarily
+        $errorLog = ini_set('error_log', file_exists('/dev/null') ? '/dev/null' : 'nul');
+
+        $listener = new ExceptionListener('foo');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($listener);
+        $dispatcher->addListener(KernelEvents::REQUEST, function ($event) {
+            throw new HttpException(1337);
+        });
+
+        $kernel = new HttpKernel($dispatcher, $this->getTestResolver());
+
+        try {
+            $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST);
+            $this->fail('HttpKernel::handle is expected to throw HttpException');
+        } catch (HttpException $exception) {
+            $this->assertEquals(1337, $exception->getStatusCode());
+        }
+
+        // restore the old error_log
+        ini_set('error_log', $errorLog);
     }
 
     /**
@@ -118,6 +148,21 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
 
         $response = $event->getResponse();
         $this->assertEquals('xml', $response->getContent());
+    }
+
+    protected function getTestResolver()
+    {
+        $controller = function () { return new Response('foo'); };
+
+        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
+        $resolver->expects($this->any())
+            ->method('getController')
+            ->will($this->returnValue($controller));
+        $resolver->expects($this->any())
+            ->method('getArguments')
+            ->will($this->returnValue(array()));
+
+        return $resolver;
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -84,7 +84,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
             $event->setResponse(new Response('foo', $event->getException()->getStatusCode()));
         });
 
-        $kernel = new HttpKernel($dispatcher, $this->getResolver(function() { return new Response(); }));
+        $kernel = new HttpKernel($dispatcher, $this->getResolver(function () { return new Response(); }));
         $response = $kernel->handle(new Request());
 
         $this->assertEquals('foo', $response->getContent());

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests;
 
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -69,6 +70,25 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('301', $response->getStatusCode());
         $this->assertEquals('/login', $response->headers->get('Location'));
+    }
+
+    public function testHandleWhenAnAccessDeniedHttpExceptionIsThrownByAListener()
+    {
+        $dispatcher = new EventDispatcher();
+
+        $dispatcher->addListener(KernelEvents::REQUEST, function ($event) {
+            throw new AccessDeniedHttpException();
+        });
+
+        $dispatcher->addListener(KernelEvents::EXCEPTION, function (GetResponseForExceptionEvent $event) {
+            $event->setResponse(new Response('foo', $event->getException()->getStatusCode()));
+        });
+
+        $kernel = new HttpKernel($dispatcher, $this->getResolver(function() { return new Response(); }));
+        $response = $kernel->handle(new Request());
+
+        $this->assertEquals('foo', $response->getContent());
+        $this->assertEquals('403', $response->getStatusCode());
     }
 
     public function testHandleHttpException()


### PR DESCRIPTION
I tried to fix #11663, assuming it was a generic problem with HTTP exceptions thrown in kernel event listeners, but I cannot reproduce it.

As I wrote a couple of tests on the way, I thought it wouldn't hurt to PR them. Yay, TDD!

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 11663 (cannot reproduce?) |
| License | MIT |

ps: Hi from the hackday.
