### PR TITLE
[FrameworkBundle] Update deprecated service call

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -123,11 +123,11 @@ class Controller extends ContainerAware
      */
     protected function isGranted($attributes, $object = null)
     {
-        if (!$this->container->has('security.context')) {
+        if (!$this->container->has('security.authorization_checker')) {
             throw new \LogicException('The SecurityBundle is not registered in your application.');
         }
 
-        return $this->container->get('security.context')->isGranted($attributes, $object);
+        return $this->container->get('security.authorization_checker')->isGranted($attributes, $object);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none, but related to #11593 and #11690 |
| License | MIT |
| Doc PR | none |

Service `security.context` is now deprecated due to PR #11690. This commit updates PR #11593 replacing `security.context` with `security.authorization_checker` in the `isGranted()` controller shortcut introduced in Symfony 2.6.
