### PR TITLE
[Security] Fixed The "nextBytes" Docblock

### DIFF
--- a/src/Symfony/Component/Security/Core/Util/SecureRandomInterface.php
+++ b/src/Symfony/Component/Security/Core/Util/SecureRandomInterface.php
@@ -21,7 +21,7 @@ interface SecureRandomInterface
     /**
      * Generates the specified number of secure random bytes.
      *
-     * @param int     $nbBytes
+     * @param int $nbBytes
      *
      * @return string
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the `nextBytes` docblock in the `SecureRandomInterface`.

There should only be one space following the type in the `@param` annotation.
