### PR TITLE
[3.0] Bumped the minimum php version to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-    - 5.3.3
-    - 5.3
-    - 5.4
     - 5.5
     - 5.6
     - hhvm-nightly

--- a/README.md
+++ b/README.md
@@ -4,31 +4,12 @@ README
 What is Symfony?
 -----------------
 
-Symfony is a PHP 5.3 full-stack web framework. It is written with speed and
+Symfony is a PHP 5.5 full-stack web framework. It is written with speed and
 flexibility in mind. It allows developers to build better and easy to maintain
 websites with PHP.
 
 Symfony can be used to develop all kind of websites, from your personal blog
 to high traffic ones like Dailymotion or Yahoo! Answers.
-
-Requirements
-------------
-
-Symfony is only supported on PHP 5.3.3 and up.
-
-Be warned that PHP versions before 5.3.8 are known to be buggy and might not
-work for you:
-
- * before PHP 5.3.4, if you get "Notice: Trying to get property of
-   non-object", you've hit a known PHP bug (see
-   https://bugs.php.net/bug.php?id=52083 and
-   https://bugs.php.net/bug.php?id=50027);
-
- * before PHP 5.3.8, if you get an error involving annotations, you've hit a
-   known PHP bug (see https://bugs.php.net/bug.php?id=55156).
-
- * PHP 5.3.16 has a major bug in the Reflection subsystem and is not suitable to
-   run Symfony (https://bugs.php.net/bug.php?id=62715)
 
 Installation
 ------------

--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -1,8 +1,8 @@
 <?php
 
-if (PHP_VERSION_ID >= 50400 && gc_enabled()) {
-    // Disabling Zend Garbage Collection to prevent segfaults with PHP5.4+
-    // https://bugs.php.net/bug.php?id=53976
+// Disabling Zend Garbage Collection to prevent segfaults
+// https://bugs.php.net/bug.php?id=53976
+if (gc_enabled()) {
     gc_disable();
 }
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "doctrine/common": "~2.2",
         "twig/twig": "~1.12",
         "psr/log": "~1.0"
@@ -74,7 +74,6 @@
         "doctrine/doctrine-bundle": "~1.2",
         "monolog/monolog": "~1.11",
         "propel/propel1": "~1.6",
-        "ircmaxell/password-compat": "~1.0",
         "ocramius/proxy-manager": "~0.4|~1.0",
         "egulias/email-validator": "~1.2"
     },

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "doctrine/common": "~2.2"
     },
     "require-dev": {

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "monolog/monolog": "~1.11"
     },
     "require-dev": {

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/http-foundation": "~2.0",
         "symfony/http-kernel": "~2.0",
         "symfony/form": "~2.2",

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/dependency-injection": "~2.3",
         "ocramius/proxy-manager": "~0.4|~1.0"
     },

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "swiftmailer/swiftmailer": ">=4.2.0,<6.0-dev"
     },
     "suggest": {

--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -174,11 +174,7 @@ class CodeExtension extends \Twig_Extension
         $text = "$text at line $line";
 
         if (false !== $link = $this->getFileLink($file, $line)) {
-            if (PHP_VERSION_ID >= 50400) {
-                $flags = ENT_QUOTES | ENT_SUBSTITUTE;
-            } else {
-                $flags = ENT_QUOTES;
-            }
+            $flags = ENT_QUOTES | ENT_SUBSTITUTE;
 
             return sprintf('<a href="%s" title="Click to open this file" class="file_link">%s</a>', htmlspecialchars($link, $flags, $this->charset), $text);
         }

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -66,10 +66,6 @@ class FormThemeTest extends \PHPUnit_Framework_TestCase
 
     protected function getVariableGetter($name)
     {
-        if (PHP_VERSION_ID >= 50400) {
-            return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
-        }
-
-        return sprintf('$this->getContext($context, "%s")', $name);
+        return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -263,10 +263,6 @@ class SearchAndRenderBlockNodeTest extends \PHPUnit_Framework_TestCase
 
     protected function getVariableGetter($name)
     {
-        if (PHP_VERSION_ID >= 50400) {
-            return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
-        }
-
-        return sprintf('$this->getContext($context, "%s")', $name);
+        return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -38,19 +38,11 @@ class TransNodeTest extends \PHPUnit_Framework_TestCase
     }
     protected function getVariableGetterWithoutStrictCheck($name)
     {
-        if (PHP_VERSION_ID >= 50400) {
-            return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
-        }
-
-        return sprintf('$this->getContext($context, "%s", true)', $name);
+        return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
     }
 
     protected function getVariableGetterWithStrictCheck($name)
     {
-        if (PHP_VERSION_ID >= 50400) {
-            return sprintf('(isset($context["%s"]) ? $context["%s"] : $this->getContext($context, "%s"))', $name, $name, $name);
-        }
-
-        return sprintf('$this->getContext($context, "%s")', $name);
+        return sprintf('(isset($context["%s"]) ? $context["%s"] : $this->getContext($context, "%s"))', $name, $name, $name);
     }
 }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/security-csrf": "~2.4",
         "twig/twig": "~1.12"
     },

--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/http-kernel": "~2.6",
         "symfony/twig-bridge": "~2.6",
         "symfony/var-dumper": "~2.6"

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -30,7 +30,7 @@ class ServerRunCommand extends ContainerAwareCommand
      */
     public function isEnabled()
     {
-        if (PHP_VERSION_ID < 50400 || defined('HHVM_VERSION')) {
+        if (defined('HHVM_VERSION')) {
             return false;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -493,14 +493,7 @@ class Configuration implements ConfigurationInterface
             ->validate()
                 ->ifTrue(function ($v) { return !isset($v['validation']['api']) || 'auto' === $v['validation']['api']; })
                 ->then(function ($v) {
-                    // This condition is duplicated in ValidatorBuilder. This
-                    // duplication is necessary in order to know the desired
-                    // API version already during container configuration
-                    // (to adjust service classes etc.)
-                    // See https://github.com/symfony/symfony/issues/11580
-                    $v['validation']['api'] = PHP_VERSION_ID < 50309
-                        ? '2.4'
-                        : '2.5-bc';
+                    $v['validation']['api'] = '2.5-bc';
 
                     return $v;
                 })

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -166,11 +166,7 @@ class CodeHelper extends Helper
         }
 
         if (false !== $link = $this->getFileLink($file, $line)) {
-            if (PHP_VERSION_ID >= 50400) {
-                $flags = ENT_QUOTES | ENT_SUBSTITUTE;
-            } else {
-                $flags = ENT_QUOTES;
-            }
+            $flags = ENT_QUOTES | ENT_SUBSTITUTE;
 
             return sprintf('<a href="%s" title="Click to open this file" class="file_link">%s</a>', htmlspecialchars($link, $flags, $this->charset), $text);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/JsonDescriptorTest.php
@@ -15,13 +15,6 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\JsonDescriptor;
 
 class JsonDescriptorTest extends AbstractDescriptorTest
 {
-    protected function setUp()
-    {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Test skipped on PHP 5.3 as JSON_PRETTY_PRINT does not exist.');
-        }
-    }
-
     protected function getDescriptor()
     {
         return new JsonDescriptor();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -131,7 +131,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'static_method' => array('loadValidatorMetadata'),
                 'translation_domain' => 'validators',
                 'strict_email' => false,
-                'api' => PHP_VERSION_ID < 50309 ? '2.4' : '2.5-bc',
+                'api' => '2.5-bc',
             ),
             'annotations' => array(
                 'cache' => 'file',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -295,11 +295,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals(array(new Reference('validator.mapping.cache.apc')), $calls[5][1]);
         $this->assertSame('setApiVersion', $calls[6][0]);
 
-        if (PHP_VERSION_ID < 50309) {
-            $this->assertEquals(array(Validation::API_VERSION_2_4), $calls[6][1]);
-        } else {
-            $this->assertEquals(array(Validation::API_VERSION_2_5_BC), $calls[6][1]);
-        }
+        $this->assertEquals(array(Validation::API_VERSION_2_5_BC), $calls[6][1]);
     }
 
     public function testFullyConfiguredValidationService()
@@ -448,11 +444,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('setApiVersion', $calls[5][0]);
         // no cache, no annotations
 
-        if (PHP_VERSION_ID < 50309) {
-            $this->assertSame(array(Validation::API_VERSION_2_4), $calls[5][1]);
-        } else {
-            $this->assertSame(array(Validation::API_VERSION_2_5_BC), $calls[5][1]);
-        }
+        $this->assertSame(array(Validation::API_VERSION_2_5_BC), $calls[5][1]);
     }
 
     /**
@@ -472,11 +464,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('setApiVersion', $calls[5][0]);
         // no cache, no annotations
 
-        if (PHP_VERSION_ID < 50309) {
-            $this->assertSame(array(Validation::API_VERSION_2_4), $calls[5][1]);
-        } else {
-            $this->assertSame(array(Validation::API_VERSION_2_5_BC), $calls[5][1]);
-        }
+        $this->assertSame(array(Validation::API_VERSION_2_5_BC), $calls[5][1]);
     }
 
     public function testFormsCanBeEnabledWithoutCsrfProtection()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/dependency-injection" : "~2.2",
         "symfony/config" : "~2.4",
         "symfony/event-dispatcher": "~2.5",

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
@@ -30,10 +30,6 @@ class SecurityRoutingIntegrationTest extends WebTestCase
      */
     public function testRoutingErrorIsExposedWhenNotProtected($config)
     {
-        if (defined('PHP_WINDOWS_VERSION_BUILD') && PHP_VERSION_ID < 50309) {
-            $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120 fixed in http://svn.php.net/viewvc?view=revision&revision=318366');
-        }
-
         $client = $this->createClient(array('test_case' => 'StandardFormLogin', 'root_config' => $config));
         $client->insulate();
         $client->request('GET', '/unprotected_resource');
@@ -46,10 +42,6 @@ class SecurityRoutingIntegrationTest extends WebTestCase
      */
     public function testRoutingErrorIsNotExposedForProtectedResourceWhenLoggedInWithInsufficientRights($config)
     {
-        if (defined('PHP_WINDOWS_VERSION_BUILD') && PHP_VERSION_ID < 50309) {
-            $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120 fixed in http://svn.php.net/viewvc?view=revision&revision=318366');
-        }
-
         $client = $this->createClient(array('test_case' => 'StandardFormLogin', 'root_config' => $config));
         $client->insulate();
 

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/security": "~2.6",
         "symfony/http-kernel": "~2.2"
     },

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/twig-bridge": "~2.5",
         "symfony/http-foundation": "~2.5",
         "symfony/http-kernel": "~2.1"

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/http-kernel": "~2.3",
         "symfony/routing": "~2.2",
         "symfony/twig-bridge": "~2.2"

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/dom-crawler": "~2.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
+++ b/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
@@ -11,14 +11,6 @@
 
 namespace Symfony\Component\ClassLoader;
 
-if (!defined('SYMFONY_TRAIT')) {
-    if (PHP_VERSION_ID >= 50400) {
-        define('SYMFONY_TRAIT', T_TRAIT);
-    } else {
-        define('SYMFONY_TRAIT', 0);
-    }
-}
-
 /**
  * ClassMapGenerator
  *
@@ -117,7 +109,7 @@ class ClassMapGenerator
                     break;
                 case T_CLASS:
                 case T_INTERFACE:
-                case SYMFONY_TRAIT:
+                case T_TRAIT:
                     // Find the classname
                     while (($t = $tokens[++$i]) && is_array($t)) {
                         if (T_STRING === $t[0]) {

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -22,12 +22,6 @@ class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
 {
     public function testTraitDependencies()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Requires PHP > 5.4');
-
-            return;
-        }
-
         require_once __DIR__.'/Fixtures/deps/traits.php';
 
         $r = new \ReflectionClass('Symfony\Component\ClassLoader\ClassCollectionLoader');
@@ -100,12 +94,6 @@ class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testClassWithTraitsReordering(array $classes)
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Requires PHP > 5.4');
-
-            return;
-        }
-
         require_once __DIR__.'/Fixtures/ClassesWithParents/ATrait.php';
         require_once __DIR__.'/Fixtures/ClassesWithParents/BTrait.php';
         require_once __DIR__.'/Fixtures/ClassesWithParents/CTrait.php';

--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -102,18 +102,15 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
                 'ClassMap\\SomeParent' => realpath(__DIR__).'/Fixtures/classmap/SomeParent.php',
                 'ClassMap\\SomeClass' => realpath(__DIR__).'/Fixtures/classmap/SomeClass.php',
             )),
-        );
-
-        if (PHP_VERSION_ID >= 50400) {
-            $data[] = array(__DIR__.'/Fixtures/php5.4', array(
+            array(__DIR__.'/Fixtures/php5.4', array(
                 'TFoo' => __DIR__.'/Fixtures/php5.4/traits.php',
                 'CFoo' => __DIR__.'/Fixtures/php5.4/traits.php',
                 'Foo\\TBar' => __DIR__.'/Fixtures/php5.4/traits.php',
                 'Foo\\IBar' => __DIR__.'/Fixtures/php5.4/traits.php',
                 'Foo\\TFooBar' => __DIR__.'/Fixtures/php5.4/traits.php',
                 'Foo\\CBar' => __DIR__.'/Fixtures/php5.4/traits.php',
-            ));
-        }
+            )),
+        );
 
         return $data;
     }

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -17,7 +17,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/finder": "~2.0"

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/filesystem": "~2.3"
     },
     "autoload": {

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -229,10 +229,6 @@ class TextDescriptor extends Descriptor
      */
     private function formatDefaultValue($default)
     {
-        if (PHP_VERSION_ID < 50400) {
-            return str_replace('\/', '/', json_encode($default));
-        }
-
         return json_encode($default, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/event-dispatcher": "~2.1",

--- a/src/Symfony/Component/CssSelector/composer.json
+++ b/src/Symfony/Component/CssSelector/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\CssSelector\\": "" }

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -357,26 +357,12 @@ class ErrorHandler
         $type &= $level | $this->screamedErrors;
 
         if ($type && ($log || $throw)) {
-            if (PHP_VERSION_ID < 50400 && isset($context['GLOBALS']) && ($this->scopedErrors & $type)) {
-                $e = $context;                  // Whatever the signature of the method,
-                unset($e['GLOBALS'], $context); // $context is always a reference in 5.3
-                $context = $e;
-            }
-
             if ($throw) {
                 if (($this->scopedErrors & $type) && class_exists('Symfony\Component\Debug\Exception\ContextErrorException')) {
                     // Checking for class existence is a work around for https://bugs.php.net/42098
                     $throw = new ContextErrorException($this->levels[$type].': '.$message, 0, $type, $file, $line, $context);
                 } else {
                     $throw = new \ErrorException($this->levels[$type].': '.$message, 0, $type, $file, $line);
-                }
-
-                if (PHP_VERSION_ID <= 50407 && (PHP_VERSION_ID >= 50400 || PHP_VERSION_ID <= 50317)) {
-                    // Exceptions thrown from error handlers are sometimes not caught by the exception
-                    // handler and shutdown handlers are bypassed before 5.4.8/5.3.18.
-                    // We temporarily re-enable display_errors to prevent any blank page related to this bug.
-
-                    $throw->errorHandlerCanary = new ErrorHandlerCanary();
                 }
 
                 throw $throw;
@@ -401,7 +387,7 @@ class ErrorHandler
                         $e['stack'] = debug_backtrace(true); // Provide object
                     }
                 } elseif ($trace) {
-                    $e['stack'] = debug_backtrace(PHP_VERSION_ID >= 50306 ? DEBUG_BACKTRACE_IGNORE_ARGS : false);
+                    $e['stack'] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
                 }
             }
 

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -424,7 +424,7 @@ EOF;
             $str = iconv($charset, 'UTF-8', $str);
         }
 
-        return htmlspecialchars($str, ENT_QUOTES | (PHP_VERSION_ID >= 50400 ? ENT_SUBSTITUTE : 0), 'UTF-8');
+        return htmlspecialchars($str, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 
     /**

--- a/src/Symfony/Component/Debug/composer.json
+++ b/src/Symfony/Component/Debug/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.0",

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -575,15 +575,7 @@ class Crawler extends \SplObjectStorage
 
         $html = '';
         foreach ($this->getNode(0)->childNodes as $child) {
-            if (PHP_VERSION_ID >= 50306) {
-                // node parameter was added to the saveHTML() method in PHP 5.3.6
-                // @see http://php.net/manual/en/domdocument.savehtml.php
-                $html .= $child->ownerDocument->saveHTML($child);
-            } else {
-                $document = new \DOMDocument('1.0', 'UTF-8');
-                $document->appendChild($document->importNode($child, true));
-                $html .= rtrim($document->saveHTML());
-            }
+            $html .= $child->ownerDocument->saveHTML($child);
         }
 
         return $html;

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/css-selector": "~2.0"

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/dependency-injection": "~2.6",

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -336,10 +336,6 @@ class Parser
 
                 $node = new Node\GetAttrNode($node, $arg, $arguments, $type);
             } elseif ('[' === $token->value) {
-                if ($node instanceof Node\GetAttrNode && Node\GetAttrNode::METHOD_CALL === $node->attributes['type'] && PHP_VERSION_ID < 50400) {
-                    throw new SyntaxError('Array calls on a method call is only supported on PHP 5.4+', $token->cursor);
-                }
-
                 $this->stream->next();
                 $arg = $this->parseExpression();
                 $this->stream->expect(Token::PUNCTUATION_TYPE, ']');

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\ExpressionLanguage\\": "" }

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Filesystem\\": "" }

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Finder\\": "" }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -66,12 +66,6 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
 
         $this->generateFormat = $this->parseFormat = $format;
 
-        // The pipe in the parser pattern only works as of PHP 5.3.7
-        // See http://bugs.php.net/54316
-        $this->parseUsingPipe = null === $parseUsingPipe
-            ? PHP_VERSION_ID >= 50307
-            : $parseUsingPipe;
-
         // See http://php.net/manual/en/datetime.createfromformat.php
         // The character "|" in the format makes sure that the parts of a date
         // that are *not* specified in the format are reset to the corresponding

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php
@@ -70,11 +70,7 @@ class DefaultCsrfProvider implements CsrfProviderInterface
      */
     protected function getSessionId()
     {
-        if (PHP_VERSION_ID >= 50400) {
-            if (PHP_SESSION_NONE === session_status()) {
-                session_start();
-            }
-        } elseif (!session_id()) {
+        if (PHP_SESSION_NONE === session_status()) {
             session_start();
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -30,6 +30,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
             array('H:i:00', '16:05:00', '1970-01-01 16:05:00 UTC'),
             array('H:i', '16:05', '1970-01-01 16:05:00 UTC'),
             array('H', '16', '1970-01-01 16:00:00 UTC'),
+            array('Y-z', '2010-33', '2010-02-03 00:00:00 UTC'),
 
             // different day representations
             array('Y-m-j', '2010-02-3', '2010-02-03 00:00:00 UTC'),
@@ -58,11 +59,6 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
             // seconds since Unix
             array('U', '1265213106', '2010-02-03 16:05:06 UTC'),
         );
-
-        // This test will fail < 5.3.9 - see https://bugs.php.net/51994
-        if (PHP_VERSION_ID >= 50309) {
-            $data[] = array('Y-z', '2010-33', '2010-02-03 00:00:00 UTC');
-        }
 
         return $data;
     }
@@ -111,10 +107,6 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
      */
     public function testReverseTransformUsingPipe($format, $input, $output)
     {
-        if (PHP_VERSION_ID < 50307) {
-            $this->markTestSkipped('Pipe usage requires PHP 5.3.7 or newer.');
-        }
-
         $reverseTransformer = new DateTimeToStringTransformer('UTC', 'UTC', $format, true);
 
         $output = new \DateTime($output);

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/DefaultCsrfProviderTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/DefaultCsrfProviderTest.php
@@ -49,10 +49,6 @@ class DefaultCsrfProviderTest extends \PHPUnit_Framework_TestCase
     {
         session_id('touti');
 
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('This test requires PHP >= 5.4');
-        }
-
         $this->assertSame(PHP_SESSION_NONE, session_status());
 
         $token = $this->provider->generateCsrfToken('foo');

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/event-dispatcher": "~2.1",
         "symfony/intl": "~2.3",
         "symfony/options-resolver": "~2.1",

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php
@@ -17,12 +17,6 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  * @see http://php.net/sessionhandler
  */
 
-if (PHP_VERSION_ID >= 50400) {
-    class NativeSessionHandler extends \SessionHandler
-    {
-    }
-} else {
-    class NativeSessionHandler
-    {
-    }
+class NativeSessionHandler extends \SessionHandler
+{
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -100,11 +100,7 @@ class NativeSessionStorage implements SessionStorageInterface
         session_cache_limiter(''); // disable by default because it's managed by HeaderBag (if used)
         ini_set('session.use_cookies', 1);
 
-        if (PHP_VERSION_ID >= 50400) {
-            session_register_shutdown();
-        } else {
-            register_shutdown_function('session_write_close');
-        }
+        session_register_shutdown();
 
         $this->setMetadataBag($metaBag);
         $this->setOptions($options);
@@ -130,13 +126,8 @@ class NativeSessionStorage implements SessionStorageInterface
             return true;
         }
 
-        if (PHP_VERSION_ID >= 50400 && \PHP_SESSION_ACTIVE === session_status()) {
+        if (\PHP_SESSION_ACTIVE === session_status()) {
             throw new \RuntimeException('Failed to start the session: already started by PHP.');
-        }
-
-        if (PHP_VERSION_ID < 50400 && !$this->closed && isset($_SESSION) && session_id()) {
-            // not 100% fool-proof, but is the most reliable way to determine if a session is active in PHP 5.3
-            throw new \RuntimeException('Failed to start the session: already started by PHP ($_SESSION is set).');
         }
 
         if (ini_get('session.use_cookies') && headers_sent($file, $line)) {
@@ -149,10 +140,6 @@ class NativeSessionStorage implements SessionStorageInterface
         }
 
         $this->loadSession();
-        if (!$this->saveHandler->isWrapper() && !$this->saveHandler->isSessionHandlerInterface()) {
-            // This condition matches only PHP 5.3 with internal save handlers
-            $this->saveHandler->setActive(true);
-        }
 
         return true;
     }
@@ -211,11 +198,6 @@ class NativeSessionStorage implements SessionStorageInterface
     public function save()
     {
         session_write_close();
-
-        if (!$this->saveHandler->isWrapper() && !$this->saveHandler->isSessionHandlerInterface()) {
-            // This condition matches only PHP 5.3 with internal save handlers
-            $this->saveHandler->setActive(false);
-        }
 
         $this->closed = true;
         $this->started = false;
@@ -362,24 +344,12 @@ class NativeSessionStorage implements SessionStorageInterface
         if (!$saveHandler instanceof AbstractProxy && $saveHandler instanceof \SessionHandlerInterface) {
             $saveHandler = new SessionHandlerProxy($saveHandler);
         } elseif (!$saveHandler instanceof AbstractProxy) {
-            $saveHandler = PHP_VERSION_ID >= 50400 ?
-                new SessionHandlerProxy(new \SessionHandler()) : new NativeProxy();
+            $saveHandler = new SessionHandlerProxy(new \SessionHandler());
         }
         $this->saveHandler = $saveHandler;
 
         if ($this->saveHandler instanceof \SessionHandlerInterface) {
-            if (PHP_VERSION_ID >= 50400) {
-                session_set_save_handler($this->saveHandler, false);
-            } else {
-                session_set_save_handler(
-                    array($this->saveHandler, 'open'),
-                    array($this->saveHandler, 'close'),
-                    array($this->saveHandler, 'read'),
-                    array($this->saveHandler, 'write'),
-                    array($this->saveHandler, 'destroy'),
-                    array($this->saveHandler, 'gc')
-                );
-            }
+            session_set_save_handler($this->saveHandler, false);
         }
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
@@ -43,10 +43,6 @@ class PhpBridgeSessionStorage extends NativeSessionStorage
         }
 
         $this->loadSession();
-        if (!$this->saveHandler->isWrapper() && !$this->saveHandler->isSessionHandlerInterface()) {
-            // This condition matches only PHP 5.3 + internal save handlers
-            $this->saveHandler->setActive(true);
-        }
 
         return true;
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
@@ -72,32 +72,7 @@ abstract class AbstractProxy
      */
     public function isActive()
     {
-        if (PHP_VERSION_ID >= 50400) {
-            return $this->active = \PHP_SESSION_ACTIVE === session_status();
-        }
-
-        return $this->active;
-    }
-
-    /**
-     * Sets the active flag.
-     *
-     * Has no effect under PHP 5.4+ as status is detected
-     * automatically in isActive()
-     *
-     * @internal
-     *
-     * @param bool $flag
-     *
-     * @throws \LogicException
-     */
-    public function setActive($flag)
-    {
-        if (PHP_VERSION_ID >= 50400) {
-            throw new \LogicException('This method is disabled in PHP 5.4.0+');
-        }
-
-        $this->active = (bool) $flag;
+        return $this->active = \PHP_SESSION_ACTIVE === session_status();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -27,13 +27,8 @@ class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new NativeSessionStorage(array('name' => 'TESTING'), new NativeFileSessionHandler(sys_get_temp_dir()));
 
-        if (PHP_VERSION_ID < 50400) {
-            $this->assertEquals('files', $storage->getSaveHandler()->getSaveHandlerName());
-            $this->assertEquals('files', ini_get('session.save_handler'));
-        } else {
-            $this->assertEquals('files', $storage->getSaveHandler()->getSaveHandlerName());
-            $this->assertEquals('user', ini_get('session.save_handler'));
-        }
+        $this->assertEquals('files', $storage->getSaveHandler()->getSaveHandlerName());
+        $this->assertEquals('user', ini_get('session.save_handler'));
 
         $this->assertEquals(sys_get_temp_dir(), ini_get('session.save_path'));
         $this->assertEquals('TESTING', ini_get('session.name'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeSessionHandlerTest.php
@@ -26,14 +26,7 @@ class NativeSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $handler = new NativeSessionHandler();
 
-        // note for PHPUnit optimisers - the use of assertTrue/False
-        // here is deliberate since the tests do not require the classes to exist - drak
-        if (PHP_VERSION_ID < 50400) {
-            $this->assertFalse($handler instanceof \SessionHandler);
-            $this->assertTrue($handler instanceof NativeSessionHandler);
-        } else {
-            $this->assertTrue($handler instanceof \SessionHandler);
-            $this->assertTrue($handler instanceof NativeSessionHandler);
-        }
+        $this->assertTrue($handler instanceof \SessionHandler);
+        $this->assertTrue($handler instanceof NativeSessionHandler);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -164,34 +164,8 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
         $storage->setSaveHandler(new \stdClass());
     }
 
-    public function testSetSaveHandler53()
+    public function testSetSaveHandler()
     {
-        if (PHP_VERSION_ID >= 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
-        }
-
-        ini_set('session.save_handler', 'files');
-        $storage = $this->getStorage();
-        $storage->setSaveHandler();
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy', $storage->getSaveHandler());
-        $storage->setSaveHandler(null);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy', $storage->getSaveHandler());
-        $storage->setSaveHandler(new NativeSessionHandler());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy', $storage->getSaveHandler());
-        $storage->setSaveHandler(new SessionHandlerProxy(new NullSessionHandler()));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
-        $storage->setSaveHandler(new NullSessionHandler());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
-        $storage->setSaveHandler(new NativeProxy());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy', $storage->getSaveHandler());
-    }
-
-    public function testSetSaveHandler54()
-    {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
-        }
-
         ini_set('session.save_handler', 'files');
         $storage = $this->getStorage();
         $storage->setSaveHandler();
@@ -211,7 +185,7 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testStartedOutside()
+    public function testStarted()
     {
         $storage = $this->getStorage();
 
@@ -221,10 +195,8 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
 
         session_start();
         $this->assertTrue(isset($_SESSION));
-        if (PHP_VERSION_ID >= 50400) {
-            // this only works in PHP >= 5.4 where session_status is available
-            $this->assertTrue($storage->getSaveHandler()->isActive());
-        }
+        $this->assertTrue($storage->getSaveHandler()->isActive());
+
         // PHP session might have started, but the storage driver has not, so false is correct here
         $this->assertFalse($storage->isStarted());
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -58,36 +58,8 @@ class PhpBridgeSessionStorageTest extends \PHPUnit_Framework_TestCase
         return $storage;
     }
 
-    public function testPhpSession53()
+    public function testPhpSession()
     {
-        if (PHP_VERSION_ID >= 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
-        }
-
-        $storage = $this->getStorage();
-
-        $this->assertFalse(isset($_SESSION));
-        $this->assertFalse($storage->getSaveHandler()->isActive());
-
-        session_start();
-        $this->assertTrue(isset($_SESSION));
-        // in PHP 5.3 we cannot reliably tell if a session has started
-        $this->assertFalse($storage->getSaveHandler()->isActive());
-        // PHP session might have started, but the storage driver has not, so false is correct here
-        $this->assertFalse($storage->isStarted());
-
-        $key = $storage->getMetadataBag()->getStorageKey();
-        $this->assertFalse(isset($_SESSION[$key]));
-        $storage->start();
-        $this->assertTrue(isset($_SESSION[$key]));
-    }
-
-    public function testPhpSession54()
-    {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
-        }
-
         $storage = $this->getStorage();
 
         $this->assertFalse(isset($_SESSION));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -85,52 +85,15 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->proxy->isWrapper());
     }
 
-    public function testIsActivePhp53()
-    {
-        if (PHP_VERSION_ID >= 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
-        }
-
-        $this->assertFalse($this->proxy->isActive());
-    }
-
     /**
      * @runInSeparateProcess
      */
-    public function testIsActivePhp54()
+    public function testIsActive()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
-        }
 
         $this->assertFalse($this->proxy->isActive());
         session_start();
         $this->assertTrue($this->proxy->isActive());
-    }
-
-    public function testSetActivePhp53()
-    {
-        if (PHP_VERSION_ID >= 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
-        }
-
-        $this->proxy->setActive(true);
-        $this->assertTrue($this->proxy->isActive());
-        $this->proxy->setActive(false);
-        $this->assertFalse($this->proxy->isActive());
-    }
-
-    /**
-     * @runInSeparateProcess
-     * @expectedException \LogicException
-     */
-    public function testSetActivePhp54()
-    {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
-        }
-
-        $this->proxy->setActive(true);
     }
 
     /**
@@ -145,28 +108,11 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \LogicException
-     */
-    public function testNameExceptionPhp53()
-    {
-        if (PHP_VERSION_ID >= 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
-        }
-
-        $this->proxy->setActive(true);
-        $this->proxy->setName('foo');
-    }
-
-    /**
      * @runInSeparateProcess
      * @expectedException \LogicException
      */
-    public function testNameExceptionPhp54()
+    public function testNameException()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
-        }
-
         session_start();
         $this->proxy->setName('foo');
     }
@@ -183,28 +129,11 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \LogicException
-     */
-    public function testIdExceptionPhp53()
-    {
-        if (PHP_VERSION_ID >= 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.3 only.');
-        }
-
-        $this->proxy->setActive(true);
-        $this->proxy->setId('foo');
-    }
-
-    /**
      * @runInSeparateProcess
      * @expectedException \LogicException
      */
-    public function testIdExceptionPhp54()
+    public function testIdException()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Test skipped, for PHP 5.4 only.');
-        }
-
         session_start();
         $this->proxy->setId('foo');
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -44,7 +44,7 @@ class SessionHandlerProxyTest extends \PHPUnit_Framework_TestCase
         $this->proxy = null;
     }
 
-    public function testOpen()
+    public function testOpenTrue()
     {
         $this->mock->expects($this->once())
             ->method('open')
@@ -52,11 +52,7 @@ class SessionHandlerProxyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->proxy->isActive());
         $this->proxy->open('name', 'id');
-        if (PHP_VERSION_ID < 50400) {
-            $this->assertTrue($this->proxy->isActive());
-        } else {
-            $this->assertFalse($this->proxy->isActive());
-        }
+        $this->assertFalse($this->proxy->isActive());
     }
 
     public function testOpenFalse()

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/expression-language": "~2.4"

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -60,12 +60,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
             $this->isCollected = false;
         }
 
-        $trace = PHP_VERSION_ID >= 50306 ? DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS : true;
-        if (PHP_VERSION_ID >= 50400) {
-            $trace = debug_backtrace($trace, 7);
-        } else {
-            $trace = debug_backtrace($trace);
-        }
+        $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 7);
 
         $file = $trace[0]['file'];
         $line = $trace[0]['line'];

--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -107,11 +107,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
         }
         $renderedAttributes = '';
         if (count($attributes) > 0) {
-            if (PHP_VERSION_ID >= 50400) {
-                $flags = ENT_QUOTES | ENT_SUBSTITUTE;
-            } else {
-                $flags = ENT_QUOTES;
-            }
+            $flags = ENT_QUOTES | ENT_SUBSTITUTE;
             foreach ($attributes as $attribute => $value) {
                 $renderedAttributes .= sprintf(
                     ' %s="%s"',

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -181,15 +181,11 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set('foobar', 'foobar');
         $controller = array(new self(), 'controllerMethod3');
 
-        if (PHP_VERSION_ID === 50316) {
-            $this->markTestSkipped('PHP 5.3.16 has a major bug in the Reflection sub-system');
-        } else {
-            try {
-                $resolver->getArguments($request, $controller);
-                $this->fail('->getArguments() throws a \RuntimeException exception if it cannot determine the argument value');
-            } catch (\Exception $e) {
-                $this->assertInstanceOf('\RuntimeException', $e, '->getArguments() throws a \RuntimeException exception if it cannot determine the argument value');
-            }
+        try {
+            $resolver->getArguments($request, $controller);
+            $this->fail('->getArguments() throws a \RuntimeException exception if it cannot determine the argument value');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\RuntimeException', $e, '->getArguments() throws a \RuntimeException exception if it cannot determine the argument value');
         }
 
         $request = Request::create('/');

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/event-dispatcher": "~2.5",
         "symfony/http-foundation": "~2.5",
         "symfony/debug": "~2.6",

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/JsonBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/JsonBundleWriter.php
@@ -35,14 +35,8 @@ class JsonBundleWriter implements BundleWriterInterface
             }
         });
 
-        if (PHP_VERSION_ID >= 50400) {
-            // Use JSON_PRETTY_PRINT so that we can see what changed in Git diffs
-            file_put_contents(
-                $path.'/'.$locale.'.json',
-                json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n"
-            );
-        } else {
-            file_put_contents($path.'/'.$locale.'.json', json_encode($data)."\n");
-        }
+        $contents = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n";
+
+        file_put_contents($path.'/'.$locale.'.json', $contents);
     }
 }

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -185,10 +185,9 @@ class IntlDateFormatter
     }
 
     /**
-     * Format the date/time value (timestamp) as a string
+     * Format the date/time value (timestamp) as a string.
      *
-     * @param int|\DateTime $timestamp The timestamp to format. \DateTime objects
-     *                                 are supported as of PHP 5.3.4.
+     * @param int|\DateTime $timestamp The timestamp to format.
      *
      * @return string|bool The formatted value or false if formatting failed.
      *
@@ -200,20 +199,16 @@ class IntlDateFormatter
     {
         // intl allows timestamps to be passed as arrays - we don't
         if (is_array($timestamp)) {
-            $message = PHP_VERSION_ID >= 50304 ?
-                'Only integer Unix timestamps and DateTime objects are supported' :
-                'Only integer Unix timestamps are supported';
+            $message = 'Only integer Unix timestamps and DateTime objects are supported';
 
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'timestamp', $timestamp, $message);
         }
 
         // behave like the intl extension
         $argumentError = null;
-        if (PHP_VERSION_ID < 50304 && !is_int($timestamp)) {
-            $argumentError = 'datefmt_format: takes either an array  or an integer timestamp value ';
-        } elseif (PHP_VERSION_ID >= 50304 && !is_int($timestamp) && !$timestamp instanceof \DateTime) {
+        if (!is_int($timestamp) && !$timestamp instanceof \DateTime) {
             $argumentError = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object';
-            if (PHP_VERSION_ID >= 50500 && !is_int($timestamp)) {
+            if (!is_int($timestamp)) {
                 $argumentError = sprintf('datefmt_format: string \'%s\' is not numeric, which would be required for it to be a valid date', $timestamp);
             }
         }
@@ -227,7 +222,7 @@ class IntlDateFormatter
         }
 
         // As of PHP 5.3.4, IntlDateFormatter::format() accepts DateTime instances
-        if (PHP_VERSION_ID >= 50304 && $timestamp instanceof \DateTime) {
+        if ($timestamp instanceof \DateTime) {
             $timestamp = $timestamp->getTimestamp();
         }
 
@@ -375,10 +370,7 @@ class IntlDateFormatter
             return $this->timeZoneId;
         }
 
-        // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if (PHP_VERSION_ID >= 50500) {
-            return date_default_timezone_get();
-        }
+        return date_default_timezone_get();
     }
 
     /**
@@ -540,16 +532,7 @@ class IntlDateFormatter
     public function setTimeZoneId($timeZoneId)
     {
         if (null === $timeZoneId) {
-            // In PHP 5.5 if $timeZoneId is null it fallbacks to `date_default_timezone_get()` method
-            if (PHP_VERSION_ID >= 50500) {
-                $timeZoneId = date_default_timezone_get();
-            } else {
-                // TODO: changes were made to ext/intl in PHP 5.4.4 release that need to be investigated since it will
-                // use ini's date.timezone when the time zone is not provided. As a not well tested workaround, uses UTC.
-                // See the first two items of the commit message for more information:
-                // https://github.com/php/php-src/commit/eb346ef0f419b90739aadfb6cc7b7436c5b521d9
-                $timeZoneId = getenv('TZ') ?: 'UTC';
-            }
+            $timeZoneId = date_default_timezone_get();
 
             $this->unitializedTimeZoneId = true;
         }

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -839,38 +839,12 @@ class NumberFormatter
      *
      * @param mixed $value The value to be converted
      *
-     * @return int|float The converted value
-     *
-     * @see https://bugs.php.net/bug.php?id=59597 Bug #59597
+     * @return int| The converted value
      */
     private function getInt64Value($value)
     {
         if ($value > self::$int64Range['positive'] || $value < self::$int64Range['negative']) {
             return false;
-        }
-
-        if (PHP_INT_SIZE !== 8 && ($value > self::$int32Range['positive'] || $value <= self::$int32Range['negative'])) {
-            // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
-            // The negative PHP_INT_MAX was being converted to float
-            if (
-                $value == self::$int32Range['negative'] &&
-                ((PHP_VERSION_ID < 50400 && PHP_VERSION_ID >= 50314) || PHP_VERSION_ID >= 50404)
-            ) {
-                return (int) $value;
-            }
-
-            return (float) $value;
-        }
-
-        if (PHP_INT_SIZE === 8) {
-            // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
-            // A 32 bit integer was being generated instead of a 64 bit integer
-            if (
-                  ($value > self::$int32Range['positive'] || $value < self::$int32Range['negative']) &&
-                  (PHP_VERSION_ID < 50314 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404))
-            ) {
-                $value = (-2147483648 - ($value % -2147483648)) * ($value / abs($value));
-            }
         }
 
         return (int) $value;

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
@@ -34,10 +34,6 @@ class JsonBundleWriterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('This test requires at least PHP 5.4.0.');
-        }
-
         $this->writer = new JsonBundleWriter();
         $this->directory = sys_get_temp_dir().'/JsonBundleWriterTest/'.rand(1000, 9999);
         $this->filesystem = new Filesystem();
@@ -47,10 +43,6 @@ class JsonBundleWriterTest extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        if (PHP_VERSION_ID < 50400) {
-            return;
-        }
-
         $this->filesystem->remove($this->directory);
     }
 

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -36,12 +36,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
 
-        // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if (PHP_VERSION_ID >= 50500) {
-            $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
-        } else {
-            $this->assertNull($formatter->getTimeZoneId());
-        }
+        $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
     }
 
     /**
@@ -59,6 +54,8 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function formatProvider()
     {
+        $dateTime = new \DateTime('@0');
+
         $formatData = array(
             /* general */
             array('y-M-d', 0, '1970-1-1'),
@@ -235,21 +232,15 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
             array('zzz', 0, 'GMT'),
             array('zzzz', 0, 'GMT'),
             array('zzzzz', 0, 'GMT'),
+
+            // general, DateTime
+            array('y-M-d', $dateTime, '1970-1-1'),
+            array("EEE, MMM d, ''yy", $dateTime, "Thu, Jan 1, '70"),
+            array('h:mm a', $dateTime, '12:00 AM'),
+            array('yyyyy.MMMM.dd hh:mm aaa', $dateTime, '01970.January.01 12:00 AM'),
+            array("yyyy.MM.dd 'at' HH:mm:ss zzz", $dateTime, '1970.01.01 at 00:00:00 GMT'),
+            array('K:mm a, z', $dateTime, '0:00 AM, GMT'),
         );
-
-        // As of PHP 5.3.4, IntlDateFormatter::format() accepts DateTime instances
-        if (PHP_VERSION_ID >= 50304) {
-            $dateTime = new \DateTime('@0');
-
-            /* general, DateTime */
-            $formatData[] = array('y-M-d', $dateTime, '1970-1-1');
-            $formatData[] = array("EEE, MMM d, ''yy", $dateTime, "Thu, Jan 1, '70");
-            $formatData[] = array('h:mm a', $dateTime, '12:00 AM');
-            $formatData[] = array('yyyyy.MMMM.dd hh:mm aaa', $dateTime, '01970.January.01 12:00 AM');
-
-            $formatData[] = array("yyyy.MM.dd 'at' HH:mm:ss zzz", $dateTime, '1970.01.01 at 00:00:00 GMT');
-            $formatData[] = array('K:mm a, z', $dateTime, '0:00 AM, GMT');
-        }
 
         return $formatData;
     }
@@ -268,22 +259,8 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function formatErrorProvider()
     {
-        // With PHP 5.5 IntlDateFormatter accepts empty values ('0')
-        if (PHP_VERSION_ID >= 50500) {
-            return array(
-                array('y-M-d', 'foobar', 'datefmt_format: string \'foobar\' is not numeric, which would be required for it to be a valid date: U_ILLEGAL_ARGUMENT_ERROR'),
-            );
-        }
-
-        $message = 'datefmt_format: takes either an array  or an integer timestamp value : U_ILLEGAL_ARGUMENT_ERROR';
-
-        if (PHP_VERSION_ID >= 50304) {
-            $message = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object: U_ILLEGAL_ARGUMENT_ERROR';
-        }
-
         return array(
-            array('y-M-d', '0', $message),
-            array('y-M-d', 'foobar', $message),
+            array('y-M-d', 'foobar', 'datefmt_format: string \'foobar\' is not numeric, which would be required for it to be a valid date: U_ILLEGAL_ARGUMENT_ERROR'),
         );
     }
 
@@ -323,15 +300,11 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
             array(0, 'Europe/Dublin', '1970-01-01 01:00:00'),
             array(0, 'Europe/Warsaw', '1970-01-01 01:00:00'),
             array(0, 'Pacific/Fiji', '1970-01-01 12:00:00'),
+            array(0, 'Foo/Bar', '1970-01-01 00:00:00'),
+            array(0, 'Foo/Bar', '1970-01-01 00:00:00'),
+            array(0, 'UTC+04:30', '1970-01-01 00:00:00'),
+            array(0, 'UTC+04:AA', '1970-01-01 00:00:00'),
         );
-
-        // As of PHP 5.5, intl ext no longer fallbacks invalid time zones to UTC
-        if (PHP_VERSION_ID < 50500) {
-            // When time zone not exists, uses UTC by default
-            $data[] = array(0, 'Foo/Bar', '1970-01-01 00:00:00');
-            $data[] = array(0, 'UTC+04:30', '1970-01-01 00:00:00');
-            $data[] = array(0, 'UTC+04:AA', '1970-01-01 00:00:00');
-        }
 
         return $data;
     }
@@ -340,11 +313,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (PHP_VERSION_ID >= 50500) {
-            $formatter->setTimeZone('GMT+03:00');
-        } else {
-            $formatter->setTimeZoneId('GMT+03:00');
-        }
+        $formatter->setTimeZone('GMT+03:00');
 
         $this->assertEquals('GMT+03:00', $formatter->format(0));
     }
@@ -353,11 +322,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (PHP_VERSION_ID >= 50500) {
-            $formatter->setTimeZone('GMT+00:30');
-        } else {
-            $formatter->setTimeZoneId('GMT+00:30');
-        }
+        $formatter->setTimeZone('GMT+00:30');
 
         $this->assertEquals('GMT+00:30', $formatter->format(0));
     }
@@ -366,11 +331,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (PHP_VERSION_ID >= 50500) {
-            $formatter->setTimeZone('Pacific/Fiji');
-        } else {
-            $formatter->setTimeZoneId('Pacific/Fiji');
-        }
+        $formatter->setTimeZone('Pacific/Fiji');
 
         $this->assertEquals('Fiji Standard Time', $formatter->format(0));
     }
@@ -386,35 +347,8 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testFormatWithTimezoneFromEnvironmentVariable()
-    {
-        if (PHP_VERSION_ID >= 50500) {
-            $this->markTestSkipped('IntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
-        }
-
-        $tz = getenv('TZ');
-        putenv('TZ=Europe/London');
-
-        $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
-        $formatter->setPattern('yyyy-MM-dd HH:mm:ss');
-
-        $this->assertEquals(
-            $this->getDateTime(0, 'Europe/London')->format('Y-m-d H:i:s'),
-            $formatter->format(0)
-        );
-
-        $this->assertEquals('Europe/London', getenv('TZ'));
-
-        // Restores TZ.
-        putenv('TZ='.$tz);
-    }
-
     public function testFormatWithTimezoneFromPhp()
     {
-        if (PHP_VERSION_ID < 50500) {
-            $this->markTestSkipped('Only in PHP 5.5 IntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
-        }
-
         $tz = date_default_timezone_get();
         date_default_timezone_set('Europe/London');
 
@@ -842,11 +776,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter();
 
-        if (PHP_VERSION_ID >= 50500) {
-            $formatter->setTimeZone($timeZoneId);
-        } else {
-            $formatter->setTimeZoneId($timeZoneId);
-        }
+        $formatter->setTimeZone($timeZoneId);
 
         $this->assertEquals($expectedTimeZoneId, $formatter->getTimeZoneId());
     }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -56,12 +56,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
             $formatter->format($localtime);
         } catch (\Exception $e) {
             $this->assertInstanceOf('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException', $e);
-
-            if (PHP_VERSION_ID >= 50304) {
-                $this->assertStringEndsWith('Only integer Unix timestamps and DateTime objects are supported.  Please install the "intl" extension for full localization capabilities.', $e->getMessage());
-            } else {
-                $this->assertStringEndsWith('Only integer Unix timestamps are supported.  Please install the "intl" extension for full localization capabilities.', $e->getMessage());
-            }
+            $this->assertStringEndsWith('Only integer Unix timestamps and DateTime objects are supported.  Please install the "intl" extension for full localization capabilities.', $e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -687,13 +687,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
 
         $parsedValue = $formatter->parse('-2,147,483,648', NumberFormatter::TYPE_INT64);
 
-        // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
-        // The negative PHP_INT_MAX was being converted to float
-        if ((PHP_VERSION_ID < 50400 && PHP_VERSION_ID >= 50314) || PHP_VERSION_ID >= 50404) {
-            $this->assertInternalType('int', $parsedValue);
-        } else {
-            $this->assertInternalType('float', $parsedValue);
-        }
+        $this->assertInternalType('int', $parsedValue);
 
         $this->assertEquals(-2147483648, $parsedValue);
     }
@@ -744,24 +738,12 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
         $parsedValue = $formatter->parse('2,147,483,648', NumberFormatter::TYPE_INT64);
         $this->assertInternalType('integer', $parsedValue);
 
-        // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
-        // A 32 bit integer was being generated instead of a 64 bit integer
-        if (PHP_VERSION_ID < 50314 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404)) {
-            $this->assertEquals(-2147483648, $parsedValue, '->parse() TYPE_INT64 does not use true 64 bit integers, using only the 32 bit range (PHP < 5.3.14 and PHP < 5.4.4).');
-        } else {
-            $this->assertEquals(2147483648, $parsedValue, '->parse() TYPE_INT64 uses true 64 bit integers (PHP >= 5.3.14 and PHP >= 5.4.4).');
-        }
+        $this->assertEquals(2147483648, $parsedValue, '->parse() TYPE_INT64 uses true 64 bit integers (PHP >= 5.3.14 and PHP >= 5.4.4).');
 
         $parsedValue = $formatter->parse('-2,147,483,649', NumberFormatter::TYPE_INT64);
         $this->assertInternalType('integer', $parsedValue);
 
-        // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
-        // A 32 bit integer was being generated instead of a 64 bit integer
-        if (PHP_VERSION_ID < 50314 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404)) {
-            $this->assertEquals(2147483647, $parsedValue, '->parse() TYPE_INT64 does not use true 64 bit integers, using only the 32 bit range  (PHP < 5.3.14 and PHP < 5.4.4).');
-        } else {
-            $this->assertEquals(-2147483649, $parsedValue, '->parse() TYPE_INT64 uses true 64 bit integers (PHP >= 5.3.14 and PHP >= 5.4.4).');
-        }
+        $this->assertEquals(-2147483649, $parsedValue, '->parse() TYPE_INT64 uses true 64 bit integers (PHP >= 5.3.14 and PHP >= 5.4.4).');
     }
 
     /**

--- a/src/Symfony/Component/Intl/composer.json
+++ b/src/Symfony/Component/Intl/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/filesystem": ">=2.1"

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/intl": ">=2.3"
     },
     "autoload": {

--- a/src/Symfony/Component/OptionsResolver/composer.json
+++ b/src/Symfony/Component/OptionsResolver/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\OptionsResolver\\": "" }

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Process\\": "" }

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\PropertyAccess\\": "" }

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/config": "~2.2",

--- a/src/Symfony/Component/Security/Acl/composer.json
+++ b/src/Symfony/Component/Security/Acl/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/security-core": "~2.4"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -34,10 +34,6 @@ class BCryptPasswordEncoder extends BasePasswordEncoder
      */
     public function __construct($cost)
     {
-        if (!function_exists('password_hash')) {
-            throw new \RuntimeException('To use the BCrypt encoder, you need to upgrade to PHP 5.5 or install the "ircmaxell/password-compat" via Composer.');
-        }
-
         $cost = (int) $cost;
         if ($cost < 4 || $cost > 31) {
             throw new \InvalidArgumentException('Cost must be in the range of 4-31.');

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
@@ -47,8 +47,6 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testResultLength()
     {
-        $this->skipIfPhpVersionIsNotSupported();
-
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertEquals(60, strlen($result));
@@ -56,19 +54,10 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testValidation()
     {
-        $this->skipIfPhpVersionIsNotSupported();
-
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertTrue($encoder->isPasswordValid($result, self::PASSWORD, null));
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));
-    }
-
-    private function skipIfPhpVersionIsNotSupported()
-    {
-        if (PHP_VERSION_ID < 50307) {
-            $this->markTestSkipped('Requires PHP >= 5.3.7');
-        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Util/SecureRandom.php
+++ b/src/Symfony/Component/Security/Core/Util/SecureRandom.php
@@ -43,9 +43,7 @@ final class SecureRandom implements SecureRandomInterface
         $this->logger = $logger;
 
         // determine whether to use OpenSSL
-        if (defined('PHP_WINDOWS_VERSION_BUILD') && PHP_VERSION_ID < 50304) {
-            $this->useOpenSsl = false;
-        } elseif (!function_exists('openssl_random_pseudo_bytes')) {
+        if (!function_exists('openssl_random_pseudo_bytes')) {
             if (null !== $this->logger) {
                 $this->logger->notice('It is recommended that you enable the "openssl" extension for random number generation.');
             }

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/event-dispatcher": "~2.1",

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
@@ -51,10 +51,6 @@ class NativeSessionTokenStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testStoreTokenInClosedSessionWithExistingSessionId()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('This test requires PHP 5.4 or later.');
-        }
-
         session_id('foobar');
 
         $this->assertSame(PHP_SESSION_NONE, session_status());

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/NativeSessionTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/NativeSessionTokenStorage.php
@@ -108,11 +108,7 @@ class NativeSessionTokenStorage implements TokenStorageInterface
 
     private function startSession()
     {
-        if (PHP_VERSION_ID >= 50400) {
-            if (PHP_SESSION_NONE === session_status()) {
-                session_start();
-            }
-        } elseif (!session_id()) {
+        if (PHP_SESSION_NONE === session_status()) {
             session_start();
         }
 

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/security-core": "~2.4"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/security-core": "~2.4",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "~2.4",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "~2.1",
         "symfony/http-kernel": "~2.4"
@@ -33,7 +33,6 @@
         "doctrine/common": "~2.2",
         "doctrine/dbal": "~2.2",
         "psr/log": "~1.0",
-        "ircmaxell/password-compat": "~1.0",
         "symfony/expression-language": "~2.4"
     },
     "suggest": {
@@ -42,8 +41,7 @@
         "symfony/validator": "For using the user password constraint",
         "symfony/routing": "For using the HttpUtils class to create sub-requests, redirect the user, and match URLs",
         "doctrine/dbal": "For using the built-in ACL implementation",
-        "symfony/expression-language": "For using the expression voter",
-        "ircmaxell/password-compat": "For using the BCrypt password encoder in PHP <5.5"
+        "symfony/expression-language": "For using the expression voter"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Security\\": "" }

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -99,11 +99,7 @@ class JsonDecode implements DecoderInterface
         $recursionDepth = $context['json_decode_recursion_depth'];
         $options = $context['json_decode_options'];
 
-        if (PHP_VERSION_ID >= 50400) {
-            $decodedData = json_decode($data, $associative, $recursionDepth, $options);
-        } else {
-            $decodedData = json_decode($data, $associative, $recursionDepth);
-        }
+        $decodedData = json_decode($data, $associative, $recursionDepth, $options);
 
         if (JSON_ERROR_NONE !== $this->lastError = json_last_error()) {
             throw new UnexpectedValueException(JsonEncoder::getLastErrorMessage());

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Serializer\\": "" }

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Stopwatch\\": "" }

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -458,11 +458,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     protected function initializeEscapers()
     {
         $that = $this;
-        if (PHP_VERSION_ID >= 50400) {
-            $flags = ENT_QUOTES | ENT_SUBSTITUTE;
-        } else {
-            $flags = ENT_QUOTES;
-        }
+        $flags = ENT_QUOTES | ENT_SUBSTITUTE;
 
         $this->escapers = array(
             'html' =>

--- a/src/Symfony/Component/Templating/composer.json
+++ b/src/Symfony/Component/Templating/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "psr/log": "~1.0"

--- a/src/Symfony/Component/Translation/Tests/Dumper/JsonFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/JsonFileDumperTest.php
@@ -18,10 +18,6 @@ class JsonFileDumperTest extends \PHPUnit_Framework_TestCase
 {
     public function testDump()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestIncomplete('PHP below 5.4 doesn\'t support JSON pretty printing');
-        }
-
         $catalogue = new MessageCatalogue('en');
         $catalogue->add(array('foo' => 'bar'));
 

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "symfony/config": "~2.0",

--- a/src/Symfony/Component/Validator/Tests/Validator/LegacyValidator2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/LegacyValidator2Dot5ApiTest.php
@@ -19,15 +19,6 @@ use Symfony\Component\Validator\Validator\LegacyValidator;
 
 class LegacyValidator2Dot5ApiTest extends Abstract2Dot5ApiTest
 {
-    protected function setUp()
-    {
-        if (PHP_VERSION_ID < 50309) {
-            $this->markTestSkipped('Not supported prior to PHP 5.3.9');
-        }
-
-        parent::setUp();
-    }
-
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
         $contextFactory = new LegacyExecutionContextFactory($metadataFactory, new DefaultTranslator());

--- a/src/Symfony/Component/Validator/Tests/Validator/LegacyValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/LegacyValidatorLegacyApiTest.php
@@ -19,15 +19,6 @@ use Symfony\Component\Validator\Validator\LegacyValidator;
 
 class LegacyValidatorLegacyApiTest extends AbstractLegacyApiTest
 {
-    protected function setUp()
-    {
-        if (PHP_VERSION_ID < 50309) {
-            $this->markTestSkipped('Not supported prior to PHP 5.3.9');
-        }
-
-        parent::setUp();
-    }
-
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
         $contextFactory = new LegacyExecutionContextFactory($metadataFactory, new DefaultTranslator());

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -112,13 +112,7 @@ class ValidatorBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultApiVersion()
     {
-        if (PHP_VERSION_ID < 50309) {
-            // Old implementation on PHP < 5.3.9
-            $this->assertInstanceOf('Symfony\Component\Validator\Validator', $this->builder->getValidator());
-        } else {
-            // Legacy compatible implementation on PHP >= 5.3.9
-            $this->assertInstanceOf('Symfony\Component\Validator\Validator\LegacyValidator', $this->builder->getValidator());
-        }
+        $this->assertInstanceOf('Symfony\Component\Validator\Validator\LegacyValidator', $this->builder->getValidator());
     }
 
     public function testSetApiVersion24()
@@ -135,10 +129,6 @@ class ValidatorBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testSetApiVersion24And25()
     {
-        if (PHP_VERSION_ID < 50309) {
-            $this->markTestSkipped('Not supported prior to PHP 5.3.9');
-        }
-
         $this->assertSame($this->builder, $this->builder->setApiVersion(Validation::API_VERSION_2_5_BC));
         $this->assertInstanceOf('Symfony\Component\Validator\Validator\LegacyValidator', $this->builder->getValidator());
     }

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -329,15 +329,6 @@ class ValidatorBuilder implements ValidatorBuilderInterface
             ));
         }
 
-        if (PHP_VERSION_ID < 50309 && $apiVersion === Validation::API_VERSION_2_5_BC) {
-            throw new InvalidArgumentException(sprintf(
-                'The Validator API that is compatible with both Symfony 2.4 '.
-                'and Symfony 2.5 can only be used on PHP 5.3.9 and higher. '.
-                'Your current PHP version is %s.',
-                PHP_VERSION
-            ));
-        }
-
         $this->apiVersion = $apiVersion;
 
         return $this;
@@ -389,9 +380,7 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         $apiVersion = $this->apiVersion;
 
         if (null === $apiVersion) {
-            $apiVersion = PHP_VERSION_ID < 50309
-                ? Validation::API_VERSION_2_4
-                : Validation::API_VERSION_2_5_BC;
+            $apiVersion = Validation::API_VERSION_2_5_BC;
         }
 
         if (Validation::API_VERSION_2_4 === $apiVersion) {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "symfony/translation": "~2.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -266,7 +266,7 @@ class VarCloner extends AbstractCloner
         } else {
             // check if we are nested in an output buffering handler to prevent a fatal error with ob_start() below
             $obFuncs = array('ob_clean', 'ob_end_clean', 'ob_flush', 'ob_end_flush', 'ob_get_contents', 'ob_get_flush');
-            foreach (debug_backtrace(PHP_VERSION_ID >= 50400 ? DEBUG_BACKTRACE_IGNORE_ARGS : false) as $frame) {
+            foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
                 if (isset($frame['function'][0]) && !isset($frame['class']) && 'o' === $frame['function'][0] && in_array($frame['function'], $obFuncs)) {
                     $frame['line'] = 0;
                     break;

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -38,7 +38,7 @@ class CliDumperTest extends \PHPUnit_Framework_TestCase
         ob_start();
         $dumper->dump($data);
         $out = ob_get_clean();
-        $closureLabel = PHP_VERSION_ID >= 50400 ? 'public method' : 'function';
+        $closureLabel = 'public method';
         $out = preg_replace('/[ \t]+$/m', '', $out);
         $intMax = PHP_INT_MAX;
         $res1 = (int) $var['res'];

--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -40,7 +40,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
         ob_start();
         $dumper->dump($data);
         $out = ob_get_clean();
-        $closureLabel = PHP_VERSION_ID >= 50400 ? 'public method' : 'function';
+        $closureLabel = 'public method';
         $out = preg_replace('/[ \t]+$/m', '', $out);
         $var['file'] = htmlspecialchars($var['file'], ENT_QUOTES, 'UTF-8');
         $intMax = PHP_INT_MAX;

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "suggest": {
         "ext-symfony_debug": ""

--- a/src/Symfony/Component/Yaml/Exception/ParseException.php
+++ b/src/Symfony/Component/Yaml/Exception/ParseException.php
@@ -125,12 +125,7 @@ class ParseException extends RuntimeException
         }
 
         if (null !== $this->parsedFile) {
-            if (PHP_VERSION_ID >= 50400) {
-                $jsonOptions = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
-            } else {
-                $jsonOptions = 0;
-            }
-            $this->message .= sprintf(' in %s', json_encode($this->parsedFile, $jsonOptions));
+            $this->message .= sprintf(' in %s', json_encode($this->parsedFile, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
         }
 
         if ($this->parsedLine >= 0) {

--- a/src/Symfony/Component/Yaml/Tests/ParseExceptionTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParseExceptionTest.php
@@ -18,11 +18,7 @@ class ParseExceptionTest extends \PHPUnit_Framework_TestCase
     public function testGetMessage()
     {
         $exception = new ParseException('Error message', 42, 'foo: bar', '/var/www/app/config.yml');
-        if (PHP_VERSION_ID >= 50400) {
-            $message = 'Error message in "/var/www/app/config.yml" at line 42 (near "foo: bar")';
-        } else {
-            $message = 'Error message in "\\/var\\/www\\/app\\/config.yml" at line 42 (near "foo: bar")';
-        }
+        $message = 'Error message in "/var/www/app/config.yml" at line 42 (near "foo: bar")';
 
         $this->assertEquals($message, $exception->getMessage());
     }
@@ -30,11 +26,7 @@ class ParseExceptionTest extends \PHPUnit_Framework_TestCase
     public function testGetMessageWithUnicodeInFilename()
     {
         $exception = new ParseException('Error message', 42, 'foo: bar', 'äöü.yml');
-        if (PHP_VERSION_ID >= 50400) {
-            $message = 'Error message in "äöü.yml" at line 42 (near "foo: bar")';
-        } else {
-            $message = 'Error message in "\u00e4\u00f6\u00fc.yml" at line 42 (near "foo: bar")';
-        }
+        $message = 'Error message in "äöü.yml" at line 42 (near "foo: bar")';
 
         $this->assertEquals($message, $exception->getMessage());
     }

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Yaml\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request bumps the minimum php version of symfony 3.0 to php 5.5.

This also removes all the hacky workarounds for php 5.3 and 5.4.
