### PR TITLE
Deprecate interface Symfony\Component\Validator\ExecutionContextInterface

### DIFF
--- a/src/Symfony/Component/Validator/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/ExecutionContextInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator;
 
+trigger_error('The "Symfony\Component\Validator\ExecutionContextInterface" interface was deprecated in version 2.5 and will be removed in 3.0. Use "Symfony\Component\Validator\Context\ExecutionContextInterface" instead.', E_USER_DEPRECATED);
+
 /**
  * Stores the validator's state during validation.
  *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | [#12683] |
| License | MIT |

Deprecate interface Symfony\Component\Validator\ExecutionContextInterface
