### PR TITLE
[PHPUnit] ignore E_USER_DEPRECATED notices

### DIFF
--- a/src/Symfony/Bridge/Doctrine/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Doctrine/phpunit.xml.dist
@@ -6,6 +6,12 @@
          colors="true"
          bootstrap="Tests/bootstrap.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony Doctrine Bridge Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Bridge/Monolog/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Monolog/phpunit.xml.dist
@@ -6,6 +6,12 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony Monolog Bridge Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Bridge/Propel1/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Propel1/phpunit.xml.dist
@@ -6,6 +6,12 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony Propel1 Bridge Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Bridge/ProxyManager/phpunit.xml.dist
+++ b/src/Symfony/Bridge/ProxyManager/phpunit.xml.dist
@@ -6,6 +6,12 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony ProxyManager Bridge Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Bridge/Twig/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Twig/phpunit.xml.dist
@@ -6,6 +6,12 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony Twig Bridge Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Bundle/DebugBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/DebugBundle/phpunit.xml.dist
@@ -6,6 +6,11 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+    <!-- Disable E_USER_DEPRECATED until 3.0 -->
+    <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
 
     <testsuites>
         <testsuite name="Symfony DebugBundle Test Suite">

--- a/src/Symfony/Bundle/FrameworkBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/FrameworkBundle/phpunit.xml.dist
@@ -6,6 +6,12 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony FrameworkBundle Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Bundle/SecurityBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/SecurityBundle/phpunit.xml.dist
@@ -6,6 +6,11 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
 
     <testsuites>
         <testsuite name="Symfony SecurityBundle Test Suite">

--- a/src/Symfony/Bundle/TwigBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/TwigBundle/phpunit.xml.dist
@@ -6,6 +6,11 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
 
     <testsuites>
         <testsuite name="Symfony TwigBundle Test Suite">

--- a/src/Symfony/Bundle/WebProfilerBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/WebProfilerBundle/phpunit.xml.dist
@@ -6,6 +6,11 @@
          colors="true"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
 
     <testsuites>
         <testsuite name="Symfony WebProfilerBundle Test Suite">

--- a/src/Symfony/Component/Security/Acl/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Acl/phpunit.xml.dist
@@ -11,6 +11,12 @@
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony Security Component ACL Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Component/Security/Core/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Core/phpunit.xml.dist
@@ -11,6 +11,12 @@
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony Security Component Core Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Component/Security/Csrf/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Csrf/phpunit.xml.dist
@@ -11,6 +11,12 @@
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony Security Component CSRF Test Suite">
             <directory>./Tests/</directory>

--- a/src/Symfony/Component/Security/Http/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Http/phpunit.xml.dist
@@ -11,6 +11,12 @@
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
+
     <testsuites>
         <testsuite name="Symfony Security Component HTTP Test Suite">
             <directory>./Tests/</directory>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This updates the PHPUnit configuration files that have not been
updated in #12705.
