### PR TITLE
Removed a dev annotation from a version constraint

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -36,7 +36,7 @@
         "symfony/console": "~2.0",
         "symfony/finder": "~2.0",
         "symfony/security": "~2.4",
-        "symfony/form": "~2.6@dev",
+        "symfony/form": "~2.6",
         "symfony/class-loader": "~2.1",
         "symfony/expression-language": "~2.4",
         "symfony/process": "~2.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request removes an unneeded dev annotation from a version constraint.

This annotation is no longer required because the stable tag is now sufficient, and also, even if we did want the dev version, we still wouldn't need this annotation because it's a dev-dependency, and the minimum stability is set to dev anyway.
