### PR TITLE
[2.3] Updated the swiftmailer version constraint

### DIFF
--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "swiftmailer/swiftmailer": ">=4.2.0,<6.0-dev"
+        "swiftmailer/swiftmailer": "~4.2|~5.0"
     },
     "suggest": {
         "symfony/http-kernel": ""


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the `swiftmailer/swiftmailer` version constraint in the 2.3 branch.

`"~4.2|~5.0"` is far cleaner than `">=4.2.0,<6.0-dev"`, and does the same thing.

---

This accompanies #12832 on the 2.5 branch.
