### PR TITLE
[Console] [DialogHelper] Fix PHP Fatal error: Cannot call constructor in DialogHelper.php on line 37

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -30,12 +30,6 @@ class DialogHelper extends InputAwareHelper
     private static $shell;
     private static $stty;
 
-    public function __construct()
-    {
-        trigger_error('DialogHelper is deprecated since version 2.5 and will be removed in 3.0. Use QuestionHelper instead.', E_USER_DEPRECATED);
-
-        parent::__construct();
-    }
     /**
      * Asks the user to select a value.
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Since yesterday our composer builds have been failing due to an error originating from Symfony/console. We've also been seeing duplicated deprecation warnings:

```
PHP Deprecated:  \Symfony\Component\Console\Helper\DialogHelper is deprecated since version 2.5 and will be removed in 3.0. Use QuestionHelper instead. in vendor/symfony/console/Symfony/Component/Console/Helper/DialogHelper.php on line 14
PHP Deprecated:  DialogHelper is deprecated since version 2.5 and will be removed in 3.0. Use QuestionHelper instead. in vendor/symfony/console/Symfony/Component/Console/Helper/DialogHelper.php on line 35
PHP Fatal error:  Cannot call constructor in vendor/symfony/console/Symfony/Component/Console/Helper/DialogHelper.php on line 37
```

It looks like this was introduced in PR #12737. Then #12759 was raised to change the warning to the header to only print a single warning. But rather than #12759 having #12737 as a parent and reverting it - it's parent is from before #12737 was merged. So there's now a situation of both PR having being merged - one adding deprecation warning to file header, and one adding deprecation to construct() (and also causing fatal error.)

This PR fixes the issue by reverting the breaking parent::construct() added by #12737 so essentially only #12759 is active, which adds a single deprecation warning, and does not break the code.

NB: This is the test failure for the Console component - test fails since #12737. This patch fixes this and passes all tests for the Console component.

```
$ phpunit src/Symfony/Component/Console
PHP Fatal error:  Cannot call constructor in src/Symfony/Component/Console/Helper/DialogHelper.php on line 37
```

Jason
