### PR TITLE
[Process] Add deprecated logs on Process::setInput() and ProcessBuilder::setInput().

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1092,6 +1092,7 @@ class Process
      * Sets the input.
      *
      * This content will be passed to the underlying process standard input.
+     * Deprecation: As of Symfony 2.5, this method only accepts scalar values.
      *
      * @param string|null $input The content
      *
@@ -1101,6 +1102,13 @@ class Process
      */
     public function setInput($input)
     {
+        if (!is_scalar($input)) {
+            trigger_error(
+                'Passing a non-scalar input is deprecated since version 2.5 and will be removed in 3.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
         if ($this->isRunning()) {
             throw new LogicException('Input can not be set while the process is running.');
         }

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -167,7 +167,7 @@ class ProcessBuilder
     /**
      * Sets the input of the process.
      *
-     * Deprecation: As of Symfony 2.5, this method only accepts string values.
+     * Deprecation: As of Symfony 2.5, this method only accepts scalar values.
      *
      * @param string|null $input The input as a string
      *
@@ -177,6 +177,13 @@ class ProcessBuilder
      */
     public function setInput($input)
     {
+        if (!is_scalar($input)) {
+            trigger_error(
+                'Passing a non-scalar input is deprecated since version 2.5 and will be removed in 3.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->input = ProcessUtils::validateInput(sprintf('%s::%s', __CLASS__, __FUNCTION__), $input);
 
         return $this;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12703 |
| License | MIT |
| Doc PR |  |
