### PR TITLE
[2.3] Fixed the proxy-manager version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "monolog/monolog": "~1.3",
         "propel/propel1": "~1.6",
         "ircmaxell/password-compat": "~1.0",
-        "ocramius/proxy-manager": ">=0.3.1,<0.4-dev"
+        "ocramius/proxy-manager": "~0.3.1"
     },
     "autoload": {
         "psr-0": { "Symfony\\": "src/" },

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/dependency-injection": "~2.3",
-        "ocramius/proxy-manager": ">=0.3.1,<0.4-dev"
+        "ocramius/proxy-manager": "~0.3.1"
     },
     "require-dev": {
         "symfony/config": "~2.3"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the `ocramius/proxy-manager` version constraint in the 2.3 branch.

`"~0.3.1"` is far cleaner than `">=0.3.1,<0.4-dev"`, and does the same thing.
