### PR TITLE
[DEPRECATION] Added deprecated trigger for ApacheMatcherDumper and ApacheUrlMatcher

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Matcher\Dumper;
 
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * Dumps a set of Apache mod_rewrite rules.
@@ -25,6 +26,20 @@ use Symfony\Component\Routing\Route;
  */
 class ApacheMatcherDumper extends MatcherDumper
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(RouteCollection $routes)
+    {
+        trigger_error(
+            'The Symfony\Component\Routing\Matcher\Dumper\ApacheMatcherDumper is deprecated '.
+            'since it\'s hard to replicate the behaviour of the PHP implementation and '.
+            'the performance gains are minimal.',
+            E_USER_DEPRECATED
+        );
+        parent::__construct($routes);
+    }
+
     /**
      * Dumps a set of Apache mod_rewrite rules.
      *

--- a/src/Symfony/Component/Routing/Matcher/Dumper/MatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/MatcherDumper.php
@@ -32,6 +32,13 @@ abstract class MatcherDumper implements MatcherDumperInterface
      */
     public function __construct(RouteCollection $routes)
     {
+        trigger_error(
+            'The Symfony\Component\Routing\Matcher\Dumper\MatcherDumper is deprecated '.
+            'since it\'s hard to replicate the behaviour of the PHP implementation and '.
+            'the performance gains are minimal.',
+            E_USER_DEPRECATED
+        );
+
         $this->routes = $routes;
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12655 |
| License | MIT |
| Doc PR |  |
