### PR TITLE
[Console] improve deprecation warning triggers

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -950,9 +950,9 @@ class Application
     {
         return new HelperSet(array(
             new FormatterHelper(),
-            new DialogHelper(),
-            new ProgressHelper(),
-            new TableHelper(),
+            new DialogHelper(false),
+            new ProgressHelper(false),
+            new TableHelper(false),
             new DebugFormatterHelper(),
             new ProcessHelper(),
             new QuestionHelper(),

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Console\Helper;
 
-trigger_error('\Symfony\Component\Console\Helper\DialogHelper is deprecated since version 2.5 and will be removed in 3.0. Use QuestionHelper instead.', E_USER_DEPRECATED);
-
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
@@ -29,6 +27,13 @@ class DialogHelper extends InputAwareHelper
     private $inputStream;
     private static $shell;
     private static $stty;
+
+    public function __construct($triggerDeprecationError = true)
+    {
+        if ($triggerDeprecationError) {
+            trigger_error('"Symfony\Component\Console\Helper\DialogHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\QuestionHelper" instead.', E_USER_DEPRECATED);
+        }
+    }
 
     /**
      * Asks the user to select a value.

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -78,6 +78,14 @@ class HelperSet implements \IteratorAggregate
             throw new \InvalidArgumentException(sprintf('The helper "%s" is not defined.', $name));
         }
 
+        if ('dialog' === $name && $this->helpers[$name] instanceof DialogHelper) {
+            trigger_error('"Symfony\Component\Console\Helper\DialogHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\QuestionHelper" instead.', E_USER_DEPRECATED);
+        } elseif ('progress' === $name && $this->helpers[$name] instanceof ProgressHelper) {
+            trigger_error('"Symfony\Component\Console\Helper\ProgressHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\ProgressBar" instead.', E_USER_DEPRECATED);
+        } elseif ('table' === $name && $this->helpers[$name] instanceof TableHelper) {
+            trigger_error('"Symfony\Component\Console\Helper\TableHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\Table" instead.', E_USER_DEPRECATED);
+        }
+
         return $this->helpers[$name];
     }
 

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Console\Helper;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
-trigger_error('The "ProgressHelper" class is deprecated since version 2.5 and will be removed in 3.0. Use "ProgressBar" class instead.', E_USER_DEPRECATED);
-
 /**
  * The Progress class provides helpers to display progress output.
  *
@@ -118,6 +116,13 @@ class ProgressHelper extends Helper
         array(129600, '1 day'),
         array(604800, 'days', 86400),
     );
+
+    public function __construct($triggerDeprecationError = true)
+    {
+        if ($triggerDeprecationError) {
+            trigger_error('"Symfony\Component\Console\Helper\ProgressHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\ProgressBar" instead.', E_USER_DEPRECATED);
+        }
+    }
 
     /**
      * Sets the progress bar width.

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -33,9 +33,11 @@ class TableHelper extends Helper
      */
     private $table;
 
-    public function __construct()
+    public function __construct($triggerDeprecationError = true)
     {
-        trigger_error('The TableHelper class was deprecated in version 2.5 and will be removed in 3.0. Use Symfony\Component\Console\Helper\Table instead.', E_USER_DEPRECATED);
+        if ($triggerDeprecationError) {
+            trigger_error('"Symfony\Component\Console\Helper\TableHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\Table" instead.', E_USER_DEPRECATED);
+        }
 
         $this->table = new Table(new NullOutput());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12771, #12791 |
| License | MIT |
| Doc PR |  |

Since the default helper set of the Console `Application` relies on
the `DialogHelper`, the `ProgressHelper` and the `TableHelper`, there
must be a way to not always trigger `E_USER_DEPRECATION` errors when
one of these helper is used.
