### PR TITLE
Deprecate interface Symfony\Component\Validator\PropertyMetadataInterface

### DIFF
--- a/src/Symfony/Component/Validator/PropertyMetadataInterface.php
+++ b/src/Symfony/Component/Validator/PropertyMetadataInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator;
 
+trigger_error('Symfony\Component\Validator\PropertyMetadataInterface was deprecated in version 2.5 and will be removed in version 3.0. Please use Symfony\Component\Validator\Mapping\PropertyMetadataInterface instead', E_USER_DEPRECATED);
+
 /**
  * A container for validation metadata of a property.
  *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12678 |
| License | MIT |

Deprecate interface Symfony\Component\Validator\PropertyMetadataInterface
