### PR TITLE
Fixed the symfony/config version constraint

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -21,7 +21,7 @@
         "ocramius/proxy-manager": ">=0.3.1,<0.4-dev"
     },
     "require-dev": {
-        "symfony/config": "2.3"
+        "symfony/config": "~2.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the `symfony/config` version constraint in the proxy manager bridge.

Before this pull, composer was only allowing `v2.3.0` to be downloaded. This surely was not the intention. I've updated the version constraint from `"2.3"` to `"~2.3"` thus allowing all 2.x versions that are equal to or greater than `v2.3.0`.
