### PR TITLE
Configure firewall's kernel exception listener with configured entry point or a default entry point

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -334,10 +334,10 @@ class SecurityExtension extends Extension
         }
 
         // Determine default entry point
-        $defaultEntryPoint = isset($firewall['entry_point']) ? $firewall['entry_point'] : null;
+        $configuredEntryPoint = isset($firewall['entry_point']) ? $firewall['entry_point'] : null;
 
         // Authentication listeners
-        list($authListeners, $defaultEntryPoint) = $this->createAuthenticationListeners($container, $id, $firewall, $authenticationProviders, $defaultProvider, $defaultEntryPoint);
+        list($authListeners, $defaultEntryPoint) = $this->createAuthenticationListeners($container, $id, $firewall, $authenticationProviders, $defaultProvider, $configuredEntryPoint);
 
         $listeners = array_merge($listeners, $authListeners);
 
@@ -350,7 +350,7 @@ class SecurityExtension extends Extension
         $listeners[] = new Reference('security.access_listener');
 
         // Exception listener
-        $exceptionListener = new Reference($this->createExceptionListener($container, $firewall, $id, $defaultEntryPoint));
+        $exceptionListener = new Reference($this->createExceptionListener($container, $firewall, $id, $configuredEntryPoint ?: $defaultEntryPoint));
 
         return array($matcher, $listeners, $exceptionListener);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
@@ -35,6 +35,20 @@ class FirewallEntryPointTest extends WebTestCase
         );
     }
 
+    public function testItUsesTheConfiguredEntryPointFromTheExceptionListenerWithFormLoginAndNoCredentials()
+    {
+        $client = $this->createClient(array('test_case' => 'FirewallEntryPoint', 'root_config' => 'config_form_login.yml'));
+        $client->insulate();
+
+        $client->request('GET', '/secure/resource');
+
+        $this->assertEquals(
+            EntryPointStub::RESPONSE_TEXT,
+            $client->getResponse()->getContent(),
+            "Custom entry point wasn't started"
+        );
+    }
+
     protected function setUp()
     {
         parent::setUp();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config_form_login.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config_form_login.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: ./config.yml }
+
+security:
+    firewalls:
+        secure:
+            pattern: ^/
+            form_login:
+                check_path: /login_check


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | when relying on buggy behaviour |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12581 #12801 |
| License | MIT |
| Doc PR | — |

The #12296 PR introduced a bug where the firewall's exception listener was sometimes configured with the default entry point returned by `SecurityExtension#createAuthenticationListeners()`. These changes add a regression test and make the configured entry point (if any) always take precedence over a default entry point.

If someone can confirm this fix, it would have my preference merging this over reverting #12296 for Symfony 2.6.1.
