### PR TITLE
[DEPRECATION] Added deprecated trigger for ApacheMatcherDumper and ApacheUrlMatcher

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+trigger_error('The Symfony\Component\Routing\Matcher\Dumper\ApacheUrlMatcher is deprecated since it\'s hard to replicate the behaviour of the PHP implementation and the performance gains are minimal.', E_USER_DEPRECATED);
+
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
 /**

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Routing\Matcher\Dumper;
 
+trigger_error('The Symfony\Component\Routing\Matcher\Dumper\ApacheMatcherDumper is deprecated since it\'s hard to replicate the behaviour of the PHP implementation and the performance gains are minimal.', E_USER_DEPRECATED);
+
 use Symfony\Component\Routing\Route;
 
 /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12655 |
| License | MIT |
| Doc PR |  |
