### PR TITLE
[Console] Removed the use of $this->getHelperSet() as it is null by default

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -355,7 +355,13 @@ class QuestionHelper extends Helper
         $attempts = $question->getMaxAttempts();
         while (null === $attempts || $attempts--) {
             if (null !== $error) {
-                $output->writeln($this->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+                if (null !== $this->getHelperSet() && $this->getHelperSet()->has('formatter')) {
+                    $message = $this->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error');
+                } else {
+                    $message = '<error>'.$error->getMessage().'</error>';
+                }
+
+                $output->writeln($message);
             }
 
             try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12805 |
| License | MIT |
| Doc PR | ~ |

Before:
![capture d ecran 2014-12-02 a 15 51 38](https://cloud.githubusercontent.com/assets/667519/5264798/303bf87a-7a3e-11e4-9b45-68e8a86bab60.png)

After:
![capture d ecran 2014-12-02 a 16 36 25](https://cloud.githubusercontent.com/assets/667519/5265299/b13190d6-7a41-11e4-9e68-d889ea290cae.png)
