### PR TITLE
Tweaked the password-compat version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "doctrine/orm": "~2.2,>=2.2.3",
         "monolog/monolog": "~1.3",
         "propel/propel1": "~1.6",
-        "ircmaxell/password-compat": "1.0.*",
+        "ircmaxell/password-compat": "~1.0",
         "ocramius/proxy-manager": ">=0.3.1,<0.4-dev"
     },
     "autoload": {

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -28,7 +28,7 @@
         "doctrine/common": "~2.2",
         "doctrine/dbal": "~2.2",
         "psr/log": "~1.0",
-        "ircmaxell/password-compat": "1.0.*"
+        "ircmaxell/password-compat": "~1.0"
     },
     "suggest": {
         "symfony/class-loader": "",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request tweaks the `"ircmaxell/password-compat` version constraint in the 2.3 branch.

I've updated the version constraint to `"~1.0"` match the way we require all "stable" releases. Note that this version constraint is technically different, but I consider it safe still.
