### PR TITLE
Deprecate Symfony\Component\Validator\GlobalExecutionContextInterface

### DIFF
--- a/src/Symfony/Component/Validator/GlobalExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/GlobalExecutionContextInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator;
 
+trigger_error('Symfony\Component\Validator\GlobalExecutionContextInterface was deprecated in version 2.5 and will be removed in version 3.0. Please use Symfony\Component\Validator\Context\ExecutionContextInterface instead', E_USER_DEPRECATED);
+
 /**
  * Stores the node-independent state of a validation run.
  *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12689 |
| License | MIT |

Deprecate interface Symfony\Component\Validator\GlobalExecutionContextInterface
