### PR TITLE
[ExpressionLanguage] Make ArrayNode::getKeyValuePairs method public

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/ArrayNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ArrayNode.php
@@ -53,7 +53,7 @@ class ArrayNode extends Node
         return $result;
     }
 
-    protected function getKeyValuePairs()
+    public function getKeyValuePairs()
     {
         $pairs = array();
         foreach (array_chunk($this->nodes, 2) as $pair) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I want to get nodes from an ArrayNode instance but i get an array of keys and values instead of only values. Internally Symfony has a getKeyValuePairs method that normalize the array of nodes. Can be useful to anyone if this method is public instead of protected.
