### PR TITLE
Deprecate property "methods" Class Symfony\Component\Validator\Constraints\Callback

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Callback.php
+++ b/src/Symfony/Component/Validator/Constraints/Callback.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+trigger_error('The property "methods" is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+
 use Symfony\Component\Validator\Constraint;
 
 /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | [#12672] |
| License | MIT |

Deprecate property "methods" Class Symfony\Component\Validator\Constraints\Callback
