### PR TITLE
[Process] Inherit the error_reporting from parent

### DIFF
--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -53,6 +53,8 @@ class PhpProcess extends Process
      */
     public function setPhpBinary($php)
     {
+        $php .= ' -d error_reporting='.error_reporting();
+
         $this->setCommandLine($php);
     }
 
@@ -65,7 +67,8 @@ class PhpProcess extends Process
             if (false === $php = $this->executableFinder->find()) {
                 throw new RuntimeException('Unable to find the PHP executable.');
             }
-            $this->setCommandLine($php);
+
+            $this->setPhpBinary($php);
         }
 
         parent::start($callback);


### PR DESCRIPTION
There are several builds failing due to the new E_DEPRECATED_USER messages. This is also an issue in the functional tests. The problem is that the PhpProcess started to run the functional test does not inherit the error_reporting setting from the parent.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | somewhat |
| Deprecations? | yes |
| Tests pass? | no (but broken upstream) |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Relates #12623
Relates #12705
