### PR TITLE
[Filesystem] fix lock file permissions

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/LockHandlerTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/LockHandlerTest.php
@@ -28,7 +28,7 @@ class LockHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $lock = new LockHandler('<?php echo "% hello word ! %" ?>');
 
-        $file = sprintf('%s/-php-echo-hello-word--4b3d9d0d27ddef3a78a64685dda3a963e478659a9e5240feaf7b4173a8f28d5f', sys_get_temp_dir());
+        $file = sprintf('%s/sf.-php-echo-hello-word-.4b3d9d0d27ddef3a78a64685dda3a963e478659a9e5240feaf7b4173a8f28d5f.lock', sys_get_temp_dir());
         // ensure the file does not exist before the lock
         @unlink($file);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12589, #12634 |
| License | MIT |
| Doc PR | - |

This PR replaces #12634. It tunes permissions on lock files so that locking is allowed for any OS user.
