### PR TITLE
Docblock Fixes

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -40,10 +40,11 @@ class ContainerAwareEventManager extends EventManager
     /**
      * Dispatches an event to all registered listeners.
      *
-     * @param string $eventName The name of the event to dispatch. The name of the event is
-     *                          the name of the method that is invoked on listeners.
+     * @param string    $eventName The name of the event to dispatch. The name of the event is
+     *                             the name of the method that is invoked on listeners.
      * @param EventArgs $eventArgs The event arguments to pass to the event handlers/listeners.
      *                             If not supplied, the single empty EventArgs instance is used.
+     *
      * @return bool
      */
     public function dispatchEvent($eventName, EventArgs $eventArgs = null)
@@ -81,7 +82,7 @@ class ContainerAwareEventManager extends EventManager
      *
      * @param string $event
      *
-     * @return bool    TRUE if the specified event has any listeners, FALSE otherwise.
+     * @return bool TRUE if the specified event has any listeners, FALSE otherwise.
      */
     public function hasListeners($event)
     {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -35,7 +35,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
      * @param string $connections     Parameter ID for connections
      * @param string $managerTemplate sprintf() template for generating the event
      *                                manager's service ID for a connection name
-     * @param string $tagPrefix Tag prefix for listeners and subscribers
+     * @param string $tagPrefix       Tag prefix for listeners and subscribers
      */
     public function __construct($connections, $managerTemplate, $tagPrefix)
     {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
@@ -118,7 +118,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      * @return string a service definition name
      *
      * @throws ParameterNotFoundException if non of the managerParameters has a
-     *      non-empty value.
+     *                                    non-empty value.
      */
     protected function getChainDriverServiceName(ContainerBuilder $container)
     {
@@ -138,7 +138,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      * Create the service definition for the metadata driver.
      *
      * @param ContainerBuilder $container passed on in case an extending class
-     *      needs access to the container.
+     *                                    needs access to the container.
      *
      * @return Definition|Reference the metadata driver to add to all chain drivers
      */
@@ -156,7 +156,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      *
      * @param ContainerBuilder $container
      *
-     * @return bool    whether this compiler pass really should register the mappings
+     * @return bool whether this compiler pass really should register the mappings
      */
     protected function enabled(ContainerBuilder $container)
     {

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -365,8 +365,8 @@ class EntityChoiceList extends ObjectChoiceList
      *
      * @param mixed $entity The choice to create an index for
      *
-     * @return int|string     A unique index containing only ASCII letters,
-     *                        digits and underscores.
+     * @return int|string A unique index containing only ASCII letters,
+     *                    digits and underscores.
      */
     protected function createIndex($entity)
     {
@@ -386,7 +386,7 @@ class EntityChoiceList extends ObjectChoiceList
      *
      * @param mixed $entity The choice to create a value for
      *
-     * @return int|string     A unique value without character limitations.
+     * @return int|string A unique value without character limitations.
      */
     protected function createValue($entity)
     {
@@ -444,7 +444,7 @@ class EntityChoiceList extends ObjectChoiceList
      *
      * @param object $entity The entity for which to get the identifier
      *
-     * @return array          The identifier values
+     * @return array The identifier values
      *
      * @throws RuntimeException If the entity does not exist in Doctrine's identity map
      */

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityLoaderInterface.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityLoaderInterface.php
@@ -31,7 +31,7 @@ interface EntityLoaderInterface
      * @param string $identifier The identifier field of the object. This method
      *                           is not applicable for fields with multiple
      *                           identifiers.
-     * @param array $values The values of the identifiers.
+     * @param array  $values     The values of the identifiers.
      *
      * @return array The entities.
      */

--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
@@ -54,7 +54,7 @@ class CollectionToArrayTransformer implements DataTransformerInterface
      *
      * @param mixed $array An array of entities
      *
-     * @return Collection   A collection of entities
+     * @return Collection A collection of entities
      */
     public function reverseTransform($array)
     {

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -22,6 +22,7 @@ class EntityType extends DoctrineType
      * @param ObjectManager $manager
      * @param mixed         $queryBuilder
      * @param string        $class
+     *
      * @return ORMQueryBuilderLoader
      */
     public function getLoader(ObjectManager $manager, $queryBuilder, $class)

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -60,8 +60,8 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param int     $level
-     * @param string  $message
+     * @param int    $level
+     * @param string $message
      *
      * @return array Record
      */

--- a/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
+++ b/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
@@ -70,12 +70,12 @@ class ModelChoiceList extends ObjectChoiceList
      *
      * @see \Symfony\Bridge\Propel1\Form\Type\ModelType How to use the preferred choices.
      *
-     * @param string                   $class             The FQCN of the model class to be loaded.
-     * @param string                   $labelPath         A property path pointing to the property used for the choice labels.
-     * @param array                    $choices           An optional array to use, rather than fetching the models.
-     * @param ModelCriteria            $queryObject       The query to use retrieving model data from database.
-     * @param string                   $groupPath         A property path pointing to the property used to group the choices.
-     * @param array|ModelCriteria      $preferred         The preferred items of this choice.
+     * @param string                    $class            The FQCN of the model class to be loaded.
+     * @param string                    $labelPath        A property path pointing to the property used for the choice labels.
+     * @param array                     $choices          An optional array to use, rather than fetching the models.
+     * @param ModelCriteria             $queryObject      The query to use retrieving model data from database.
+     * @param string                    $groupPath        A property path pointing to the property used to group the choices.
+     * @param array|ModelCriteria       $preferred        The preferred items of this choice.
      *                                                    Either an array if $choices is given,
      *                                                    or a ModelCriteria to be merged with the $queryObject.
      * @param PropertyAccessorInterface $propertyAccessor The reflection graph for reading property paths.
@@ -358,8 +358,8 @@ class ModelChoiceList extends ObjectChoiceList
      *
      * @param mixed $model The choice to create an index for
      *
-     * @return int|string     A unique index containing only ASCII letters,
-     *                        digits and underscores.
+     * @return int|string A unique index containing only ASCII letters,
+     *                    digits and underscores.
      */
     protected function createIndex($model)
     {
@@ -379,7 +379,7 @@ class ModelChoiceList extends ObjectChoiceList
      *
      * @param mixed $model The choice to create a value for
      *
-     * @return int|string     A unique value without character limitations.
+     * @return int|string A unique value without character limitations.
      */
     protected function createValue($model)
     {

--- a/src/Symfony/Bridge/Propel1/Security/User/PropelUserProvider.php
+++ b/src/Symfony/Bridge/Propel1/Security/User/PropelUserProvider.php
@@ -47,8 +47,8 @@ class PropelUserProvider implements UserProviderInterface
     /**
      * Default constructor
      *
-     * @param string      $class        The User model class.
-     * @param string|null $property     The property to use to retrieve a user.
+     * @param string      $class    The User model class.
+     * @param string|null $property The property to use to retrieve a user.
      */
     public function __construct($class, $property = null)
     {

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
@@ -39,7 +39,7 @@ class LazyServiceProjectServiceContainer extends Container
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @param bool    $lazyLoad whether to try lazy-loading the service with a proxy
+     * @param bool $lazyLoad whether to try lazy-loading the service with a proxy
      *
      * @return stdClass A stdClass instance.
      */
@@ -97,7 +97,7 @@ class stdClass_c1d194250ee2e2b7d2eab8b8212368a8 extends \stdClass implements \Pr
 
     /**
      * @param string $name
-     * @param mixed $value
+     * @param mixed  $value
      */
     public function __set($name, $value)
     {

--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -152,9 +152,9 @@ class CodeExtension extends \Twig_Extension
     /**
      * Formats a file path.
      *
-     * @param string  $file An absolute file path
-     * @param int     $line The line number
-     * @param string  $text Use this text for the link rather than the file path
+     * @param string $file An absolute file path
+     * @param int    $line The line number
+     * @param string $text Use this text for the link rather than the file path
      *
      * @return string
      */
@@ -187,8 +187,8 @@ class CodeExtension extends \Twig_Extension
     /**
      * Returns the link for a given file/line pair.
      *
-     * @param string  $file An absolute file path
-     * @param int     $line The line number
+     * @param string $file An absolute file path
+     * @param int    $line The line number
      *
      * @return string A link of false
      */

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -137,7 +137,7 @@ class FormExtension extends \Twig_Extension
      * @param ChoiceView   $choice        The choice to check.
      * @param string|array $selectedValue The selected value to compare.
      *
-     * @return bool    Whether the choice is selected.
+     * @return bool Whether the choice is selected.
      *
      * @see ChoiceView::isSelected()
      */

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -45,8 +45,8 @@ class HttpKernelExtension extends \Twig_Extension
     /**
      * Renders a fragment.
      *
-     * @param string|ControllerReference $uri      A URI as a string or a ControllerReference instance
-     * @param array                      $options  An array of options
+     * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
+     * @param array                      $options An array of options
      *
      * @return string The fragment content
      *

--- a/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
+++ b/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
@@ -74,7 +74,7 @@ class TwigRendererEngine extends AbstractRendererEngine implements TwigRendererE
      * @param FormView $view      The form view for finding the applying themes.
      * @param string   $blockName The name of the block to load.
      *
-     * @return bool    True if the resource could be loaded, false otherwise.
+     * @return bool True if the resource could be loaded, false otherwise.
      */
     protected function loadResourceForBlockName($cacheKey, FormView $view, $blockName)
     {

--- a/src/Symfony/Bridge/Twig/TwigEngine.php
+++ b/src/Symfony/Bridge/Twig/TwigEngine.php
@@ -71,7 +71,7 @@ class TwigEngine implements EngineInterface, StreamingEngineInterface
      *
      * @param mixed $name A template name
      *
-     * @return bool    true if the template exists, false otherwise
+     * @return bool true if the template exists, false otherwise
      */
     public function exists($name)
     {
@@ -99,7 +99,7 @@ class TwigEngine implements EngineInterface, StreamingEngineInterface
      *
      * @param string $name A template name
      *
-     * @return bool    True if this class supports the given resource, false otherwise
+     * @return bool True if this class supports the given resource, false otherwise
      */
     public function supports($name)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
@@ -49,7 +49,7 @@ class RouterCacheWarmer implements CacheWarmerInterface
     /**
      * Checks whether this warmer is optional or not.
      *
-     * @return bool    always true
+     * @return bool always true
      */
     public function isOptional()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
@@ -55,7 +55,7 @@ class TemplatePathsCacheWarmer extends CacheWarmer
     /**
      * Checks whether this warmer is optional or not.
      *
-     * @return bool    always true
+     * @return bool always true
      */
     public function isOptional()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -63,7 +63,7 @@ class Application extends BaseApplication
      * @param InputInterface  $input  An Input instance
      * @param OutputInterface $output An Output instance
      *
-     * @return int     0 if everything went fine, or an error code
+     * @return int 0 if everything went fine, or an error code
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -36,9 +36,9 @@ class Controller extends ContainerAware
     /**
      * Generates a URL from the given parameters.
      *
-     * @param string         $route         The name of the route
-     * @param mixed          $parameters    An array of parameters
-     * @param bool|string    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     * @param string      $route         The name of the route
+     * @param mixed       $parameters    An array of parameters
+     * @param bool|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The generated URL
      *
@@ -69,8 +69,8 @@ class Controller extends ContainerAware
     /**
      * Returns a RedirectResponse to the given URL.
      *
-     * @param string  $url    The URL to redirect to
-     * @param int     $status The status code to use for the Response
+     * @param string $url    The URL to redirect to
+     * @param int    $status The status code to use for the Response
      *
      * @return RedirectResponse
      */
@@ -139,7 +139,7 @@ class Controller extends ContainerAware
      *
      *     throw $this->createNotFoundException('Page not found!');
      *
-     * @param string    $message  A message
+     * @param string     $message  A message
      * @param \Exception $previous The previous exception
      *
      * @return NotFoundHttpException
@@ -233,7 +233,7 @@ class Controller extends ContainerAware
      *
      * @param string $id The service id
      *
-     * @return bool    true if the service id is defined, false otherwise
+     * @return bool true if the service id is defined, false otherwise
      */
     public function has($id)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -48,7 +48,7 @@ class ControllerResolver extends BaseControllerResolver
      *
      * @return mixed A PHP callable
      *
-     * @throws \LogicException When the name could not be parsed
+     * @throws \LogicException           When the name could not be parsed
      * @throws \InvalidArgumentException When the controller class does not exist
      */
     protected function createController($controller)

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -34,10 +34,10 @@ class RedirectController extends ContainerAware
      * In case the route name is empty, the status code will be 404 when permanent is false
      * and 410 otherwise.
      *
-     * @param Request       $request          The request instance
-     * @param string        $route            The route name to redirect to
-     * @param bool          $permanent        Whether the redirection is permanent
-     * @param bool|array    $ignoreAttributes Whether to ignore attributes or an array of attributes to ignore
+     * @param Request    $request          The request instance
+     * @param string     $route            The route name to redirect to
+     * @param bool       $permanent        Whether the redirection is permanent
+     * @param bool|array $ignoreAttributes Whether to ignore attributes or an array of attributes to ignore
      *
      * @return Response A Response instance
      *
@@ -70,12 +70,12 @@ class RedirectController extends ContainerAware
      * In case the path is empty, the status code will be 404 when permanent is false
      * and 410 otherwise.
      *
-     * @param Request      $request   The request instance
-     * @param string       $path      The absolute path or URL to redirect to
-     * @param bool         $permanent Whether the redirect is permanent or not
-     * @param string|null  $scheme    The URL scheme (null to keep the current one)
-     * @param int|null     $httpPort  The HTTP port (null to keep the current one for the same scheme or the configured port in the container)
-     * @param int|null     $httpsPort The HTTPS port (null to keep the current one for the same scheme or the configured port in the container)
+     * @param Request     $request   The request instance
+     * @param string      $path      The absolute path or URL to redirect to
+     * @param bool        $permanent Whether the redirect is permanent or not
+     * @param string|null $scheme    The URL scheme (null to keep the current one)
+     * @param int|null    $httpPort  The HTTP port (null to keep the current one for the same scheme or the configured port in the container)
+     * @param int|null    $httpsPort The HTTPS port (null to keep the current one for the same scheme or the configured port in the container)
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -24,10 +24,10 @@ class TemplateController extends ContainerAware
     /**
      * Renders a template.
      *
-     * @param string       $template  The template name
-     * @param int|null     $maxAge    Max age for client caching
-     * @param int|null     $sharedAge Max age for shared (proxy) caching
-     * @param bool|null    $private   Whether or not caching should apply for client caches only
+     * @param string    $template  The template name
+     * @param int|null  $maxAge    Max age for client caching
+     * @param int|null  $sharedAge Max age for shared (proxy) caching
+     * @param bool|null $private   Whether or not caching should apply for client caches only
      *
      * @return Response A Response instance
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -108,7 +108,7 @@ class GlobalVariables
     /**
      * Returns the current app debug mode.
      *
-     * @return bool    The current debug mode
+     * @return bool The current debug mode
      */
     public function getDebug()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -146,9 +146,9 @@ class CodeHelper extends Helper
     /**
      * Formats a file path.
      *
-     * @param string  $file An absolute file path
-     * @param int     $line The line number
-     * @param string  $text Use this text for the link rather than the file path
+     * @param string $file An absolute file path
+     * @param int    $line The line number
+     * @param string $text Use this text for the link rather than the file path
      *
      * @return string
      */
@@ -181,8 +181,8 @@ class CodeHelper extends Helper
     /**
      * Returns the link for a given file/line pair.
      *
-     * @param string  $file An absolute file path
-     * @param int     $line The line number
+     * @param string $file An absolute file path
+     * @param int    $line The line number
      *
      * @return string A link of false
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
@@ -36,9 +36,9 @@ class RouterHelper extends Helper
     /**
      * Generates a URL from the given parameters.
      *
-     * @param string         $name          The name of the route
-     * @param mixed          $parameters    An array of parameters
-     * @param bool|string    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     * @param string      $name          The name of the route
+     * @param mixed       $parameters    An array of parameters
+     * @param bool|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The generated URL
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
@@ -40,7 +40,7 @@ class FilesystemLoader implements LoaderInterface
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return FileStorage|bool    false if the template cannot be loaded, a Storage instance otherwise
+     * @return FileStorage|bool false if the template cannot be loaded, a Storage instance otherwise
      */
     public function load(TemplateReferenceInterface $template)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TimedPhpEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TimedPhpEngine.php
@@ -28,11 +28,11 @@ class TimedPhpEngine extends PhpEngine
     /**
      * Constructor.
      *
-     * @param TemplateNameParserInterface $parser      A TemplateNameParserInterface instance
-     * @param ContainerInterface          $container   A ContainerInterface instance
-     * @param LoaderInterface             $loader      A LoaderInterface instance
-     * @param Stopwatch                   $stopwatch   A Stopwatch instance
-     * @param GlobalVariables             $globals     A GlobalVariables instance
+     * @param TemplateNameParserInterface $parser    A TemplateNameParserInterface instance
+     * @param ContainerInterface          $container A ContainerInterface instance
+     * @param LoaderInterface             $loader    A LoaderInterface instance
+     * @param Stopwatch                   $stopwatch A Stopwatch instance
+     * @param GlobalVariables             $globals   A GlobalVariables instance
      */
     public function __construct(TemplateNameParserInterface $parser, ContainerInterface $container, LoaderInterface $loader, Stopwatch $stopwatch, GlobalVariables $globals = null)
     {

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -65,7 +65,7 @@ class SecurityDataCollector extends DataCollector
     /**
      * Checks if security is enabled.
      *
-     * @return bool    true if security is enabled, false otherwise
+     * @return bool true if security is enabled, false otherwise
      */
     public function isEnabled()
     {
@@ -95,7 +95,7 @@ class SecurityDataCollector extends DataCollector
     /**
      * Checks if the user is authenticated or not.
      *
-     * @return bool    true if the user is authenticated, false otherwise
+     * @return bool true if the user is authenticated, false otherwise
      */
     public function isAuthenticated()
     {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -146,7 +146,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
      *
      * @param array $config
      *
-     * @return bool    Whether a possibly configured RememberMeServices should be set for this listener
+     * @return bool Whether a possibly configured RememberMeServices should be set for this listener
      */
     protected function isRememberMeAware($config)
     {

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -81,8 +81,8 @@ class LogoutUrlHelper extends Helper
     /**
      * Generates the logout URL for the firewall.
      *
-     * @param string         $key           The firewall key
-     * @param bool|string    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     * @param string      $key           The firewall key
+     * @param bool|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The logout URL
      *

--- a/src/Symfony/Bundle/SecurityBundle/Twig/Extension/LogoutUrlExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/Twig/Extension/LogoutUrlExtension.php
@@ -47,6 +47,7 @@ class LogoutUrlExtension extends \Twig_Extension
      * Generate the relative logout URL for the firewall.
      *
      * @param string $key The firewall key
+     *
      * @return string The relative logout URL
      */
     public function getLogoutPath($key)
@@ -58,6 +59,7 @@ class LogoutUrlExtension extends \Twig_Extension
      * Generate the absolute logout URL for the firewall.
      *
      * @param string $key The firewall key
+     *
      * @return string The absolute logout URL
      */
     public function getLogoutUrl($key)

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
@@ -69,7 +69,7 @@ class TemplateCacheCacheWarmer implements CacheWarmerInterface
     /**
      * Checks whether this warmer is optional or not.
      *
-     * @return bool    always true
+     * @return bool always true
      */
     public function isOptional()
     {

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -64,7 +64,7 @@ class ExceptionController
     }
 
     /**
-     * @param int     $startObLevel
+     * @param int $startObLevel
      *
      * @return string
      */
@@ -86,7 +86,7 @@ class ExceptionController
     /**
      * @param Request $request
      * @param string  $format
-     * @param int     $code       An HTTP response status code
+     * @param int     $code    An HTTP response status code
      * @param bool    $debug
      *
      * @return TemplateReferenceInterface

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -155,8 +155,8 @@ class ProfilerController
     /**
      * Renders the Web Debug Toolbar.
      *
-     * @param Request $request  The current HTTP Request
-     * @param string  $token    The profiler token
+     * @param Request $request The current HTTP Request
+     * @param string  $token   The profiler token
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -115,7 +115,7 @@
         /**
          * Query an element with a CSS selector.
          *
-         * @param  string selector a CSS-selector-compatible query string.
+         * @param string selector a CSS-selector-compatible query string.
          *
          * @return DOMElement|null
          */

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -70,7 +70,7 @@ abstract class Client
     /**
      * Sets whether to automatically follow redirects or not.
      *
-     * @param bool    $followRedirect Whether to follow redirects
+     * @param bool $followRedirect Whether to follow redirects
      *
      * @api
      */
@@ -82,7 +82,7 @@ abstract class Client
     /**
      * Sets the maximum number of requests that crawler can follow.
      *
-     * @param int     $maxRedirects
+     * @param int $maxRedirects
      */
     public function setMaxRedirects($maxRedirects)
     {
@@ -93,7 +93,7 @@ abstract class Client
     /**
      * Sets the insulated flag.
      *
-     * @param bool    $insulated Whether to insulate the requests or not
+     * @param bool $insulated Whether to insulate the requests or not
      *
      * @throws \RuntimeException When Symfony Process Component is not installed
      *
@@ -281,13 +281,13 @@ abstract class Client
     /**
      * Calls a URI.
      *
-     * @param string  $method        The request method
-     * @param string  $uri           The URI to fetch
-     * @param array   $parameters    The Request parameters
-     * @param array   $files         The files
-     * @param array   $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
-     * @param string  $content       The raw body data
-     * @param bool    $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     * @param string $method        The request method
+     * @param string $uri           The URI to fetch
+     * @param array  $parameters    The Request parameters
+     * @param array  $files         The files
+     * @param array  $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string $content       The raw body data
+     * @param bool   $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
      *
      * @return Crawler
      *

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -48,14 +48,14 @@ class Cookie
     /**
      * Sets a cookie.
      *
-     * @param string  $name         The cookie name
-     * @param string  $value        The value of the cookie
-     * @param string  $expires      The time the cookie expires
-     * @param string  $path         The path on the server in which the cookie will be available on
-     * @param string  $domain       The domain that the cookie is available
-     * @param bool    $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param bool    $httponly     The cookie httponly flag
-     * @param bool    $encodedValue Whether the value is encoded or not
+     * @param string $name         The cookie name
+     * @param string $value        The value of the cookie
+     * @param string $expires      The time the cookie expires
+     * @param string $path         The path on the server in which the cookie will be available on
+     * @param string $domain       The domain that the cookie is available
+     * @param bool   $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param bool   $httponly     The cookie httponly flag
+     * @param bool   $encodedValue Whether the value is encoded or not
      *
      * @api
      */
@@ -297,7 +297,7 @@ class Cookie
     /**
      * Returns the secure flag of the cookie.
      *
-     * @return bool    The cookie secure flag
+     * @return bool The cookie secure flag
      *
      * @api
      */
@@ -309,7 +309,7 @@ class Cookie
     /**
      * Returns the httponly flag of the cookie.
      *
-     * @return bool    The cookie httponly flag
+     * @return bool The cookie httponly flag
      *
      * @api
      */
@@ -321,7 +321,7 @@ class Cookie
     /**
      * Returns true if the cookie has expired.
      *
-     * @return bool    true if the cookie has expired, false otherwise
+     * @return bool true if the cookie has expired, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -198,8 +198,8 @@ class CookieJar
     /**
      * Returns not yet expired cookie values for the given URI.
      *
-     * @param string  $uri             A URI
-     * @param bool    $returnsRawValue Returns raw value or urldecoded value
+     * @param string $uri             A URI
+     * @param bool   $returnsRawValue Returns raw value or urldecoded value
      *
      * @return array An array of cookie values
      */

--- a/src/Symfony/Component/BrowserKit/History.php
+++ b/src/Symfony/Component/BrowserKit/History.php
@@ -53,7 +53,7 @@ class History
     /**
      * Returns true if the history is empty.
      *
-     * @return bool    true if the history is empty, false otherwise
+     * @return bool true if the history is empty, false otherwise
      */
     public function isEmpty()
     {

--- a/src/Symfony/Component/BrowserKit/Response.php
+++ b/src/Symfony/Component/BrowserKit/Response.php
@@ -30,9 +30,9 @@ class Response
      * The headers array is a set of key/value pairs. If a header is present multiple times
      * then the value is an array of all the values.
      *
-     * @param string  $content The content of the response
-     * @param int     $status  The response status code
-     * @param array   $headers An array of headers
+     * @param string $content The content of the response
+     * @param int    $status  The response status code
+     * @param array  $headers An array of headers
      *
      * @api
      */
@@ -92,7 +92,7 @@ class Response
     /**
      * Gets the response status code.
      *
-     * @return int     The response status code
+     * @return int The response status code
      *
      * @api
      */
@@ -116,8 +116,8 @@ class Response
     /**
      * Gets a response header.
      *
-     * @param string  $header The header name
-     * @param bool    $first  Whether to return the first value or all header values
+     * @param string $header The header name
+     * @param bool   $first  Whether to return the first value or all header values
      *
      * @return string|array The first header value if $first is true, an array of values otherwise
      */

--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -54,8 +54,8 @@ class ApcClassLoader
     /**
      * Constructor.
      *
-     * @param string $prefix      The APC namespace prefix to use.
-     * @param object $decorated   A class loader object that implements the findFile() method.
+     * @param string $prefix    The APC namespace prefix to use.
+     * @param object $decorated A class loader object that implements the findFile() method.
      *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
@@ -79,7 +79,7 @@ class ApcClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param bool    $prepend Whether to prepend the autoloader or not
+     * @param bool $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {
@@ -99,7 +99,7 @@ class ApcClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return bool|null    True, if loaded
+     * @return bool|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -25,12 +25,12 @@ class ClassCollectionLoader
     /**
      * Loads a list of classes and caches them in one big file.
      *
-     * @param array   $classes    An array of classes to load
-     * @param string  $cacheDir   A cache directory
-     * @param string  $name       The cache name prefix
-     * @param bool    $autoReload Whether to flush the cache when the cache is stale or not
-     * @param bool    $adaptive   Whether to remove already declared classes or not
-     * @param string  $extension  File extension of the resulting file
+     * @param array  $classes    An array of classes to load
+     * @param string $cacheDir   A cache directory
+     * @param string $name       The cache name prefix
+     * @param bool   $autoReload Whether to flush the cache when the cache is stale or not
+     * @param bool   $adaptive   Whether to remove already declared classes or not
+     * @param string $extension  File extension of the resulting file
      *
      * @throws \InvalidArgumentException When class can't be loaded
      */
@@ -335,10 +335,10 @@ class ClassCollectionLoader
      * This function does not check for circular dependencies as it should never
      * occur with PHP traits.
      *
-     * @param array             $tree       The dependency tree
-     * @param \ReflectionClass  $node       The node
-     * @param \ArrayObject      $resolved   An array of already resolved dependencies
-     * @param \ArrayObject      $unresolved An array of dependencies to be resolved
+     * @param array            $tree       The dependency tree
+     * @param \ReflectionClass $node       The node
+     * @param \ArrayObject     $resolved   An array of already resolved dependencies
+     * @param \ArrayObject     $unresolved An array of dependencies to be resolved
      *
      * @return \ArrayObject The dependencies for the given node
      *

--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -103,7 +103,7 @@ class ClassLoader
     /**
      * Turns on searching the include for class files.
      *
-     * @param bool    $useIncludePath
+     * @param bool $useIncludePath
      */
     public function setUseIncludePath($useIncludePath)
     {
@@ -124,7 +124,7 @@ class ClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param bool    $prepend Whether to prepend the autoloader or not
+     * @param bool $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {
@@ -144,7 +144,7 @@ class ClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return bool|null    True, if loaded
+     * @return bool|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -86,7 +86,7 @@ class DebugClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return bool|null    True, if loaded
+     * @return bool|null True, if loaded
      *
      * @throws \RuntimeException
      */

--- a/src/Symfony/Component/ClassLoader/MapClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/MapClassLoader.php
@@ -33,7 +33,7 @@ class MapClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param bool    $prepend Whether to prepend the autoloader or not
+     * @param bool $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {

--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -70,7 +70,7 @@ class UniversalClassLoader
      * Turns on searching the include for class files. Allows easy loading
      * of installed PEAR packages
      *
-     * @param bool    $useIncludePath
+     * @param bool $useIncludePath
      */
     public function useIncludePath($useIncludePath)
     {
@@ -229,7 +229,7 @@ class UniversalClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param bool    $prepend Whether to prepend the autoloader or not
+     * @param bool $prepend Whether to prepend the autoloader or not
      *
      * @api
      */
@@ -243,7 +243,7 @@ class UniversalClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return bool|null    True, if loaded
+     * @return bool|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
@@ -53,8 +53,8 @@ class WinCacheClassLoader
     /**
      * Constructor.
      *
-     * @param string $prefix      The WinCache namespace prefix to use.
-     * @param object $decorated   A class loader object that implements the findFile() method.
+     * @param string $prefix    The WinCache namespace prefix to use.
+     * @param object $decorated A class loader object that implements the findFile() method.
      *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
@@ -76,7 +76,7 @@ class WinCacheClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param bool    $prepend Whether to prepend the autoloader or not
+     * @param bool $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {
@@ -96,7 +96,7 @@ class WinCacheClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return bool|null    True, if loaded
+     * @return bool|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
@@ -52,8 +52,8 @@ class XcacheClassLoader
     /**
      * Constructor.
      *
-     * @param string $prefix      The XCache namespace prefix to use.
-     * @param object $decorated   A class loader object that implements the findFile() method.
+     * @param string $prefix    The XCache namespace prefix to use.
+     * @param object $decorated A class loader object that implements the findFile() method.
      *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
@@ -77,7 +77,7 @@ class XcacheClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param bool    $prepend Whether to prepend the autoloader or not
+     * @param bool $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {
@@ -97,7 +97,7 @@ class XcacheClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return bool|null    True, if loaded
+     * @return bool|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -31,8 +31,8 @@ class ConfigCache
     /**
      * Constructor.
      *
-     * @param string  $file  The absolute cache path
-     * @param bool    $debug Whether debugging is enabled or not
+     * @param string $file  The absolute cache path
+     * @param bool   $debug Whether debugging is enabled or not
      */
     public function __construct($file, $debug)
     {
@@ -56,7 +56,7 @@ class ConfigCache
      * This method always returns true when debug is off and the
      * cache file exists.
      *
-     * @return bool    true if the cache is fresh, false otherwise
+     * @return bool true if the cache is fresh, false otherwise
      */
     public function isFresh()
     {

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -109,7 +109,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      * Sets whether to add default values for this array if it has not been
      * defined in any of the configuration files.
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      */
     public function setAddIfNotSet($boolean)
     {
@@ -119,7 +119,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets whether false is allowed as value indicating that the array should be unset.
      *
-     * @param bool    $allow
+     * @param bool $allow
      */
     public function setAllowFalse($allow)
     {
@@ -129,7 +129,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets whether new keys can be defined in subsequent configurations.
      *
-     * @param bool    $allow
+     * @param bool $allow
      */
     public function setAllowNewKeys($allow)
     {
@@ -139,7 +139,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets if deep merging should occur.
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      */
     public function setPerformDeepMerging($boolean)
     {
@@ -149,7 +149,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Whether extra keys should just be ignore without an exception.
      *
-     * @param bool    $boolean To allow extra keys
+     * @param bool $boolean To allow extra keys
      */
     public function setIgnoreExtraKeys($boolean)
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -138,7 +138,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Set this node as required.
      *
-     * @param bool    $boolean Required node
+     * @param bool $boolean Required node
      */
     public function setRequired($boolean)
     {
@@ -148,7 +148,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Sets if this node can be overridden.
      *
-     * @param bool    $allow
+     * @param bool $allow
      */
     public function setAllowOverwrite($allow)
     {

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -105,7 +105,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     /**
      * Adds children with a default value when none are defined.
      *
-     * @param int|string|array|null     $children The number of children|The child name|The children names to be added
+     * @param int|string|array|null $children The number of children|The child name|The children names to be added
      *
      * This method is applicable to prototype nodes only.
      *
@@ -184,8 +184,8 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      *
      * This method is applicable to prototype nodes only.
      *
-     * @param string  $name          The name of the key
-     * @param bool    $removeKeyItem Whether or not the key item should be removed.
+     * @param string $name          The name of the key
+     * @param bool   $removeKeyItem Whether or not the key item should be removed.
      *
      * @return ArrayNodeDefinition
      */
@@ -200,7 +200,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     /**
      * Sets whether the node can be unset.
      *
-     * @param bool    $allow
+     * @param bool $allow
      *
      * @return ArrayNodeDefinition
      */
@@ -303,7 +303,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     /**
      * Sets key normalization.
      *
-     * @param bool    $bool Whether to enable key normalization
+     * @param bool $bool Whether to enable key normalization
      *
      * @return ArrayNodeDefinition
      */

--- a/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
@@ -37,7 +37,7 @@ class MergeBuilder
     /**
      * Sets whether the node can be unset.
      *
-     * @param bool    $allow
+     * @param bool $allow
      *
      * @return MergeBuilder
      */
@@ -51,7 +51,7 @@ class MergeBuilder
     /**
      * Sets whether the node can be overwritten.
      *
-     * @param bool    $deny Whether the overwriting is forbidden or not
+     * @param bool $deny Whether the overwriting is forbidden or not
      *
      * @return MergeBuilder
      */

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -96,7 +96,7 @@ abstract class NodeDefinition implements NodeParentInterface
      * Sets an attribute on the node.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return NodeDefinition
      */
@@ -120,7 +120,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Creates the node.
      *
-     * @param bool    $forceRootNode Whether to force this node as the root node
+     * @param bool $forceRootNode Whether to force this node as the root node
      *
      * @return NodeInterface
      */
@@ -282,7 +282,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Sets whether the node can be overwritten.
      *
-     * @param bool    $deny Whether the overwriting is forbidden or not
+     * @param bool $deny Whether the overwriting is forbidden or not
      *
      * @return NodeDefinition
      */

--- a/src/Symfony/Component/Config/Definition/NodeInterface.php
+++ b/src/Symfony/Component/Config/Definition/NodeInterface.php
@@ -38,21 +38,21 @@ interface NodeInterface
     /**
      * Returns true when the node is required.
      *
-     * @return bool    If the node is required
+     * @return bool If the node is required
      */
     public function isRequired();
 
     /**
      * Returns true when the node has a default value.
      *
-     * @return bool    If the node has a default value
+     * @return bool If the node has a default value
      */
     public function hasDefaultValue();
 
     /**
      * Returns the default value of the node.
      *
-     * @return mixed The default value
+     * @return mixed             The default value
      * @throws \RuntimeException if the node has no default value
      */
     public function getDefaultValue();

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -48,7 +48,7 @@ class PrototypedArrayNode extends ArrayNode
      * Sets the minimum number of elements that a prototype based node must
      * contain. By default this is zero, meaning no elements.
      *
-     * @param int     $number
+     * @param int $number
      */
     public function setMinNumberOfElements($number)
     {
@@ -76,8 +76,8 @@ class PrototypedArrayNode extends ArrayNode
      * If you'd like "'id' => 'my_name'" to still be present in the resulting
      * array, then you can set the second argument of this method to false.
      *
-     * @param string  $attribute The name of the attribute which value is to be used as a key
-     * @param bool    $remove    Whether or not to remove the key
+     * @param string $attribute The name of the attribute which value is to be used as a key
+     * @param bool   $remove    Whether or not to remove the key
      */
     public function setKeyAttribute($attribute, $remove = true)
     {
@@ -124,7 +124,7 @@ class PrototypedArrayNode extends ArrayNode
     /**
      * Adds default children when none are set.
      *
-     * @param int|string|array|null     $children The number of children|The child name|The children names to be added
+     * @param int|string|array|null $children The number of children|The child name|The children names to be added
      */
     public function setAddChildrenIfNoneSet($children = array('defaults'))
     {

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -55,7 +55,7 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets if this node is allowed to have an empty value.
      *
-     * @param bool    $boolean True if this entity will accept empty values.
+     * @param bool $boolean True if this entity will accept empty values.
      */
     public function setAllowEmptyValue($boolean)
     {

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -151,7 +151,8 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Create a test treebuilder with a variable node, and init the validation
+     * Create a test treebuilder with a variable node, and init the validation.
+     *
      * @return TreeBuilder
      */
     protected function getTestBuilder()
@@ -167,10 +168,12 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Close the validation process and finalize with the given config
+     * Close the validation process and finalize with the given config.
+     *
      * @param TreeBuilder $testBuilder The tree builder to finalize
      * @param array       $config      The config you want to use for the finalization, if nothing provided
-     *                       a simple array('key'=>'value') will be used
+     *                                 a simple array('key'=>'value') will be used
+     *
      * @return array The finalized config values
      */
     protected function finalizeTestBuilder($testBuilder, $config = null)
@@ -185,8 +188,10 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Return a closure that will return the given value
-     * @param $val The value that the closure must return
+     * Return a closure that will return the given value.
+     *
+     * @param mixed $val The value that the closure must return
+     *
      * @return Closure
      */
     protected function returnClosure($val)
@@ -201,7 +206,8 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed       $value       The value to test
      * @param TreeBuilder $treeBuilder The tree builder to finalize
-     * @param mixed       $config      The config values that new to be finalized
+     *
+     * @param mixed $config The config values that new to be finalized
      */
     protected function assertFinalizedValueIs($value, $treeBuilder, $config = null)
     {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -161,7 +161,7 @@ class Command
      * @param InputInterface  $input  An InputInterface instance
      * @param OutputInterface $output An OutputInterface instance
      *
-     * @return null|int     null or 0 if everything went fine, or an error code
+     * @return null|int null or 0 if everything went fine, or an error code
      *
      * @throws \LogicException When this abstract method is not implemented
      * @see    setCode()
@@ -204,7 +204,7 @@ class Command
      * @param InputInterface  $input  An InputInterface instance
      * @param OutputInterface $output An OutputInterface instance
      *
-     * @return int     The command exit code
+     * @return int The command exit code
      *
      * @throws \Exception
      *
@@ -279,7 +279,7 @@ class Command
      *
      * This method is not part of public API and should not be used directly.
      *
-     * @param bool    $mergeArgs Whether to merge or not the Application definition arguments to Command definition arguments
+     * @param bool $mergeArgs Whether to merge or not the Application definition arguments to Command definition arguments
      */
     public function mergeApplicationDefinition($mergeArgs = true)
     {
@@ -353,10 +353,10 @@ class Command
     /**
      * Adds an argument.
      *
-     * @param string  $name        The argument name
-     * @param int     $mode        The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
-     * @param string  $description A description text
-     * @param mixed   $default     The default value (for InputArgument::OPTIONAL mode only)
+     * @param string $name        The argument name
+     * @param int    $mode        The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
+     * @param string $description A description text
+     * @param mixed  $default     The default value (for InputArgument::OPTIONAL mode only)
      *
      * @return Command The current instance
      *
@@ -372,11 +372,11 @@ class Command
     /**
      * Adds an option.
      *
-     * @param string  $name        The option name
-     * @param string  $shortcut    The shortcut (can be null)
-     * @param int     $mode        The option mode: One of the InputOption::VALUE_* constants
-     * @param string  $description A description text
-     * @param mixed   $default     The default value (must be null for InputOption::VALUE_REQUIRED or InputOption::VALUE_NONE)
+     * @param string $name        The option name
+     * @param string $shortcut    The shortcut (can be null)
+     * @param int    $mode        The option mode: One of the InputOption::VALUE_* constants
+     * @param string $description A description text
+     * @param mixed  $default     The default value (must be null for InputOption::VALUE_REQUIRED or InputOption::VALUE_NONE)
      *
      * @return Command The current instance
      *
@@ -486,7 +486,7 @@ class Command
      * Returns the processed help for the command replacing the %command.name% and
      * %command.full_name% patterns with the real values dynamically.
      *
-     * @return string  The processed help for the command
+     * @return string The processed help for the command
      */
     public function getProcessedHelp()
     {
@@ -587,7 +587,7 @@ class Command
     /**
      * Returns an XML representation of the command.
      *
-     * @param bool    $asDom Whether to return a DOM or an XML string
+     * @param bool $asDom Whether to return a DOM or an XML string
      *
      * @return string|\DOMDocument An XML string representing the command
      *

--- a/src/Symfony/Component/Console/Event/ConsoleExceptionEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleExceptionEvent.php
@@ -58,7 +58,7 @@ class ConsoleExceptionEvent extends ConsoleEvent
     /**
      * Gets the exit code.
      *
-     * @return int     The command exit code
+     * @return int The command exit code
      */
     public function getExitCode()
     {

--- a/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
@@ -39,7 +39,7 @@ class ConsoleTerminateEvent extends ConsoleEvent
     /**
      * Sets the exit code.
      *
-     * @param int     $exitCode The command exit code
+     * @param int $exitCode The command exit code
      */
     public function setExitCode($exitCode)
     {
@@ -49,7 +49,7 @@ class ConsoleTerminateEvent extends ConsoleEvent
     /**
      * Gets the exit code.
      *
-     * @return int     The command exit code
+     * @return int The command exit code
      */
     public function getExitCode()
     {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -39,7 +39,7 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Initializes console output formatter.
      *
-     * @param bool             $decorated Whether this formatter should actually decorate strings
+     * @param bool                            $decorated Whether this formatter should actually decorate strings
      * @param OutputFormatterStyleInterface[] $styles    Array of "name => FormatterStyle" instances
      *
      * @api
@@ -63,7 +63,7 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Sets the decorated flag.
      *
-     * @param bool    $decorated Whether to decorate the messages or not
+     * @param bool $decorated Whether to decorate the messages or not
      *
      * @api
      */
@@ -75,7 +75,7 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Gets the decorated flag.
      *
-     * @return bool    true if the output will decorate messages, false otherwise
+     * @return bool true if the output will decorate messages, false otherwise
      *
      * @api
      */
@@ -194,7 +194,7 @@ class OutputFormatter implements OutputFormatterInterface
      *
      * @param string $string
      *
-     * @return OutputFormatterStyle|bool    false if string is not format string
+     * @return OutputFormatterStyle|bool false if string is not format string
      */
     private function createStyleFromString($string)
     {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
@@ -23,7 +23,7 @@ interface OutputFormatterInterface
     /**
      * Sets the decorated flag.
      *
-     * @param bool    $decorated Whether to decorate the messages or not
+     * @param bool $decorated Whether to decorate the messages or not
      *
      * @api
      */
@@ -32,7 +32,7 @@ interface OutputFormatterInterface
     /**
      * Gets the decorated flag.
      *
-     * @return bool    true if the output will decorate messages, false otherwise
+     * @return bool true if the output will decorate messages, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
@@ -62,7 +62,7 @@ class OutputFormatterStyleStack
      *
      * @return OutputFormatterStyleInterface
      *
-     * @throws \InvalidArgumentException  When style tags incorrectly nested
+     * @throws \InvalidArgumentException When style tags incorrectly nested
      */
     public function pop(OutputFormatterStyleInterface $style = null)
     {

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -32,11 +32,11 @@ class DialogHelper extends Helper
      * @param string|array    $question     The question to ask
      * @param array           $choices      List of choices to pick from
      * @param bool|string     $default      The default answer if the user enters nothing
-     * @param bool|int        $attempts Max number of times to ask before giving up (false by default, which means infinite)
+     * @param bool|int        $attempts     Max number of times to ask before giving up (false by default, which means infinite)
      * @param string          $errorMessage Message which will be shown if invalid value from choice list would be picked
      * @param bool            $multiselect  Select more than one value separated by comma
      *
-     * @return int|string|array     The selected value or values (the key of the choices array)
+     * @return int|string|array The selected value or values (the key of the choices array)
      *
      * @throws \InvalidArgumentException
      */
@@ -226,7 +226,7 @@ class DialogHelper extends Helper
      * @param string|array    $question The question to ask
      * @param bool            $default  The default answer if the user enters nothing
      *
-     * @return bool    true if the user has confirmed, false otherwise
+     * @return bool true if the user has confirmed, false otherwise
      */
     public function askConfirmation(OutputInterface $output, $question, $default = true)
     {
@@ -249,7 +249,7 @@ class DialogHelper extends Helper
      * @param string|array    $question The question
      * @param bool            $fallback In case the response can not be hidden, whether to fallback on non-hidden question or not
      *
-     * @return string         The answer
+     * @return string The answer
      *
      * @throws \RuntimeException In case the fallback is deactivated and the response can not be hidden
      */
@@ -354,7 +354,7 @@ class DialogHelper extends Helper
      * @param int|false       $attempts  Max number of times to ask before giving up (false by default, which means infinite)
      * @param bool            $fallback  In case the response can not be hidden, whether to fallback on non-hidden question or not
      *
-     * @return string         The response
+     * @return string The response
      *
      * @throws \Exception        When any of the validators return an error
      * @throws \RuntimeException In case the fallback is deactivated and the response can not be hidden
@@ -404,7 +404,7 @@ class DialogHelper extends Helper
     /**
      * Return a valid Unix shell
      *
-     * @return string|bool     The valid shell name, false in case no valid shell is found
+     * @return string|bool The valid shell name, false in case no valid shell is found
      */
     private function getShell()
     {
@@ -442,12 +442,12 @@ class DialogHelper extends Helper
     /**
      * Validate an attempt
      *
-     * @param callable         $interviewer  A callable that will ask for a question and return the result
-     * @param OutputInterface  $output       An Output instance
-     * @param callable         $validator    A PHP callback
-     * @param int|false        $attempts     Max number of times to ask before giving up ; false will ask infinitely
+     * @param callable        $interviewer A callable that will ask for a question and return the result
+     * @param OutputInterface $output      An Output instance
+     * @param callable        $validator   A PHP callback
+     * @param int|false       $attempts    Max number of times to ask before giving up ; false will ask infinitely
      *
-     * @return string   The validated response
+     * @return string The validated response
      *
      * @throws \Exception In case the max number of attempts has been reached and no valid response has been given
      */

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -45,7 +45,7 @@ abstract class Helper implements HelperInterface
      *
      * @param string $string The string to check its length
      *
-     * @return int     The length of the string
+     * @return int The length of the string
      */
     protected function strlen($string)
     {

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -57,7 +57,7 @@ class HelperSet
      *
      * @param string $name The helper name
      *
-     * @return bool    true if the helper is defined, false otherwise
+     * @return bool true if the helper is defined, false otherwise
      */
     public function has($name)
     {

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -220,8 +220,8 @@ class ProgressHelper extends Helper
     /**
      * Advances the progress output X steps.
      *
-     * @param int     $step   Number of steps to advance
-     * @param bool    $redraw Whether to redraw or not
+     * @param int  $step   Number of steps to advance
+     * @param bool $redraw Whether to redraw or not
      *
      * @throws \LogicException
      */
@@ -248,8 +248,8 @@ class ProgressHelper extends Helper
     /**
      * Sets the current progress.
      *
-     * @param int     $current The current progress
-     * @param bool    $redraw  Whether to redraw or not
+     * @param int  $current The current progress
+     * @param bool $redraw  Whether to redraw or not
      *
      * @throws \LogicException
      */
@@ -282,7 +282,7 @@ class ProgressHelper extends Helper
     /**
      * Outputs the current progress string.
      *
-     * @param bool    $finish Forces the end result
+     * @param bool $finish Forces the end result
      *
      * @throws \LogicException
      */
@@ -343,7 +343,7 @@ class ProgressHelper extends Helper
     /**
      * Generates the array map of format variables to values.
      *
-     * @param bool    $finish Forces the end result
+     * @param bool $finish Forces the end result
      *
      * @return array Array of format vars and values
      */
@@ -401,7 +401,7 @@ class ProgressHelper extends Helper
     /**
      * Converts seconds into human-readable format.
      *
-     * @param int     $secs Number of seconds
+     * @param int $secs Number of seconds
      *
      * @return string Time in readable format
      */
@@ -426,8 +426,8 @@ class ProgressHelper extends Helper
     /**
      * Overwrites a previous message to the output.
      *
-     * @param OutputInterface $output   An Output instance
-     * @param string          $message  The message
+     * @param OutputInterface $output  An Output instance
+     * @param string          $message The message
      */
     private function overwrite(OutputInterface $output, $message)
     {

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -279,7 +279,7 @@ class TableHelper extends Helper
     /**
      * Sets cell padding type.
      *
-     * @param int     $padType STR_PAD_*
+     * @param int $padType STR_PAD_*
      *
      * @return TableHelper
      */
@@ -377,9 +377,9 @@ class TableHelper extends Helper
     /**
      * Renders table cell with padding.
      *
-     * @param array   $row
-     * @param int     $column
-     * @param string  $cellFormat
+     * @param array  $row
+     * @param int    $column
+     * @param string $cellFormat
      */
     private function renderCell(array $row, $column, $cellFormat)
     {
@@ -427,7 +427,7 @@ class TableHelper extends Helper
     /**
      * Gets column width.
      *
-     * @param int     $column
+     * @param int $column
      *
      * @return int
      */
@@ -449,8 +449,8 @@ class TableHelper extends Helper
     /**
      * Gets cell width.
      *
-     * @param array   $row
-     * @param int     $column
+     * @param array $row
+     * @param int   $column
      *
      * @return int
      */

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -278,7 +278,7 @@ class ArgvInput extends Input
      *
      * @param string|array $values The value(s) to look for in the raw parameters (can be an array)
      *
-     * @return bool    true if the value is contained in the raw parameters
+     * @return bool true if the value is contained in the raw parameters
      */
     public function hasParameterOption($values)
     {

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -65,7 +65,7 @@ class ArrayInput extends Input
      *
      * @param string|array $values The values to look for in the raw parameters (can be an array)
      *
-     * @return bool    true if the value is contained in the raw parameters
+     * @return bool true if the value is contained in the raw parameters
      */
     public function hasParameterOption($values)
     {

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -80,7 +80,7 @@ abstract class Input implements InputInterface
     /**
      * Checks if the input is interactive.
      *
-     * @return bool    Returns true if the input is interactive
+     * @return bool Returns true if the input is interactive
      */
     public function isInteractive()
     {
@@ -90,7 +90,7 @@ abstract class Input implements InputInterface
     /**
      * Sets the input interactivity.
      *
-     * @param bool    $interactive If the input should be interactive
+     * @param bool $interactive If the input should be interactive
      */
     public function setInteractive($interactive)
     {
@@ -145,9 +145,9 @@ abstract class Input implements InputInterface
     /**
      * Returns true if an InputArgument object exists by name or position.
      *
-     * @param string|int     $name The InputArgument name or position
+     * @param string|int $name The InputArgument name or position
      *
-     * @return bool    true if the InputArgument object exists, false otherwise
+     * @return bool true if the InputArgument object exists, false otherwise
      */
     public function hasArgument($name)
     {
@@ -185,8 +185,8 @@ abstract class Input implements InputInterface
     /**
      * Sets an option value by name.
      *
-     * @param string         $name  The option name
-     * @param string|bool    $value The option value
+     * @param string      $name  The option name
+     * @param string|bool $value The option value
      *
      * @throws \InvalidArgumentException When option given doesn't exist
      */
@@ -204,7 +204,7 @@ abstract class Input implements InputInterface
      *
      * @param string $name The InputOption name
      *
-     * @return bool    true if the InputOption object exists, false otherwise
+     * @return bool true if the InputOption object exists, false otherwise
      */
     public function hasOption($name)
     {

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -32,10 +32,10 @@ class InputArgument
     /**
      * Constructor.
      *
-     * @param string  $name        The argument name
-     * @param int     $mode        The argument mode: self::REQUIRED or self::OPTIONAL
-     * @param string  $description A description text
-     * @param mixed   $default     The default value (for self::OPTIONAL mode only)
+     * @param string $name        The argument name
+     * @param int    $mode        The argument mode: self::REQUIRED or self::OPTIONAL
+     * @param string $description A description text
+     * @param mixed  $default     The default value (for self::OPTIONAL mode only)
      *
      * @throws \InvalidArgumentException When argument mode is not valid
      *
@@ -69,7 +69,7 @@ class InputArgument
     /**
      * Returns true if the argument is required.
      *
-     * @return bool    true if parameter mode is self::REQUIRED, false otherwise
+     * @return bool true if parameter mode is self::REQUIRED, false otherwise
      */
     public function isRequired()
     {
@@ -79,7 +79,7 @@ class InputArgument
     /**
      * Returns true if the argument can take multiple values.
      *
-     * @return bool    true if mode is self::IS_ARRAY, false otherwise
+     * @return bool true if mode is self::IS_ARRAY, false otherwise
      */
     public function isArray()
     {

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -143,7 +143,7 @@ class InputDefinition
     /**
      * Returns an InputArgument by name or by position.
      *
-     * @param string|int     $name The InputArgument name or position
+     * @param string|int $name The InputArgument name or position
      *
      * @return InputArgument An InputArgument object
      *
@@ -165,9 +165,9 @@ class InputDefinition
     /**
      * Returns true if an InputArgument object exists by name or position.
      *
-     * @param string|int     $name The InputArgument name or position
+     * @param string|int $name The InputArgument name or position
      *
-     * @return bool    true if the InputArgument object exists, false otherwise
+     * @return bool true if the InputArgument object exists, false otherwise
      *
      * @api
      */
@@ -193,7 +193,7 @@ class InputDefinition
     /**
      * Returns the number of InputArguments.
      *
-     * @return int     The number of InputArguments
+     * @return int The number of InputArguments
      */
     public function getArgumentCount()
     {
@@ -203,7 +203,7 @@ class InputDefinition
     /**
      * Returns the number of required InputArguments.
      *
-     * @return int     The number of required InputArguments
+     * @return int The number of required InputArguments
      */
     public function getArgumentRequiredCount()
     {
@@ -309,7 +309,7 @@ class InputDefinition
      *
      * @param string $name The InputOption name
      *
-     * @return bool    true if the InputOption object exists, false otherwise
+     * @return bool true if the InputOption object exists, false otherwise
      *
      * @api
      */
@@ -335,7 +335,7 @@ class InputDefinition
      *
      * @param string $name The InputOption shortcut
      *
-     * @return bool    true if the InputOption object exists, false otherwise
+     * @return bool true if the InputOption object exists, false otherwise
      */
     public function hasShortcut($name)
     {
@@ -428,7 +428,7 @@ class InputDefinition
     /**
      * Returns an XML representation of the InputDefinition.
      *
-     * @param bool    $asDom Whether to return a DOM or an XML string
+     * @param bool $asDom Whether to return a DOM or an XML string
      *
      * @return string|\DOMDocument An XML string representing the InputDefinition
      *

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -33,7 +33,7 @@ interface InputInterface
      *
      * @param string|array $values The values to look for in the raw parameters (can be an array)
      *
-     * @return bool    true if the value is contained in the raw parameters
+     * @return bool true if the value is contained in the raw parameters
      */
     public function hasParameterOption($values);
 
@@ -95,9 +95,9 @@ interface InputInterface
     /**
      * Returns true if an InputArgument object exists by name or position.
      *
-     * @param string|int     $name The InputArgument name or position
+     * @param string|int $name The InputArgument name or position
      *
-     * @return bool    true if the InputArgument object exists, false otherwise
+     * @return bool true if the InputArgument object exists, false otherwise
      */
     public function hasArgument($name);
 
@@ -120,8 +120,8 @@ interface InputInterface
     /**
      * Sets an option value by name.
      *
-     * @param string         $name  The option name
-     * @param string|bool    $value The option value
+     * @param string      $name  The option name
+     * @param string|bool $value The option value
      *
      * @throws \InvalidArgumentException When option given doesn't exist
      */
@@ -132,7 +132,7 @@ interface InputInterface
      *
      * @param string $name The InputOption name
      *
-     * @return bool    true if the InputOption object exists, false otherwise
+     * @return bool true if the InputOption object exists, false otherwise
      */
     public function hasOption($name);
 
@@ -146,7 +146,7 @@ interface InputInterface
     /**
      * Sets the input interactivity.
      *
-     * @param bool    $interactive If the input should be interactive
+     * @param bool $interactive If the input should be interactive
      */
     public function setInteractive($interactive);
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -112,7 +112,7 @@ class InputOption
     /**
      * Returns true if the option accepts a value.
      *
-     * @return bool    true if value mode is not self::VALUE_NONE, false otherwise
+     * @return bool true if value mode is not self::VALUE_NONE, false otherwise
      */
     public function acceptValue()
     {
@@ -122,7 +122,7 @@ class InputOption
     /**
      * Returns true if the option requires a value.
      *
-     * @return bool    true if value mode is self::VALUE_REQUIRED, false otherwise
+     * @return bool true if value mode is self::VALUE_REQUIRED, false otherwise
      */
     public function isValueRequired()
     {
@@ -132,7 +132,7 @@ class InputOption
     /**
      * Returns true if the option takes an optional value.
      *
-     * @return bool    true if value mode is self::VALUE_OPTIONAL, false otherwise
+     * @return bool true if value mode is self::VALUE_OPTIONAL, false otherwise
      */
     public function isValueOptional()
     {
@@ -142,7 +142,7 @@ class InputOption
     /**
      * Returns true if the option can take multiple values.
      *
-     * @return bool    true if mode is self::VALUE_IS_ARRAY, false otherwise
+     * @return bool true if mode is self::VALUE_IS_ARRAY, false otherwise
      */
     public function isArray()
     {
@@ -194,9 +194,10 @@ class InputOption
     }
 
     /**
-     * Checks whether the given option equals this one
+     * Checks whether the given option equals this one.
      *
      * @param InputOption $option option to compare
+     *
      * @return bool
      */
     public function equals(InputOption $option)

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -138,8 +138,8 @@ abstract class Output implements OutputInterface
     /**
      * Writes a message to the output.
      *
-     * @param string  $message A message to write to the output
-     * @param bool    $newline Whether to add a newline or not
+     * @param string $message A message to write to the output
+     * @param bool   $newline Whether to add a newline or not
      */
     abstract protected function doWrite($message, $newline);
 }

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -60,7 +60,7 @@ interface OutputInterface
     /**
      * Sets the verbosity of the output.
      *
-     * @param int     $level The level of verbosity (one of the VERBOSITY constants)
+     * @param int $level The level of verbosity (one of the VERBOSITY constants)
      *
      * @api
      */
@@ -69,7 +69,7 @@ interface OutputInterface
     /**
      * Gets the current verbosity of the output.
      *
-     * @return int     The current level of verbosity (one of the VERBOSITY constants)
+     * @return int The current level of verbosity (one of the VERBOSITY constants)
      *
      * @api
      */
@@ -78,7 +78,7 @@ interface OutputInterface
     /**
      * Sets the decorated flag.
      *
-     * @param bool    $decorated Whether to decorate the messages
+     * @param bool $decorated Whether to decorate the messages
      *
      * @api
      */
@@ -87,7 +87,7 @@ interface OutputInterface
     /**
      * Gets the decorated flag.
      *
-     * @return bool    true if the output will decorate messages, false otherwise
+     * @return bool true if the output will decorate messages, false otherwise
      *
      * @api
      */
@@ -105,7 +105,7 @@ interface OutputInterface
     /**
      * Returns current output formatter instance.
      *
-     * @return  OutputFormatterInterface
+     * @return OutputFormatterInterface
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -92,7 +92,7 @@ class StreamOutput extends Output
      *  -  Windows without Ansicon and ConEmu
      *  -  non tty consoles
      *
-     * @return bool    true if the stream supports colorization, false otherwise
+     * @return bool true if the stream supports colorization, false otherwise
      */
     protected function hasColorSupport()
     {

--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -164,7 +164,7 @@ EOF;
      *
      * @param string $text The last segment of the entered text
      *
-     * @return bool|array    A list of guessed strings or true
+     * @return bool|array A list of guessed strings or true
      */
     private function autocompleter($text)
     {

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -55,7 +55,7 @@ class ApplicationTester
      * @param array $input   An array of arguments and options
      * @param array $options An array of options
      *
-     * @return int     The command exit code
+     * @return int The command exit code
      */
     public function run(array $input, $options = array())
     {
@@ -78,7 +78,7 @@ class ApplicationTester
     /**
      * Gets the display returned by the last execution of the application.
      *
-     * @param bool    $normalize Whether to normalize end of lines to \n or not
+     * @param bool $normalize Whether to normalize end of lines to \n or not
      *
      * @return string The display
      */

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -50,7 +50,7 @@ class CommandTester
      * @param array $input   An array of arguments and options
      * @param array $options An array of options
      *
-     * @return int     The command exit code
+     * @return int The command exit code
      */
     public function execute(array $input, array $options = array())
     {
@@ -73,7 +73,7 @@ class CommandTester
     /**
      * Gets the display returned by the last execution of the command.
      *
-     * @param bool    $normalize Whether to normalize end of lines to \n or not
+     * @param bool $normalize Whether to normalize end of lines to \n or not
      *
      * @return string The display
      */

--- a/src/Symfony/Component/CssSelector/CssSelector.php
+++ b/src/Symfony/Component/CssSelector/CssSelector.php
@@ -40,8 +40,8 @@ class CssSelector
      * Optionally, a prefix can be added to the resulting XPath
      * expression with the $prefix parameter.
      *
-     * @param mixed   $cssExpr The CSS expression.
-     * @param string  $prefix  An optional prefix for the XPath expression.
+     * @param mixed  $cssExpr The CSS expression.
+     * @param string $prefix  An optional prefix for the XPath expression.
      *
      * @return string
      *

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -45,8 +45,8 @@ class NodeExtension extends AbstractExtension
     }
 
     /**
-     * @param int     $flag
-     * @param bool    $on
+     * @param int  $flag
+     * @param bool $on
      *
      * @return NodeExtension
      */

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -227,7 +227,7 @@ class Translator implements TranslatorInterface
     }
 
     /**
-     * @param XPathExpr $xpath
+     * @param XPathExpr    $xpath
      * @param FunctionNode $function
      *
      * @return XPathExpr

--- a/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
@@ -37,10 +37,10 @@ class XPathExpr
     private $condition;
 
     /**
-     * @param string  $path
-     * @param string  $element
-     * @param string  $condition
-     * @param bool    $starPrefix
+     * @param string $path
+     * @param string $element
+     * @param string $condition
+     * @param bool   $starPrefix
      */
     public function __construct($path = '', $element = '*', $condition = '', $starPrefix = false)
     {

--- a/src/Symfony/Component/Debug/Debug.php
+++ b/src/Symfony/Component/Debug/Debug.php
@@ -30,8 +30,8 @@ class Debug
      * If the Symfony ClassLoader component is available, a special
      * class loader is also registered.
      *
-     * @param int     $errorReportingLevel The level of error reporting you want
-     * @param bool    $displayErrors       Whether to display errors (for development) or just log them (for production)
+     * @param int  $errorReportingLevel The level of error reporting you want
+     * @param bool $displayErrors       Whether to display errors (for development) or just log them (for production)
      */
     public static function enable($errorReportingLevel = null, $displayErrors = true)
     {

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -56,8 +56,8 @@ class ErrorHandler
     /**
      * Registers the error handler.
      *
-     * @param int     $level The level at which the conversion to Exception is done (null to use the error_reporting() value and 0 to disable)
-     * @param bool    $displayErrors Display errors (for dev environment) or just log they (production usage)
+     * @param int  $level         The level at which the conversion to Exception is done (null to use the error_reporting() value and 0 to disable)
+     * @param bool $displayErrors Display errors (for dev environment) or just log they (production usage)
      *
      * @return ErrorHandler The registered error handler
      */

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -39,7 +39,7 @@ class ExceptionHandler
     /**
      * Registers the exception handler.
      *
-     * @param bool    $debug
+     * @param bool $debug
      *
      * @return ExceptionHandler The registered exception handler
      */

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -22,8 +22,8 @@ class Alias
     /**
      * Constructor.
      *
-     * @param string  $id     Alias identifier
-     * @param bool    $public If this alias is public
+     * @param string $id     Alias identifier
+     * @param bool   $public If this alias is public
      *
      * @api
      */
@@ -48,7 +48,7 @@ class Alias
     /**
      * Sets if this Alias is public.
      *
-     * @param bool    $boolean If this Alias should be public
+     * @param bool $boolean If this Alias should be public
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -36,7 +36,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
     /**
      * Constructor.
      *
-     * @param bool    $onlyConstructorArguments Sets this Service Reference pass to ignore method calls
+     * @param bool $onlyConstructorArguments Sets this Service Reference pass to ignore method calls
      */
     public function __construct($onlyConstructorArguments = false)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -109,7 +109,7 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
      * @param string           $id
      * @param Definition       $definition
      *
-     * @return bool    If the definition is inlineable
+     * @return bool If the definition is inlineable
      */
     private function isInlineableDefinition(ContainerBuilder $container, $id, Definition $definition)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -69,8 +69,8 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
     /**
      * Processes arguments to determine invalid references.
      *
-     * @param array   $arguments    An array of Reference objects
-     * @param bool    $inMethodCall
+     * @param array $arguments    An array of Reference objects
+     * @param bool  $inMethodCall
      *
      * @return array
      *

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
@@ -65,7 +65,7 @@ class ServiceReferenceGraphNode
     /**
      * Checks if the value of this node is an Alias.
      *
-     * @return bool    True if the value is an Alias instance
+     * @return bool True if the value is an Alias instance
      */
     public function isAlias()
     {
@@ -75,7 +75,7 @@ class ServiceReferenceGraphNode
     /**
      * Checks if the value of this node is a Definition.
      *
-     * @return bool    True if the value is a Definition instance
+     * @return bool True if the value is a Definition instance
      */
     public function isDefinition()
     {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -115,7 +115,7 @@ class Container implements IntrospectableContainerInterface
     /**
      * Returns true if the container parameter bag are frozen.
      *
-     * @return bool    true if the container parameter bag are frozen, false otherwise
+     * @return bool true if the container parameter bag are frozen, false otherwise
      *
      * @api
      */
@@ -141,7 +141,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $name The parameter name
      *
-     * @return mixed  The parameter value
+     * @return mixed The parameter value
      *
      * @throws InvalidArgumentException if the parameter is not defined
      *
@@ -157,7 +157,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $name The parameter name
      *
-     * @return bool    The presence of parameter in container
+     * @return bool The presence of parameter in container
      *
      * @api
      */
@@ -189,7 +189,7 @@ class Container implements IntrospectableContainerInterface
      * @param object $service The service instance
      * @param string $scope   The scope of the service
      *
-     * @throws RuntimeException When trying to set a service in an inactive scope
+     * @throws RuntimeException         When trying to set a service in an inactive scope
      * @throws InvalidArgumentException When trying to set a service in the prototype scope
      *
      * @api
@@ -236,7 +236,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return bool    true if the service is defined, false otherwise
+     * @return bool true if the service is defined, false otherwise
      *
      * @api
      */
@@ -261,8 +261,8 @@ class Container implements IntrospectableContainerInterface
      * If a service is defined both through a set() method and
      * with a get{$id}Service() method, the former has always precedence.
      *
-     * @param string  $id              The service identifier
-     * @param int     $invalidBehavior The behavior when the service does not exist
+     * @param string $id              The service identifier
+     * @param int    $invalidBehavior The behavior when the service does not exist
      *
      * @return object The associated service
      *
@@ -353,7 +353,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return bool    true if service has already been initialized, false otherwise
+     * @return bool true if service has already been initialized, false otherwise
      */
     public function initialized($id)
     {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -84,7 +84,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * If you are not using the loaders and therefore don't want
      * to depend on the Config component, set this flag to false.
      *
-     * @param bool    $track true if you want to track resources, false otherwise
+     * @param bool $track true if you want to track resources, false otherwise
      */
     public function setResourceTracking($track)
     {
@@ -94,7 +94,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Checks if resources are tracked.
      *
-     * @return bool    true if resources are tracked, false otherwise
+     * @return bool true if resources are tracked, false otherwise
      */
     public function isTrackingResources()
     {
@@ -168,7 +168,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $name The name of the extension
      *
-     * @return bool    If the extension exists
+     * @return bool If the extension exists
      *
      * @api
      */
@@ -273,7 +273,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param string $extension The extension alias or namespace
      * @param array  $values    An array of values that customizes the extension
      *
-     * @return ContainerBuilder The current instance
+     * @return ContainerBuilder       The current instance
      * @throws BadMethodCallException When this ContainerBuilder is frozen
      *
      * @throws \LogicException if the container is frozen
@@ -430,7 +430,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return bool    true if the service is defined, false otherwise
+     * @return bool true if the service is defined, false otherwise
      *
      * @api
      */
@@ -444,8 +444,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Gets a service.
      *
-     * @param string  $id              The service identifier
-     * @param int     $invalidBehavior The behavior when the service does not exist
+     * @param string $id              The service identifier
+     * @param int    $invalidBehavior The behavior when the service does not exist
      *
      * @return object The associated service
      *
@@ -574,8 +574,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Prepends a config array to the configs of the given extension.
      *
-     * @param string $name    The name of the extension
-     * @param array  $config  The config to set
+     * @param string $name   The name of the extension
+     * @param array  $config The config to set
      */
     public function prependExtensionConfig($name, array $config)
     {
@@ -669,8 +669,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Sets an alias for an existing service.
      *
-     * @param string        $alias The alias to create
-     * @param string|Alias  $id    The service to alias
+     * @param string       $alias The alias to create
+     * @param string|Alias $id    The service to alias
      *
      * @throws InvalidArgumentException if the id is not a string or an Alias
      * @throws InvalidArgumentException if the alias is for itself
@@ -713,7 +713,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return bool    true if the alias exists, false otherwise
+     * @return bool true if the alias exists, false otherwise
      *
      * @api
      */
@@ -843,7 +843,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return bool    true if the service definition exists, false otherwise
+     * @return bool true if the service definition exists, false otherwise
      *
      * @api
      */
@@ -905,9 +905,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @return object The service described by the service definition
      *
-     * @throws RuntimeException When the scope is inactive
-     * @throws RuntimeException When the factory definition is incomplete
-     * @throws RuntimeException When the service is a synthetic service
+     * @throws RuntimeException         When the scope is inactive
+     * @throws RuntimeException         When the factory definition is incomplete
+     * @throws RuntimeException         When the service is a synthetic service
      * @throws InvalidArgumentException When configure callable is not callable
      *
      * @internal this method is public because of PHP 5.3 limitations, do not use it explicitly in your code

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -50,9 +50,9 @@ interface ContainerInterface
      *
      * @return object The associated service
      *
-     * @throws InvalidArgumentException if the service is not defined
+     * @throws InvalidArgumentException          if the service is not defined
      * @throws ServiceCircularReferenceException When a circular reference is detected
-     * @throws ServiceNotFoundException When the service is not defined
+     * @throws ServiceNotFoundException          When the service is not defined
      *
      * @see Reference
      *
@@ -65,7 +65,7 @@ interface ContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return bool    true if the service is defined, false otherwise
+     * @return bool true if the service is defined, false otherwise
      *
      * @api
      */
@@ -76,7 +76,7 @@ interface ContainerInterface
      *
      * @param string $name The parameter name
      *
-     * @return mixed  The parameter value
+     * @return mixed The parameter value
      *
      * @throws InvalidArgumentException if the parameter is not defined
      *
@@ -89,7 +89,7 @@ interface ContainerInterface
      *
      * @param string $name The parameter name
      *
-     * @return bool    The presence of parameter in container
+     * @return bool The presence of parameter in container
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -240,8 +240,8 @@ class Definition
     /**
      * Sets a specific argument
      *
-     * @param int     $index
-     * @param mixed   $argument
+     * @param int   $index
+     * @param mixed $argument
      *
      * @return Definition The current instance
      *
@@ -275,7 +275,7 @@ class Definition
     /**
      * Gets an argument to pass to the service constructor/factory method.
      *
-     * @param int     $index
+     * @param int $index
      *
      * @return mixed The argument value
      *
@@ -548,7 +548,7 @@ class Definition
     /**
      * Sets the visibility of this service.
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      *
      * @return Definition The current instance
      *
@@ -576,7 +576,7 @@ class Definition
     /**
      * Sets the synchronized flag of this service.
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      *
      * @return Definition The current instance
      *
@@ -604,7 +604,7 @@ class Definition
     /**
      * Sets the lazy flag of this service.
      *
-     * @param bool    $lazy
+     * @param bool $lazy
      *
      * @return Definition The current instance
      */
@@ -629,7 +629,7 @@ class Definition
      * Sets whether this definition is synthetic, that is not constructed by the
      * container, but dynamically injected.
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      *
      * @return Definition the current instance
      *
@@ -659,7 +659,7 @@ class Definition
      * Whether this definition is abstract, that means it merely serves as a
      * template for other definitions.
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      *
      * @return Definition the current instance
      *

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -167,7 +167,7 @@ class DefinitionDecorator extends Definition
      * If replaceArgument() has been used to replace an argument, this method
      * will return the replacement value.
      *
-     * @param int     $index
+     * @param int $index
      *
      * @return mixed The argument value
      *
@@ -198,10 +198,10 @@ class DefinitionDecorator extends Definition
      * certain conventions when you want to overwrite the arguments of the
      * parent definition, otherwise your arguments will only be appended.
      *
-     * @param int     $index
-     * @param mixed   $value
+     * @param int   $index
+     * @param mixed $value
      *
-     * @return DefinitionDecorator the current instance
+     * @return DefinitionDecorator      the current instance
      * @throws InvalidArgumentException when $index isn't an integer
      *
      * @api

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -122,10 +122,10 @@ class GraphvizDumper extends Dumper
     /**
      * Finds all edges belonging to a specific service id.
      *
-     * @param string  $id        The service id used to find edges
-     * @param array   $arguments An array of arguments
-     * @param bool    $required
-     * @param string  $name
+     * @param string $id        The service id used to find edges
+     * @param array  $arguments An array of arguments
+     * @param bool   $required
+     * @param string $name
      *
      * @return array An array of edges
      */

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -240,7 +240,7 @@ class PhpDumper extends Dumper
      *
      * @return string
      *
-     * @throws RuntimeException When the factory definition is incomplete
+     * @throws RuntimeException                  When the factory definition is incomplete
      * @throws ServiceCircularReferenceException When a circular reference is detected
      */
     private function addServiceInlinedDefinitions($id, $definition)
@@ -958,9 +958,9 @@ EOF;
     /**
      * Exports parameters.
      *
-     * @param array   $parameters
-     * @param string  $path
-     * @param int     $indent
+     * @param array  $parameters
+     * @param string $path
+     * @param int    $indent
      *
      * @return string
      *
@@ -1029,9 +1029,9 @@ EOF;
     /**
      * Builds service calls from arguments.
      *
-     * @param array  $arguments
-     * @param array  &$calls    By reference
-     * @param array  &$behavior By reference
+     * @param array $arguments
+     * @param array &$calls    By reference
+     * @param array &$behavior By reference
      */
     private function getServiceCallsFromArguments(array $arguments, array &$calls, array &$behavior)
     {
@@ -1107,10 +1107,10 @@ EOF;
     /**
      * Checks if a service id has a reference.
      *
-     * @param string  $id
-     * @param array   $arguments
-     * @param bool    $deep
-     * @param array   $visited
+     * @param string $id
+     * @param array  $arguments
+     * @param bool   $deep
+     * @param array  $visited
      *
      * @return bool
      */
@@ -1145,8 +1145,8 @@ EOF;
     /**
      * Dumps values.
      *
-     * @param array   $value
-     * @param bool    $interpolate
+     * @param array $value
+     * @param bool  $interpolate
      *
      * @return string
      *

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -274,8 +274,8 @@ class YamlDumper extends Dumper
     /**
      * Prepares parameters.
      *
-     * @param array   $parameters
-     * @param bool    $escape
+     * @param array $parameters
+     * @param bool  $escape
      *
      * @return array
      */

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -109,7 +109,7 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
      * @param ContainerBuilder $container
      * @param array            $config
      *
-     * @return bool    Whether the configuration is enabled
+     * @return bool Whether the configuration is enabled
      *
      * @throws InvalidArgumentException When the config is not enableable
      */

--- a/src/Symfony/Component/DependencyInjection/IntrospectableContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/IntrospectableContainerInterface.php
@@ -25,7 +25,7 @@ interface IntrospectableContainerInterface extends ContainerInterface
      *
      * @param string $id
      *
-     * @return bool    true if the service has been initialized, false otherwise
+     * @return bool true if the service has been initialized, false otherwise
      *
      */
     public function initialized($id);

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -82,7 +82,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @param string $name The parameter name
      *
-     * @return mixed  The parameter value
+     * @return mixed The parameter value
      *
      * @throws ParameterNotFoundException if the parameter is not defined
      *
@@ -129,7 +129,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @param string $name The parameter name
      *
-     * @return bool    true if the parameter name is defined, false otherwise
+     * @return bool true if the parameter name is defined, false otherwise
      *
      * @api
      */
@@ -183,9 +183,9 @@ class ParameterBag implements ParameterBagInterface
      *
      * @return mixed The resolved value
      *
-     * @throws ParameterNotFoundException if a placeholder references a parameter that does not exist
+     * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected
-     * @throws RuntimeException when a given parameter has a type problem.
+     * @throws RuntimeException                    when a given parameter has a type problem.
      */
     public function resolveValue($value, array $resolving = array())
     {
@@ -213,9 +213,9 @@ class ParameterBag implements ParameterBagInterface
      *
      * @return string The resolved string
      *
-     * @throws ParameterNotFoundException if a placeholder references a parameter that does not exist
+     * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected
-     * @throws RuntimeException when a given parameter has a type problem.
+     * @throws RuntimeException                    when a given parameter has a type problem.
      */
     public function resolveString($value, array $resolving = array())
     {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -52,7 +52,7 @@ interface ParameterBagInterface
      *
      * @param string $name The parameter name
      *
-     * @return mixed  The parameter value
+     * @return mixed The parameter value
      *
      * @throws ParameterNotFoundException if the parameter is not defined
      *
@@ -75,7 +75,7 @@ interface ParameterBagInterface
      *
      * @param string $name The parameter name
      *
-     * @return bool    true if the parameter name is defined, false otherwise
+     * @return bool true if the parameter name is defined, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Reference.php
+++ b/src/Symfony/Component/DependencyInjection/Reference.php
@@ -27,9 +27,9 @@ class Reference
     /**
      * Constructor.
      *
-     * @param string  $id              The service identifier
-     * @param int     $invalidBehavior The behavior when the service does not exist
-     * @param bool    $strict          Sets how this reference is validated
+     * @param string $id              The service identifier
+     * @param int    $invalidBehavior The behavior when the service does not exist
+     * @param bool   $strict          Sets how this reference is validated
      *
      * @see Container
      */

--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -35,8 +35,8 @@ class SimpleXMLElement extends \SimpleXMLElement
     /**
      * Returns arguments as valid PHP types.
      *
-     * @param string  $name
-     * @param bool    $lowercase
+     * @param string $name
+     * @param bool   $lowercase
      *
      * @return mixed
      */

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -284,7 +284,7 @@ class Crawler extends \SplObjectStorage
     /**
      * Returns a node given its position in the node list.
      *
-     * @param int     $position The position
+     * @param int $position The position
      *
      * @return Crawler A new instance of the Crawler with the selected node, or an empty Crawler if it does not exist.
      *
@@ -873,7 +873,7 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
-     * @param int     $position
+     * @param int $position
      *
      * @return \DOMElement|null
      */

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -38,7 +38,7 @@ class ChoiceFormField extends FormField
     /**
      * Returns true if the field should be included in the submitted values.
      *
-     * @return bool    true if the field should be included in the submitted values, false otherwise
+     * @return bool true if the field should be included in the submitted values, false otherwise
      */
     public function hasValue()
     {
@@ -188,7 +188,7 @@ class ChoiceFormField extends FormField
     /**
      * Returns true if the field accepts multiple values.
      *
-     * @return bool    true if the field accepts multiple values, false otherwise
+     * @return bool true if the field accepts multiple values, false otherwise
      */
     public function isMultiple()
     {

--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -23,7 +23,7 @@ class FileFormField extends FormField
     /**
      * Sets the PHP error code associated with the field.
      *
-     * @param int     $error The error code (one of UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE, UPLOAD_ERR_PARTIAL, UPLOAD_ERR_NO_FILE, UPLOAD_ERR_NO_TMP_DIR, UPLOAD_ERR_CANT_WRITE, or UPLOAD_ERR_EXTENSION)
+     * @param int $error The error code (one of UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE, UPLOAD_ERR_PARTIAL, UPLOAD_ERR_NO_FILE, UPLOAD_ERR_NO_TMP_DIR, UPLOAD_ERR_CANT_WRITE, or UPLOAD_ERR_EXTENSION)
      *
      * @throws \InvalidArgumentException When error code doesn't exist
      */

--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -92,7 +92,7 @@ abstract class FormField
     /**
      * Returns true if the field should be included in the submitted values.
      *
-     * @return bool    true if the field should be included in the submitted values, false otherwise
+     * @return bool true if the field should be included in the submitted values, false otherwise
      */
     public function hasValue()
     {

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -233,7 +233,7 @@ class Form extends Link implements \ArrayAccess
      *
      * @param string $name The field name
      *
-     * @return bool    true if the field exists, false otherwise
+     * @return bool true if the field exists, false otherwise
      *
      * @api
      */
@@ -301,7 +301,7 @@ class Form extends Link implements \ArrayAccess
      *
      * @param string $name The field name
      *
-     * @return bool    true if the field exists, false otherwise
+     * @return bool true if the field exists, false otherwise
      */
     public function offsetExists($name)
     {

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -99,7 +99,7 @@ class FormFieldRegistry
      *
      * @param string $name The fully qualified name of the field
      *
-     * @return bool    Whether the form has the given field
+     * @return bool Whether the form has the given field
      */
     public function has($name)
     {

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -56,10 +56,10 @@ class ContainerAwareEventDispatcher extends EventDispatcher
      *
      * @param string $eventName Event for which the listener is added
      * @param array  $callback  The service ID of the listener service & the method
-     *                            name that has to be called
-     * @param int     $priority The higher this value, the earlier an event listener
-     *                            will be triggered in the chain.
-     *                            Defaults to 0.
+     *                          name that has to be called
+     * @param int    $priority  The higher this value, the earlier an event listener
+     *                          will be triggered in the chain.
+     *                          Defaults to 0.
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -48,7 +48,7 @@ class Event
      * Returns whether further event listeners should be triggered.
      *
      * @see Event::stopPropagation
-     * @return bool    Whether propagation was already stopped for this event.
+     * @return bool Whether propagation was already stopped for this event.
      *
      * @api
      */

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -28,7 +28,7 @@ interface EventDispatcherInterface
      * @param string $eventName The name of the event to dispatch. The name of
      *                          the event is the name of the method that is
      *                          invoked on listeners.
-     * @param Event $event The event to pass to the event handlers/listeners.
+     * @param Event  $event     The event to pass to the event handlers/listeners.
      *                          If not supplied, an empty Event instance is created.
      *
      * @return Event
@@ -90,7 +90,7 @@ interface EventDispatcherInterface
      *
      * @param string $eventName The name of the event
      *
-     * @return bool    true if the specified event has any listeners, false otherwise
+     * @return bool true if the specified event has any listeners, false otherwise
      */
     public function hasListeners($eventName = null);
 }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -27,9 +27,9 @@ class Filesystem
      *
      * By default, if the target already exists, it is not overridden.
      *
-     * @param string  $originFile The original filename
-     * @param string  $targetFile The target filename
-     * @param bool    $override   Whether to override an existing file or not
+     * @param string $originFile The original filename
+     * @param string $targetFile The target filename
+     * @param bool   $override   Whether to override an existing file or not
      *
      * @throws IOException When copy fails
      */
@@ -96,7 +96,7 @@ class Filesystem
      *
      * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to check
      *
-     * @return bool    true if the file exists, false otherwise
+     * @return bool true if the file exists, false otherwise
      */
     public function exists($files)
     {
@@ -244,9 +244,9 @@ class Filesystem
     /**
      * Renames a file or a directory.
      *
-     * @param string  $origin    The origin filename or directory
-     * @param string  $target    The new filename or directory
-     * @param bool    $overwrite Whether to overwrite the target if it already exists
+     * @param string $origin    The origin filename or directory
+     * @param string $target    The new filename or directory
+     * @param bool   $overwrite Whether to overwrite the target if it already exists
      *
      * @throws IOException When target file or directory already exists
      * @throws IOException When origin cannot be renamed
@@ -266,9 +266,9 @@ class Filesystem
     /**
      * Creates a symbolic link or copy a directory.
      *
-     * @param string  $originDir     The origin directory path
-     * @param string  $targetDir     The symbolic link name
-     * @param bool    $copyOnWindows Whether to copy files if on Windows
+     * @param string $originDir     The origin directory path
+     * @param string $targetDir     The symbolic link name
+     * @param bool   $copyOnWindows Whether to copy files if on Windows
      *
      * @throws IOException When symlink fails
      */
@@ -351,10 +351,10 @@ class Filesystem
      * @param string       $targetDir The target directory
      * @param \Traversable $iterator  A Traversable instance
      * @param array        $options   An array of boolean options
-     *                               Valid options are:
-     *                                 - $options['override'] Whether to override an existing file on copy or not (see copy())
-     *                                 - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink())
-     *                                 - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
+     *                                Valid options are:
+     *                                - $options['override'] Whether to override an existing file on copy or not (see copy())
+     *                                - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink())
+     *                                - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
      *
      * @throws IOException When file type is unknown
      */
@@ -456,11 +456,12 @@ class Filesystem
     /**
      * Atomically dumps content into a file.
      *
-     * @param  string       $filename The file to be written to.
-     * @param  string       $content  The data to write into the file.
-     * @param  null|int     $mode     The file mode (octal). If null, file permissions are not modified
-     *                                Deprecated since version 2.3.12, to be removed in 3.0.
-     * @throws IOException            If the file cannot be written to.
+     * @param string   $filename The file to be written to.
+     * @param string   $content  The data to write into the file.
+     * @param null|int $mode     The file mode (octal). If null, file permissions are not modified
+     *                           Deprecated since version 2.3.12, to be removed in 3.0.
+     *
+     * @throws IOException If the file cannot be written to.
      */
     public function dumpFile($filename, $content, $mode = 0666)
     {

--- a/src/Symfony/Component/Finder/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractAdapter.php
@@ -230,7 +230,7 @@ abstract class AbstractAdapter implements AdapterInterface
      *
      * @see isSupported
      *
-     * @return bool    Whether the adapter is supported
+     * @return bool Whether the adapter is supported
      */
     abstract protected function canBeUsed();
 }

--- a/src/Symfony/Component/Finder/Adapter/AdapterInterface.php
+++ b/src/Symfony/Component/Finder/Adapter/AdapterInterface.php
@@ -17,14 +17,14 @@ namespace Symfony\Component\Finder\Adapter;
 interface AdapterInterface
 {
     /**
-     * @param bool    $followLinks
+     * @param bool $followLinks
      *
      * @return AdapterInterface Current instance
      */
     public function setFollowLinks($followLinks);
 
     /**
-     * @param int     $mode
+     * @param int $mode
      *
      * @return AdapterInterface Current instance
      */
@@ -94,7 +94,7 @@ interface AdapterInterface
     public function setFilters(array $filters);
 
     /**
-     * @param \Closure|int     $sort
+     * @param \Closure|int $sort
      *
      * @return AdapterInterface Current instance
      */
@@ -115,7 +115,7 @@ interface AdapterInterface
     public function setNotPath(array $notPaths);
 
     /**
-     * @param bool    $ignore
+     * @param bool $ignore
      *
      * @return AdapterInterface Current instance
      */

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -415,7 +415,7 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Excludes "hidden" directories and files (starting with a dot).
      *
-     * @param bool    $ignoreDotFiles Whether to exclude "hidden" files or not
+     * @param bool $ignoreDotFiles Whether to exclude "hidden" files or not
      *
      * @return Finder The current Finder instance
      *
@@ -437,7 +437,7 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Forces the finder to ignore version control directories.
      *
-     * @param bool    $ignoreVCS Whether to exclude VCS files or not
+     * @param bool $ignoreVCS Whether to exclude VCS files or not
      *
      * @return Finder The current Finder instance
      *
@@ -632,7 +632,7 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * By default, scanning unreadable directories content throws an AccessDeniedException.
      *
-     * @param bool    $ignore
+     * @param bool $ignore
      *
      * @return Finder The current Finder instance
      */

--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -38,9 +38,9 @@ class Glob
     /**
      * Returns a regexp which is the equivalent of the glob pattern.
      *
-     * @param string  $glob                The glob pattern
-     * @param bool    $strictLeadingDot
-     * @param bool    $strictWildcardSlash
+     * @param string $glob                The glob pattern
+     * @param bool   $strictLeadingDot
+     * @param bool   $strictWildcardSlash
      *
      * @return string regex The regexp
      */

--- a/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
@@ -46,7 +46,7 @@ class CustomFilterIterator extends FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
@@ -38,7 +38,7 @@ class DateRangeFilterIterator extends FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/DepthRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DepthRangeFilterIterator.php
@@ -23,9 +23,9 @@ class DepthRangeFilterIterator extends FilterIterator
     /**
      * Constructor.
      *
-     * @param \RecursiveIteratorIterator $iterator    The Iterator to filter
-     * @param int                        $minDepth    The min depth
-     * @param int                        $maxDepth    The max depth
+     * @param \RecursiveIteratorIterator $iterator The Iterator to filter
+     * @param int                        $minDepth The min depth
+     * @param int                        $maxDepth The max depth
      */
     public function __construct(\RecursiveIteratorIterator $iterator, $minDepth = 0, $maxDepth = PHP_INT_MAX)
     {
@@ -38,7 +38,7 @@ class DepthRangeFilterIterator extends FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -39,7 +39,7 @@ class ExcludeDirectoryFilterIterator extends FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
@@ -39,7 +39,7 @@ class FileTypeFilterIterator extends FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
@@ -22,7 +22,7 @@ class FilecontentFilterIterator extends MultiplePcreFilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
@@ -23,7 +23,7 @@ class FilenameFilterIterator extends MultiplePcreFilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
@@ -50,7 +50,7 @@ abstract class MultiplePcreFilterIterator extends FilterIterator
      *
      * @param string $str
      *
-     * @return bool    Whether the given string is a regex
+     * @return bool Whether the given string is a regex
      */
     protected function isRegex($str)
     {

--- a/src/Symfony/Component/Finder/Iterator/PathFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/PathFilterIterator.php
@@ -22,7 +22,7 @@ class PathFilterIterator extends MultiplePcreFilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -34,9 +34,9 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
     /**
      * Constructor.
      *
-     * @param string  $path
-     * @param int     $flags
-     * @param bool    $ignoreUnreadableDirs
+     * @param string $path
+     * @param int    $flags
+     * @param bool   $ignoreUnreadableDirs
      *
      * @throws \RuntimeException
      */
@@ -104,7 +104,7 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
     /**
      * Checks if the stream is rewindable.
      *
-     * @return bool    true when the stream is rewindable, false otherwise
+     * @return bool true when the stream is rewindable, false otherwise
      */
     public function isRewindable()
     {

--- a/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
@@ -38,7 +38,7 @@ class SizeRangeFilterIterator extends FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return bool    true if the value should be kept, false otherwise
+     * @return bool true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Tests/Iterator/IteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/IteratorTestCase.php
@@ -62,7 +62,7 @@ abstract class IteratorTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Same as IteratorTestCase::assertIterator with foreach usage
      *
-     * @param array $expected
+     * @param array        $expected
      * @param \Traversable $iterator
      */
     protected function assertIteratorInForeach($expected, \Traversable $iterator)
@@ -82,7 +82,7 @@ abstract class IteratorTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Same as IteratorTestCase::assertOrderedIterator with foreach usage
      *
-     * @param array $expected
+     * @param array        $expected
      * @param \Traversable $iterator
      */
     protected function assertOrderedIteratorInForeach($expected, \Traversable $iterator)

--- a/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
@@ -18,10 +18,10 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
     /**
      * @dataProvider getPaths
      *
-     * @param string  $path
-     * @param bool    $seekable
-     * @param bool    $contains
-     * @param string  $message
+     * @param string $path
+     * @param bool   $seekable
+     * @param bool   $contains
+     * @param string $message
      */
     public function testRewind($path, $seekable, $contains, $message = null)
     {
@@ -39,10 +39,10 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
     /**
      * @dataProvider getPaths
      *
-     * @param string  $path
-     * @param bool    $seekable
-     * @param bool    $contains
-     * @param string  $message
+     * @param string $path
+     * @param bool   $seekable
+     * @param bool   $contains
+     * @param string $message
      */
     public function testSeek($path, $seekable, $contains, $message = null)
     {

--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -131,7 +131,7 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
      * @param FormView $view      The form view for finding the applying themes.
      * @param string   $blockName The name of the block to load.
      *
-     * @return bool    True if the resource could be loaded, false otherwise.
+     * @return bool True if the resource could be loaded, false otherwise.
      */
     abstract protected function loadResourceForBlockName($cacheKey, FormView $view, $blockName);
 
@@ -149,7 +149,7 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
      * @param int      $hierarchyLevel     The level in the block hierarchy that
      *                                     should be loaded.
      *
-     * @return bool    True if the resource could be loaded, false otherwise.
+     * @return bool True if the resource could be loaded, false otherwise.
      */
     private function loadResourceForBlockNameHierarchy($cacheKey, FormView $view, array $blockNameHierarchy, $hierarchyLevel)
     {

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -69,16 +69,16 @@ class ChoiceList implements ChoiceListInterface
     /**
      * Creates a new choice list.
      *
-     * @param array|\Traversable $choices The array of choices. Choices may also be given
-     *                                    as hierarchy of unlimited depth. Hierarchies are
-     *                                    created by creating nested arrays. The title of
-     *                                    the sub-hierarchy can be stored in the array
-     *                                    key pointing to the nested array. The topmost
-     *                                    level of the hierarchy may also be a \Traversable.
-     * @param array $labels               The array of labels. The structure of this array
-     *                                    should match the structure of $choices.
-     * @param array $preferredChoices     A flat array of choices that should be
-     *                                    presented to the user with priority.
+     * @param array|\Traversable $choices          The array of choices. Choices may also be given
+     *                                             as hierarchy of unlimited depth. Hierarchies are
+     *                                             created by creating nested arrays. The title of
+     *                                             the sub-hierarchy can be stored in the array
+     *                                             key pointing to the nested array. The topmost
+     *                                             level of the hierarchy may also be a \Traversable.
+     * @param array              $labels           The array of labels. The structure of this array
+     *                                             should match the structure of $choices.
+     * @param array              $preferredChoices A flat array of choices that should be
+     *                                             presented to the user with priority.
      *
      * @throws UnexpectedTypeException If the choices are not an array or \Traversable.
      */

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -64,23 +64,23 @@ class ObjectChoiceList extends ChoiceList
     /**
      * Creates a new object choice list.
      *
-     * @param array|\Traversable       $choices           The array of choices. Choices may also be given
+     * @param array|\Traversable        $choices          The array of choices. Choices may also be given
      *                                                    as hierarchy of unlimited depth by creating nested
      *                                                    arrays. The title of the sub-hierarchy can be
      *                                                    stored in the array key pointing to the nested
      *                                                    array. The topmost level of the hierarchy may also
      *                                                    be a \Traversable.
-     * @param string                   $labelPath         A property path pointing to the property used
+     * @param string                    $labelPath        A property path pointing to the property used
      *                                                    for the choice labels. The value is obtained
      *                                                    by calling the getter on the object. If the
      *                                                    path is NULL, the object's __toString() method
      *                                                    is used instead.
-     * @param array                    $preferredChoices  A flat array of choices that should be
+     * @param array                     $preferredChoices A flat array of choices that should be
      *                                                    presented to the user with priority.
-     * @param string                   $groupPath         A property path pointing to the property used
+     * @param string                    $groupPath        A property path pointing to the property used
      *                                                    to group the choices. Only allowed if
      *                                                    the choices are given as flat array.
-     * @param string                   $valuePath         A property path pointing to the property used
+     * @param string                    $valuePath        A property path pointing to the property used
      *                                                    for the choice values. If not given, integers
      *                                                    are generated instead.
      * @param PropertyAccessorInterface $propertyAccessor The reflection graph for reading property paths.

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
@@ -34,11 +34,11 @@ class SimpleChoiceList extends ChoiceList
     /**
      * Creates a new simple choice list.
      *
-     * @param array $choices The array of choices with the choices as keys and
-     *                       the labels as values. Choices may also be given
-     *                       as hierarchy of unlimited depth by creating nested
-     *                       arrays. The title of the sub-hierarchy is stored
-     *                       in the array key pointing to the nested array.
+     * @param array $choices          The array of choices with the choices as keys and
+     *                                the labels as values. Choices may also be given
+     *                                as hierarchy of unlimited depth by creating nested
+     *                                arrays. The title of the sub-hierarchy is stored
+     *                                in the array key pointing to the nested array.
      * @param array $preferredChoices A flat array of choices that should be
      *                                presented to the user with priority.
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -32,12 +32,12 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
      *
      * @see BaseDateTimeTransformer::formats for available format options
      *
-     * @param string  $inputTimezone  The name of the input timezone
-     * @param string  $outputTimezone The name of the output timezone
-     * @param int     $dateFormat     The date format
-     * @param int     $timeFormat     The time format
-     * @param int     $calendar       One of the \IntlDateFormatter calendar constants
-     * @param string  $pattern        A pattern to pass to \IntlDateFormatter
+     * @param string $inputTimezone  The name of the input timezone
+     * @param string $outputTimezone The name of the output timezone
+     * @param int    $dateFormat     The date format
+     * @param int    $timeFormat     The time format
+     * @param int    $calendar       One of the \IntlDateFormatter calendar constants
+     * @param string $pattern        A pattern to pass to \IntlDateFormatter
      *
      * @throws UnexpectedTypeException If a format is not supported or if a timezone is not a string
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -53,10 +53,10 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
      *
      * @see \DateTime::format() for supported formats
      *
-     * @param string  $inputTimezone  The name of the input timezone
-     * @param string  $outputTimezone The name of the output timezone
-     * @param string  $format         The date format
-     * @param bool    $parseUsingPipe Whether to parse by appending a pipe "|" to the parse format
+     * @param string $inputTimezone  The name of the input timezone
+     * @param string $outputTimezone The name of the output timezone
+     * @param string $format         The date format
+     * @param bool   $parseUsingPipe Whether to parse by appending a pipe "|" to the parse format
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderInterface.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderInterface.php
@@ -43,7 +43,7 @@ interface CsrfProviderInterface
      * @param string $intention The intention used when generating the CSRF token
      * @param string $token     The token supplied by the browser
      *
-     * @return bool    Whether the token supplied by the browser is correct
+     * @return bool Whether the token supplied by the browser is correct
      */
     public function isCsrfTokenValid($intention, $token);
 }

--- a/src/Symfony/Component/Form/Extension/Templating/TemplatingRendererEngine.php
+++ b/src/Symfony/Component/Form/Extension/Templating/TemplatingRendererEngine.php
@@ -52,7 +52,7 @@ class TemplatingRendererEngine extends AbstractRendererEngine
      * @param FormView $view      The form view for finding the applying themes.
      * @param string   $blockName The name of the block to load.
      *
-     * @return bool    True if the resource could be loaded, false otherwise.
+     * @return bool True if the resource could be loaded, false otherwise.
      */
     protected function loadResourceForBlockName($cacheKey, FormView $view, $blockName)
     {
@@ -110,7 +110,7 @@ class TemplatingRendererEngine extends AbstractRendererEngine
      * @param string $blockName The name of the block to load a resource for.
      * @param mixed  $theme     The theme to load the block from.
      *
-     * @return bool    True if the resource could be loaded, false otherwise.
+     * @return bool True if the resource could be loaded, false otherwise.
      */
     protected function loadResourceFromTheme($cacheKey, $blockName, $theme)
     {

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -101,9 +101,9 @@ class FormValidator extends ConstraintValidator
     /**
      * Returns whether the data of a form may be walked.
      *
-     * @param  FormInterface $form The form to test.
+     * @param FormInterface $form The form to test.
      *
-     * @return bool    Whether the graph walker may walk the data.
+     * @return bool Whether the graph walker may walk the data.
      */
     private static function allowDataWalking(FormInterface $form)
     {
@@ -133,7 +133,7 @@ class FormValidator extends ConstraintValidator
     /**
      * Returns the validation groups of the given form.
      *
-     * @param  FormInterface $form The form.
+     * @param FormInterface $form The form.
      *
      * @return array The validation groups.
      */

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
@@ -55,7 +55,7 @@ class MappingRule
      * If the rule matches, the form mapped by the rule is returned.
      * Otherwise this method returns false.
      *
-     * @param  string $propertyPath The property path to match against the rule.
+     * @param string $propertyPath The property path to match against the rule.
      *
      * @return null|FormInterface The mapped form or null.
      */
@@ -71,7 +71,7 @@ class MappingRule
      *
      * @param string $propertyPath The property path to match against the rule.
      *
-     * @return bool    Whether the property path is a prefix of the rule or not.
+     * @return bool Whether the property path is a prefix of the rule or not.
      */
     public function isPrefix($propertyPath)
     {

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -228,8 +228,8 @@ class ViolationMapper implements ViolationMapperInterface
     /**
      * Reconstructs a property path from a violation path and a form tree.
      *
-     * @param  ViolationPath $violationPath The violation path.
-     * @param  FormInterface $origin        The root form of the tree.
+     * @param ViolationPath $violationPath The violation path.
+     * @param FormInterface $origin        The root form of the tree.
      *
      * @return RelativePath The reconstructed path.
      */

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapperInterface.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapperInterface.php
@@ -23,11 +23,11 @@ interface ViolationMapperInterface
      * Maps a constraint violation to a form in the form tree under
      * the given form.
      *
-     * @param ConstraintViolation $violation The violation to map.
-     * @param FormInterface       $form      The root form of the tree
-     *                                       to map it to.
+     * @param ConstraintViolation $violation            The violation to map.
+     * @param FormInterface       $form                 The root form of the tree
+     *                                                  to map it to.
      * @param bool                $allowNonSynchronized Whether to allow
-     *                                       mapping to non-synchronized forms.
+     *                                                  mapping to non-synchronized forms.
      */
     public function mapViolation(ConstraintViolation $violation, FormInterface $form, $allowNonSynchronized = false);
 }

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -206,9 +206,9 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
      * In this example, "address" and "office" map to forms, while
      * "street does not.
      *
-     * @param  int     $index The element index.
+     * @param int $index The element index.
      *
-     * @return bool    Whether the element maps to a form.
+     * @return bool Whether the element maps to a form.
      *
      * @throws OutOfBoundsException If the offset is invalid.
      */

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -782,7 +782,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * This method should only be used to help debug a form.
      *
-     * @param int     $level The indentation level (used internally)
+     * @param int $level The indentation level (used internally)
      *
      * @return string A string representation of all errors
      */
@@ -992,7 +992,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns the number of form children (implements the \Countable interface).
      *
-     * @return int     The number of embedded form children
+     * @return int The number of embedded form children
      */
     public function count()
     {

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -245,7 +245,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     /**
      * Converts an unresolved child into a {@link FormBuilder} instance.
      *
-     * @param  string $name The name of the unresolved child.
+     * @param string $name The name of the unresolved child.
      *
      * @return FormBuilder The created instance.
      */

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -50,7 +50,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * view to the normalized format.
      *
      * @param DataTransformerInterface $viewTransformer
-     * @param bool                     $forcePrepend if set to true, prepend instead of appending
+     * @param bool                     $forcePrepend    if set to true, prepend instead of appending
      *
      * @return self The configuration object.
      */
@@ -72,7 +72,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * normalized to the model format.
      *
      * @param DataTransformerInterface $modelTransformer
-     * @param bool                     $forceAppend if set to true, append instead of prepending
+     * @param bool                     $forceAppend      if set to true, append instead of prepending
      *
      * @return self The configuration object.
      */
@@ -153,8 +153,8 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * Sets the property path that the form should be mapped to.
      *
      * @param null|string|PropertyPathInterface $propertyPath
-     *             The property path or null if the path should be set
-     *             automatically based on the form's name.
+     *                                                        The property path or null if the path should be set
+     *                                                        automatically based on the form's name.
      *
      * @return self The configuration object.
      */
@@ -174,7 +174,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * Sets whether the form's data should be modified by reference.
      *
      * @param bool $byReference Whether the data should be
-     *                              modified by reference.
+     *                          modified by reference.
      *
      * @return self The configuration object.
      */

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -21,13 +21,13 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Sets the parent form.
      *
-     * @param  FormInterface|null $parent The parent form or null if it's the root.
+     * @param FormInterface|null $parent The parent form or null if it's the root.
      *
      * @return FormInterface The form instance
      *
      * @throws Exception\AlreadySubmittedException If the form has already been submitted.
-     * @throws Exception\LogicException        When trying to set a parent for a form with
-     *                                         an empty name.
+     * @throws Exception\LogicException            When trying to set a parent for a form with
+     *                                             an empty name.
      */
     public function setParent(FormInterface $parent = null);
 
@@ -41,15 +41,15 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Adds or replaces a child to the form.
      *
-     * @param FormInterface|string|int     $child   The FormInterface instance or the name of the child.
-     * @param string|null                  $type    The child's type, if a name was passed.
-     * @param array                        $options The child's options, if a name was passed.
+     * @param FormInterface|string|int $child   The FormInterface instance or the name of the child.
+     * @param string|null              $type    The child's type, if a name was passed.
+     * @param array                    $options The child's options, if a name was passed.
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadySubmittedException   If the form has already been submitted.
-     * @throws Exception\LogicException          When trying to add a child to a non-compound form.
-     * @throws Exception\UnexpectedTypeException If $child or $type has an unexpected type.
+     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
+     * @throws Exception\LogicException            When trying to add a child to a non-compound form.
+     * @throws Exception\UnexpectedTypeException   If $child or $type has an unexpected type.
      */
     public function add($child, $type = null, array $options = array());
 
@@ -76,7 +76,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Removes a child from the form.
      *
-     * @param  string $name The name of the child to remove
+     * @param string $name The name of the child to remove
      *
      * @return FormInterface The form instance
      *
@@ -101,14 +101,14 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Updates the form with default data.
      *
-     * @param  mixed $modelData The data formatted as expected for the underlying object
+     * @param mixed $modelData The data formatted as expected for the underlying object
      *
      * @return FormInterface The form instance
      *
      * @throws Exception\AlreadySubmittedException If the form has already been submitted.
-     * @throws Exception\LogicException        If listeners try to call setData in a cycle. Or if
-     *                                         the view data does not match the expected type
-     *                                         according to {@link FormConfigInterface::getDataClass}.
+     * @throws Exception\LogicException            If listeners try to call setData in a cycle. Or if
+     *                                             the view data does not match the expected type
+     *                                             according to {@link FormConfigInterface::getDataClass}.
      */
     public function setData($modelData);
 
@@ -152,7 +152,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the form is submitted.
      *
-     * @return bool    true if the form is submitted, false otherwise
+     * @return bool true if the form is submitted, false otherwise
      */
     public function isSubmitted();
 
@@ -173,7 +173,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Adds an error to this form.
      *
-     * @param  FormError $error
+     * @param FormError $error
      *
      * @return FormInterface The form instance
      */

--- a/src/Symfony/Component/Form/FormRendererEngineInterface.php
+++ b/src/Symfony/Component/Form/FormRendererEngineInterface.php
@@ -120,7 +120,7 @@ interface FormRendererEngineInterface
      *                                     looking. Level 0 indicates the root block, i.e.
      *                                     the first element of $blockNameHierarchy.
      *
-     * @return int|bool        The hierarchy level or false, if no resource was found.
+     * @return int|bool The hierarchy level or false, if no resource was found.
      */
     public function getResourceHierarchyLevel(FormView $view, array $blockNameHierarchy, $hierarchyLevel);
 

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -58,7 +58,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Returns whether the view was already rendered.
      *
-     * @return bool    Whether this view's widget is rendered.
+     * @return bool Whether this view's widget is rendered.
      */
     public function isRendered()
     {

--- a/src/Symfony/Component/Form/PreloadedExtension.php
+++ b/src/Symfony/Component/Form/PreloadedExtension.php
@@ -38,9 +38,9 @@ class PreloadedExtension implements FormExtensionInterface
     /**
      * Creates a new preloaded extension.
      *
-     * @param FormTypeInterface[]                 $types         The types that the extension should support.
+     * @param FormTypeInterface[]           $types       The types that the extension should support.
      * @param array[FormTypeExtensionInterface[]] typeExtensions The type extensions that the extension should support.
-     * @param FormTypeGuesserInterface|null       $typeGuesser   The guesser that the extension should support.
+     * @param FormTypeGuesserInterface|null $typeGuesser The guesser that the extension should support.
      */
     public function __construct(array $types, array $typeExtensions, FormTypeGuesserInterface $typeGuesser = null)
     {

--- a/src/Symfony/Component/Form/Tests/AbstractFormTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractFormTest.php
@@ -70,7 +70,7 @@ abstract class AbstractFormTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param  string $name
+     * @param string $name
      *
      * @return \PHPUnit_Framework_MockObject_MockObject
      */

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -61,7 +61,8 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param FormConfigInterface $config
-     * @param bool    $synchronized
+     * @param bool                $synchronized
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getForm(FormConfigInterface $config, $synchronized = true, $submitted = true)

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -269,7 +269,7 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param string $name
-     * @param array $options
+     * @param array  $options
      *
      * @return FormBuilder
      */

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -30,7 +30,7 @@ class FormUtil
      * a form and needs to be consistent. PHP's keyword `empty` cannot
      * be used as it also considers 0 and "0" to be empty.
      *
-     * @param  mixed $data
+     * @param mixed $data
      *
      * @return bool
      */

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -72,7 +72,7 @@ class BinaryFileResponse extends Response
     /**
      * Sets the file to stream.
      *
-     * @param \SplFileInfo|string $file The file to stream
+     * @param \SplFileInfo|string $file               The file to stream
      * @param string              $contentDisposition
      * @param bool                $autoEtag
      * @param bool                $autoLastModified

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -31,13 +31,13 @@ class Cookie
     /**
      * Constructor.
      *
-     * @param string                   $name     The name of the cookie
-     * @param string                   $value    The value of the cookie
-     * @param int|string|\DateTime     $expire   The time the cookie expires
-     * @param string                   $path     The path on the server in which the cookie will be available on
-     * @param string                   $domain   The domain that the cookie is available to
-     * @param bool                     $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param bool                     $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
+     * @param string               $name     The name of the cookie
+     * @param string               $value    The value of the cookie
+     * @param int|string|\DateTime $expire   The time the cookie expires
+     * @param string               $path     The path on the server in which the cookie will be available on
+     * @param string               $domain   The domain that the cookie is available to
+     * @param bool                 $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param bool                 $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      *
      * @throws \InvalidArgumentException
      *

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -28,8 +28,8 @@ class File extends \SplFileInfo
     /**
      * Constructs a new file from the given path.
      *
-     * @param string  $path      The path to the file
-     * @param bool    $checkPath Whether to check the path or not
+     * @param string $path      The path to the file
+     * @param bool   $checkPath Whether to check the path or not
      *
      * @throws FileNotFoundException If the given path is not a file
      *

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser.php
@@ -83,7 +83,7 @@ class ExtensionGuesser implements ExtensionGuesserInterface
      *
      * @param string $mimeType The mime type
      *
-     * @return string          The guessed extension or NULL, if none could be guessed
+     * @return string The guessed extension or NULL, if none could be guessed
      */
     public function guess($mimeType)
     {

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesserInterface.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesserInterface.php
@@ -17,10 +17,11 @@ namespace Symfony\Component\HttpFoundation\File\MimeType;
 interface ExtensionGuesserInterface
 {
     /**
-     * Makes a best guess for a file extension, given a mime type
+     * Makes a best guess for a file extension, given a mime type.
      *
      * @param string $mimeType The mime type
-     * @return string          The guessed extension or NULL, if none could be guessed
+     *
+     * @return string The guessed extension or NULL, if none could be guessed
      */
     public function guess($mimeType);
 }

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
@@ -103,7 +103,7 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
      *
      * @param string $path The path to the file
      *
-     * @return string         The mime type or NULL, if none could be guessed
+     * @return string The mime type or NULL, if none could be guessed
      *
      * @throws \LogicException
      * @throws FileNotFoundException

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesserInterface.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesserInterface.php
@@ -26,10 +26,10 @@ interface MimeTypeGuesserInterface
      *
      * @param string $path The path to the file
      *
-     * @return string         The mime type or NULL, if none could be guessed
+     * @return string The mime type or NULL, if none could be guessed
      *
-     * @throws FileNotFoundException  If the file does not exist
-     * @throws AccessDeniedException  If the file could not be read
+     * @throws FileNotFoundException If the file does not exist
+     * @throws AccessDeniedException If the file could not be read
      */
     public function guess($path);
 }

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -77,12 +77,12 @@ class UploadedFile extends File
      *
      * Calling any other method on an non-valid instance will cause an unpredictable result.
      *
-     * @param string  $path         The full temporary path to the file
-     * @param string  $originalName The original file name
-     * @param string  $mimeType     The type of the file as provided by PHP
-     * @param int     $size         The file size
-     * @param int     $error        The error constant of the upload (one of PHP's UPLOAD_ERR_XXX constants)
-     * @param bool    $test         Whether the test mode is active
+     * @param string $path         The full temporary path to the file
+     * @param string $originalName The original file name
+     * @param string $mimeType     The type of the file as provided by PHP
+     * @param int    $size         The file size
+     * @param int    $error        The error constant of the upload (one of PHP's UPLOAD_ERR_XXX constants)
+     * @param bool   $test         Whether the test mode is active
      *
      * @throws FileException         If file_uploads is disabled
      * @throws FileNotFoundException If the file does not exist
@@ -179,7 +179,7 @@ class UploadedFile extends File
      * It is extracted from the request from which the file has been uploaded.
      * Then it should not be considered as a safe value.
      *
-     * @return int|null     The file size
+     * @return int|null The file size
      *
      * @api
      */
@@ -194,7 +194,7 @@ class UploadedFile extends File
      * If the upload was successful, the constant UPLOAD_ERR_OK is returned.
      * Otherwise one of the other UPLOAD_ERR_XXX constants is returned.
      *
-     * @return int     The upload error
+     * @return int The upload error
      *
      * @api
      */
@@ -206,7 +206,7 @@ class UploadedFile extends File
     /**
      * Returns whether the file was uploaded successfully.
      *
-     * @return bool    True if the file has been uploaded with HTTP and no error occurred.
+     * @return bool True if the file has been uploaded with HTTP and no error occurred.
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -117,9 +117,9 @@ class HeaderBag implements \IteratorAggregate, \Countable
     /**
      * Returns a header value by name.
      *
-     * @param string  $key     The header name
-     * @param mixed   $default The default value
-     * @param bool    $first   Whether to return the first value or all header values
+     * @param string $key     The header name
+     * @param mixed  $default The default value
+     * @param bool   $first   Whether to return the first value or all header values
      *
      * @return string|array The first header value if $first is true, an array of values otherwise
      *
@@ -175,7 +175,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      *
      * @param string $key The HTTP header
      *
-     * @return bool    true if the parameter exists, false otherwise
+     * @return bool true if the parameter exists, false otherwise
      *
      * @api
      */
@@ -190,7 +190,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      * @param string $key   The HTTP header name
      * @param string $value The HTTP value
      *
-     * @return bool    true if the value is contained in the header, false otherwise
+     * @return bool true if the value is contained in the header, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -28,10 +28,10 @@ class IpUtils
     /**
      * Checks if an IPv4 or IPv6 address is contained in the list of given IPs or subnets
      *
-     * @param string       $requestIp   IP to check
-     * @param string|array $ips         List of IPs or subnets (can be a string if only a single one)
+     * @param string       $requestIp IP to check
+     * @param string|array $ips       List of IPs or subnets (can be a string if only a single one)
      *
-     * @return bool    Whether the IP is valid
+     * @return bool Whether the IP is valid
      */
     public static function checkIp($requestIp, $ips)
     {
@@ -57,7 +57,7 @@ class IpUtils
      * @param string $requestIp IPv4 address to check
      * @param string $ip        IPv4 address or subnet in CIDR notation
      *
-     * @return bool    Whether the IP is valid
+     * @return bool Whether the IP is valid
      */
     public static function checkIp4($requestIp, $ip)
     {
@@ -85,7 +85,7 @@ class IpUtils
      * @param string $requestIp IPv6 address to check
      * @param string $ip        IPv6 address or subnet in CIDR notation
      *
-     * @return bool    Whether the IP is valid
+     * @return bool Whether the IP is valid
      *
      * @throws \RuntimeException When IPV6 support is not enabled
      */

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -30,9 +30,9 @@ class JsonResponse extends Response
     /**
      * Constructor.
      *
-     * @param mixed   $data    The response data
-     * @param int     $status  The response status code
-     * @param array   $headers An array of response headers
+     * @param mixed $data    The response data
+     * @param int   $status  The response status code
+     * @param array $headers An array of response headers
      */
     public function __construct($data = null, $status = 200, $headers = array())
     {

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -90,9 +90,9 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns a parameter by name.
      *
-     * @param string  $path    The key
-     * @param mixed   $default The default value if the parameter key does not exist
-     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
+     * @param string $path    The key
+     * @param mixed  $default The default value if the parameter key does not exist
+     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return mixed
      *
@@ -167,7 +167,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key The key
      *
-     * @return bool    true if the parameter exists, false otherwise
+     * @return bool true if the parameter exists, false otherwise
      *
      * @api
      */
@@ -191,9 +191,9 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the alphabetic characters of the parameter value.
      *
-     * @param string  $key     The parameter key
-     * @param mixed   $default The default value if the parameter key does not exist
-     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
+     * @param string $key     The parameter key
+     * @param mixed  $default The default value if the parameter key does not exist
+     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      *
@@ -207,9 +207,9 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the alphabetic characters and digits of the parameter value.
      *
-     * @param string  $key     The parameter key
-     * @param mixed   $default The default value if the parameter key does not exist
-     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
+     * @param string $key     The parameter key
+     * @param mixed  $default The default value if the parameter key does not exist
+     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      *
@@ -223,9 +223,9 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the digits of the parameter value.
      *
-     * @param string  $key     The parameter key
-     * @param mixed   $default The default value if the parameter key does not exist
-     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
+     * @param string $key     The parameter key
+     * @param mixed  $default The default value if the parameter key does not exist
+     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      *
@@ -240,11 +240,11 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter value converted to integer.
      *
-     * @param string  $key     The parameter key
-     * @param mixed   $default The default value if the parameter key does not exist
-     * @param bool    $deep    If true, a path like foo[bar] will find deeper items
+     * @param string $key     The parameter key
+     * @param mixed  $default The default value if the parameter key does not exist
+     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
-     * @return int     The filtered value
+     * @return int The filtered value
      *
      * @api
      */
@@ -256,11 +256,11 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Filter key.
      *
-     * @param string  $key     Key.
-     * @param mixed   $default Default = null.
-     * @param bool    $deep    Default = false.
-     * @param int     $filter  FILTER_* constant.
-     * @param mixed   $options Filter options.
+     * @param string $key     Key.
+     * @param mixed  $default Default = null.
+     * @param bool   $deep    Default = false.
+     * @param int    $filter  FILTER_* constant.
+     * @param mixed  $options Filter options.
      *
      * @see http://php.net/manual/en/function.filter-var.php
      *

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -25,9 +25,9 @@ class RedirectResponse extends Response
     /**
      * Creates a redirect response so that it conforms to the rules defined for a redirect status code.
      *
-     * @param string  $url     The URL to redirect to
-     * @param int     $status  The status code (302 by default)
-     * @param array   $headers The headers (Location is always set to the given URL)
+     * @param string $url     The URL to redirect to
+     * @param int    $status  The status code (302 by default)
+     * @param array  $headers The headers (Location is always set to the given URL)
      *
      * @throws \InvalidArgumentException
      *
@@ -71,7 +71,7 @@ class RedirectResponse extends Response
     /**
      * Sets the redirect target of this response.
      *
-     * @param string  $url     The URL to redirect to
+     * @param string $url The URL to redirect to
      *
      * @return RedirectResponse The current response.
      *

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -662,7 +662,7 @@ class Request
     /**
      * Checks whether support for the _method request parameter is enabled.
      *
-     * @return bool    True when the _method request parameter is enabled, false otherwise
+     * @return bool True when the _method request parameter is enabled, false otherwise
      */
     public static function getHttpMethodParameterOverride()
     {
@@ -684,9 +684,9 @@ class Request
      * It is better to explicitly get request parameters from the appropriate
      * public property instead (query, attributes, request).
      *
-     * @param string  $key     the key
-     * @param mixed   $default the default value
-     * @param bool    $deep    is parameter deep in multidimensional array
+     * @param string $key     the key
+     * @param mixed  $default the default value
+     * @param bool   $deep    is parameter deep in multidimensional array
      *
      * @return mixed
      */
@@ -740,7 +740,7 @@ class Request
      * like whether the session is started or not. It is just a way to check if this Request
      * is associated with a Session instance.
      *
-     * @return bool    true when the Request contains a Session object, false otherwise
+     * @return bool true when the Request contains a Session object, false otherwise
      *
      * @api
      */
@@ -1433,7 +1433,7 @@ class Request
     /**
      * Returns the request body content.
      *
-     * @param bool    $asResource If true, a resource will be returned
+     * @param bool $asResource If true, a resource will be returned
      *
      * @return string|resource The request body content or a resource to read the body stream.
      *
@@ -1594,7 +1594,7 @@ class Request
      * It is known to work with common JavaScript frameworks:
      * @link http://en.wikipedia.org/wiki/List_of_Ajax_frameworks#JavaScript
      *
-     * @return bool    true if the request is an XMLHttpRequest, false otherwise
+     * @return bool true if the request is an XMLHttpRequest, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/RequestMatcherInterface.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcherInterface.php
@@ -25,7 +25,7 @@ interface RequestMatcherInterface
      *
      * @param Request $request The request to check for a match
      *
-     * @return bool    true if the request matches, false otherwise
+     * @return bool true if the request matches, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -127,9 +127,9 @@ class Response
     /**
      * Constructor.
      *
-     * @param string  $content The response content
-     * @param int     $status  The response status code
-     * @param array   $headers An array of response headers
+     * @param string $content The response content
+     * @param int    $status  The response status code
+     * @param array  $headers An array of response headers
      *
      * @throws \InvalidArgumentException When the HTTP status code is not valid
      *
@@ -154,9 +154,9 @@ class Response
      *     return Response::create($body, 200)
      *         ->setSharedMaxAge(300);
      *
-     * @param string  $content The response content
-     * @param int     $status  The response status code
-     * @param array   $headers An array of response headers
+     * @param string $content The response content
+     * @param int    $status  The response status code
+     * @param array  $headers An array of response headers
      *
      * @return Response
      */
@@ -408,8 +408,8 @@ class Response
     /**
      * Sets the response status code.
      *
-     * @param int     $code HTTP status code
-     * @param mixed   $text HTTP status text
+     * @param int   $code HTTP status code
+     * @param mixed $text HTTP status text
      *
      * If the status text is null it will be automatically populated for the known
      * status codes and left empty otherwise.
@@ -447,7 +447,7 @@ class Response
     /**
      * Retrieves the status code for the current web response.
      *
-     * @return int     Status code
+     * @return int Status code
      *
      * @api
      */
@@ -493,7 +493,7 @@ class Response
      * Responses with neither a freshness lifetime (Expires, max-age) nor cache
      * validator (Last-Modified, ETag) are considered uncacheable.
      *
-     * @return bool    true if the response is worth caching, false otherwise
+     * @return bool true if the response is worth caching, false otherwise
      *
      * @api
      */
@@ -517,7 +517,7 @@ class Response
      * origin. A response is considered fresh when it includes a Cache-Control/max-age
      * indicator or Expires header and the calculated age is less than the freshness lifetime.
      *
-     * @return bool    true if the response is fresh, false otherwise
+     * @return bool true if the response is fresh, false otherwise
      *
      * @api
      */
@@ -530,7 +530,7 @@ class Response
      * Returns true if the response includes headers that can be used to validate
      * the response with the origin server using a conditional GET request.
      *
-     * @return bool    true if the response is validateable, false otherwise
+     * @return bool true if the response is validateable, false otherwise
      *
      * @api
      */
@@ -581,7 +581,7 @@ class Response
      * When present, the TTL of the response should not be overridden to be
      * greater than the value provided by the origin.
      *
-     * @return bool    true if the response must be revalidated by a cache, false otherwise
+     * @return bool true if the response must be revalidated by a cache, false otherwise
      *
      * @api
      */
@@ -624,7 +624,7 @@ class Response
     /**
      * Returns the age of the response.
      *
-     * @return int     The age of the response in seconds
+     * @return int The age of the response in seconds
      */
     public function getAge()
     {
@@ -699,7 +699,7 @@ class Response
      * First, it checks for a s-maxage directive, then a max-age directive, and then it falls
      * back on an expires header. It returns null when no maximum age can be established.
      *
-     * @return int|null     Number of seconds
+     * @return int|null Number of seconds
      *
      * @api
      */
@@ -723,7 +723,7 @@ class Response
      *
      * This methods sets the Cache-Control max-age directive.
      *
-     * @param int     $value Number of seconds
+     * @param int $value Number of seconds
      *
      * @return Response
      *
@@ -741,7 +741,7 @@ class Response
      *
      * This methods sets the Cache-Control s-maxage directive.
      *
-     * @param int     $value Number of seconds
+     * @param int $value Number of seconds
      *
      * @return Response
      *
@@ -763,7 +763,7 @@ class Response
      * When the responses TTL is <= 0, the response may not be served from cache without first
      * revalidating with the origin.
      *
-     * @return int|null     The TTL in seconds
+     * @return int|null The TTL in seconds
      *
      * @api
      */
@@ -779,7 +779,7 @@ class Response
      *
      * This method adjusts the Cache-Control/s-maxage directive.
      *
-     * @param int     $seconds Number of seconds
+     * @param int $seconds Number of seconds
      *
      * @return Response
      *
@@ -797,7 +797,7 @@ class Response
      *
      * This method adjusts the Cache-Control/max-age directive.
      *
-     * @param int     $seconds Number of seconds
+     * @param int $seconds Number of seconds
      *
      * @return Response
      *
@@ -967,7 +967,7 @@ class Response
     /**
      * Returns true if the response includes a Vary header.
      *
-     * @return bool    true if the response includes a Vary header, false otherwise
+     * @return bool true if the response includes a Vary header, false otherwise
      *
      * @api
      */
@@ -1023,7 +1023,7 @@ class Response
      *
      * @param Request $request A Request instance
      *
-     * @return bool    true if the Response validators match the Request, false otherwise
+     * @return bool true if the Response validators match the Request, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBagInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBagInterface.php
@@ -25,7 +25,7 @@ interface AttributeBagInterface extends SessionBagInterface
      *
      * @param string $name The attribute name
      *
-     * @return bool    true if the attribute is defined, false otherwise
+     * @return bool true if the attribute is defined, false otherwise
      */
     public function has($name);
 

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
@@ -99,8 +99,8 @@ class NamespacedAttributeBag extends AttributeBag
      *
      * This method allows structured namespacing of session attributes.
      *
-     * @param string  $name         Key name
-     * @param bool    $writeContext Write context, default false
+     * @param string $name         Key name
+     * @param bool   $writeContext Write context, default false
      *
      * @return array
      */

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -23,7 +23,7 @@ interface SessionInterface
     /**
      * Starts the session storage.
      *
-     * @return bool    True if session started.
+     * @return bool True if session started.
      *
      * @throws \RuntimeException If session fails to start.
      *
@@ -73,12 +73,12 @@ interface SessionInterface
      * Clears all session attributes and flashes and regenerates the
      * session and deletes the old session from persistence.
      *
-     * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
-     *                          will leave the system settings unchanged, 0 sets the cookie
-     *                          to expire with browser session. Time is in seconds, and is
-     *                          not a Unix timestamp.
+     * @param int $lifetime Sets the cookie lifetime for the session cookie. A null value
+     *                      will leave the system settings unchanged, 0 sets the cookie
+     *                      to expire with browser session. Time is in seconds, and is
+     *                      not a Unix timestamp.
      *
-     * @return bool    True if session invalidated, false if error.
+     * @return bool True if session invalidated, false if error.
      *
      * @api
      */
@@ -88,13 +88,13 @@ interface SessionInterface
      * Migrates the current session to a new session id while maintaining all
      * session attributes.
      *
-     * @param bool    $destroy  Whether to delete the old session or leave it to garbage collection.
-     * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
-     *                          will leave the system settings unchanged, 0 sets the cookie
-     *                          to expire with browser session. Time is in seconds, and is
-     *                          not a Unix timestamp.
+     * @param bool $destroy  Whether to delete the old session or leave it to garbage collection.
+     * @param int  $lifetime Sets the cookie lifetime for the session cookie. A null value
+     *                       will leave the system settings unchanged, 0 sets the cookie
+     *                       to expire with browser session. Time is in seconds, and is
+     *                       not a Unix timestamp.
      *
-     * @return bool    True if session migrated, false if error.
+     * @return bool True if session migrated, false if error.
      *
      * @api
      */
@@ -114,7 +114,7 @@ interface SessionInterface
      *
      * @param string $name The attribute name
      *
-     * @return bool    true if the attribute is defined, false otherwise
+     * @return bool true if the attribute is defined, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
@@ -87,10 +87,10 @@ class MetadataBag implements SessionBagInterface
     /**
      * Stamps a new session's metadata.
      *
-     * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
-     *                          will leave the system settings unchanged, 0 sets the cookie
-     *                          to expire with browser session. Time is in seconds, and is
-     *                          not a Unix timestamp.
+     * @param int $lifetime Sets the cookie lifetime for the session cookie. A null value
+     *                      will leave the system settings unchanged, 0 sets the cookie
+     *                      to expire with browser session. Time is in seconds, and is
+     *                      not a Unix timestamp.
      */
     public function stampNew($lifetime = null)
     {
@@ -108,7 +108,7 @@ class MetadataBag implements SessionBagInterface
     /**
      * Gets the created timestamp metadata.
      *
-     * @return int     Unix timestamp
+     * @return int Unix timestamp
      */
     public function getCreated()
     {
@@ -118,7 +118,7 @@ class MetadataBag implements SessionBagInterface
     /**
      * Gets the last used metadata.
      *
-     * @return int     Unix timestamp
+     * @return int Unix timestamp
      */
     public function getLastUsed()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
@@ -87,7 +87,7 @@ abstract class AbstractProxy
      *
      * @internal
      *
-     * @param bool    $flag
+     * @param bool $flag
      *
      * @throws \LogicException
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/NativeProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/NativeProxy.php
@@ -32,7 +32,7 @@ class NativeProxy extends AbstractProxy
     /**
      * Returns true if this handler wraps an internal PHP session save handler using \SessionHandler.
      *
-     * @return bool    False.
+     * @return bool False.
      */
     public function isWrapper()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
@@ -28,7 +28,7 @@ interface SessionStorageInterface
      *
      * @throws \RuntimeException If something goes wrong starting the session.
      *
-     * @return bool    True if started.
+     * @return bool True if started.
      *
      * @api
      */
@@ -37,7 +37,7 @@ interface SessionStorageInterface
     /**
      * Checks if the session is started.
      *
-     * @return bool    True if started, false otherwise.
+     * @return bool True if started, false otherwise.
      */
     public function isStarted();
 
@@ -96,13 +96,13 @@ interface SessionStorageInterface
      * Otherwise session data could get lost again for concurrent requests with the
      * new ID. One result could be that you get logged out after just logging in.
      *
-     * @param bool    $destroy  Destroy session when regenerating?
-     * @param int     $lifetime Sets the cookie lifetime for the session cookie. A null value
-     *                          will leave the system settings unchanged, 0 sets the cookie
-     *                          to expire with browser session. Time is in seconds, and is
-     *                          not a Unix timestamp.
+     * @param bool $destroy  Destroy session when regenerating?
+     * @param int  $lifetime Sets the cookie lifetime for the session cookie. A null value
+     *                       will leave the system settings unchanged, 0 sets the cookie
+     *                       to expire with browser session. Time is in seconds, and is
+     *                       not a Unix timestamp.
      *
-     * @return bool    True if session regenerated, false if error
+     * @return bool True if session regenerated, false if error
      *
      * @throws \RuntimeException If an error occurs while regenerating this storage
      *

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -34,9 +34,9 @@ class StreamedResponse extends Response
     /**
      * Constructor.
      *
-     * @param mixed   $callback A valid PHP callback
-     * @param int     $status   The response status code
-     * @param array   $headers  An array of response headers
+     * @param mixed $callback A valid PHP callback
+     * @param int   $status   The response status code
+     * @param array $headers  An array of response headers
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -51,7 +51,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
     /**
      * Checks whether this warmer is optional or not.
      *
-     * @return bool    always false
+     * @return bool always false
      */
     public function isOptional()
     {

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerInterface.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerInterface.php
@@ -26,7 +26,7 @@ interface CacheWarmerInterface extends WarmableInterface
      * A warmer should return true if the cache can be
      * generated incrementally and on-demand.
      *
-     * @return bool    true if the warmer is optional, false otherwise
+     * @return bool true if the warmer is optional, false otherwise
      */
     public function isOptional();
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -47,8 +47,8 @@ class ControllerResolver implements ControllerResolverInterface
      *
      * @param Request $request A Request instance
      *
-     * @return mixed|bool    A PHP callable representing the Controller,
-     *                       or false if this resolver is not able to determine the controller
+     * @return mixed|bool A PHP callable representing the Controller,
+     *                    or false if this resolver is not able to determine the controller
      *
      * @throws \InvalidArgumentException|\LogicException If the controller can't be found
      *

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
@@ -38,8 +38,8 @@ interface ControllerResolverInterface
      *
      * @param Request $request A Request instance
      *
-     * @return mixed|bool    A PHP callable representing the Controller,
-     *                       or false if this resolver is not able to determine the controller
+     * @return mixed|bool A PHP callable representing the Controller,
+     *                    or false if this resolver is not able to determine the controller
      *
      * @throws \InvalidArgumentException|\LogicException If the controller can't be found
      *

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -143,7 +143,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if the debug is enabled.
      *
-     * @return bool    true if debug is enabled, false otherwise
+     * @return bool true if debug is enabled, false otherwise
      */
     public function isDebug()
     {
@@ -153,7 +153,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if the XDebug is enabled.
      *
-     * @return bool    true if XDebug is enabled, false otherwise
+     * @return bool true if XDebug is enabled, false otherwise
      */
     public function hasXDebug()
     {
@@ -163,7 +163,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if EAccelerator is enabled.
      *
-     * @return bool    true if EAccelerator is enabled, false otherwise
+     * @return bool true if EAccelerator is enabled, false otherwise
      */
     public function hasEAccelerator()
     {
@@ -173,7 +173,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if APC is enabled.
      *
-     * @return bool    true if APC is enabled, false otherwise
+     * @return bool true if APC is enabled, false otherwise
      */
     public function hasApc()
     {
@@ -183,7 +183,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if Zend OPcache is enabled
      *
-     * @return bool    true if Zend OPcache is enabled, false otherwise
+     * @return bool true if Zend OPcache is enabled, false otherwise
      */
     public function hasZendOpcache()
     {
@@ -193,7 +193,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if XCache is enabled.
      *
-     * @return bool    true if XCache is enabled, false otherwise
+     * @return bool true if XCache is enabled, false otherwise
      */
     public function hasXCache()
     {
@@ -203,7 +203,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if WinCache is enabled.
      *
-     * @return bool    true if WinCache is enabled, false otherwise
+     * @return bool true if WinCache is enabled, false otherwise
      */
     public function hasWinCache()
     {
@@ -213,7 +213,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if any accelerator is enabled.
      *
-     * @return bool    true if any accelerator is enabled, false otherwise
+     * @return bool true if any accelerator is enabled, false otherwise
      */
     public function hasAccelerator()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
@@ -37,7 +37,7 @@ class ExceptionDataCollector extends DataCollector
     /**
      * Checks if the exception is not null.
      *
-     * @return bool    true if the exception is not null, false otherwise
+     * @return bool true if the exception is not null, false otherwise
      */
     public function hasException()
     {
@@ -67,7 +67,7 @@ class ExceptionDataCollector extends DataCollector
     /**
      * Gets the exception code.
      *
-     * @return int     The exception code
+     * @return int The exception code
      */
     public function getCode()
     {
@@ -77,7 +77,7 @@ class ExceptionDataCollector extends DataCollector
     /**
      * Gets the status code.
      *
-     * @return int     The status code
+     * @return int The status code
      */
     public function getStatusCode()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/MemoryDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/MemoryDataCollector.php
@@ -40,7 +40,7 @@ class MemoryDataCollector extends DataCollector
     /**
      * Gets the memory.
      *
-     * @return int     The memory
+     * @return int The memory
      */
     public function getMemory()
     {
@@ -50,7 +50,7 @@ class MemoryDataCollector extends DataCollector
     /**
      * Gets the PHP memory limit.
      *
-     * @return int     The memory limit
+     * @return int The memory limit
      */
     public function getMemoryLimit()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/RouterDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RouterDataCollector.php
@@ -69,7 +69,7 @@ class RouterDataCollector extends DataCollector
     }
 
     /**
-     * @return bool    Whether this request will result in a redirect
+     * @return bool Whether this request will result in a redirect
      */
     public function getRedirect()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
@@ -105,7 +105,7 @@ class TimeDataCollector extends DataCollector
     /**
      * Gets the request time.
      *
-     * @return int     The time
+     * @return int The time
      */
     public function getStartTime()
     {

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -324,8 +324,8 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
     /**
      * Updates the stopwatch data in the profile hierarchy.
      *
-     * @param string  $token          Profile token
-     * @param bool    $updateChildren Whether to update the children altogether
+     * @param string $token          Profile token
+     * @param bool   $updateChildren Whether to update the children altogether
      */
     private function updateProfiles($token, $updateChildren)
     {

--- a/src/Symfony/Component/HttpKernel/Event/GetResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseEvent.php
@@ -61,7 +61,7 @@ class GetResponseEvent extends KernelEvent
     /**
      * Returns whether a response was set
      *
-     * @return bool    Whether a response was set
+     * @return bool Whether a response was set
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
@@ -47,7 +47,7 @@ class GetResponseForExceptionEvent extends GetResponseEvent
     /**
      * Returns the thrown exception
      *
-     * @return \Exception  The thrown exception
+     * @return \Exception The thrown exception
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Event/KernelEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/KernelEvent.php
@@ -77,8 +77,8 @@ class KernelEvent extends Event
     /**
      * Returns the request type the kernel is currently processing
      *
-     * @return int      One of HttpKernelInterface::MASTER_REQUEST and
-     *                  HttpKernelInterface::SUB_REQUEST
+     * @return int One of HttpKernelInterface::MASTER_REQUEST and
+     *             HttpKernelInterface::SUB_REQUEST
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
@@ -21,9 +21,9 @@ class BadRequestHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
@@ -21,9 +21,9 @@ class ConflictHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
@@ -21,9 +21,9 @@ class GoneHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/HttpExceptionInterface.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpExceptionInterface.php
@@ -21,7 +21,7 @@ interface HttpExceptionInterface
     /**
      * Returns the status code.
      *
-     * @return int     An HTTP response status code
+     * @return int An HTTP response status code
      */
     public function getStatusCode();
 

--- a/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
@@ -21,9 +21,9 @@ class LengthRequiredHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
@@ -21,9 +21,9 @@ class NotAcceptableHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
@@ -21,9 +21,9 @@ class PreconditionFailedHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
@@ -22,9 +22,9 @@ class PreconditionRequiredHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
@@ -21,10 +21,10 @@ class ServiceUnavailableHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param int|string  $retryAfter The number of seconds or HTTP-date after which the request may be retried
-     * @param string      $message    The internal exception message
-     * @param \Exception  $previous   The previous exception
-     * @param int         $code       The internal exception code
+     * @param int|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
+     * @param string     $message    The internal exception message
+     * @param \Exception $previous   The previous exception
+     * @param int        $code       The internal exception code
      */
     public function __construct($retryAfter = null, $message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
@@ -22,10 +22,10 @@ class TooManyRequestsHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param int|string     $retryAfter The number of seconds or HTTP-date after which the request may be retried
-     * @param string         $message    The internal exception message
-     * @param \Exception     $previous   The previous exception
-     * @param int            $code       The internal exception code
+     * @param int|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
+     * @param string     $message    The internal exception message
+     * @param \Exception $previous   The previous exception
+     * @param int        $code       The internal exception code
      */
     public function __construct($retryAfter = null, $message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
@@ -21,9 +21,9 @@ class UnsupportedMediaTypeHttpException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -64,7 +64,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
     /**
      * Checks if a templating engine has been set.
      *
-     * @return bool    true if the templating engine has been set, false otherwise
+     * @return bool true if the templating engine has been set, false otherwise
      */
     public function hasTemplating()
     {

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -39,9 +39,9 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
     /**
      * Generates a fragment URI for a given controller.
      *
-     * @param ControllerReference  $reference A ControllerReference instance
-     * @param Request              $request   A Request instance
-     * @param bool                 $absolute  Whether to generate an absolute URL or not
+     * @param ControllerReference $reference A ControllerReference instance
+     * @param Request             $request   A Request instance
+     * @param bool                $absolute  Whether to generate an absolute URL or not
      *
      * @return string A fragment URI
      */

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -34,7 +34,7 @@ class Esi
      * Constructor.
      *
      * @param array $contentTypes An array of content-type that should be parsed for ESI information.
-     *                           (default: text/html, text/xml, application/xhtml+xml, and application/xml)
+     *                            (default: text/html, text/xml, application/xhtml+xml, and application/xml)
      */
     public function __construct(array $contentTypes = array('text/html', 'text/xml', 'application/xhtml+xml', 'application/xml'))
     {
@@ -56,7 +56,7 @@ class Esi
      *
      * @param Request $request A Request instance
      *
-     * @return bool    true if one surrogate has ESI/1.0 capability, false otherwise
+     * @return bool true if one surrogate has ESI/1.0 capability, false otherwise
      */
     public function hasSurrogateEsiCapability(Request $request)
     {
@@ -99,7 +99,7 @@ class Esi
      *
      * @param Response $response A Response instance
      *
-     * @return bool    true if the Response needs to be parsed, false otherwise
+     * @return bool true if the Response needs to be parsed, false otherwise
      */
     public function needsEsiParsing(Response $response)
     {
@@ -113,10 +113,10 @@ class Esi
     /**
      * Renders an ESI tag.
      *
-     * @param string  $uri          A URI
-     * @param string  $alt          An alternate URI
-     * @param bool    $ignoreErrors Whether to ignore errors or not
-     * @param string  $comment      A comment to add as an esi:include tag
+     * @param string $uri          A URI
+     * @param string $alt          An alternate URI
+     * @param bool   $ignoreErrors Whether to ignore errors or not
+     * @param string $comment      A comment to add as an esi:include tag
      *
      * @return string
      */

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -501,7 +501,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * @param Request  $request A Request instance
      * @param Response $entry   A Response instance
      *
-     * @return bool    true if the cache entry if fresh enough, false otherwise
+     * @return bool true if the cache entry if fresh enough, false otherwise
      */
     protected function isFreshEnough(Request $request, Response $entry)
     {
@@ -522,7 +522,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * @param Request  $request A Request instance
      * @param Response $entry   A Response instance
      *
-     * @return bool    true if the cache entry can be returned even if it is staled, false otherwise
+     * @return bool true if the cache entry can be returned even if it is staled, false otherwise
      */
     protected function lock(Request $request, Response $entry)
     {
@@ -654,7 +654,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param Request $request A Request instance
      *
-     * @return bool    true if the Request is private, false otherwise
+     * @return bool true if the Request is private, false otherwise
      */
     private function isPrivateRequest(Request $request)
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -69,7 +69,7 @@ class Store implements StoreInterface
      *
      * @param Request $request A Request instance
      *
-     * @return bool|string    true if the lock is acquired, the path to the current lock otherwise
+     * @return bool|string true if the lock is acquired, the path to the current lock otherwise
      */
     public function lock(Request $request)
     {
@@ -95,7 +95,7 @@ class Store implements StoreInterface
      *
      * @param Request $request A Request instance
      *
-     * @return bool    False if the lock file does not exist or cannot be unlocked, true otherwise
+     * @return bool False if the lock file does not exist or cannot be unlocked, true otherwise
      */
     public function unlock(Request $request)
     {
@@ -257,7 +257,7 @@ class Store implements StoreInterface
      * @param array  $env1 A Request HTTP header array
      * @param array  $env2 A Request HTTP header array
      *
-     * @return bool    true if the two environments match, false otherwise
+     * @return bool true if the two environments match, false otherwise
      */
     private function requestsMatch($vary, $env1, $env2)
     {
@@ -300,7 +300,7 @@ class Store implements StoreInterface
      *
      * @param string $url A URL
      *
-     * @return bool    true if the URL exists and has been purged, false otherwise
+     * @return bool true if the URL exists and has been purged, false otherwise
      */
     public function purge($url)
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
@@ -58,7 +58,7 @@ interface StoreInterface
      *
      * @param Request $request A Request instance
      *
-     * @return bool|string    true if the lock is acquired, the path to the current lock otherwise
+     * @return bool|string true if the lock is acquired, the path to the current lock otherwise
      */
     public function lock(Request $request);
 
@@ -67,7 +67,7 @@ interface StoreInterface
      *
      * @param Request $request A Request instance
      *
-     * @return bool    False if the lock file does not exist or cannot be unlocked, true otherwise
+     * @return bool False if the lock file does not exist or cannot be unlocked, true otherwise
      */
     public function unlock(Request $request);
 
@@ -76,7 +76,7 @@ interface StoreInterface
      *
      * @param Request $request A Request instance
      *
-     * @return bool    true if lock exists, false otherwise
+     * @return bool true if lock exists, false otherwise
      */
     public function isLocked(Request $request);
 
@@ -85,7 +85,7 @@ interface StoreInterface
      *
      * @param string $url A URL
      *
-     * @return bool    true if the URL exists and has been purged, false otherwise
+     * @return bool true if the URL exists and has been purged, false otherwise
      */
     public function purge($url);
 

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -88,7 +88,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      *
      * @return Response A Response instance
      *
-     * @throws \LogicException If one of the listener does not behave as expected
+     * @throws \LogicException       If one of the listener does not behave as expected
      * @throws NotFoundHttpException When controller cannot be found
      */
     private function handleRaw(Request $request, $type = self::MASTER_REQUEST)

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -34,8 +34,8 @@ interface HttpKernelInterface
      *
      * @param Request $request A Request instance
      * @param int     $type    The type of the request
-     *                          (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
-     * @param bool    $catch Whether to catch exceptions or not
+     *                         (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param bool    $catch   Whether to catch exceptions or not
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -69,8 +69,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     /**
      * Constructor.
      *
-     * @param string  $environment The environment
-     * @param bool    $debug       Whether to enable debugging or not
+     * @param string $environment The environment
+     * @param bool   $debug       Whether to enable debugging or not
      *
      * @api
      */
@@ -260,9 +260,9 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * before looking in the bundle resource folder.
      *
-     * @param string  $name  A resource name to locate
-     * @param string  $dir   A directory where to look for the resource first
-     * @param bool    $first Whether to return the first path or paths for all matching bundles
+     * @param string $name  A resource name to locate
+     * @param string $dir   A directory where to look for the resource first
+     * @param bool   $first Whether to return the first path or paths for all matching bundles
      *
      * @return string|array The absolute path of the resource or an array if $first is false
      *

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -74,7 +74,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      *
      * @param string $class A class name
      *
-     * @return bool    true if the class belongs to an active bundle, false otherwise
+     * @return bool true if the class belongs to an active bundle, false otherwise
      *
      * @api
      */
@@ -83,8 +83,8 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Returns a bundle and optionally its descendants by its name.
      *
-     * @param string  $name  Bundle name
-     * @param bool    $first Whether to return the first bundle only or together with its descendants
+     * @param string $name  Bundle name
+     * @param bool   $first Whether to return the first bundle only or together with its descendants
      *
      * @return BundleInterface|BundleInterface[] A BundleInterface instance or an array of BundleInterface instances if $first is false
      *
@@ -111,9 +111,9 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      *
      *     $dir/BundleName/path/without/Resources
      *
-     * @param string  $name  A resource name to locate
-     * @param string  $dir   A directory where to look for the resource first
-     * @param bool    $first Whether to return the first path or paths for all matching bundles
+     * @param string $name  A resource name to locate
+     * @param string $dir   A directory where to look for the resource first
+     * @param bool   $first Whether to return the first path or paths for all matching bundles
      *
      * @return string|array The absolute path of the resource or an array if $first is false
      *
@@ -145,7 +145,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Checks if debug mode is enabled.
      *
-     * @return bool    true if debug mode is enabled, false otherwise
+     * @return bool true if debug mode is enabled, false otherwise
      *
      * @api
      */
@@ -172,7 +172,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Gets the request start time (not available if debug is disabled).
      *
-     * @return int     The request start timestamp
+     * @return int The request start timestamp
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerInterface.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerInterface.php
@@ -32,7 +32,7 @@ interface DebugLoggerInterface
     /**
      * Returns the number of errors.
      *
-     * @return int     The number of errors
+     * @return int The number of errors
      */
     public function countErrors();
 }

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -20,10 +20,10 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     /**
      * Constructor.
      *
-     * @param string  $dsn      A data source name
-     * @param string  $username Not used
-     * @param string  $password Not used
-     * @param int     $lifetime The lifetime to use for the purge
+     * @param string $dsn      A data source name
+     * @param string $username Not used
+     * @param string $password Not used
+     * @param int    $lifetime The lifetime to use for the purge
      */
     public function __construct($dsn, $username = '', $password = '', $lifetime = 86400)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -28,10 +28,10 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
     /**
      * Constructor.
      *
-     * @param string  $dsn      A data source name
-     * @param string  $username The username for the database
-     * @param string  $password The password for the database
-     * @param int     $lifetime The lifetime to use for the purge
+     * @param string $dsn      A data source name
+     * @param string $username The username for the database
+     * @param string $password The password for the database
+     * @param int    $lifetime The lifetime to use for the purge
      */
     public function __construct($dsn, $username = '', $password = '', $lifetime = 86400)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
@@ -48,7 +48,7 @@ interface ProfilerStorageInterface
      *
      * @param Profile $profile A Profile instance
      *
-     * @return bool    Write operation successful
+     * @return bool Write operation successful
      */
     public function write(Profile $profile);
 

--- a/src/Symfony/Component/HttpKernel/README.md
+++ b/src/Symfony/Component/HttpKernel/README.md
@@ -13,7 +13,7 @@ interface HttpKernelInterface
     /**
      * Handles a Request to convert it to a Response.
      *
-     * @param  Request $request A Request instance
+     * @param Request $request A Request instance
      *
      * @return Response A Response instance
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcacheMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcacheMock.php
@@ -30,9 +30,9 @@ class MemcacheMock
     /**
      * Open memcached server connection
      *
-     * @param string  $host
-     * @param int     $port
-     * @param int     $timeout
+     * @param string $host
+     * @param int    $port
+     * @param int    $timeout
      *
      * @return bool
      */
@@ -50,9 +50,9 @@ class MemcacheMock
     /**
      * Open memcached server persistent connection
      *
-     * @param string  $host
-     * @param int     $port
-     * @param int     $timeout
+     * @param string $host
+     * @param int    $port
+     * @param int    $timeout
      *
      * @return bool
      */
@@ -96,10 +96,10 @@ class MemcacheMock
     /**
      * Add an item to the server only if such key doesn't exist at the server yet.
      *
-     * @param string  $key
-     * @param mixed   $var
-     * @param int     $flag
-     * @param int     $expire
+     * @param string $key
+     * @param mixed  $var
+     * @param int    $flag
+     * @param int    $expire
      *
      * @return bool
      */
@@ -121,10 +121,10 @@ class MemcacheMock
     /**
      * Store data at the server.
      *
-     * @param string  $key
-     * @param string  $var
-     * @param int     $flag
-     * @param int     $expire
+     * @param string $key
+     * @param string $var
+     * @param int    $flag
+     * @param int    $expire
      *
      * @return bool
      */
@@ -142,10 +142,10 @@ class MemcacheMock
     /**
      * Replace value of the existing item.
      *
-     * @param string  $key
-     * @param mixed   $var
-     * @param int     $flag
-     * @param int     $expire
+     * @param string $key
+     * @param mixed  $var
+     * @param int    $flag
+     * @param int    $expire
      *
      * @return bool
      */
@@ -167,8 +167,8 @@ class MemcacheMock
     /**
      * Retrieve item from the server.
      *
-     * @param string|array  $key
-     * @param int|array     $flags
+     * @param string|array $key
+     * @param int|array    $flags
      *
      * @return mixed
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcachedMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcachedMock.php
@@ -30,8 +30,8 @@ class MemcachedMock
     /**
      * Set a Memcached option
      *
-     * @param int     $option
-     * @param mixed   $value
+     * @param int   $option
+     * @param mixed $value
      *
      * @return bool
      */
@@ -43,9 +43,9 @@ class MemcachedMock
     /**
      * Add a memcached server to connection pool
      *
-     * @param string  $host
-     * @param int     $port
-     * @param int     $weight
+     * @param string $host
+     * @param int    $port
+     * @param int    $weight
      *
      * @return bool
      */
@@ -63,9 +63,9 @@ class MemcachedMock
     /**
      * Add an item to the server only if such key doesn't exist at the server yet.
      *
-     * @param string  $key
-     * @param mixed   $value
-     * @param int     $expiration
+     * @param string $key
+     * @param mixed  $value
+     * @param int    $expiration
      *
      * @return bool
      */
@@ -87,9 +87,9 @@ class MemcachedMock
     /**
      * Store data at the server.
      *
-     * @param string  $key
-     * @param mixed   $value
-     * @param int     $expiration
+     * @param string $key
+     * @param mixed  $value
+     * @param int    $expiration
      *
      * @return bool
      */
@@ -107,9 +107,9 @@ class MemcachedMock
     /**
      * Replace value of the existing item.
      *
-     * @param string  $key
-     * @param mixed   $value
-     * @param int     $expiration
+     * @param string $key
+     * @param mixed  $value
+     * @param int    $expiration
      *
      * @return bool
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
@@ -30,9 +30,9 @@ class RedisMock
     /**
      * Add a server to connection pool
      *
-     * @param string  $host
-     * @param int     $port
-     * @param float   $timeout
+     * @param string $host
+     * @param int    $port
+     * @param float  $timeout
      *
      * @return bool
      */
@@ -50,8 +50,8 @@ class RedisMock
     /**
      * Set client option.
      *
-     * @param int     $name
-     * @param int     $value
+     * @param int $name
+     * @param int $value
      *
      * @return bool
      */
@@ -83,9 +83,9 @@ class RedisMock
     /**
      * Store data at the server with expiration time.
      *
-     * @param string  $key
-     * @param int     $ttl
-     * @param mixed   $value
+     * @param string $key
+     * @param int    $ttl
+     * @param mixed  $value
      *
      * @return bool
      */
@@ -103,8 +103,8 @@ class RedisMock
     /**
      * Sets an expiration time on an item.
      *
-     * @param string  $key
-     * @param int     $ttl
+     * @param string $key
+     * @param int    $ttl
      *
      * @return bool
      */
@@ -143,7 +143,7 @@ class RedisMock
      * @param string $key
      * @param string $value
      *
-     * @return int     Size of the value after the append.
+     * @return int Size of the value after the append.
      */
     public function append($key, $value)
     {

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -54,7 +54,7 @@ class UriSigner
      *
      * @param string $uri A signed URI
      *
-     * @return bool    True if the URI is signed correctly, false otherwise
+     * @return bool True if the URI is signed correctly, false otherwise
      */
     public function check($uri)
     {

--- a/src/Symfony/Component/Intl/Collator/Collator.php
+++ b/src/Symfony/Component/Intl/Collator/Collator.php
@@ -72,7 +72,7 @@ class Collator
      *
      * @param string $locale The locale code. The only currently supported locale is "en".
      *
-     * @throws MethodArgumentValueNotImplementedException  When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
      */
     public function __construct($locale)
     {
@@ -88,7 +88,7 @@ class Collator
      *
      * @return Collator
      *
-     * @throws MethodArgumentValueNotImplementedException  When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
      */
     public static function create($locale)
     {
@@ -98,13 +98,13 @@ class Collator
     /**
      * Sort array maintaining index association
      *
-     * @param array   &$array    Input array
-     * @param int     $sortFlag  Flags for sorting, can be one of the following:
-     *                           Collator::SORT_REGULAR - compare items normally (don't change types)
-     *                           Collator::SORT_NUMERIC - compare items numerically
-     *                           Collator::SORT_STRING - compare items as strings
+     * @param array &$array   Input array
+     * @param int   $sortFlag Flags for sorting, can be one of the following:
+     *                        Collator::SORT_REGULAR - compare items normally (don't change types)
+     *                        Collator::SORT_NUMERIC - compare items numerically
+     *                        Collator::SORT_STRING - compare items as strings
      *
-     * @return bool    True on success or false on failure
+     * @return bool True on success or false on failure
      */
     public function asort(&$array, $sortFlag = self::SORT_REGULAR)
     {
@@ -125,10 +125,10 @@ class Collator
      * @param string $str1 The first string to compare
      * @param string $str2 The second string to compare
      *
-     * @return bool|int        Return the comparison result or false on failure:
-     *                         1 if $str1 is greater than $str2
-     *                         0 if $str1 is equal than $str2
-     *                         -1 if $str1 is less than $str2
+     * @return bool|int Return the comparison result or false on failure:
+     *                  1 if $str1 is greater than $str2
+     *                  0 if $str1 is equal than $str2
+     *                  -1 if $str1 is less than $str2
      *
      * @see http://www.php.net/manual/en/collator.compare.php
      *
@@ -144,7 +144,7 @@ class Collator
      *
      * @param int $attr An attribute specifier, one of the attribute constants
      *
-     * @return bool|int      The attribute value on success or false on error
+     * @return bool|int The attribute value on success or false on error
      *
      * @see http://www.php.net/manual/en/collator.getattribute.php
      *
@@ -207,7 +207,7 @@ class Collator
     /**
      * Not supported. Get current collator's strength
      *
-     * @return bool|int      The current collator's strength or false on failure
+     * @return bool|int The current collator's strength or false on failure
      *
      * @see http://www.php.net/manual/en/collator.getstrength.php
      *
@@ -224,7 +224,7 @@ class Collator
      * @param int $attr An attribute specifier, one of the attribute constants
      * @param int $val  The attribute value, one of the attribute value constants
      *
-     * @return bool    True on success or false on failure
+     * @return bool True on success or false on failure
      *
      * @see http://www.php.net/manual/en/collator.setattribute.php
      *
@@ -239,14 +239,14 @@ class Collator
      * Not supported. Set the collator's strength
      *
      * @param int $strength Strength to set, possible values:
-     *                           Collator::PRIMARY
-     *                           Collator::SECONDARY
-     *                           Collator::TERTIARY
-     *                           Collator::QUATERNARY
-     *                           Collator::IDENTICAL
-     *                           Collator::DEFAULT
+     *                      Collator::PRIMARY
+     *                      Collator::SECONDARY
+     *                      Collator::TERTIARY
+     *                      Collator::QUATERNARY
+     *                      Collator::IDENTICAL
+     *                      Collator::DEFAULT
      *
-     * @return bool    True on success or false on failure
+     * @return bool True on success or false on failure
      *
      * @see http://www.php.net/manual/en/collator.setstrength.php
      *
@@ -260,9 +260,9 @@ class Collator
     /**
      * Not supported. Sort array using specified collator and sort keys
      *
-     * @param  array   &$arr   Array of strings to sort
+     * @param array &$arr Array of strings to sort
      *
-     * @return bool    True on success or false on failure
+     * @return bool True on success or false on failure
      *
      * @see http://www.php.net/manual/en/collator.sortwithsortkeys.php
      *
@@ -276,13 +276,13 @@ class Collator
     /**
      * Not supported. Sort array using specified collator
      *
-     * @param  array   &$arr       Array of string to sort
-     * @param int $sortFlag Optional sorting type, one of the following:
-     *                             Collator::SORT_REGULAR
-     *                             Collator::SORT_NUMERIC
-     *                             Collator::SORT_STRING
+     * @param array &$arr     Array of string to sort
+     * @param int   $sortFlag Optional sorting type, one of the following:
+     *                        Collator::SORT_REGULAR
+     *                        Collator::SORT_NUMERIC
+     *                        Collator::SORT_STRING
      *
-     * @return bool    True on success or false on failure
+     * @return bool True on success or false on failure
      *
      * @see http://www.php.net/manual/en/collator.sort.php
      *

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
@@ -151,8 +151,8 @@ class TextBundleWriter implements BundleWriterInterface
     /**
      * Writes a "string" node.
      *
-     * @param resource $file         The file handle to write to.
-     * @param string   $value        The value of the node.
+     * @param resource $file          The file handle to write to.
+     * @param string   $value         The value of the node.
      * @param bool     $requireBraces Whether to require braces to be printed
      *                                around the value.
      *

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
@@ -84,7 +84,7 @@ class FullTransformer
      *
      * @param \DateTime $dateTime A DateTime object to be used to generate the formatted value
      *
-     * @return string               The formatted value
+     * @return string The formatted value
      */
     public function format(\DateTime $dateTime)
     {
@@ -103,9 +103,9 @@ class FullTransformer
      * @param string    $dateChars The date characters to be replaced with a formatted ICU value
      * @param \DateTime $dateTime  A DateTime object to be used to generate the formatted value
      *
-     * @return string                   The formatted value
+     * @return string The formatted value
      *
-     * @throws NotImplementedException  When it encounters a not implemented date character
+     * @throws NotImplementedException When it encounters a not implemented date character
      */
     public function formatReplace($dateChars, $dateTime)
     {
@@ -131,11 +131,11 @@ class FullTransformer
      * Parse a pattern based string to a timestamp value
      *
      * @param \DateTime $dateTime A configured DateTime object to use to perform the date calculation
-     * @param string   $value    String to convert to a time value
+     * @param string    $value    String to convert to a time value
      *
-     * @return int                       The corresponding Unix timestamp
+     * @return int The corresponding Unix timestamp
      *
-     * @throws \InvalidArgumentException  When the value can not be matched with pattern
+     * @throws \InvalidArgumentException When the value can not be matched with pattern
      */
     public function parse(\DateTime $dateTime, $value)
     {
@@ -171,8 +171,8 @@ class FullTransformer
      *
      * @param string $pattern The pattern to create the reverse matching regular expression
      *
-     * @return string            The reverse matching regular expression with named captures being formed by the
-     *                           transformer index in the $transformer array
+     * @return string The reverse matching regular expression with named captures being formed by the
+     *                transformer index in the $transformer array
      */
     public function getReverseMatchingRegExp($pattern)
     {
@@ -210,7 +210,7 @@ class FullTransformer
      *
      * @param string $quoteMatch The string to check
      *
-     * @return bool                 true if matches, false otherwise
+     * @return bool true if matches, false otherwise
      */
     public function isQuoteMatch($quoteMatch)
     {
@@ -222,7 +222,7 @@ class FullTransformer
      *
      * @param string $quoteMatch The string to replace the quotes
      *
-     * @return string               A string with the single quotes replaced
+     * @return string A string with the single quotes replaced
      */
     public function replaceQuoteMatch($quoteMatch)
     {
@@ -238,7 +238,7 @@ class FullTransformer
      *
      * @param string $specialChars A string of chars to build the regular expression
      *
-     * @return string                 The chars match regular expression
+     * @return string The chars match regular expression
      */
     protected function buildCharsMatch($specialChars)
     {
@@ -284,7 +284,7 @@ class FullTransformer
      * @param \DateTime $dateTime The DateTime object to be used to calculate the timestamp
      * @param array     $options  An array with the matched values to be used to calculate the timestamp
      *
-     * @return bool|int           The calculated timestamp or false if matched date is invalid
+     * @return bool|int The calculated timestamp or false if matched date is invalid
      */
     protected function calculateUnixTimestamp(\DateTime $dateTime, array $options)
     {

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/HourTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/HourTransformer.php
@@ -24,7 +24,7 @@ abstract class HourTransformer extends Transformer
      * @param int    $hour   The hour value
      * @param string $marker An optional AM/PM marker
      *
-     * @return int              The normalized hour value
+     * @return int The normalized hour value
      */
     abstract public function normalizeHour($hour, $marker = null);
 }

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimeZoneTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimeZoneTransformer.php
@@ -23,7 +23,7 @@ class TimeZoneTransformer extends Transformer
     /**
      * {@inheritdoc}
      *
-     * @throws NotImplementedException  When time zone is different than UTC or GMT (Etc/GMT)
+     * @throws NotImplementedException When time zone is different than UTC or GMT (Etc/GMT)
      */
     public function format(\DateTime $dateTime, $length)
     {
@@ -69,13 +69,13 @@ class TimeZoneTransformer extends Transformer
      *
      * @param string $formattedTimeZone A GMT timezone string (GMT-03:00, e.g.)
      *
-     * @return string                     A timezone identifier
+     * @return string A timezone identifier
      *
      * @see    http://php.net/manual/en/timezones.others.php
      * @see    http://www.twinsun.com/tz/tz-link.htm
      *
      * @throws NotImplementedException   When the GMT time zone have minutes offset different than zero
-     * @throws \InvalidArgumentException  When the value can not be matched with pattern
+     * @throws \InvalidArgumentException When the value can not be matched with pattern
      */
     public static function getEtcTimeZoneId($formattedTimeZone)
     {

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Transformer.php
@@ -25,7 +25,7 @@ abstract class Transformer
      * @param \DateTime $dateTime A DateTime object to be used to generate the formatted value
      * @param int       $length   The formatted value string length
      *
-     * @return string               The formatted value
+     * @return string The formatted value
      */
     abstract public function format(\DateTime $dateTime, $length);
 
@@ -34,7 +34,7 @@ abstract class Transformer
      *
      * @param int $length The length of the value to be reverse matched
      *
-     * @return string           The reverse matching regular expression
+     * @return string The reverse matching regular expression
      */
     abstract public function getReverseMatchingRegExp($length);
 
@@ -45,7 +45,7 @@ abstract class Transformer
      * @param string $matched The matched value
      * @param int    $length  The length of the Transformer pattern string
      *
-     * @return array             An associative array
+     * @return array An associative array
      */
     abstract public function extractDateOptions($matched, $length);
 
@@ -55,7 +55,7 @@ abstract class Transformer
      * @param string $value  The string to be padded
      * @param int    $length The length to pad
      *
-     * @return string           The padded string
+     * @return string The padded string
      */
     protected function padLeft($value, $length)
     {

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -135,13 +135,13 @@ class IntlDateFormatter
      * @param string $timezone Timezone identifier
      * @param int    $calendar Calendar to use for formatting or parsing. The only currently
      *                         supported value is IntlDateFormatter::GREGORIAN.
-     * @param string $pattern Optional pattern to use when formatting
+     * @param string $pattern  Optional pattern to use when formatting
      *
      * @see http://www.php.net/manual/en/intldateformatter.create.php
      * @see http://userguide.icu-project.org/formatparse/datetime
      *
-     * @throws MethodArgumentValueNotImplementedException  When $locale different than "en" is passed
-     * @throws MethodArgumentValueNotImplementedException  When $calendar different than GREGORIAN is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
     public function __construct($locale, $datetype, $timetype, $timezone = null, $calendar = self::GREGORIAN, $pattern = null)
     {
@@ -168,16 +168,16 @@ class IntlDateFormatter
      * @param int    $timetype Type of time formatting, one of the format type constants
      * @param string $timezone Timezone identifier
      * @param int    $calendar Calendar to use for formatting or parsing; default is Gregorian.
-     *                           One of the calendar constants.
-     * @param string $pattern Optional pattern to use when formatting
+     *                         One of the calendar constants.
+     * @param string $pattern  Optional pattern to use when formatting
      *
      * @return IntlDateFormatter
      *
      * @see http://www.php.net/manual/en/intldateformatter.create.php
      * @see http://userguide.icu-project.org/formatparse/datetime
      *
-     * @throws MethodArgumentValueNotImplementedException  When $locale different than "en" is passed
-     * @throws MethodArgumentValueNotImplementedException  When $calendar different than GREGORIAN is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
     public static function create($locale, $datetype, $timetype, $timezone = null, $calendar = self::GREGORIAN, $pattern = null)
     {
@@ -187,10 +187,10 @@ class IntlDateFormatter
     /**
      * Format the date/time value (timestamp) as a string
      *
-     * @param int|\DateTime     $timestamp The timestamp to format. \DateTime objects
-     *                                     are supported as of PHP 5.3.4.
+     * @param int|\DateTime $timestamp The timestamp to format. \DateTime objects
+     *                                 are supported as of PHP 5.3.4.
      *
-     * @return string|bool    The formatted value or false if formatting failed.
+     * @return string|bool The formatted value or false if formatting failed.
      *
      * @see http://www.php.net/manual/en/intldateformatter.format.php
      *
@@ -398,7 +398,7 @@ class IntlDateFormatter
     /**
      * Returns whether the formatter is lenient
      *
-     * @return bool    Currently always returns false.
+     * @return bool Currently always returns false.
      *
      * @see http://www.php.net/manual/en/intldateformatter.islenient.php
      *
@@ -414,9 +414,9 @@ class IntlDateFormatter
      *
      * @param string $value    String to convert to a time value
      * @param int    $position Position at which to start the parsing in $value (zero-based).
-     *                              If no error occurs before $value is consumed, $parse_pos will
-     *                              contain -1 otherwise it will contain the position at which parsing
-     *                              ended. If $parse_pos > strlen($value), the parse fails immediately.
+     *                         If no error occurs before $value is consumed, $parse_pos will
+     *                         contain -1 otherwise it will contain the position at which parsing
+     *                         ended. If $parse_pos > strlen($value), the parse fails immediately.
      *
      * @return string Localtime compatible array of integers: contains 24 hour clock value in tm_hour field
      *
@@ -468,7 +468,7 @@ class IntlDateFormatter
      *
      * @param string $calendar The calendar to use. Default is IntlDateFormatter::GREGORIAN.
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/intldateformatter.setcalendar.php
      *
@@ -487,10 +487,10 @@ class IntlDateFormatter
      * patterns, parsing as much as possible to obtain a value. Extra space, unrecognized tokens, or
      * invalid values ("February 30th") are not accepted.
      *
-     * @param bool    $lenient Sets whether the parser is lenient or not. Currently
-     *                         only false (strict) is supported.
+     * @param bool $lenient Sets whether the parser is lenient or not. Currently
+     *                      only false (strict) is supported.
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/intldateformatter.setlenient.php
      *
@@ -510,7 +510,7 @@ class IntlDateFormatter
      *
      * @param string $pattern A pattern string in conformance with the ICU IntlDateFormatter documentation
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/intldateformatter.setpattern.php
      * @see http://userguide.icu-project.org/formatparse/datetime
@@ -530,10 +530,10 @@ class IntlDateFormatter
      * Set the formatter's timezone identifier
      *
      * @param string $timeZoneId The time zone ID string of the time zone to use.
-     *                               If NULL or the empty string, the default time zone for the
-     *                               runtime is used.
+     *                           If NULL or the empty string, the default time zone for the
+     *                           runtime is used.
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/intldateformatter.settimezoneid.php
      */
@@ -580,9 +580,9 @@ class IntlDateFormatter
     /**
      * This method was added in PHP 5.5 as replacement for `setTimeZoneId()`
      *
-     * @param  mixed $timeZone
+     * @param mixed $timeZone
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/intldateformatter.settimezone.php
      */

--- a/src/Symfony/Component/Intl/Globals/IntlGlobals.php
+++ b/src/Symfony/Component/Intl/Globals/IntlGlobals.php
@@ -67,7 +67,7 @@ abstract class IntlGlobals
     /**
      * Returns whether the error code indicates a failure
      *
-     * @param int     $errorCode The error code returned by IntlGlobals::getErrorCode()
+     * @param int $errorCode The error code returned by IntlGlobals::getErrorCode()
      *
      * @return bool
      */
@@ -104,7 +104,7 @@ abstract class IntlGlobals
     /**
      * Returns the symbolic name for a given error code
      *
-     * @param int     $code The error code returned by IntlGlobals::getErrorCode()
+     * @param int $code The error code returned by IntlGlobals::getErrorCode()
      *
      * @return string
      */
@@ -120,8 +120,8 @@ abstract class IntlGlobals
     /**
      * Sets the current error
      *
-     * @param int     $code    One of the error constants in this class
-     * @param string  $message The ICU class error message
+     * @param int    $code    One of the error constants in this class
+     * @param string $message The ICU class error message
      *
      * @throws \InvalidArgumentException If the code is not one of the error constants in this class
      */

--- a/src/Symfony/Component/Intl/Locale/Locale.php
+++ b/src/Symfony/Component/Intl/Locale/Locale.php
@@ -74,9 +74,9 @@ class Locale
     /**
      * Not supported. Checks if a language tag filter matches with locale
      *
-     * @param string  $langtag      The language tag to check
-     * @param string  $locale       The language range to check against
-     * @param bool    $canonicalize
+     * @param string $langtag      The language tag to check
+     * @param string $locale       The language range to check against
+     * @param bool   $canonicalize
      *
      * @return string The corresponding locale code
      *
@@ -223,7 +223,7 @@ class Locale
      *
      * @param string $locale The locale code to extract the language code from
      *
-     * @return string|null        The extracted language code or null in case of error
+     * @return string|null The extracted language code or null in case of error
      *
      * @see http://www.php.net/manual/en/locale.getprimarylanguage.php
      *
@@ -239,7 +239,7 @@ class Locale
      *
      * @param string $locale The locale code to extract the region code from
      *
-     * @return string|null        The extracted region code or null if not present
+     * @return string|null The extracted region code or null if not present
      *
      * @see http://www.php.net/manual/en/locale.getregion.php
      *
@@ -255,7 +255,7 @@ class Locale
      *
      * @param string $locale The locale code to extract the script code from
      *
-     * @return string|null        The extracted script code or null if not present
+     * @return string|null The extracted script code or null if not present
      *
      * @see http://www.php.net/manual/en/locale.getscript.php
      *
@@ -269,10 +269,10 @@ class Locale
     /**
      * Not supported. Returns the closest language tag for the locale
      *
-     * @param array   $langtag      A list of the language tags to compare to locale
-     * @param string  $locale       The locale to use as the language range when matching
-     * @param bool    $canonicalize If true, the arguments will be converted to canonical form before matching
-     * @param string  $default      The locale to use if no match is found
+     * @param array  $langtag      A list of the language tags to compare to locale
+     * @param string $locale       The locale to use as the language range when matching
+     * @param bool   $canonicalize If true, the arguments will be converted to canonical form before matching
+     * @param string $default      The locale to use if no match is found
      *
      * @see http://www.php.net/manual/en/locale.lookup.php
      *
@@ -304,7 +304,7 @@ class Locale
      *
      * @param string $locale The locale code
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/locale.parselocale.php
      *

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -257,9 +257,9 @@ class NumberFormatter
      * @see http://www.icu-project.org/apiref/icu4c/classDecimalFormat.html#_details
      * @see http://www.icu-project.org/apiref/icu4c/classRuleBasedNumberFormat.html#_details
      *
-     * @throws MethodArgumentValueNotImplementedException  When $locale different than "en" is passed
-     * @throws MethodArgumentValueNotImplementedException  When the $style is not supported
-     * @throws MethodArgumentNotImplementedException       When the pattern value is different than null
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When the $style is not supported
+     * @throws MethodArgumentNotImplementedException      When the pattern value is different than null
      */
     public function __construct($locale = 'en', $style = null, $pattern = null)
     {
@@ -296,9 +296,9 @@ class NumberFormatter
      * @see http://www.icu-project.org/apiref/icu4c/classDecimalFormat.html#_details
      * @see http://www.icu-project.org/apiref/icu4c/classRuleBasedNumberFormat.html#_details
      *
-     * @throws MethodArgumentValueNotImplementedException  When $locale different than "en" is passed
-     * @throws MethodArgumentValueNotImplementedException  When the $style is not supported
-     * @throws MethodArgumentNotImplementedException       When the pattern value is different than null
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When the $style is not supported
+     * @throws MethodArgumentNotImplementedException      When the pattern value is different than null
      */
     public static function create($locale = 'en', $style = null, $pattern = null)
     {
@@ -347,7 +347,7 @@ class NumberFormatter
      * @param int    $type  Type of the formatting, one of the format type constants.
      *                      Only type NumberFormatter::TYPE_DEFAULT is currently supported.
      *
-     * @return bool|string    The formatted value or false on error
+     * @return bool|string The formatted value or false on error
      *
      * @see http://www.php.net/manual/en/numberformatter.format.php
      *
@@ -391,7 +391,7 @@ class NumberFormatter
      *
      * @param int $attr An attribute specifier, one of the numeric attribute constants
      *
-     * @return bool|int    The attribute value on success or false on error
+     * @return bool|int The attribute value on success or false on error
      *
      * @see http://www.php.net/manual/en/numberformatter.getattribute.php
      */
@@ -444,7 +444,7 @@ class NumberFormatter
     /**
      * Not supported. Returns the formatter's pattern
      *
-     * @return bool|string        The pattern string used by the formatter or false on error
+     * @return bool|string The pattern string used by the formatter or false on error
      *
      * @see http://www.php.net/manual/en/numberformatter.getpattern.php
      *
@@ -460,7 +460,7 @@ class NumberFormatter
      *
      * @param int $attr A symbol specifier, one of the format symbol constants
      *
-     * @return bool|string           The symbol value or false on error
+     * @return bool|string The symbol value or false on error
      *
      * @see http://www.php.net/manual/en/numberformatter.getsymbol.php
      */
@@ -474,7 +474,7 @@ class NumberFormatter
      *
      * @param int $attr An attribute specifier, one of the text attribute constants
      *
-     * @return bool|string           The attribute value or false on error
+     * @return bool|string The attribute value or false on error
      *
      * @see http://www.php.net/manual/en/numberformatter.gettextattribute.php
      */
@@ -490,7 +490,7 @@ class NumberFormatter
      * @param string $currency Parameter to receive the currency name (reference)
      * @param int    $position Offset to begin the parsing on return this value will hold the offset at which the parsing ended
      *
-     * @return bool|string              The parsed numeric value of false on error
+     * @return bool|string The parsed numeric value of false on error
      *
      * @see http://www.php.net/manual/en/numberformatter.parsecurrency.php
      *
@@ -508,7 +508,7 @@ class NumberFormatter
      * @param int    $type     Type of the formatting, one of the format type constants. NumberFormatter::TYPE_DOUBLE by default
      * @param int    $position Offset to begin the parsing on return this value will hold the offset at which the parsing ended
      *
-     * @return bool|string                                  The parsed value of false on error
+     * @return bool|string The parsed value of false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.parse.php
      */
@@ -553,12 +553,12 @@ class NumberFormatter
      *                   NumberFormatter::ROUND_HALFEVEN, NumberFormatter::ROUND_HALFDOWN and
      *                   NumberFormatter::ROUND_HALFUP.
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/numberformatter.setattribute.php
      *
-     * @throws MethodArgumentValueNotImplementedException  When the $attr is not supported
-     * @throws MethodArgumentValueNotImplementedException  When the $value is not supported
+     * @throws MethodArgumentValueNotImplementedException When the $attr is not supported
+     * @throws MethodArgumentValueNotImplementedException When the $value is not supported
      */
     public function setAttribute($attr, $value)
     {
@@ -599,7 +599,7 @@ class NumberFormatter
      *
      * @param string $pattern A pattern string in conformance with the ICU DecimalFormat documentation
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/numberformatter.setpattern.php
      * @see http://www.icu-project.org/apiref/icu4c/classDecimalFormat.html#_details
@@ -617,7 +617,7 @@ class NumberFormatter
      * @param int    $attr  A symbol specifier, one of the format symbol constants
      * @param string $value The value for the symbol
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/numberformatter.setsymbol.php
      *
@@ -634,7 +634,7 @@ class NumberFormatter
      * @param int $attr  An attribute specifier, one of the text attribute constants
      * @param int $value The attribute value
      *
-     * @return bool    true on success or false on failure
+     * @return bool true on success or false on failure
      *
      * @see http://www.php.net/manual/en/numberformatter.settextattribute.php
      *
@@ -693,10 +693,10 @@ class NumberFormatter
     /**
      * Rounds a value.
      *
-     * @param int|float     $value     The value to round
-     * @param int           $precision The number of decimal digits to round to
+     * @param int|float $value     The value to round
+     * @param int       $precision The number of decimal digits to round to
      *
-     * @return int|float     The rounded value
+     * @return int|float The rounded value
      */
     private function round($value, $precision)
     {
@@ -711,8 +711,8 @@ class NumberFormatter
     /**
      * Formats a number.
      *
-     * @param int|float     $value     The numeric value to format
-     * @param int           $precision The number of decimal digits to use
+     * @param int|float $value     The numeric value to format
+     * @param int       $precision The number of decimal digits to use
      *
      * @return string The formatted number
      */
@@ -726,8 +726,8 @@ class NumberFormatter
     /**
      * Returns the precision value if the DECIMAL style is being used and the FRACTION_DIGITS attribute is unitialized.
      *
-     * @param int|float     $value     The value to get the precision from if the FRACTION_DIGITS attribute is unitialized
-     * @param int           $precision The precision value to returns if the FRACTION_DIGITS attribute is initialized
+     * @param int|float $value     The value to get the precision from if the FRACTION_DIGITS attribute is unitialized
+     * @param int       $precision The precision value to returns if the FRACTION_DIGITS attribute is initialized
      *
      * @return int The precision value
      */
@@ -752,7 +752,7 @@ class NumberFormatter
      *
      * @param string $attr The attribute name
      *
-     * @return bool    true if the value was set by client, false otherwise
+     * @return bool true if the value was set by client, false otherwise
      */
     private function isInitializedAttribute($attr)
     {
@@ -765,7 +765,7 @@ class NumberFormatter
      * @param mixed $value The value to be converted
      * @param int   $type  The type to convert. Can be TYPE_DOUBLE (float) or TYPE_INT32 (int)
      *
-     * @return int|float     The converted value
+     * @return int|float The converted value
      */
     private function convertValueDataType($value, $type)
     {
@@ -801,7 +801,7 @@ class NumberFormatter
      *
      * @param mixed $value The value to be converted
      *
-     * @return int|float       The converted value
+     * @return int|float The converted value
      *
      * @see https://bugs.php.net/bug.php?id=59597 Bug #59597
      */
@@ -843,7 +843,7 @@ class NumberFormatter
      *
      * @param int $value The rounding mode value to check
      *
-     * @return bool    true if the rounding mode is invalid, false otherwise
+     * @return bool true if the rounding mode is invalid, false otherwise
      */
     private function isInvalidRoundingMode($value)
     {

--- a/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundleInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundleInterface.php
@@ -21,9 +21,9 @@ interface CurrencyBundleInterface extends ResourceBundleInterface
     /**
      * Returns the symbol used for a currency.
      *
-     * @param string $currency A currency code (e.g. "EUR").
-     * @param string $displayLocale   Optional. The locale to return the result in.
-     *                         Defaults to {@link \Locale::getDefault()}.
+     * @param string $currency      A currency code (e.g. "EUR").
+     * @param string $displayLocale Optional. The locale to return the result in.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string|null The currency symbol or NULL if not found.
      */
@@ -32,9 +32,9 @@ interface CurrencyBundleInterface extends ResourceBundleInterface
     /**
      * Returns the name of a currency.
      *
-     * @param string $currency A currency code (e.g. "EUR").
-     * @param string $displayLocale   Optional. The locale to return the name in.
-     *                         Defaults to {@link \Locale::getDefault()}.
+     * @param string $currency      A currency code (e.g. "EUR").
+     * @param string $displayLocale Optional. The locale to return the name in.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string|null The name of the currency or NULL if not found.
      */
@@ -44,7 +44,7 @@ interface CurrencyBundleInterface extends ResourceBundleInterface
      * Returns the names of all known currencies.
      *
      * @param string $displayLocale Optional. The locale to return the names in.
-     *                       Defaults to {@link \Locale::getDefault()}.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string[] A list of currency names indexed by currency codes.
      */
@@ -55,7 +55,7 @@ interface CurrencyBundleInterface extends ResourceBundleInterface
      *
      * @param string $currency A currency code (e.g. "EUR").
      *
-     * @return int|null     The number of digits after the comma or NULL if not found.
+     * @return int|null The number of digits after the comma or NULL if not found.
      */
     public function getFractionDigits($currency);
 
@@ -68,7 +68,7 @@ interface CurrencyBundleInterface extends ResourceBundleInterface
      *
      * @param string $currency A currency code (e.g. "EUR").
      *
-     * @return float|int|null     The rounding increment or NULL if not found.
+     * @return float|int|null The rounding increment or NULL if not found.
      */
     public function getRoundingIncrement($currency);
 }

--- a/src/Symfony/Component/Intl/ResourceBundle/LanguageBundleInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LanguageBundleInterface.php
@@ -21,10 +21,10 @@ interface LanguageBundleInterface extends ResourceBundleInterface
     /**
      * Returns the name of a language.
      *
-     * @param string      $language   A language code (e.g. "en").
-     * @param string|null $region Optional. A region code (e.g. "US").
+     * @param string      $language      A language code (e.g. "en").
+     * @param string|null $region        Optional. A region code (e.g. "US").
      * @param string      $displayLocale Optional. The locale to return the name in.
-     *                            Defaults to {@link \Locale::getDefault()}.
+     *                                   Defaults to {@link \Locale::getDefault()}.
      *
      * @return string|null The name of the language or NULL if not found.
      */
@@ -34,7 +34,7 @@ interface LanguageBundleInterface extends ResourceBundleInterface
      * Returns the names of all known languages.
      *
      * @param string $displayLocale Optional. The locale to return the names in.
-     *                       Defaults to {@link \Locale::getDefault()}.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string[] A list of language names indexed by language codes.
      */
@@ -43,10 +43,10 @@ interface LanguageBundleInterface extends ResourceBundleInterface
     /**
      * Returns the name of a script.
      *
-     * @param string $script A script code (e.g. "Hans").
-     * @param string $language   Optional. A language code (e.g. "zh").
+     * @param string $script        A script code (e.g. "Hans").
+     * @param string $language      Optional. A language code (e.g. "zh").
      * @param string $displayLocale Optional. The locale to return the name in.
-     *                       Defaults to {@link \Locale::getDefault()}.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string|null The name of the script or NULL if not found.
      */
@@ -56,7 +56,7 @@ interface LanguageBundleInterface extends ResourceBundleInterface
      * Returns the names of all known scripts.
      *
      * @param string $displayLocale Optional. The locale to return the names in.
-     *                       Defaults to {@link \Locale::getDefault()}.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string[] A list of script names indexed by script codes.
      */

--- a/src/Symfony/Component/Intl/ResourceBundle/LocaleBundleInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LocaleBundleInterface.php
@@ -21,9 +21,9 @@ interface LocaleBundleInterface extends ResourceBundleInterface
     /**
      * Returns the name of a locale.
      *
-     * @param string $locale The locale to return the name of (e.g. "de_AT").
-     * @param string $displayLocale   Optional. The locale to return the name in.
-     *                         Defaults to {@link \Locale::getDefault()}.
+     * @param string $locale        The locale to return the name of (e.g. "de_AT").
+     * @param string $displayLocale Optional. The locale to return the name in.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string|null The name of the locale or NULL if not found.
      */
@@ -33,7 +33,7 @@ interface LocaleBundleInterface extends ResourceBundleInterface
      * Returns the names of all known locales.
      *
      * @param string $displayLocale Optional. The locale to return the names in.
-     *                       Defaults to {@link \Locale::getDefault()}.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string[] A list of locale names indexed by locale codes.
      */

--- a/src/Symfony/Component/Intl/ResourceBundle/RegionBundleInterface.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/RegionBundleInterface.php
@@ -21,9 +21,9 @@ interface RegionBundleInterface extends ResourceBundleInterface
     /**
      * Returns the name of a country.
      *
-     * @param string $country A country code (e.g. "US").
-     * @param string $displayLocale  Optional. The locale to return the name in.
-     *                        Defaults to {@link \Locale::getDefault()}.
+     * @param string $country       A country code (e.g. "US").
+     * @param string $displayLocale Optional. The locale to return the name in.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string|null The name of the country or NULL if not found.
      */
@@ -33,7 +33,7 @@ interface RegionBundleInterface extends ResourceBundleInterface
      * Returns the names of all known countries.
      *
      * @param string $displayLocale Optional. The locale to return the names in.
-     *                       Defaults to {@link \Locale::getDefault()}.
+     *                              Defaults to {@link \Locale::getDefault()}.
      *
      * @return string[] A list of country names indexed by country codes.
      */

--- a/src/Symfony/Component/Intl/Resources/stubs/functions.php
+++ b/src/Symfony/Component/Intl/Resources/stubs/functions.php
@@ -18,9 +18,9 @@ if (!function_exists('intl_is_failure')) {
      *
      * @author Bernhard Schussek <bschussek@gmail.com>
      *
-     * @param int     $errorCode  The error code returned by intl_get_error_code().
+     * @param int $errorCode The error code returned by intl_get_error_code().
      *
-     * @return bool    Whether the error code indicates an error.
+     * @return bool Whether the error code indicates an error.
      *
      * @see \Symfony\Component\Intl\Globals\StubIntlGlobals::isFailure
      */
@@ -35,8 +35,8 @@ if (!function_exists('intl_is_failure')) {
      *
      * @author Bernhard Schussek <bschussek@gmail.com>
      *
-     * @return bool    The error code of the last intl function call or
-     *                 IntlGlobals::U_ZERO_ERROR if no error occurred.
+     * @return bool The error code of the last intl function call or
+     *              IntlGlobals::U_ZERO_ERROR if no error occurred.
      *
      * @see \Symfony\Component\Intl\Globals\StubIntlGlobals::getErrorCode
      */
@@ -51,8 +51,8 @@ if (!function_exists('intl_is_failure')) {
      *
      * @author Bernhard Schussek <bschussek@gmail.com>
      *
-     * @return bool    The error message of the last intl function call or
-     *                 "U_ZERO_ERROR" if no error occurred.
+     * @return bool The error message of the last intl function call or
+     *              "U_ZERO_ERROR" if no error occurred.
      *
      * @see \Symfony\Component\Intl\Globals\StubIntlGlobals::getErrorMessage
      */
@@ -65,7 +65,7 @@ if (!function_exists('intl_is_failure')) {
      * Stub implementation for the {@link intl_error_name()} function of the intl
      * extension.
      *
-     * @param int     $errorCode The error code.
+     * @param int $errorCode The error code.
      *
      * @return string The name of the error code constant.
      *

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -905,7 +905,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
      * @param $datetype
      * @param $timetype
      * @param null $timezone
-     * @param int $calendar
+     * @param int  $calendar
      * @param null $pattern
      *
      * @return mixed
@@ -923,7 +923,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     abstract protected function getIntlErrorCode();
 
     /**
-     * @param int     $errorCode
+     * @param int $errorCode
      *
      * @return bool
      */

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -707,8 +707,8 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param string $locale
-     * @param null $style
-     * @param null $pattern
+     * @param null   $style
+     * @param null   $pattern
      *
      * @return \NumberFormatter
      */
@@ -725,7 +725,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
     abstract protected function getIntlErrorCode();
 
     /**
-     * @param int     $errorCode
+     * @param int $errorCode
      *
      * @return bool
      */

--- a/src/Symfony/Component/Intl/Util/IcuVersion.php
+++ b/src/Symfony/Component/Intl/Util/IcuVersion.php
@@ -43,13 +43,13 @@ class IcuVersion
      *     IcuVersion::compare('1', '10', '==')
      *     // => true
      *
-     * @param string       $version1  A version string.
-     * @param string       $version2  A version string to compare.
-     * @param string       $operator  The comparison operator.
-     * @param int|null     $precision The number of components to compare. Pass
-     *                                NULL to compare the versions unchanged.
+     * @param string   $version1  A version string.
+     * @param string   $version2  A version string to compare.
+     * @param string   $operator  The comparison operator.
+     * @param int|null $precision The number of components to compare. Pass
+     *                            NULL to compare the versions unchanged.
      *
-     * @return bool    Whether the comparison succeeded.
+     * @return bool Whether the comparison succeeded.
      *
      * @see normalize()
      */
@@ -80,9 +80,9 @@ class IcuVersion
      *     IcuVersion::normalize('1.2.3.4', 2);
      *     // => '12.3'
      *
-     * @param string       $version   An ICU version string.
-     * @param int|null     $precision The number of components to include. Pass
-     *                                NULL to return the version unchanged.
+     * @param string   $version   An ICU version string.
+     * @param int|null $precision The number of components to include. Pass
+     *                            NULL to return the version unchanged.
      *
      * @return string|null The normalized ICU version or NULL if it couldn't be
      *                     normalized.

--- a/src/Symfony/Component/Intl/Util/Version.php
+++ b/src/Symfony/Component/Intl/Util/Version.php
@@ -33,13 +33,13 @@ class Version
      *     Version::compare('1.2.3', '1.2.4', '==', 2)
      *     // => true
      *
-     * @param string       $version1  A version string.
-     * @param string       $version2  A version string to compare.
-     * @param string       $operator  The comparison operator.
-     * @param int|null     $precision The number of components to compare. Pass
-     *                                NULL to compare the versions unchanged.
+     * @param string   $version1  A version string.
+     * @param string   $version2  A version string to compare.
+     * @param string   $operator  The comparison operator.
+     * @param int|null $precision The number of components to compare. Pass
+     *                            NULL to compare the versions unchanged.
      *
-     * @return bool    Whether the comparison succeeded.
+     * @return bool Whether the comparison succeeded.
      *
      * @see normalize()
      */
@@ -63,9 +63,9 @@ class Version
      *     Version::normalize('1.2.3', 2);
      *     // => '1.2'
      *
-     * @param string       $version   A version string.
-     * @param int|null     $precision The number of components to include. Pass
-     *                                NULL to return the version unchanged.
+     * @param string   $version   A version string.
+     * @param int|null $precision The number of components to include. Pass
+     *                            NULL to return the version unchanged.
      *
      * @return string|null The normalized version or NULL if it couldn't be
      *                     normalized.

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -47,9 +47,9 @@ class Locale extends \Locale
      *
      * @param string $locale The locale to use for the country names
      *
-     * @return array              The country names with their codes as keys
+     * @return array The country names with their codes as keys
      *
-     * @throws \RuntimeException  When the resource bundles cannot be loaded
+     * @throws \RuntimeException When the resource bundles cannot be loaded
      */
     public static function getDisplayCountries($locale)
     {
@@ -63,9 +63,9 @@ class Locale extends \Locale
     /**
      * Returns all available country codes
      *
-     * @return array              The country codes
+     * @return array The country codes
      *
-     * @throws \RuntimeException  When the resource bundles cannot be loaded
+     * @throws \RuntimeException When the resource bundles cannot be loaded
      */
     public static function getCountries()
     {
@@ -77,9 +77,9 @@ class Locale extends \Locale
      *
      * @param string $locale The locale to use for the language names
      *
-     * @return array              The language names with their codes as keys
+     * @return array The language names with their codes as keys
      *
-     * @throws \RuntimeException  When the resource bundles cannot be loaded
+     * @throws \RuntimeException When the resource bundles cannot be loaded
      */
     public static function getDisplayLanguages($locale)
     {
@@ -93,9 +93,9 @@ class Locale extends \Locale
     /**
      * Returns all available language codes
      *
-     * @return array              The language codes
+     * @return array The language codes
      *
-     * @throws \RuntimeException  When the resource bundles cannot be loaded
+     * @throws \RuntimeException When the resource bundles cannot be loaded
      */
     public static function getLanguages()
     {
@@ -107,9 +107,9 @@ class Locale extends \Locale
      *
      * @param string $locale The locale to use for the locale names
      *
-     * @return array              The locale names with their codes as keys
+     * @return array The locale names with their codes as keys
      *
-     * @throws \RuntimeException  When the resource bundles cannot be loaded
+     * @throws \RuntimeException When the resource bundles cannot be loaded
      */
     public static function getDisplayLocales($locale)
     {
@@ -123,9 +123,9 @@ class Locale extends \Locale
     /**
      * Returns all available locale codes
      *
-     * @return array              The locale codes
+     * @return array The locale codes
      *
-     * @throws \RuntimeException  When the resource bundles cannot be loaded
+     * @throws \RuntimeException When the resource bundles cannot be loaded
      */
     public static function getLocales()
     {

--- a/src/Symfony/Component/Locale/Stub/StubLocale.php
+++ b/src/Symfony/Component/Locale/Stub/StubLocale.php
@@ -45,7 +45,7 @@ class StubLocale extends Locale
      *
      * @param string $locale
      *
-     * @return array  The currencies data
+     * @return array The currencies data
      */
     public static function getCurrenciesData($locale)
     {
@@ -61,9 +61,9 @@ class StubLocale extends Locale
      *
      * @param string $locale The locale to use for the currencies names
      *
-     * @return array                     The currencies names with their codes as keys
+     * @return array The currencies names with their codes as keys
      *
-     * @throws \InvalidArgumentException  When the locale is different than 'en'
+     * @throws \InvalidArgumentException When the locale is different than 'en'
      */
     public static function getDisplayCurrencies($locale)
     {
@@ -77,7 +77,7 @@ class StubLocale extends Locale
     /**
      * Returns all available currencies codes
      *
-     * @return array  The currencies codes
+     * @return array The currencies codes
      */
     public static function getCurrencies()
     {

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -244,7 +244,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
      *
      * @param string $option The option name.
      *
-     * @return bool    Whether the option exists.
+     * @return bool Whether the option exists.
      */
     public function has($option)
     {
@@ -324,7 +324,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
      *
      * @param string $option The option name.
      *
-     * @return bool    Whether the option exists.
+     * @return bool Whether the option exists.
      *
      * @see \ArrayAccess::offsetExists()
      */

--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -97,8 +97,8 @@ interface OptionsResolverInterface
      * @return OptionsResolverInterface The resolver instance.
      *
      * @throws Exception\InvalidOptionsException If an option has not been defined
-     *                                 (see {@link isKnown()}) for which
-     *                                 an allowed value is set.
+     *                                           (see {@link isKnown()}) for which
+     *                                           an allowed value is set.
      */
     public function setAllowedValues(array $allowedValues);
 
@@ -114,8 +114,8 @@ interface OptionsResolverInterface
      * @return OptionsResolverInterface The resolver instance.
      *
      * @throws Exception\InvalidOptionsException If an option has not been defined
-     *                                 (see {@link isKnown()}) for which
-     *                                 an allowed value is set.
+     *                                           (see {@link isKnown()}) for which
+     *                                           an allowed value is set.
      */
     public function addAllowedValues(array $allowedValues);
 
@@ -175,7 +175,7 @@ interface OptionsResolverInterface
      *
      * @param string $option The name of the option.
      *
-     * @return bool    Whether the option is known.
+     * @return bool Whether the option is known.
      */
     public function isKnown($option);
 
@@ -188,7 +188,7 @@ interface OptionsResolverInterface
      *
      * @param string $option The name of the option.
      *
-     * @return bool    Whether the option is required.
+     * @return bool Whether the option is required.
      */
     public function isRequired($option);
 

--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -31,11 +31,11 @@ class PhpProcess extends Process
     /**
      * Constructor.
      *
-     * @param string  $script  The PHP script to run (as a string)
-     * @param string  $cwd     The working directory
-     * @param array   $env     The environment variables
-     * @param int     $timeout The timeout in seconds
-     * @param array   $options An array of options for proc_open
+     * @param string $script  The PHP script to run (as a string)
+     * @param string $cwd     The working directory
+     * @param array  $env     The environment variables
+     * @param int    $timeout The timeout in seconds
+     * @param array  $options An array of options for proc_open
      *
      * @api
      */

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -121,12 +121,12 @@ class Process
     /**
      * Constructor.
      *
-     * @param string             $commandline The command line to run
-     * @param string|null        $cwd         The working directory or null to use the working dir of the current PHP process
-     * @param array|null         $env         The environment variables or null to inherit
-     * @param string|null        $stdin       The STDIN content
-     * @param int|float|null     $timeout     The timeout in seconds or null to disable
-     * @param array              $options     An array of options for proc_open
+     * @param string         $commandline The command line to run
+     * @param string|null    $cwd         The working directory or null to use the working dir of the current PHP process
+     * @param array|null     $env         The environment variables or null to inherit
+     * @param string|null    $stdin       The STDIN content
+     * @param int|float|null $timeout     The timeout in seconds or null to disable
+     * @param array          $options     An array of options for proc_open
      *
      * @throws RuntimeException When proc_open is not installed
      *
@@ -183,7 +183,7 @@ class Process
      * @param callback|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR
      *
-     * @return int     The exit status code
+     * @return int The exit status code
      *
      * @throws RuntimeException When process can't be launched
      * @throws RuntimeException When process stopped after receiving signal
@@ -297,7 +297,7 @@ class Process
      *
      * @param callback|null $callback A valid PHP callback
      *
-     * @return int     The exitcode of the process
+     * @return int The exitcode of the process
      *
      * @throws RuntimeException When process timed out
      * @throws RuntimeException When process stopped after receiving signal
@@ -333,7 +333,7 @@ class Process
     /**
      * Returns the Pid (process identifier), if applicable.
      *
-     * @return int|null     The process id if running, null otherwise
+     * @return int|null The process id if running, null otherwise
      *
      * @throws RuntimeException In case --enable-sigchild is activated
      */
@@ -351,7 +351,7 @@ class Process
     /**
      * Sends a POSIX signal to the process.
      *
-     * @param  int     $signal A valid POSIX signal (see http://www.php.net/manual/en/pcntl.constants.php)
+     * @param int $signal A valid POSIX signal (see http://www.php.net/manual/en/pcntl.constants.php)
      *
      * @return Process
      *
@@ -450,7 +450,7 @@ class Process
     /**
      * Returns the exit code returned by the process.
      *
-     * @return null|int     The exit status code, null if the Process is not terminated
+     * @return null|int The exit status code, null if the Process is not terminated
      *
      * @throws RuntimeException In case --enable-sigchild is activated and the sigchild compatibility mode is disabled
      *
@@ -492,7 +492,7 @@ class Process
     /**
      * Checks if the process ended successfully.
      *
-     * @return bool    true if the process ended successfully, false otherwise
+     * @return bool true if the process ended successfully, false otherwise
      *
      * @api
      */
@@ -594,7 +594,7 @@ class Process
     /**
      * Checks if the process is currently running.
      *
-     * @return bool    true if the process is currently running, false otherwise
+     * @return bool true if the process is currently running, false otherwise
      */
     public function isRunning()
     {
@@ -610,7 +610,7 @@ class Process
     /**
      * Checks if the process has been started with no regard to the current state.
      *
-     * @return bool    true if status is ready, false otherwise
+     * @return bool true if status is ready, false otherwise
      */
     public function isStarted()
     {
@@ -620,7 +620,7 @@ class Process
     /**
      * Checks if the process is terminated.
      *
-     * @return bool    true if process is terminated, false otherwise
+     * @return bool true if process is terminated, false otherwise
      */
     public function isTerminated()
     {
@@ -646,10 +646,10 @@ class Process
     /**
      * Stops the process.
      *
-     * @param int|float     $timeout The timeout in seconds
-     * @param int           $signal  A POSIX signal to send in case the process has not stop at timeout, default is SIGKILL
+     * @param int|float $timeout The timeout in seconds
+     * @param int       $signal  A POSIX signal to send in case the process has not stop at timeout, default is SIGKILL
      *
-     * @return int     The exit-code of the process
+     * @return int The exit-code of the process
      *
      * @throws RuntimeException if the process got signaled
      */
@@ -747,7 +747,7 @@ class Process
      *
      * To disable the timeout, set this value to null.
      *
-     * @param int|float|null     $timeout The timeout in seconds
+     * @param int|float|null $timeout The timeout in seconds
      *
      * @return self The current Process instance
      *
@@ -771,7 +771,7 @@ class Process
     /**
      * Enables or disables the TTY mode.
      *
-     * @param bool    $tty True to enabled and false to disable
+     * @param bool $tty True to enabled and false to disable
      *
      * @return self The current Process instance
      *
@@ -791,7 +791,7 @@ class Process
     /**
      * Checks if the TTY mode is enabled.
      *
-     * @return bool    true if the TTY mode is enabled, false otherwise
+     * @return bool true if the TTY mode is enabled, false otherwise
      */
     public function isTty()
     {
@@ -936,7 +936,7 @@ class Process
     /**
      * Sets whether or not Windows compatibility is enabled.
      *
-     * @param bool    $enhance
+     * @param bool $enhance
      *
      * @return self The current Process instance
      */
@@ -964,7 +964,7 @@ class Process
      * determine the success of a process when PHP has been compiled with
      * the --enable-sigchild option
      *
-     * @param bool    $enhance
+     * @param bool $enhance
      *
      * @return self The current Process instance
      */
@@ -1049,7 +1049,7 @@ class Process
     /**
      * Updates the status of the process, reads pipes.
      *
-     * @param bool    $blocking Whether to use a blocking read call.
+     * @param bool $blocking Whether to use a blocking read call.
      */
     protected function updateStatus($blocking)
     {
@@ -1091,8 +1091,8 @@ class Process
     /**
      * Reads pipes, executes callback.
      *
-     * @param bool    $blocking Whether to use blocking calls or not.
-     * @param bool    $close    Whether to close file handles or not.
+     * @param bool $blocking Whether to use blocking calls or not.
+     * @param bool $close    Whether to close file handles or not.
      */
     private function readPipes($blocking, $close)
     {
@@ -1124,7 +1124,7 @@ class Process
     /**
      * Closes process resource, closes file handles, sets the exitcode.
      *
-     * @return int     The exitcode
+     * @return int The exitcode
      */
     private function close()
     {
@@ -1170,10 +1170,10 @@ class Process
     /**
      * Sends a POSIX signal to the process.
      *
-     * @param  int     $signal         A valid POSIX signal (see http://www.php.net/manual/en/pcntl.constants.php)
-     * @param  bool    $throwException Whether to throw exception in case signal failed
+     * @param int  $signal         A valid POSIX signal (see http://www.php.net/manual/en/pcntl.constants.php)
+     * @param bool $throwException Whether to throw exception in case signal failed
      *
-     * @return bool    True if the signal was sent successfully, false otherwise
+     * @return bool True if the signal was sent successfully, false otherwise
      *
      * @throws LogicException   In case the process is not running
      * @throws RuntimeException In case --enable-sigchild is activated

--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -151,7 +151,7 @@ class ProcessPipes
     /**
      * Reads data in file handles and pipes.
      *
-     * @param bool    $blocking Whether to use blocking calls or not.
+     * @param bool $blocking Whether to use blocking calls or not.
      *
      * @return array An array of read data indexed by their fd.
      */
@@ -163,7 +163,7 @@ class ProcessPipes
     /**
      * Reads data in file handles and pipes, closes them if EOF is reached.
      *
-     * @param bool    $blocking Whether to use blocking calls or not.
+     * @param bool $blocking Whether to use blocking calls or not.
      *
      * @return array An array of read data indexed by their fd.
      */
@@ -240,7 +240,7 @@ class ProcessPipes
     /**
      * Reads data in file handles.
      *
-     * @param bool    $close Whether to close file handles or not.
+     * @param bool $close Whether to close file handles or not.
      *
      * @return array An array of read data indexed by their fd.
      */
@@ -276,8 +276,8 @@ class ProcessPipes
     /**
      * Reads data in file pipes streams.
      *
-     * @param bool    $blocking Whether to use blocking calls or not.
-     * @param bool    $close    Whether to close file handles or not.
+     * @param bool $blocking Whether to use blocking calls or not.
+     * @param bool $close    Whether to close file handles or not.
      *
      * @return array An array of read data indexed by their fd.
      */

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -879,12 +879,12 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string  $commandline
-     * @param null    $cwd
-     * @param array   $env
-     * @param null    $stdin
-     * @param int     $timeout
-     * @param array   $options
+     * @param string $commandline
+     * @param null   $cwd
+     * @param array  $env
+     * @param null   $stdin
+     * @param int    $timeout
+     * @param array  $options
      *
      * @return Process
      */

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -374,7 +374,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * Camelizes a given string.
      *
-     * @param  string $string Some string
+     * @param string $string Some string
      *
      * @return string The camelized version of the string
      */
@@ -420,12 +420,12 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * Returns whether a method is public and has a specific number of required parameters.
      *
-     * @param  \ReflectionClass $class      The class of the method
-     * @param  string           $methodName The method name
-     * @param  int              $parameters The number of parameters
+     * @param \ReflectionClass $class      The class of the method
+     * @param string           $methodName The method name
+     * @param int              $parameters The number of parameters
      *
-     * @return bool    Whether the method is public and has $parameters
-     *                                      required parameters
+     * @return bool Whether the method is public and has $parameters
+     *              required parameters
      */
     private function isAccessible(\ReflectionClass $class, $methodName, $parameters)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
@@ -48,7 +48,7 @@ class PropertyAccessorBuilder
     }
 
     /**
-     * @return bool    true if the use of "__call" by the ProperyAccessor is enabled
+     * @return bool true if the use of "__call" by the ProperyAccessor is enabled
      */
     public function isMagicCallEnabled()
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -93,8 +93,8 @@ class PropertyPathBuilder
     /**
      * Removes elements from the current path.
      *
-     * @param int     $offset The offset at which to remove
-     * @param int     $length The length of the removed piece
+     * @param int $offset The offset at which to remove
+     * @param int $length The length of the removed piece
      *
      * @throws OutOfBoundsException if offset is invalid
      */
@@ -147,8 +147,8 @@ class PropertyPathBuilder
     /**
      * Replaces a property element by an index element.
      *
-     * @param int     $offset The offset at which to replace
-     * @param string  $name   The new name of the element. Optional.
+     * @param int    $offset The offset at which to replace
+     * @param string $name   The new name of the element. Optional.
      *
      * @throws OutOfBoundsException If the offset is invalid
      */
@@ -168,8 +168,8 @@ class PropertyPathBuilder
     /**
      * Replaces an index element by a property element.
      *
-     * @param int     $offset The offset at which to replace
-     * @param string  $name   The new name of the element. Optional.
+     * @param int    $offset The offset at which to replace
+     * @param string $name   The new name of the element. Optional.
      *
      * @throws OutOfBoundsException If the offset is invalid
      */
@@ -189,7 +189,7 @@ class PropertyPathBuilder
     /**
      * Returns the length of the current path.
      *
-     * @return int     The path length
+     * @return int The path length
      */
     public function getLength()
     {
@@ -235,9 +235,9 @@ class PropertyPathBuilder
      * removed at $offset and another chunk of length $insertionLength
      * can be inserted.
      *
-     * @param  int     $offset          The offset where the removed chunk starts
-     * @param  int     $cutLength       The length of the removed chunk
-     * @param  int     $insertionLength The length of the inserted chunk
+     * @param int $offset          The offset where the removed chunk starts
+     * @param int $cutLength       The length of the removed chunk
+     * @param int $insertionLength The length of the inserted chunk
      */
     private function resize($offset, $cutLength, $insertionLength)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -28,7 +28,7 @@ interface PropertyPathInterface extends \Traversable
     /**
      * Returns the length of the property path, i.e. the number of elements.
      *
-     * @return int     The path length
+     * @return int The path length
      */
     public function getLength();
 
@@ -54,7 +54,7 @@ interface PropertyPathInterface extends \Traversable
     /**
      * Returns the element at the given index in the property path
      *
-     * @param  int     $index The index key
+     * @param int $index The index key
      *
      * @return string A property or index name
      *
@@ -65,9 +65,9 @@ interface PropertyPathInterface extends \Traversable
     /**
      * Returns whether the element at the given index is a property
      *
-     * @param  int     $index The index in the property path
+     * @param int $index The index in the property path
      *
-     * @return bool    Whether the element at this index is a property
+     * @return bool Whether the element at this index is a property
      *
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */
@@ -76,9 +76,9 @@ interface PropertyPathInterface extends \Traversable
     /**
      * Returns whether the element at the given index is an array index
      *
-     * @param  int     $index The index in the property path
+     * @param int $index The index in the property path
      *
-     * @return bool    Whether the element at this index is an array index
+     * @return bool Whether the element at this index is an array index
      *
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */

--- a/src/Symfony/Component/PropertyAccess/StringUtil.php
+++ b/src/Symfony/Component/PropertyAccess/StringUtil.php
@@ -112,19 +112,20 @@ class StringUtil
     );
 
     /**
-     * This class should not be instantiated
+     * This class should not be instantiated.
      */
     private function __construct()
     {
     }
 
     /**
-     * Returns the singular form of a word
+     * Returns the singular form of a word.
      *
      * If the method can't determine the form with certainty, an array of the
      * possible singulars is returned.
      *
      * @param string $plural A word in plural form
+     *
      * @return string|array The singular form or an array of possible singular
      *                      forms
      */

--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -30,14 +30,14 @@ class CompiledRoute implements \Serializable
     /**
      * Constructor.
      *
-     * @param string      $staticPrefix       The static prefix of the compiled route
-     * @param string      $regex              The regular expression to use to match this route
-     * @param array       $tokens             An array of tokens to use to generate URL for this route
-     * @param array       $pathVariables      An array of path variables
-     * @param string|null $hostRegex          Host regex
-     * @param array       $hostTokens         Host tokens
-     * @param array       $hostVariables      An array of host variables
-     * @param array       $variables          An array of variables (variables defined in the path and in the host patterns)
+     * @param string      $staticPrefix  The static prefix of the compiled route
+     * @param string      $regex         The regular expression to use to match this route
+     * @param array       $tokens        An array of tokens to use to generate URL for this route
+     * @param array       $pathVariables An array of path variables
+     * @param string|null $hostRegex     Host regex
+     * @param array       $hostTokens    Host tokens
+     * @param array       $hostVariables An array of host variables
+     * @param array       $variables     An array of variables (variables defined in the path and in the host patterns)
      */
     public function __construct($staticPrefix, $regex, array $tokens, array $pathVariables, $hostRegex = null, array $hostTokens = array(), array $hostVariables = array(), array $variables = array())
     {

--- a/src/Symfony/Component/Routing/Generator/ConfigurableRequirementsInterface.php
+++ b/src/Symfony/Component/Routing/Generator/ConfigurableRequirementsInterface.php
@@ -41,7 +41,7 @@ interface ConfigurableRequirementsInterface
      * Enables or disables the exception on incorrect parameters.
      * Passing null will deactivate the requirements check completely.
      *
-     * @param bool|null    $enabled
+     * @param bool|null $enabled
      */
     public function setStrictRequirements($enabled);
 

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -70,9 +70,9 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      *
      * If there is no route with the given name, the generator must throw the RouteNotFoundException.
      *
-     * @param string         $name          The name of the route
-     * @param mixed          $parameters    An array of parameters
-     * @param bool|string    $referenceType The type of reference to be generated (one of the constants)
+     * @param string      $name          The name of the route
+     * @param mixed       $parameters    An array of parameters
+     * @param bool|string $referenceType The type of reference to be generated (one of the constants)
      *
      * @return string The generated URL
      *

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -105,10 +105,10 @@ class ApacheMatcherDumper extends MatcherDumper
     /**
      * Dumps a single route
      *
-     * @param  string $name Route name
-     * @param  Route  $route The route
-     * @param  array  $options Options
-     * @param  bool   $hostRegexUnique Unique identifier for the host regex
+     * @param string $name            Route name
+     * @param Route  $route           The route
+     * @param array  $options         Options
+     * @param bool   $hostRegexUnique Unique identifier for the host regex
      *
      * @return string The compiled route
      */
@@ -184,7 +184,7 @@ class ApacheMatcherDumper extends MatcherDumper
     /**
      * Returns methods allowed for a route
      *
-     * @param Route  $route The route
+     * @param Route $route The route
      *
      * @return array The methods
      */
@@ -205,7 +205,7 @@ class ApacheMatcherDumper extends MatcherDumper
     /**
      * Converts a regex to make it suitable for mod_rewrite
      *
-     * @param string  $regex The regex
+     * @param string $regex The regex
      *
      * @return string The converted regex
      */

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
@@ -116,7 +116,7 @@ class DumperCollection implements \IteratorAggregate
      *
      * @param string $name The attribute name
      *
-     * @return bool    true if the attribute is defined, false otherwise
+     * @return bool true if the attribute is defined, false otherwise
      */
     public function hasAttribute($name)
     {

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -78,7 +78,7 @@ EOF;
     /**
      * Generates the code for the match method implementing UrlMatcherInterface.
      *
-     * @param bool    $supportsRedirections Whether redirections are supported by the base class
+     * @param bool $supportsRedirections Whether redirections are supported by the base class
      *
      * @return string Match method as PHP code
      */

--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -40,14 +40,14 @@ class RequestContext
     /**
      * Constructor.
      *
-     * @param string  $baseUrl      The base URL
-     * @param string  $method       The HTTP method
-     * @param string  $host         The HTTP host name
-     * @param string  $scheme       The HTTP scheme
-     * @param int     $httpPort     The HTTP port
-     * @param int     $httpsPort    The HTTPS port
-     * @param string  $path         The path
-     * @param string  $queryString  The query string
+     * @param string $baseUrl     The base URL
+     * @param string $method      The HTTP method
+     * @param string $host        The HTTP host name
+     * @param string $scheme      The HTTP scheme
+     * @param int    $httpPort    The HTTP port
+     * @param int    $httpsPort   The HTTPS port
+     * @param string $path        The path
+     * @param string $queryString The query string
      *
      * @api
      */

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -372,7 +372,7 @@ class Route implements \Serializable
      *
      * @param string $name An option name
      *
-     * @return bool    true if the option is set, false otherwise
+     * @return bool true if the option is set, false otherwise
      */
     public function hasOption($name)
     {
@@ -441,7 +441,7 @@ class Route implements \Serializable
      *
      * @param string $name A variable name
      *
-     * @return bool    true if the default value is set, false otherwise
+     * @return bool true if the default value is set, false otherwise
      */
     public function hasDefault($name)
     {
@@ -528,7 +528,7 @@ class Route implements \Serializable
      *
      * @param string $key A variable name
      *
-     * @return bool    true if a requirement is specified, false otherwise
+     * @return bool true if a requirement is specified, false otherwise
      */
     public function hasRequirement($key)
     {

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -121,7 +121,7 @@ class RouteCollection implements \IteratorAggregate, \Countable
      * Adds a route collection at the end of the current set by appending all
      * routes of the added collection.
      *
-     * @param RouteCollection $collection      A RouteCollection instance
+     * @param RouteCollection $collection A RouteCollection instance
      *
      * @api
      */

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -191,9 +191,9 @@ class RouteCompiler implements RouteCompilerInterface
     /**
      * Computes the regexp used to match a specific token. It can be static text or a subpattern.
      *
-     * @param array   $tokens        The route tokens
-     * @param int     $index         The index of the current token
-     * @param int     $firstOptional The index of the first optional token
+     * @param array $tokens        The route tokens
+     * @param int   $index         The index of the current token
+     * @param int   $firstOptional The index of the first optional token
      *
      * @return string The regexp pattern for a single token
      */

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -223,6 +223,7 @@ class AclProvider implements AclProviderInterface
      * ACEs, and security identities.
      *
      * @param array $ancestorIds
+     *
      * @return string
      */
     protected function getLookupSql(array $ancestorIds)
@@ -328,6 +329,7 @@ SELECTCLAUSE;
      *
      * @param ObjectIdentityInterface $oid
      * @param bool                    $directChildrenOnly
+     *
      * @return string
      */
     protected function getFindChildrenSql(ObjectIdentityInterface $oid, $directChildrenOnly)
@@ -359,6 +361,7 @@ FINDCHILDREN;
      * identity.
      *
      * @param ObjectIdentityInterface $oid
+     *
      * @return string
      */
     protected function getSelectObjectIdentityIdSql(ObjectIdentityInterface $oid)
@@ -383,6 +386,7 @@ QUERY;
      * Returns the primary key of the passed object identity.
      *
      * @param ObjectIdentityInterface $oid
+     *
      * @return int
      */
     final protected function retrieveObjectIdentityPrimaryKey(ObjectIdentityInterface $oid)
@@ -491,8 +495,10 @@ QUERY;
      * @param Statement $stmt
      * @param array     $oidLookup
      * @param array     $sids
-     * @throws \RuntimeException
+     *
      * @return \SplObjectStorage
+     *
+     * @throws \RuntimeException
      */
     private function hydrateObjectIdentities(Statement $stmt, array $oidLookup, array $sids)
     {

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -354,7 +354,8 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for deleting access control entries.
      *
-     * @param int     $oidPK
+     * @param int $oidPK
+     *
      * @return string
      */
     protected function getDeleteAccessControlEntriesSql($oidPK)
@@ -369,7 +370,8 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for deleting a specific ACE.
      *
-     * @param int     $acePK
+     * @param int $acePK
+     *
      * @return string
      */
     protected function getDeleteAccessControlEntrySql($acePK)
@@ -384,7 +386,8 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for deleting an object identity.
      *
-     * @param int     $pk
+     * @param int $pk
+     *
      * @return string
      */
     protected function getDeleteObjectIdentitySql($pk)
@@ -399,7 +402,8 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for deleting relation entries.
      *
-     * @param int     $pk
+     * @param int $pk
+     *
      * @return string
      */
     protected function getDeleteObjectIdentityRelationsSql($pk)
@@ -414,16 +418,17 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Constructs the SQL for inserting an ACE.
      *
-     * @param int          $classId
-     * @param int|null     $objectIdentityId
-     * @param string|null  $field
-     * @param int          $aceOrder
-     * @param int          $securityIdentityId
-     * @param string       $strategy
-     * @param int          $mask
-     * @param bool         $granting
-     * @param bool         $auditSuccess
-     * @param bool         $auditFailure
+     * @param int         $classId
+     * @param int|null    $objectIdentityId
+     * @param string|null $field
+     * @param int         $aceOrder
+     * @param int         $securityIdentityId
+     * @param string      $strategy
+     * @param int         $mask
+     * @param bool        $granting
+     * @param bool        $auditSuccess
+     * @param bool        $auditFailure
+     *
      * @return string
      */
     protected function getInsertAccessControlEntrySql($classId, $objectIdentityId, $field, $aceOrder, $securityIdentityId, $strategy, $mask, $granting, $auditSuccess, $auditFailure)
@@ -464,6 +469,7 @@ QUERY;
      * Constructs the SQL for inserting a new class type.
      *
      * @param string $classType
+     *
      * @return string
      */
     protected function getInsertClassSql($classType)
@@ -478,8 +484,9 @@ QUERY;
     /**
      * Constructs the SQL for inserting a relation entry.
      *
-     * @param int     $objectIdentityId
-     * @param int     $ancestorId
+     * @param int $objectIdentityId
+     * @param int $ancestorId
+     *
      * @return string
      */
     protected function getInsertObjectIdentityRelationSql($objectIdentityId, $ancestorId)
@@ -495,9 +502,10 @@ QUERY;
     /**
      * Constructs the SQL for inserting an object identity.
      *
-     * @param string  $identifier
-     * @param int     $classId
-     * @param bool    $entriesInheriting
+     * @param string $identifier
+     * @param int    $classId
+     * @param bool   $entriesInheriting
+     *
      * @return string
      */
     protected function getInsertObjectIdentitySql($identifier, $classId, $entriesInheriting)
@@ -520,7 +528,9 @@ QUERY;
      * Constructs the SQL for inserting a security identity.
      *
      * @param SecurityIdentityInterface $sid
+     *
      * @throws \InvalidArgumentException
+     *
      * @return string
      */
     protected function getInsertSecurityIdentitySql(SecurityIdentityInterface $sid)
@@ -546,10 +556,11 @@ QUERY;
     /**
      * Constructs the SQL for selecting an ACE.
      *
-     * @param int     $classId
-     * @param int     $oid
-     * @param string  $field
-     * @param int     $order
+     * @param int    $classId
+     * @param int    $oid
+     * @param string $field
+     * @param int    $order
+     *
      * @return string
      */
     protected function getSelectAccessControlEntryIdSql($classId, $oid, $field, $order)
@@ -573,6 +584,7 @@ QUERY;
      * the passed class type.
      *
      * @param string $classType
+     *
      * @return string
      */
     protected function getSelectClassIdSql($classType)
@@ -588,7 +600,9 @@ QUERY;
      * Constructs the SQL for selecting the primary key of a security identity.
      *
      * @param SecurityIdentityInterface $sid
+     *
      * @throws \InvalidArgumentException
+     *
      * @return string
      */
     protected function getSelectSecurityIdentityIdSql(SecurityIdentityInterface $sid)
@@ -614,9 +628,11 @@ QUERY;
     /**
      * Constructs the SQL for updating an object identity.
      *
-     * @param int     $pk
-     * @param array   $changes
+     * @param int   $pk
+     * @param array $changes
+     *
      * @throws \InvalidArgumentException
+     *
      * @return string
      */
     protected function getUpdateObjectIdentitySql($pk, array $changes)
@@ -636,9 +652,11 @@ QUERY;
     /**
      * Constructs the SQL for updating an ACE.
      *
-     * @param int     $pk
-     * @param array   $sets
+     * @param int   $pk
+     * @param array $sets
+     *
      * @throws \InvalidArgumentException
+     *
      * @return string
      */
     protected function getUpdateAccessControlEntrySql($pk, array $sets)
@@ -673,6 +691,7 @@ QUERY;
      * If the type does not yet exist in the database, it will be created.
      *
      * @param string $classType
+     *
      * @return int
      */
     private function createOrRetrieveClassId($classType)
@@ -693,6 +712,7 @@ QUERY;
      * created.
      *
      * @param SecurityIdentityInterface $sid
+     *
      * @return int
      */
     private function createOrRetrieveSecurityIdentityId(SecurityIdentityInterface $sid)
@@ -709,7 +729,7 @@ QUERY;
     /**
      * Deletes all ACEs for the given object identity primary key.
      *
-     * @param int     $oidPK
+     * @param int $oidPK
      */
     private function deleteAccessControlEntries($oidPK)
     {
@@ -719,7 +739,7 @@ QUERY;
     /**
      * Deletes the object identity from the database.
      *
-     * @param int     $pk
+     * @param int $pk
      */
     private function deleteObjectIdentity($pk)
     {
@@ -729,7 +749,7 @@ QUERY;
     /**
      * Deletes all entries from the relations table from the database.
      *
-     * @param int     $pk
+     * @param int $pk
      */
     private function deleteObjectIdentityRelations($pk)
     {

--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -397,8 +397,9 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Deletes an ACE
      *
-     * @param string  $property
-     * @param int     $index
+     * @param string $property
+     * @param int    $index
+     *
      * @throws \OutOfBoundsException
      */
     private function deleteAce($property, $index)
@@ -421,9 +422,10 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Deletes a field-based ACE
      *
-     * @param string  $property
-     * @param int     $index
-     * @param string  $field
+     * @param string $property
+     * @param int    $index
+     * @param string $field
+     *
      * @throws \OutOfBoundsException
      */
     private function deleteFieldAce($property, $index, $field)
@@ -452,6 +454,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * @param SecurityIdentityInterface $sid
      * @param bool                      $granting
      * @param string                    $strategy
+     *
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
      */
@@ -501,6 +504,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * @param SecurityIdentityInterface $sid
      * @param bool                      $granting
      * @param string                    $strategy
+     *
      * @throws \InvalidArgumentException
      * @throws \OutOfBoundsException
      */
@@ -551,10 +555,11 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Updates an ACE
      *
-     * @param string  $property
-     * @param int     $index
-     * @param int     $mask
-     * @param string  $strategy
+     * @param string $property
+     * @param int    $index
+     * @param int    $mask
+     * @param string $strategy
+     *
      * @throws \OutOfBoundsException
      */
     private function updateAce($property, $index, $mask, $strategy = null)
@@ -578,10 +583,11 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Updates auditing for an ACE
      *
-     * @param array   &$aces
-     * @param int     $index
-     * @param bool    $auditSuccess
-     * @param bool    $auditFailure
+     * @param array &$aces
+     * @param int   $index
+     * @param bool  $auditSuccess
+     * @param bool  $auditFailure
+     *
      * @throws \OutOfBoundsException
      */
     private function updateAuditing(array &$aces, $index, $auditSuccess, $auditFailure)
@@ -604,11 +610,12 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * Updates a field-based ACE
      *
-     * @param string  $property
-     * @param int     $index
-     * @param string  $field
-     * @param int     $mask
-     * @param string  $strategy
+     * @param string $property
+     * @param int    $index
+     * @param string $field
+     * @param int    $mask
+     * @param string $strategy
+     *
      * @throws \InvalidArgumentException
      * @throws \OutOfBoundsException
      */

--- a/src/Symfony/Component/Security/Acl/Domain/DoctrineAclCache.php
+++ b/src/Symfony/Component/Security/Acl/Domain/DoctrineAclCache.php
@@ -147,6 +147,7 @@ class DoctrineAclCache implements AclCacheInterface
      * Unserializes the ACL.
      *
      * @param string $serialized
+     *
      * @return AclInterface
      */
     private function unserializeAcl($serialized)
@@ -205,6 +206,7 @@ class DoctrineAclCache implements AclCacheInterface
      * Returns the key for the object identity
      *
      * @param ObjectIdentityInterface $oid
+     *
      * @return string
      */
     private function getDataKeyByIdentity(ObjectIdentityInterface $oid)
@@ -217,6 +219,7 @@ class DoctrineAclCache implements AclCacheInterface
      * Returns the alias key for the object identity key
      *
      * @param string $aclId
+     *
      * @return string
      */
     private function getAliasKeyForIdentity($aclId)

--- a/src/Symfony/Component/Security/Acl/Domain/Entry.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Entry.php
@@ -125,7 +125,7 @@ class Entry implements AuditableEntryInterface
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      */
     public function setAuditFailure($boolean)
     {
@@ -138,7 +138,7 @@ class Entry implements AuditableEntryInterface
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      */
     public function setAuditSuccess($boolean)
     {
@@ -151,7 +151,7 @@ class Entry implements AuditableEntryInterface
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
      *
-     * @param int     $mask
+     * @param int $mask
      */
     public function setMask($mask)
     {

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -51,7 +51,9 @@ final class ObjectIdentity implements ObjectIdentityInterface
      * Constructs an ObjectIdentity for the given domain object
      *
      * @param object $domainObject
+     *
      * @throws InvalidDomainObjectException
+     *
      * @return ObjectIdentity
      */
     public static function fromDomainObject($domainObject)

--- a/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
@@ -130,7 +130,7 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      * @param SecurityIdentityInterface[] $sids               An array of SecurityIdentityInterface implementations
      * @param bool                        $administrativeMode True turns off audit logging
      *
-     * @return bool    true, or false; either granting, or denying access respectively.
+     * @return bool true, or false; either granting, or denying access respectively.
      *
      * @throws NoAceFoundException
      */

--- a/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
@@ -51,6 +51,7 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
      * Creates a user security identity from a UserInterface
      *
      * @param UserInterface $user
+     *
      * @return UserSecurityIdentity
      */
     public static function fromAccount(UserInterface $user)
@@ -62,6 +63,7 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
      * Creates a user security identity from a TokenInterface
      *
      * @param TokenInterface $token
+     *
      * @return UserSecurityIdentity
      */
     public static function fromToken(TokenInterface $token)

--- a/src/Symfony/Component/Security/Acl/Model/AclCacheInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclCacheInterface.php
@@ -37,7 +37,8 @@ interface AclCacheInterface
     /**
      * Retrieves an ACL for the given object identity primary key from the cache
      *
-     * @param int     $primaryKey
+     * @param int $primaryKey
+     *
      * @return AclInterface
      */
     public function getFromCacheById($primaryKey);
@@ -46,6 +47,7 @@ interface AclCacheInterface
      * Retrieves an ACL for the given object identity from the cache
      *
      * @param ObjectIdentityInterface $oid
+     *
      * @return AclInterface
      */
     public function getFromCacheByIdentity(ObjectIdentityInterface $oid);

--- a/src/Symfony/Component/Security/Acl/Model/AclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclInterface.php
@@ -36,6 +36,7 @@ interface AclInterface extends \Serializable
      * Returns all class-field-based ACEs associated with this ACL
      *
      * @param string $field
+     *
      * @return array
      */
     public function getClassFieldAces($field);
@@ -51,6 +52,7 @@ interface AclInterface extends \Serializable
      * Returns all object-field-based ACEs associated with this ACL
      *
      * @param string $field
+     *
      * @return array
      */
     public function getObjectFieldAces($field);
@@ -79,10 +81,11 @@ interface AclInterface extends \Serializable
     /**
      * Determines whether field access is granted
      *
-     * @param string  $field
-     * @param array   $masks
-     * @param array   $securityIdentities
-     * @param bool    $administrativeMode
+     * @param string $field
+     * @param array  $masks
+     * @param array  $securityIdentities
+     * @param bool   $administrativeMode
+     *
      * @return bool
      */
     public function isFieldGranted($field, array $masks, array $securityIdentities, $administrativeMode = false);
@@ -90,10 +93,12 @@ interface AclInterface extends \Serializable
     /**
      * Determines whether access is granted
      *
+     * @param array $masks
+     * @param array $securityIdentities
+     * @param bool  $administrativeMode
+     *
      * @throws NoAceFoundException when no ACE was applicable for this request
-     * @param array   $masks
-     * @param array   $securityIdentities
-     * @param bool    $administrativeMode
+     *
      * @return bool
      */
     public function isGranted(array $masks, array $securityIdentities, $administrativeMode = false);
@@ -102,6 +107,7 @@ interface AclInterface extends \Serializable
      * Whether the ACL has loaded ACEs for all of the passed security identities
      *
      * @param mixed $securityIdentities an implementation of SecurityIdentityInterface, or an array thereof
+     *
      * @return bool
      */
     public function isSidLoaded($securityIdentities);

--- a/src/Symfony/Component/Security/Acl/Model/AuditableAclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AuditableAclInterface.php
@@ -21,38 +21,38 @@ interface AuditableAclInterface extends MutableAclInterface
     /**
      * Updates auditing for class-based ACE
      *
-     * @param int     $index
-     * @param bool    $auditSuccess
-     * @param bool    $auditFailure
+     * @param int  $index
+     * @param bool $auditSuccess
+     * @param bool $auditFailure
      */
     public function updateClassAuditing($index, $auditSuccess, $auditFailure);
 
     /**
      * Updates auditing for class-field-based ACE
      *
-     * @param int     $index
-     * @param string  $field
-     * @param bool    $auditSuccess
-     * @param bool    $auditFailure
+     * @param int    $index
+     * @param string $field
+     * @param bool   $auditSuccess
+     * @param bool   $auditFailure
      */
     public function updateClassFieldAuditing($index, $field, $auditSuccess, $auditFailure);
 
     /**
      * Updates auditing for object-based ACE
      *
-     * @param int     $index
-     * @param bool    $auditSuccess
-     * @param bool    $auditFailure
+     * @param int  $index
+     * @param bool $auditSuccess
+     * @param bool $auditFailure
      */
     public function updateObjectAuditing($index, $auditSuccess, $auditFailure);
 
     /**
      * Updates auditing for object-field-based ACE
      *
-     * @param int     $index
-     * @param string  $field
-     * @param bool    $auditSuccess
-     * @param bool    $auditFailure
+     * @param int    $index
+     * @param string $field
+     * @param bool   $auditSuccess
+     * @param bool   $auditFailure
      */
     public function updateObjectFieldAuditing($index, $field, $auditSuccess, $auditFailure);
 }

--- a/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
@@ -24,30 +24,30 @@ interface MutableAclInterface extends AclInterface
     /**
      * Deletes a class-based ACE
      *
-     * @param int     $index
+     * @param int $index
      */
     public function deleteClassAce($index);
 
     /**
      * Deletes a class-field-based ACE
      *
-     * @param int     $index
-     * @param string  $field
+     * @param int    $index
+     * @param string $field
      */
     public function deleteClassFieldAce($index, $field);
 
     /**
      * Deletes an object-based ACE
      *
-     * @param int     $index
+     * @param int $index
      */
     public function deleteObjectAce($index);
 
     /**
      * Deletes an object-field-based ACE
      *
-     * @param int     $index
-     * @param string  $field
+     * @param int    $index
+     * @param string $field
      */
     public function deleteObjectFieldAce($index, $field);
 
@@ -107,7 +107,7 @@ interface MutableAclInterface extends AclInterface
     /**
      * Sets whether entries are inherited
      *
-     * @param bool    $boolean
+     * @param bool $boolean
      */
     public function setEntriesInheriting($boolean);
 
@@ -121,38 +121,38 @@ interface MutableAclInterface extends AclInterface
     /**
      * Updates a class-based ACE
      *
-     * @param int     $index
-     * @param int     $mask
-     * @param string  $strategy if null the strategy should not be changed
+     * @param int    $index
+     * @param int    $mask
+     * @param string $strategy if null the strategy should not be changed
      */
     public function updateClassAce($index, $mask, $strategy = null);
 
     /**
      * Updates a class-field-based ACE
      *
-     * @param int     $index
-     * @param string  $field
-     * @param int     $mask
-     * @param string  $strategy if null the strategy should not be changed
+     * @param int    $index
+     * @param string $field
+     * @param int    $mask
+     * @param string $strategy if null the strategy should not be changed
      */
     public function updateClassFieldAce($index, $field, $mask, $strategy = null);
 
     /**
      * Updates an object-based ACE
      *
-     * @param int     $index
-     * @param int     $mask
-     * @param string  $strategy if null the strategy should not be changed
+     * @param int    $index
+     * @param int    $mask
+     * @param string $strategy if null the strategy should not be changed
      */
     public function updateObjectAce($index, $mask, $strategy = null);
 
     /**
      * Updates an object-field-based ACE
      *
-     * @param int     $index
-     * @param string  $field
-     * @param int     $mask
-     * @param string  $strategy if null the strategy should not be changed
+     * @param int    $index
+     * @param string $field
+     * @param int    $mask
+     * @param string $strategy if null the strategy should not be changed
      */
     public function updateObjectFieldAce($index, $field, $mask, $strategy = null);
 }

--- a/src/Symfony/Component/Security/Acl/Model/MutableAclProviderInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/MutableAclProviderInterface.php
@@ -21,9 +21,11 @@ interface MutableAclProviderInterface extends AclProviderInterface
     /**
      * Creates a new ACL for the given object identity.
      *
-     * @throws AclAlreadyExistsException when there already is an ACL for the given
-     *                                   object identity
      * @param ObjectIdentityInterface $oid
+     *
+     * @throws AclAlreadyExistsException when there already is an ACL for the given
+     *                                       object identity
+     *
      * @return MutableAclInterface
      */
     public function createAcl(ObjectIdentityInterface $oid);

--- a/src/Symfony/Component/Security/Acl/Model/ObjectIdentityInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/ObjectIdentityInterface.php
@@ -28,6 +28,7 @@ interface ObjectIdentityInterface
      * Example for Object Equality: $object1->getId() === $object2->getId()
      *
      * @param ObjectIdentityInterface $identity
+     *
      * @return bool
      */
     public function equals(ObjectIdentityInterface $identity);

--- a/src/Symfony/Component/Security/Acl/Model/ObjectIdentityRetrievalStrategyInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/ObjectIdentityRetrievalStrategyInterface.php
@@ -22,6 +22,7 @@ interface ObjectIdentityRetrievalStrategyInterface
      * Retrieves the object identity from a domain object
      *
      * @param object $domainObject
+     *
      * @return ObjectIdentityInterface
      */
     public function getObjectIdentity($domainObject);

--- a/src/Symfony/Component/Security/Acl/Model/PermissionGrantingStrategyInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/PermissionGrantingStrategyInterface.php
@@ -25,6 +25,7 @@ interface PermissionGrantingStrategyInterface
      * @param array        $masks
      * @param array        $sids
      * @param bool         $administrativeMode
+     *
      * @return bool
      */
     public function isGranted(AclInterface $acl, array $masks, array $sids, $administrativeMode = false);

--- a/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
+++ b/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
@@ -72,7 +72,7 @@ class MaskBuilder
     /**
      * Constructor
      *
-     * @param int     $mask optional; defaults to 0
+     * @param int $mask optional; defaults to 0
      *
      * @throws \InvalidArgumentException
      */
@@ -178,9 +178,11 @@ class MaskBuilder
     /**
      * Returns the code for the passed mask
      *
-     * @param int     $mask
+     * @param int $mask
+     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
+     *
      * @return string
      */
     public static function getCode($mask)

--- a/src/Symfony/Component/Security/Acl/Permission/PermissionMapInterface.php
+++ b/src/Symfony/Component/Security/Acl/Permission/PermissionMapInterface.php
@@ -26,6 +26,7 @@ interface PermissionMapInterface
      *
      * @param string $permission
      * @param object $object
+     *
      * @return array may return null if permission/object combination is not supported
      */
     public function getMasks($permission, $object);
@@ -34,6 +35,7 @@ interface PermissionMapInterface
      * Whether this map contains the given permission
      *
      * @param string $permission
+     *
      * @return bool
      */
     public function contains($permission);

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
@@ -29,7 +29,7 @@ interface AuthenticationProviderInterface extends AuthenticationManagerInterface
      *
      * @param TokenInterface $token A TokenInterface instance
      *
-     * @return bool    true if the implementation supports the Token, false otherwise
+     * @return bool true if the implementation supports the Token, false otherwise
      */
      public function supports(TokenInterface $token);
 }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
@@ -44,6 +44,7 @@ interface TokenProviderInterface
      * @param string    $series
      * @param string    $tokenValue
      * @param \DateTime $lastUsed
+     *
      * @throws TokenNotFoundException if the token is not found
      */
     public function updateToken($series, $tokenValue, \DateTime $lastUsed);

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -89,6 +89,7 @@ abstract class AbstractToken implements TokenInterface
      * a __toString method or the username as a regular string.
      *
      * @param string|object $user The user
+     *
      * @throws \InvalidArgumentException
      */
     public function setUser($user)
@@ -192,7 +193,7 @@ abstract class AbstractToken implements TokenInterface
      *
      * @param string $name The attribute name
      *
-     * @return bool    true if the attribute exists, false otherwise
+     * @return bool true if the attribute exists, false otherwise
      */
     public function hasAttribute($name)
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -48,7 +48,7 @@ interface TokenInterface extends \Serializable
      * Returns a user representation.
      *
      * @return mixed either returns an object which implements __toString(), or
-     *                  a primitive string is returned.
+     *               a primitive string is returned.
      */
     public function getUser();
 
@@ -69,14 +69,14 @@ interface TokenInterface extends \Serializable
     /**
      * Returns whether the user is authenticated or not.
      *
-     * @return bool    true if the token has been authenticated, false otherwise
+     * @return bool true if the token has been authenticated, false otherwise
      */
     public function isAuthenticated();
 
     /**
      * Sets the authenticated flag.
      *
-     * @param bool    $isAuthenticated The authenticated flag
+     * @param bool $isAuthenticated The authenticated flag
      */
     public function setAuthenticated($isAuthenticated);
 
@@ -104,7 +104,7 @@ interface TokenInterface extends \Serializable
      *
      * @param string $name The attribute name
      *
-     * @return bool    true if the attribute exists, false otherwise
+     * @return bool true if the attribute exists, false otherwise
      */
     public function hasAttribute($name);
 

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -27,7 +27,7 @@ interface AccessDecisionManagerInterface
      * @param array          $attributes An array of attributes associated with the method being invoked
      * @param object         $object     The object to secure
      *
-     * @return bool    true if the access is granted, false otherwise
+     * @return bool true if the access is granted, false otherwise
      */
     public function decide(TokenInterface $token, array $attributes, $object = null);
 
@@ -36,7 +36,7 @@ interface AccessDecisionManagerInterface
      *
      * @param string $attribute An attribute
      *
-     * @return bool    true if this decision manager supports the attribute, false otherwise
+     * @return bool true if this decision manager supports the attribute, false otherwise
      */
     public function supportsAttribute($attribute);
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -29,7 +29,7 @@ interface VoterInterface
      *
      * @param string $attribute An attribute
      *
-     * @return bool    true if this Voter supports the attribute, false otherwise
+     * @return bool true if this Voter supports the attribute, false otherwise
      */
     public function supportsAttribute($attribute);
 
@@ -38,7 +38,7 @@ interface VoterInterface
      *
      * @param string $class A class name
      *
-     * @return bool    true if this Voter can process the class
+     * @return bool true if this Voter can process the class
      */
     public function supportsClass($class);
 
@@ -52,7 +52,7 @@ interface VoterInterface
      * @param object|null    $object     The object to secure
      * @param array          $attributes An array of attributes associated with the method being invoked
      *
-     * @return int     either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+     * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
      */
     public function vote(TokenInterface $token, $object, array $attributes);
 }

--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -27,9 +27,9 @@ class BCryptPasswordEncoder extends BasePasswordEncoder
     /**
      * Constructor.
      *
-     * @param int     $cost The algorithmic cost that should be used
+     * @param int $cost The algorithmic cost that should be used
      *
-     * @throws \RuntimeException When no BCrypt encoder is available
+     * @throws \RuntimeException         When no BCrypt encoder is available
      * @throws \InvalidArgumentException if cost is out of range
      */
     public function __construct($cost)

--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -79,7 +79,7 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      * @param string $password1 The first password
      * @param string $password2 The second password
      *
-     * @return bool    true if the two passwords are the same, false otherwise
+     * @return bool true if the two passwords are the same, false otherwise
      */
     protected function comparePasswords($password1, $password2)
     {
@@ -91,7 +91,7 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      *
      * @param string $password The password to check
      *
-     * @return bool    true if the password is too long, false otherwise
+     * @return bool true if the password is too long, false otherwise
      */
     protected function isPasswordTooLong($password)
     {

--- a/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
@@ -27,9 +27,9 @@ class MessageDigestPasswordEncoder extends BasePasswordEncoder
     /**
      * Constructor.
      *
-     * @param string  $algorithm          The digest algorithm to use
-     * @param bool    $encodeHashAsBase64 Whether to base64 encode the password hash
-     * @param int     $iterations         The number of iterations to use to stretch the password hash
+     * @param string $algorithm          The digest algorithm to use
+     * @param bool   $encodeHashAsBase64 Whether to base64 encode the password hash
+     * @param int    $iterations         The number of iterations to use to stretch the password hash
      */
     public function __construct($algorithm = 'sha512', $encodeHashAsBase64 = true, $iterations = 5000)
     {

--- a/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
@@ -35,7 +35,7 @@ interface PasswordEncoderInterface
      * @param string $raw     A raw password
      * @param string $salt    The salt
      *
-     * @return bool    true if the password is valid, false otherwise
+     * @return bool true if the password is valid, false otherwise
      */
     public function isPasswordValid($encoded, $raw, $salt);
 }

--- a/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
@@ -36,10 +36,10 @@ class Pbkdf2PasswordEncoder extends BasePasswordEncoder
     /**
      * Constructor.
      *
-     * @param string  $algorithm          The digest algorithm to use
-     * @param bool    $encodeHashAsBase64 Whether to base64 encode the password hash
-     * @param int     $iterations         The number of iterations to use to stretch the password hash
-     * @param int     $length             Length of derived key to create
+     * @param string $algorithm          The digest algorithm to use
+     * @param bool   $encodeHashAsBase64 Whether to base64 encode the password hash
+     * @param int    $iterations         The number of iterations to use to stretch the password hash
+     * @param int    $length             Length of derived key to create
      */
     public function __construct($algorithm = 'sha512', $encodeHashAsBase64 = true, $iterations = 1000, $length = 40)
     {

--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -25,7 +25,7 @@ class PlaintextPasswordEncoder extends BasePasswordEncoder
     /**
      * Constructor.
      *
-     * @param bool    $ignorePasswordCase Compare password case-insensitive
+     * @param bool $ignorePasswordCase Compare password case-insensitive
      */
     public function __construct($ignorePasswordCase = false)
     {

--- a/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
@@ -43,7 +43,7 @@ interface AdvancedUserInterface extends UserInterface
      * Internally, if this method returns false, the authentication system
      * will throw an AccountExpiredException and prevent login.
      *
-     * @return bool    true if the user's account is non expired, false otherwise
+     * @return bool true if the user's account is non expired, false otherwise
      *
      * @see AccountExpiredException
      */
@@ -55,7 +55,7 @@ interface AdvancedUserInterface extends UserInterface
      * Internally, if this method returns false, the authentication system
      * will throw a LockedException and prevent login.
      *
-     * @return bool    true if the user is not locked, false otherwise
+     * @return bool true if the user is not locked, false otherwise
      *
      * @see LockedException
      */
@@ -67,7 +67,7 @@ interface AdvancedUserInterface extends UserInterface
      * Internally, if this method returns false, the authentication system
      * will throw a CredentialsExpiredException and prevent login.
      *
-     * @return bool    true if the user's credentials are non expired, false otherwise
+     * @return bool true if the user's credentials are non expired, false otherwise
      *
      * @see CredentialsExpiredException
      */
@@ -79,7 +79,7 @@ interface AdvancedUserInterface extends UserInterface
      * Internally, if this method returns false, the authentication system
      * will throw a DisabledException and prevent login.
      *
-     * @return bool    true if the user is enabled, false otherwise
+     * @return bool true if the user is enabled, false otherwise
      *
      * @see DisabledException
      */

--- a/src/Symfony/Component/Security/Core/Util/SecureRandomInterface.php
+++ b/src/Symfony/Component/Security/Core/Util/SecureRandomInterface.php
@@ -21,7 +21,7 @@ interface SecureRandomInterface
     /**
      * Generates the specified number of secure random bytes.
      *
-     * @param int     $nbBytes
+     * @param int $nbBytes
      *
      * @return string
      */

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -34,7 +34,7 @@ class StringUtils
      * @param string $knownString The string of known length to compare against
      * @param string $userInput   The string that the user can control
      *
-     * @return bool    true if the two strings are the same, false otherwise
+     * @return bool true if the two strings are the same, false otherwise
      */
     public static function equals($knownString, $userInput)
     {

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -76,7 +76,7 @@ class LogoutListener implements ListenerInterface
      *
      * @param GetResponseEvent $event A GetResponseEvent instance
      *
-     * @throws LogoutException if the CSRF token is invalid
+     * @throws LogoutException   if the CSRF token is invalid
      * @throws \RuntimeException if the LogoutSuccessHandlerInterface instance does not return a response
      */
     public function handle(GetResponseEvent $event)

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -96,7 +96,7 @@ class HttpUtils
      * @param Request $request A Request instance
      * @param string  $path    A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
      *
-     * @return bool    true if the path is the same as the one from the Request, false otherwise
+     * @return bool true if the path is the same as the one from the Request, false otherwise
      */
     public function checkRequestPath(Request $request, $path)
     {

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -73,7 +73,7 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      * @param string $hash1 The first hash
      * @param string $hash2 The second hash
      *
-     * @return bool    true if the two hashes are the same, false otherwise
+     * @return bool true if the two hashes are the same, false otherwise
      */
     private function compareHashes($hash1, $hash2)
     {
@@ -114,10 +114,10 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
     /**
      * Generates the cookie value.
      *
-     * @param string  $class
-     * @param string  $username The username
-     * @param int     $expires  The Unix timestamp when the cookie expires
-     * @param string  $password The encoded password
+     * @param string $class
+     * @param string $username The username
+     * @param int    $expires  The Unix timestamp when the cookie expires
+     * @param string $password The encoded password
      *
      * @throws \RuntimeException if username contains invalid chars
      *
@@ -136,10 +136,10 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
     /**
      * Generates a hash for the cookie to ensure it is not being tempered with
      *
-     * @param string  $class
-     * @param string  $username The username
-     * @param int     $expires  The Unix timestamp when the cookie expires
-     * @param string  $password The encoded password
+     * @param string $class
+     * @param string $username The username
+     * @param int    $expires  The Unix timestamp when the cookie expires
+     * @param string $password The encoded password
      *
      * @throws \RuntimeException when the private key is empty
      *

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/MutableAclProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/MutableAclProviderTest.php
@@ -422,6 +422,7 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
      *
      * @param AclProvider $provider
      * @param array       $data
+     *
      * @throws \InvalidArgumentException
      * @throws \Exception
      */

--- a/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
@@ -21,9 +21,9 @@ interface DecoderInterface
     /**
      * Decodes a string into PHP data.
      *
-     * @param scalar $data      Data to decode
-     * @param string $format    Format name
-     * @param array  $context   options that decoders have access to.
+     * @param scalar $data    Data to decode
+     * @param string $format  Format name
+     * @param array  $context options that decoders have access to.
      *
      * The format parameter specifies which format the data is in; valid values
      * depend on the specific implementation. Authors implementing this interface

--- a/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
@@ -21,8 +21,8 @@ interface EncoderInterface
     /**
      * Encodes data into the given format
      *
-     * @param mixed  $data   Data to encode
-     * @param string $format Format name
+     * @param mixed  $data    Data to encode
+     * @param string $format  Format name
      * @param array  $context options that normalizers/encoders have access to.
      *
      * @return scalar

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -38,8 +38,8 @@ class JsonDecode implements DecoderInterface
     /**
      * Constructs a new JsonDecode instance.
      *
-     * @param bool     $associative True to return the result associative array, false for a nested stdClass hierarchy
-     * @param int      $depth       Specifies the recursion depth
+     * @param bool $associative True to return the result associative array, false for a nested stdClass hierarchy
+     * @param int  $depth       Specifies the recursion depth
      */
     public function __construct($associative = false, $depth = 512)
     {

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -65,6 +65,7 @@ class JsonEncode implements EncoderInterface
      * Merge default json encode options with context.
      *
      * @param array $context
+     *
      * @return array
      */
     private function resolveContext(array $context = array())

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -159,7 +159,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
 
     /**
      * @param \DOMNode $node
-     * @param string  $val
+     * @param string   $val
      *
      * @return bool
      */
@@ -290,7 +290,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      * Parse the data and convert it to DOMElements
      *
      * @param DOMNode      $parentNode
-     * @param array|object $data       data
+     * @param array|object $data            data
      * @param string       $xmlRootNodeName
      *
      * @return bool

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
@@ -28,11 +28,11 @@ interface DenormalizableInterface
      * recursively all child objects of the implementor.
      *
      * @param DenormalizerInterface $denormalizer The denormalizer is given so that you
-     *   can use it to denormalize objects contained within this object.
-     * @param array|scalar $data   The data from which to re-create the object.
-     * @param string|null  $format The format is optionally given to be able to denormalize differently
-     *   based on different input formats.
-     * @param array        $context options for denormalizing
+     *                                            can use it to denormalize objects contained within this object.
+     * @param array|scalar          $data         The data from which to re-create the object.
+     * @param string|null           $format       The format is optionally given to be able to denormalize differently
+     *                                            based on different input formats.
+     * @param array                 $context      options for denormalizing
      */
     public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = array());
 }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -21,9 +21,9 @@ interface DenormalizerInterface
     /**
      * Denormalizes data back into an object of the given class
      *
-     * @param mixed  $data   data to restore
-     * @param string $class  the expected class to instantiate
-     * @param string $format format the given data was extracted from
+     * @param mixed  $data    data to restore
+     * @param string $class   the expected class to instantiate
+     * @param string $format  format the given data was extracted from
      * @param array  $context options available to the denormalizer
      *
      * @return object

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -173,6 +173,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
      * returns attribute name in camelcase format
      *
      * @param string $attributeName
+     *
      * @return string
      */
     protected function formatAttribute($attributeName)
@@ -229,7 +230,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
      *
      * @param \ReflectionMethod $method the method to check
      *
-     * @return bool    whether the method is a getter.
+     * @return bool whether the method is a getter.
      */
     private function isGetMethod(\ReflectionMethod $method)
     {

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
@@ -28,10 +28,10 @@ interface NormalizableInterface
      * recursively all child objects of the implementor.
      *
      * @param NormalizerInterface $normalizer The normalizer is given so that you
-     *   can use it to normalize objects contained within this object.
-     * @param string|null $format The format is optionally given to be able to normalize differently
-     *   based on different output formats.
-     * @param array $context Options for normalizing this object
+     *                                        can use it to normalize objects contained within this object.
+     * @param string|null         $format     The format is optionally given to be able to normalize differently
+     *                                        based on different output formats.
+     * @param array               $context    Options for normalizing this object
      *
      * @return array|scalar
      */

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -21,9 +21,9 @@ interface NormalizerInterface
     /**
      * Normalizes an object into a set of arrays/scalars
      *
-     * @param object $object object to normalize
-     * @param string $format format the normalization result will be encoded as
-     * @param array $context Context options for the normalizer
+     * @param object $object  object to normalize
+     * @param string $format  format the normalization result will be encoded as
+     * @param array  $context Context options for the normalizer
      *
      * @return array|scalar
      */

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -214,9 +214,9 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     /**
      * Normalizes an object into a set of arrays/scalars
      *
-     * @param object $object object to normalize
-     * @param string $format format name, present to give the option to normalizers to act differently based on formats
-     * @param array $context The context data for this particular normalization
+     * @param object $object  object to normalize
+     * @param string $format  format name, present to give the option to normalizers to act differently based on formats
+     * @param array  $context The context data for this particular normalization
      *
      * @return array|scalar
      *
@@ -249,10 +249,10 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     /**
      * Denormalizes data back into an object of the given class
      *
-     * @param mixed  $data   data to restore
-     * @param string $class  the expected class to instantiate
-     * @param string $format format name, present to give the option to normalizers to act differently based on formats
-     * @param array $context The context data for this particular denormalization
+     * @param mixed  $data    data to restore
+     * @param string $class   the expected class to instantiate
+     * @param string $format  format name, present to give the option to normalizers to act differently based on formats
+     * @param array  $context The context data for this particular denormalization
      *
      * @return object
      *

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -67,7 +67,7 @@ class StopwatchEvent
     /**
      * Gets the origin.
      *
-     * @return int     The origin in milliseconds
+     * @return int The origin in milliseconds
      */
     public function getOrigin()
     {
@@ -149,7 +149,7 @@ class StopwatchEvent
     /**
      * Gets the relative time of the start of the first period.
      *
-     * @return int     The time (in milliseconds)
+     * @return int The time (in milliseconds)
      */
     public function getStartTime()
     {
@@ -159,7 +159,7 @@ class StopwatchEvent
     /**
      * Gets the relative time of the end of the last period.
      *
-     * @return int     The time (in milliseconds)
+     * @return int The time (in milliseconds)
      */
     public function getEndTime()
     {
@@ -171,7 +171,7 @@ class StopwatchEvent
     /**
      * Gets the duration of the events (including all periods).
      *
-     * @return int     The duration (in milliseconds)
+     * @return int The duration (in milliseconds)
      */
     public function getDuration()
     {
@@ -186,7 +186,7 @@ class StopwatchEvent
     /**
      * Gets the max memory usage of all periods.
      *
-     * @return int     The memory usage (in bytes)
+     * @return int The memory usage (in bytes)
      */
     public function getMemory()
     {
@@ -213,7 +213,7 @@ class StopwatchEvent
     /**
      * Formats a time.
      *
-     * @param int|float     $time A raw time
+     * @param int|float $time A raw time
      *
      * @return float The formatted time
      *

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -25,8 +25,8 @@ class StopwatchPeriod
     /**
      * Constructor
      *
-     * @param int     $start The relative time of the start of the period
-     * @param int     $end   The relative time of the end of the period
+     * @param int $start The relative time of the start of the period
+     * @param int $end   The relative time of the end of the period
      */
     public function __construct($start, $end)
     {
@@ -38,7 +38,7 @@ class StopwatchPeriod
     /**
      * Gets the relative time of the start of the period.
      *
-     * @return int     The time (in milliseconds)
+     * @return int The time (in milliseconds)
      */
     public function getStartTime()
     {
@@ -48,7 +48,7 @@ class StopwatchPeriod
     /**
      * Gets the relative time of the end of the period.
      *
-     * @return int     The time (in milliseconds)
+     * @return int The time (in milliseconds)
      */
     public function getEndTime()
     {
@@ -58,7 +58,7 @@ class StopwatchPeriod
     /**
      * Gets the time spent in this period.
      *
-     * @return int     The period duration (in milliseconds)
+     * @return int The period duration (in milliseconds)
      */
     public function getDuration()
     {
@@ -68,7 +68,7 @@ class StopwatchPeriod
     /**
      * Gets the memory usage.
      *
-     * @return int     The memory usage (in bytes)
+     * @return int The memory usage (in bytes)
      */
     public function getMemory()
     {

--- a/src/Symfony/Component/Templating/EngineInterface.php
+++ b/src/Symfony/Component/Templating/EngineInterface.php
@@ -51,7 +51,7 @@ interface EngineInterface
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return bool    true if the template exists, false otherwise
+     * @return bool true if the template exists, false otherwise
      *
      * @api
      */
@@ -62,7 +62,7 @@ interface EngineInterface
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return bool    true if this class supports the given template, false otherwise
+     * @return bool true if this class supports the given template, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/Helper/SlotsHelper.php
+++ b/src/Symfony/Component/Templating/Helper/SlotsHelper.php
@@ -83,8 +83,8 @@ class SlotsHelper extends Helper
     /**
      * Gets the slot value.
      *
-     * @param string         $name    The slot name
-     * @param bool|string    $default The default slot content
+     * @param string      $name    The slot name
+     * @param bool|string $default The default slot content
      *
      * @return string The slot content
      *
@@ -111,10 +111,10 @@ class SlotsHelper extends Helper
     /**
      * Outputs a slot.
      *
-     * @param string         $name    The slot name
-     * @param bool|string    $default The default slot content
+     * @param string      $name    The slot name
+     * @param bool|string $default The default slot content
      *
-     * @return bool    true if the slot is defined or if a default content has been provided, false otherwise
+     * @return bool true if the slot is defined or if a default content has been provided, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/Loader/CacheLoader.php
+++ b/src/Symfony/Component/Templating/Loader/CacheLoader.php
@@ -46,7 +46,7 @@ class CacheLoader extends Loader
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|bool    false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|bool false if the template cannot be loaded, a Storage instance otherwise
      */
     public function load(TemplateReferenceInterface $template)
     {

--- a/src/Symfony/Component/Templating/Loader/ChainLoader.php
+++ b/src/Symfony/Component/Templating/Loader/ChainLoader.php
@@ -51,7 +51,7 @@ class ChainLoader extends Loader
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|bool    false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|bool false if the template cannot be loaded, a Storage instance otherwise
      */
     public function load(TemplateReferenceInterface $template)
     {

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -43,7 +43,7 @@ class FilesystemLoader extends Loader
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|bool    false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|bool false if the template cannot be loaded, a Storage instance otherwise
      *
      * @api
      */
@@ -90,7 +90,7 @@ class FilesystemLoader extends Loader
      * @param TemplateReferenceInterface $template A template
      * @param int                        $time     The last modification time of the cached template (timestamp)
      *
-     * @return bool    true if the template is still fresh, false otherwise
+     * @return bool true if the template is still fresh, false otherwise
      *
      * @api
      */
@@ -108,7 +108,7 @@ class FilesystemLoader extends Loader
      *
      * @param string $file A path
      *
-     * @return bool    true if the path exists and is absolute, false otherwise
+     * @return bool true if the path exists and is absolute, false otherwise
      */
     protected static function isAbsolutePath($file)
     {

--- a/src/Symfony/Component/Templating/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Templating/Loader/LoaderInterface.php
@@ -28,7 +28,7 @@ interface LoaderInterface
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|bool    false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|bool false if the template cannot be loaded, a Storage instance otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -112,7 +112,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return bool    true if the template exists, false otherwise
+     * @return bool true if the template exists, false otherwise
      *
      * @api
      */
@@ -132,7 +132,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return bool    true if this class supports the given resource, false otherwise
+     * @return bool true if this class supports the given resource, false otherwise
      *
      * @api
      */
@@ -201,7 +201,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param string $name The helper name
      *
-     * @return bool    true if the helper is defined, false otherwise
+     * @return bool true if the helper is defined, false otherwise
      *
      * @api
      */
@@ -287,7 +287,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param string $name The helper name
      *
-     * @return bool    true if the helper is defined, false otherwise
+     * @return bool true if the helper is defined, false otherwise
      *
      * @api
      */
@@ -404,7 +404,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param string $context The context name
      *
-     * @return mixed  $escaper A PHP callable
+     * @return mixed $escaper A PHP callable
      *
      * @throws \InvalidArgumentException
      *

--- a/src/Symfony/Component/Templating/TemplateReference.php
+++ b/src/Symfony/Component/Templating/TemplateReference.php
@@ -43,7 +43,7 @@ class TemplateReference implements TemplateReferenceInterface
      *
      * @return TemplateReferenceInterface The TemplateReferenceInterface instance
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws \InvalidArgumentException if the parameter is not defined
      *
      * @api
      */
@@ -65,7 +65,7 @@ class TemplateReference implements TemplateReferenceInterface
      *
      * @return string The parameter value
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws \InvalidArgumentException if the parameter is not defined
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/TemplateReferenceInterface.php
+++ b/src/Symfony/Component/Templating/TemplateReferenceInterface.php
@@ -37,7 +37,7 @@ interface TemplateReferenceInterface
      *
      * @return TemplateReferenceInterface The TemplateReferenceInterface instance
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws \InvalidArgumentException if the parameter is not defined
      *
      * @api
      */
@@ -50,7 +50,7 @@ interface TemplateReferenceInterface
      *
      * @return string The parameter value
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws \InvalidArgumentException if the parameter is not defined
      *
      * @api
      */

--- a/src/Symfony/Component/Translation/Interval.php
+++ b/src/Symfony/Component/Translation/Interval.php
@@ -36,8 +36,8 @@ class Interval
     /**
      * Tests if the given number is in the math interval.
      *
-     * @param int     $number   A number
-     * @param string  $interval An interval
+     * @param int    $number   A number
+     * @param string $interval An interval
      *
      * @return bool
      *

--- a/src/Symfony/Component/Translation/Loader/ArrayLoader.php
+++ b/src/Symfony/Component/Translation/Loader/ArrayLoader.php
@@ -47,8 +47,8 @@ class ArrayLoader implements LoaderInterface
      * This function takes an array by reference and will modify it
      *
      * @param array  &$messages The array that will be flattened
-     * @param array  $subnode Current subnode being parsed, used internally for recursive calls
-     * @param string $path    Current path being parsed, used internally for recursive calls
+     * @param array  $subnode   Current subnode being parsed, used internally for recursive calls
+     * @param string $path      Current path being parsed, used internally for recursive calls
      */
     private function flatten(array &$messages, array $subnode = null, $path = null)
     {

--- a/src/Symfony/Component/Translation/Loader/MoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/MoFileLoader.php
@@ -168,8 +168,9 @@ class MoFileLoader extends ArrayLoader implements LoaderInterface
     /**
      * Reads an unsigned long from stream respecting endianess.
      *
-     * @param  resource $stream
-     * @param  bool     $isBigEndian
+     * @param resource $stream
+     * @param bool     $isBigEndian
+     *
      * @return int
      */
     private function readLong($stream, $isBigEndian)

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -70,7 +70,7 @@ interface MessageCatalogueInterface
      * @param string $id     The message id
      * @param string $domain The domain name
      *
-     * @return bool    true if the message has a translation, false otherwise
+     * @return bool true if the message has a translation, false otherwise
      *
      * @api
      */
@@ -82,7 +82,7 @@ interface MessageCatalogueInterface
      * @param string $id     The message id
      * @param string $domain The domain name
      *
-     * @return bool    true if the message has a translation, false otherwise
+     * @return bool true if the message has a translation, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -39,9 +39,9 @@ class MessageSelector
      * The two methods can also be mixed:
      *     {0} There are no apples|one: There is one apple|more: There are %count% apples
      *
-     * @param string  $message The message being translated
-     * @param int     $number  The number of items represented for the message
-     * @param string  $locale  The locale to use for choosing
+     * @param string $message The message being translated
+     * @param int    $number  The number of items represented for the message
+     * @param string $locale  The locale to use for choosing
      *
      * @return string
      *

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -24,10 +24,10 @@ class PluralizationRules
     /**
      * Returns the plural position to use for the given locale and number.
      *
-     * @param int     $number The number
-     * @param string  $locale The locale
+     * @param int    $number The number
+     * @param string $locale The locale
      *
-     * @return int     The plural position
+     * @return int The plural position
      */
     public static function get($number, $locale)
     {

--- a/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
+++ b/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
@@ -92,9 +92,9 @@ class PluralizationRulesTest  extends \PHPUnit_Framework_TestCase
     /**
      * We validate only on the plural coverage. Thus the real rules is not tested.
      *
-     * @param string  $nplural       plural expected
-     * @param array   $matrix        containing langcodes and their plural index values.
-     * @param bool    $expectSuccess
+     * @param string $nplural       plural expected
+     * @param array  $matrix        containing langcodes and their plural index values.
+     * @param bool   $expectSuccess
      */
     protected function validateMatrix($nplural, $matrix, $expectSuccess = true)
     {

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -39,11 +39,11 @@ interface TranslatorInterface
     /**
      * Translates the given choice message by choosing a translation according to a number.
      *
-     * @param string  $id         The message id (may also be an object that can be cast to string)
-     * @param int     $number     The number to use to find the indice of the message
-     * @param array   $parameters An array of parameters for the message
-     * @param string  $domain     The domain for the message
-     * @param string  $locale     The locale
+     * @param string $id         The message id (may also be an object that can be cast to string)
+     * @param int    $number     The number to use to find the indice of the message
+     * @param array  $parameters An array of parameters for the message
+     * @param string $domain     The domain for the message
+     * @param string $locale     The locale
      *
      * @throws \InvalidArgumentException If the locale contains invalid characters
      *

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -208,7 +208,7 @@ abstract class Constraint
      * This method should return one or more of the constants
      * Constraint::CLASS_CONSTRAINT and Constraint::PROPERTY_CONSTRAINT.
      *
-     * @return string|array  One or more constant values
+     * @return string|array One or more constant values
      *
      * @api
      */

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -61,20 +61,20 @@ class ConstraintViolation implements ConstraintViolationInterface
     /**
      * Creates a new constraint violation.
      *
-     * @param string       $message               The violation message.
-     * @param string       $messageTemplate       The raw violation message.
-     * @param array        $messageParameters     The parameters to substitute
-     *                                            in the raw message.
-     * @param mixed        $root                  The value originally passed
-     *                                            to the validator.
-     * @param string       $propertyPath          The property path from the
-     *                                            root value to the invalid
-     *                                            value.
-     * @param mixed        $invalidValue          The invalid value causing the
-     *                                            violation.
-     * @param int|null     $messagePluralization  The pluralization parameter.
-     * @param mixed        $code                  The error code of the
-     *                                            violation, if any.
+     * @param string   $message              The violation message.
+     * @param string   $messageTemplate      The raw violation message.
+     * @param array    $messageParameters    The parameters to substitute
+     *                                       in the raw message.
+     * @param mixed    $root                 The value originally passed
+     *                                       to the validator.
+     * @param string   $propertyPath         The property path from the
+     *                                       root value to the invalid
+     *                                       value.
+     * @param mixed    $invalidValue         The invalid value causing the
+     *                                       violation.
+     * @param int|null $messagePluralization The pluralization parameter.
+     * @param mixed    $code                 The error code of the
+     *                                       violation, if any.
      */
     public function __construct($message, $messageTemplate, array $messageParameters, $root, $propertyPath, $invalidValue, $messagePluralization = null, $code = null)
     {

--- a/src/Symfony/Component/Validator/ConstraintViolationInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationInterface.php
@@ -85,7 +85,7 @@ interface ConstraintViolationInterface
      * This method returns the value of the parameter for choosing the right
      * pluralization form (in this case "choices").
      *
-     * @return int|null     The number to use to pluralize of the message.
+     * @return int|null The number to use to pluralize of the message.
      */
     public function getMessagePluralization();
 

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -41,7 +41,7 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
     /**
      * Returns the violation at a given offset.
      *
-     * @param  int     $offset The offset of the violation.
+     * @param int $offset The offset of the violation.
      *
      * @return ConstraintViolationInterface The violation.
      *
@@ -54,9 +54,9 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
     /**
      * Returns whether the given offset exists.
      *
-     * @param  int     $offset The violation offset.
+     * @param int $offset The violation offset.
      *
-     * @return bool    Whether the offset exists.
+     * @return bool Whether the offset exists.
      *
      * @api
      */
@@ -75,7 +75,7 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
     /**
      * Removes a violation at a given offset.
      *
-     * @param int     $offset The offset to remove.
+     * @param int $offset The offset to remove.
      *
      * @api
      */

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -42,10 +42,10 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
     /**
      * Compares the two given values to find if their relationship is valid
      *
-     * @param mixed      $value1     The first value to compare
-     * @param mixed      $value2     The second value to compare
+     * @param mixed $value1 The first value to compare
+     * @param mixed $value2 The second value to compare
      *
-     * @return bool    true if the relationship is valid, false otherwise
+     * @return bool true if the relationship is valid, false otherwise
      */
     abstract protected function compareValues($value1, $value2);
 }

--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -98,7 +98,7 @@ class CardSchemeValidator extends ConstraintValidator
     /**
      * Validates a creditcard belongs to a specified scheme.
      *
-     * @param mixed $value
+     * @param mixed      $value
      * @param Constraint $constraint
      */
     public function validate($value, Constraint $constraint)

--- a/src/Symfony/Component/Validator/DefaultTranslator.php
+++ b/src/Symfony/Component/Validator/DefaultTranslator.php
@@ -117,11 +117,11 @@ class DefaultTranslator implements TranslatorInterface
      *
      *     // -> These are 3 donkeys.
      *
-     * @param string  $id         The message id
-     * @param int     $number     The number to use to find the index of the message
-     * @param array   $parameters An array of parameters for the message
-     * @param string  $domain     Ignored
-     * @param string  $locale     Ignored
+     * @param string $id         The message id
+     * @param int    $number     The number to use to find the index of the message
+     * @param array  $parameters An array of parameters for the message
+     * @param string $domain     Ignored
+     * @param string $locale     Ignored
      *
      * @return string The translated string
      *

--- a/src/Symfony/Component/Validator/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/ExecutionContextInterface.php
@@ -88,11 +88,11 @@ interface ExecutionContextInterface
     /**
      * Adds a violation at the current node of the validation graph.
      *
-     * @param string       $message       The error message.
-     * @param array        $params        The parameters substituted in the error message.
-     * @param mixed        $invalidValue  The invalid, validated value.
-     * @param int|null     $pluralization The number to use to pluralize of the message.
-     * @param int|null     $code          The violation code.
+     * @param string   $message       The error message.
+     * @param array    $params        The parameters substituted in the error message.
+     * @param mixed    $invalidValue  The invalid, validated value.
+     * @param int|null $pluralization The number to use to pluralize of the message.
+     * @param int|null $code          The violation code.
      *
      * @api
      */
@@ -102,12 +102,12 @@ interface ExecutionContextInterface
      * Adds a violation at the validation graph node with the given property
      * path relative to the current property path.
      *
-     * @param string       $subPath       The relative property path for the violation.
-     * @param string       $message       The error message.
-     * @param array        $params        The parameters substituted in the error message.
-     * @param mixed        $invalidValue  The invalid, validated value.
-     * @param int|null     $pluralization The number to use to pluralize of the message.
-     * @param int|null     $code          The violation code.
+     * @param string   $subPath       The relative property path for the violation.
+     * @param string   $message       The error message.
+     * @param array    $params        The parameters substituted in the error message.
+     * @param mixed    $invalidValue  The invalid, validated value.
+     * @param int|null $pluralization The number to use to pluralize of the message.
+     * @param int|null $code          The violation code.
      *
      * @api
      */

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -138,7 +138,7 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
     /**
      * Returns the fully qualified name of the class
      *
-     * @return string  The fully qualified class name
+     * @return string The fully qualified class name
      */
     public function getClassName()
     {
@@ -158,7 +158,7 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
      * will validate the group sequence. The constraints assigned to "Default"
      * can still be validated by validating the class in "<ClassName>".
      *
-     * @return string  The name of the default group
+     * @return string The name of the default group
      */
     public function getDefaultGroup()
     {
@@ -400,7 +400,7 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
     /**
      * Sets whether a group sequence provider should be used.
      *
-     * @param bool    $active
+     * @param bool $active
      *
      * @throws GroupDefinitionException
      */

--- a/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
@@ -36,10 +36,10 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * Creates a new constraint instance for the given constraint name.
      *
-     * @param string $name   The constraint name. Either a constraint relative
-     *                       to the default constraint namespace, or a fully
-     *                       qualified class name
-     * @param mixed $options The constraint options
+     * @param string $name    The constraint name. Either a constraint relative
+     *                        to the default constraint namespace, or a fully
+     *                        qualified class name
+     * @param mixed  $options The constraint options
      *
      * @return Constraint
      *

--- a/src/Symfony/Component/Validator/MetadataFactoryInterface.php
+++ b/src/Symfony/Component/Validator/MetadataFactoryInterface.php
@@ -34,7 +34,7 @@ interface MetadataFactoryInterface
      *
      * @param mixed $value Some value.
      *
-     * @return bool    Whether metadata exists for the value.
+     * @return bool Whether metadata exists for the value.
      */
     public function hasMetadataFor($value);
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -97,7 +97,8 @@ abstract class AbstractComparisonValidatorTestCase extends AbstractConstraintVal
     abstract public function provideInvalidComparisons();
 
     /**
-     * @param  array      $options Options for the constraint
+     * @param array $options Options for the constraint
+     *
      * @return Constraint
      */
     abstract protected function createConstraint(array $options);

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -80,7 +80,7 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
     }
 
     /**
-     * @param        $message
+     * @param mixed  $message
      * @param array  $parameters
      * @param string $propertyPath
      * @param string $invalidValue
@@ -182,7 +182,7 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
     }
 
     /**
-     * @param        $message
+     * @param mixed  $message
      * @param array  $parameters
      * @param string $propertyPath
      * @param string $invalidValue

--- a/src/Symfony/Component/Validator/ValidationVisitorInterface.php
+++ b/src/Symfony/Component/Validator/ValidationVisitorInterface.php
@@ -54,11 +54,11 @@ interface ValidationVisitorInterface
      * does not find metadata for the given value, it will fail with an
      * exception.
      *
-     * @param mixed   $value        The value to validate.
-     * @param string  $group        The validation group to validate.
-     * @param string  $propertyPath The current property path in the validation graph.
-     * @param bool    $traverse     Whether to traverse the value if it is traversable.
-     * @param bool    $deep         Whether to traverse nested traversable values recursively.
+     * @param mixed  $value        The value to validate.
+     * @param string $group        The validation group to validate.
+     * @param string $propertyPath The current property path in the validation graph.
+     * @param bool   $traverse     Whether to traverse the value if it is traversable.
+     * @param bool   $deep         Whether to traverse nested traversable values recursively.
      *
      * @throws Exception\NoSuchMetadataException If no metadata can be found for
      *                                           the given value.

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -28,7 +28,7 @@ class Dumper
     /**
      * Sets the indentation.
      *
-     * @param int     $num The amount of spaces to use for indentation of nested nodes.
+     * @param int $num The amount of spaces to use for indentation of nested nodes.
      */
     public function setIndentation($num)
     {
@@ -38,13 +38,13 @@ class Dumper
     /**
      * Dumps a PHP value to YAML.
      *
-     * @param mixed   $input                  The PHP value
-     * @param int     $inline                 The level where you switch to inline YAML
-     * @param int     $indent                 The level of indentation (used internally)
-     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param bool    $objectSupport          true if object support is enabled, false otherwise
+     * @param mixed $input                  The PHP value
+     * @param int   $inline                 The level where you switch to inline YAML
+     * @param int   $indent                 The level of indentation (used internally)
+     * @param bool  $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool  $objectSupport          true if object support is enabled, false otherwise
      *
-     * @return string  The YAML representation of the PHP value
+     * @return string The YAML representation of the PHP value
      */
     public function dump($input, $inline = 0, $indent = 0, $exceptionOnInvalidType = false, $objectSupport = false)
     {

--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -44,7 +44,7 @@ class Escaper
      *
      * @param string $value A PHP value
      *
-     * @return bool    True if the value would require double quotes.
+     * @return bool True if the value would require double quotes.
      */
     public static function requiresDoubleQuoting($value)
     {
@@ -68,7 +68,7 @@ class Escaper
      *
      * @param string $value A PHP value
      *
-     * @return bool    True if the value would require single quotes.
+     * @return bool True if the value would require single quotes.
      */
     public static function requiresSingleQuoting($value)
     {

--- a/src/Symfony/Component/Yaml/Exception/ParseException.php
+++ b/src/Symfony/Component/Yaml/Exception/ParseException.php
@@ -28,10 +28,10 @@ class ParseException extends RuntimeException
     /**
      * Constructor.
      *
-     * @param string    $message    The error message
-     * @param int       $parsedLine The line where the error occurred
-     * @param int       $snippet    The snippet of code near the problem
-     * @param string    $parsedFile The file name where the error occurred
+     * @param string     $message    The error message
+     * @param int        $parsedLine The line where the error occurred
+     * @param int        $snippet    The snippet of code near the problem
+     * @param string     $parsedFile The file name where the error occurred
      * @param \Exception $previous   The previous exception
      */
     public function __construct($message, $parsedLine = -1, $snippet = null, $parsedFile = null, \Exception $previous = null)
@@ -95,7 +95,7 @@ class ParseException extends RuntimeException
     /**
      * Gets the line where the error occurred.
      *
-     * @return int     The file line
+     * @return int The file line
      */
     public function getParsedLine()
     {
@@ -105,7 +105,7 @@ class ParseException extends RuntimeException
     /**
      * Sets the line where the error occurred.
      *
-     * @param int     $parsedLine The file line
+     * @param int $parsedLine The file line
      */
     public function setParsedLine($parsedLine)
     {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -29,10 +29,10 @@ class Inline
     /**
      * Converts a YAML string to a PHP array.
      *
-     * @param string  $value                  A YAML string
-     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param bool    $objectSupport          true if object support is enabled, false otherwise
-     * @param array   $references             Mapping of variable names to values
+     * @param string $value                  A YAML string
+     * @param bool   $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool   $objectSupport          true if object support is enabled, false otherwise
+     * @param array  $references             Mapping of variable names to values
      *
      * @return array A PHP array representing the YAML string
      *
@@ -83,9 +83,9 @@ class Inline
     /**
      * Dumps a given PHP variable to a YAML string.
      *
-     * @param mixed   $value                  The PHP variable to convert
-     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param bool    $objectSupport          true if object support is enabled, false otherwise
+     * @param mixed $value                  The PHP variable to convert
+     * @param bool  $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool  $objectSupport          true if object support is enabled, false otherwise
      *
      * @return string The YAML string representing the PHP array
      *
@@ -149,9 +149,9 @@ class Inline
     /**
      * Dumps a PHP array to a YAML string.
      *
-     * @param array   $value                  The PHP array to dump
-     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param bool    $objectSupport          true if object support is enabled, false otherwise
+     * @param array $value                  The PHP array to dump
+     * @param bool  $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool  $objectSupport          true if object support is enabled, false otherwise
      *
      * @return string The YAML string representing the PHP array
      */
@@ -234,7 +234,7 @@ class Inline
      * Parses a quoted scalar to YAML.
      *
      * @param string $scalar
-     * @param int     &$i
+     * @param int    &$i
      *
      * @return string A YAML string
      *

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -31,7 +31,7 @@ class Parser
     /**
      * Constructor
      *
-     * @param int     $offset The offset of YAML document (used for line numbers in error messages)
+     * @param int $offset The offset of YAML document (used for line numbers in error messages)
      */
     public function __construct($offset = 0)
     {
@@ -41,11 +41,11 @@ class Parser
     /**
      * Parses a YAML string to a PHP value.
      *
-     * @param string  $value                  A YAML string
-     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param bool    $objectSupport          true if object support is enabled, false otherwise
+     * @param string $value                  A YAML string
+     * @param bool   $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool   $objectSupport          true if object support is enabled, false otherwise
      *
-     * @return mixed  A PHP value
+     * @return mixed A PHP value
      *
      * @throws ParseException If the YAML is not valid
      */
@@ -266,7 +266,7 @@ class Parser
     /**
      * Returns the current line number (takes the offset into account).
      *
-     * @return int     The current line number
+     * @return int The current line number
      */
     private function getRealCurrentLineNb()
     {
@@ -276,7 +276,7 @@ class Parser
     /**
      * Returns the current line indentation.
      *
-     * @return int     The current line indentation
+     * @return int The current line indentation
      */
     private function getCurrentLineIndentation()
     {
@@ -391,11 +391,11 @@ class Parser
     /**
      * Parses a YAML value.
      *
-     * @param string  $value                  A YAML value
-     * @param bool    $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
-     * @param bool    $objectSupport          True if object support is enabled, false otherwise
+     * @param string $value                  A YAML value
+     * @param bool   $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
+     * @param bool   $objectSupport          True if object support is enabled, false otherwise
      *
-     * @return mixed  A PHP value
+     * @return mixed A PHP value
      *
      * @throws ParseException When reference does not exist
      */
@@ -434,11 +434,11 @@ class Parser
     /**
      * Parses a folded scalar.
      *
-     * @param string  $separator   The separator that was used to begin this folded scalar (| or >)
-     * @param string  $indicator   The indicator that was used to begin this folded scalar (+ or -)
-     * @param int     $indentation The indentation that was used to begin this folded scalar
+     * @param string $separator   The separator that was used to begin this folded scalar (| or >)
+     * @param string $indicator   The indicator that was used to begin this folded scalar (+ or -)
+     * @param int    $indentation The indentation that was used to begin this folded scalar
      *
-     * @return string  The text value
+     * @return string The text value
      */
     private function parseFoldedScalar($separator, $indicator = '', $indentation = 0)
     {
@@ -515,7 +515,7 @@ class Parser
     /**
      * Returns true if the next line is indented.
      *
-     * @return bool    Returns true if the next line is indented, false otherwise
+     * @return bool Returns true if the next line is indented, false otherwise
      */
     private function isNextLineIndented()
     {
@@ -543,7 +543,7 @@ class Parser
     /**
      * Returns true if the current line is blank or if it is a comment line.
      *
-     * @return bool    Returns true if the current line is empty or if it is a comment line, false otherwise
+     * @return bool Returns true if the current line is empty or if it is a comment line, false otherwise
      */
     private function isCurrentLineEmpty()
     {
@@ -553,7 +553,7 @@ class Parser
     /**
      * Returns true if the current line is blank.
      *
-     * @return bool    Returns true if the current line is blank, false otherwise
+     * @return bool Returns true if the current line is blank, false otherwise
      */
     private function isCurrentLineBlank()
     {
@@ -563,7 +563,7 @@ class Parser
     /**
      * Returns true if the current line is a comment line.
      *
-     * @return bool    Returns true if the current line is a comment line, false otherwise
+     * @return bool Returns true if the current line is a comment line, false otherwise
      */
     private function isCurrentLineComment()
     {
@@ -614,7 +614,7 @@ class Parser
     /**
      * Returns true if the next line starts unindented collection
      *
-     * @return bool    Returns true if the next line starts unindented collection, false otherwise
+     * @return bool Returns true if the next line starts unindented collection, false otherwise
      */
     private function isNextLineUnIndentedCollection()
     {
@@ -646,7 +646,7 @@ class Parser
     /**
      * Returns true if the string is un-indented collection item
      *
-     * @return bool    Returns true if the string is un-indented collection item, false otherwise
+     * @return bool Returns true if the string is un-indented collection item, false otherwise
      */
     private function isStringUnIndentedCollectionItem()
     {

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -38,9 +38,9 @@ class Yaml
      * you must validate the input before calling this method. Passing a file
      * as an input is a deprecated feature and will be removed in 3.0.
      *
-     * @param string  $input                  Path to a YAML file or a string containing YAML
-     * @param bool    $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
-     * @param bool    $objectSupport          True if object support is enabled, false otherwise
+     * @param string $input                  Path to a YAML file or a string containing YAML
+     * @param bool   $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
+     * @param bool   $objectSupport          True if object support is enabled, false otherwise
      *
      * @return array The YAML converted to a PHP array
      *
@@ -80,11 +80,11 @@ class Yaml
      * The dump method, when supplied with an array, will do its best
      * to convert the array into friendly YAML.
      *
-     * @param array   $array                  PHP array
-     * @param int     $inline                 The level where you switch to inline YAML
-     * @param int     $indent                 The amount of spaces to use for indentation of nested nodes.
-     * @param bool    $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param bool    $objectSupport          true if object support is enabled, false otherwise
+     * @param array $array                  PHP array
+     * @param int   $inline                 The level where you switch to inline YAML
+     * @param int   $indent                 The amount of spaces to use for indentation of nested nodes.
+     * @param bool  $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool  $objectSupport          true if object support is enabled, false otherwise
      *
      * @return string A YAML string representing the original PHP array
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the docblock alignment as requested in #12760.

It was also necessary for me to ensure the `@return` annotations were correctly separated in order to accurately align the `@param` annotations.
