### PR TITLE
[ExpressionLanguage] added default value in parse method

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -71,7 +71,7 @@ class ExpressionLanguage
      *
      * @return ParsedExpression A ParsedExpression instance
      */
-    public function parse($expression, $names)
+    public function parse($expression, $names = array())
     {
         if ($expression instanceof ParsedExpression) {
             return $expression;

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -38,10 +38,10 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
             }))
         ;
 
-        $parsedExpression = $expressionLanguage->parse('1 + 1', array());
+        $parsedExpression = $expressionLanguage->parse('1 + 1');
         $this->assertSame($savedParsedExpression, $parsedExpression);
 
-        $parsedExpression = $expressionLanguage->parse('1 + 1', array());
+        $parsedExpression = $expressionLanguage->parse('1 + 1');
         $this->assertSame($savedParsedExpression, $parsedExpression);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (component test suite) |
| License | MIT |

I was trying to follow doc instructions from here : http://symfony.com/doc/2.5/components/expression_language/caching.html#using-parsed-and-serialized-expressions.
