### PR TITLE
Fixed the syntax of a composer.json file

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/dependency-injection" : "~2.2",
-        "symfony/config" : "~2.2",
+        "symfony/dependency-injection": "~2.2",
+        "symfony/config": "~2.2",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-kernel": "~2.3",
         "symfony/filesystem": "~2.3",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the syntax of a composer.json file.

There should not be a space before a colon following a double quote. This is not bad syntax, but it just an inconsistency.
