### PR TITLE
Deprecate interface  Symfony\Component\OptionsResolver\OptionsResolverInterface

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\OptionsResolver;
 
+trigger_error('The "Symfony\Component\OptionsResolver\OptionsResolverInterface" interface was deprecated in version 2.6 and will be removed in 3.0. Use "Symfony\Component\OptionsResolver\OptionsResolver" instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\OptionsResolver\Exception\OptionDefinitionException;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | [ #12743] |
| License | MIT |

Deprecate interface  Symfony\Component\OptionsResolver\OptionsResolverInterface
