### PR TITLE
[Security] [Doctrine] Added BaseUserProviderInterface

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -54,7 +54,7 @@ class EntityUserProvider implements UserProviderInterface
         if (null !== $this->property) {
             $user = $this->repository->findOneBy(array($this->property => $username));
         } else {
-            if (!$this->repository instanceof UserProviderInterface) {
+            if (!$this->repository instanceof BaseUserProviderInterface) {
                 throw new \InvalidArgumentException(sprintf('The Doctrine repository "%s" must implement UserProviderInterface.', get_class($this->repository)));
             }
 

--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -55,7 +55,7 @@ class EntityUserProvider implements UserProviderInterface
             $user = $this->repository->findOneBy(array($this->property => $username));
         } else {
             if (!$this->repository instanceof BaseUserProviderInterface) {
-                throw new \InvalidArgumentException(sprintf('The Doctrine repository "%s" must implement UserProviderInterface.', get_class($this->repository)));
+                throw new \InvalidArgumentException(sprintf('The Doctrine repository "%s" must implement BaseUserProviderInterface.', get_class($this->repository)));
             }
 
             $user = $this->repository->loadUserByUsername($username);
@@ -77,7 +77,7 @@ class EntityUserProvider implements UserProviderInterface
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
         }
 
-        if ($this->repository instanceof UserProviderInterface) {
+        if ($this->repository instanceof BaseUserProviderInterface) {
             $refreshedUser = $this->repository->refreshUser($user);
         } else {
             // The user must be reloaded via the primary key as all other data

--- a/src/Symfony/Component/Security/Core/User/BaseUserProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/BaseUserProviderInterface.php
@@ -31,14 +31,37 @@ use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface UserProviderInterface extends BaseUserProviderInterface
+interface BaseUserProviderInterface
 {
     /**
-     * Whether this provider supports the given user class
+     * Loads the user for the given username.
      *
-     * @param string $class
+     * This method must throw UsernameNotFoundException if the user is not
+     * found.
      *
-     * @return bool
+     * @param string $username The username
+     *
+     * @return UserInterface
+     *
+     * @see UsernameNotFoundException
+     *
+     * @throws UsernameNotFoundException if the user is not found
+     *
      */
-    public function supportsClass($class);
+    public function loadUserByUsername($username);
+
+    /**
+     * Refreshes the user for the account interface.
+     *
+     * It is up to the implementation to decide if the user data should be
+     * totally reloaded (e.g. from the database), or if the UserInterface
+     * object can just be merged into some internal array of users / identity
+     * map.
+     * @param UserInterface $user
+     *
+     * @return UserInterface
+     *
+     * @throws UnsupportedUserException if the account is not supported
+     */
+    public function refreshUser(UserInterface $user);
 }

--- a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\Security\Core\User;
 
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
-use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
-
 /**
  * Represents a class that loads UserInterface objects from some source for the authentication system.
  *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11157 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/issues/4543 |

You can now implement BaseUserProviderInterface without the need of implementing `supportsClass` function.
