### PR TITLE
[3.0] Remove *.class parameters in bundles

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -4,22 +4,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="annotations.reader.class">Doctrine\Common\Annotations\AnnotationReader</parameter>
-        <parameter key="annotations.cached_reader.class">Doctrine\Common\Annotations\CachedReader</parameter>
-        <parameter key="annotations.file_cache_reader.class">Doctrine\Common\Annotations\FileCacheReader</parameter>
-    </parameters>
-
     <services>
-        <service id="annotations.reader" class="%annotations.reader.class%" public="false" />
+        <service id="annotations.reader" class="Doctrine\Common\Annotations\AnnotationReader" public="false" />
 
-        <service id="annotations.cached_reader" class="%annotations.cached_reader.class%" public="false">
+        <service id="annotations.cached_reader" class="Doctrine\Common\Annotations\CachedReader" public="false">
             <argument type="service" id="annotations.reader" />
             <argument /><!-- Cache Implementation -->
             <argument /><!-- Debug-Flag -->
         </service>
 
-        <service id="annotations.file_cache_reader" class="%annotations.file_cache_reader.class%" public="false">
+        <service id="annotations.file_cache_reader" class="Doctrine\Common\Annotations\FileCacheReader" public="false">
             <argument type="service" id="annotations.reader" />
             <argument /><!-- Cache-Directory -->
             <argument /><!-- Debug Flag -->

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -4,26 +4,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="data_collector.config.class">Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector</parameter>
-        <parameter key="data_collector.request.class">Symfony\Component\HttpKernel\DataCollector\RequestDataCollector</parameter>
-        <parameter key="data_collector.exception.class">Symfony\Component\HttpKernel\DataCollector\ExceptionDataCollector</parameter>
-        <parameter key="data_collector.events.class">Symfony\Component\HttpKernel\DataCollector\EventDataCollector</parameter>
-        <parameter key="data_collector.logger.class">Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector</parameter>
-        <parameter key="data_collector.time.class">Symfony\Component\HttpKernel\DataCollector\TimeDataCollector</parameter>
-        <parameter key="data_collector.memory.class">Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector</parameter>
-        <parameter key="data_collector.router.class">Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector</parameter>
-        <parameter key="data_collector.form.class">Symfony\Component\Form\Extension\DataCollector\FormDataCollector</parameter>
-        <parameter key="data_collector.form.extractor.class">Symfony\Component\Form\Extension\DataCollector\FormDataExtractor</parameter>
-    </parameters>
-
     <services>
-        <service id="data_collector.config" class="%data_collector.config.class%" public="false">
+        <service id="data_collector.config" class="Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/config.html.twig" id="config" priority="255" />
             <call method="setKernel"><argument type="service" id="kernel" on-invalid="ignore" /></call>
         </service>
 
-        <service id="data_collector.request" class="%data_collector.request.class%">
+        <service id="data_collector.request" class="Symfony\Component\HttpKernel\DataCollector\RequestDataCollector">
             <tag name="kernel.event_subscriber" />
             <tag name="data_collector" template="@WebProfiler/Collector/request.html.twig" id="request" priority="255" />
         </service>
@@ -32,39 +19,39 @@
             <tag name="data_collector" template="@WebProfiler/Collector/ajax.html.twig" id="ajax" priority="255" />
         </service>
 
-        <service id="data_collector.exception" class="%data_collector.exception.class%" public="false">
+        <service id="data_collector.exception" class="Symfony\Component\HttpKernel\DataCollector\ExceptionDataCollector" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/exception.html.twig" id="exception" priority="255" />
         </service>
 
-        <service id="data_collector.events" class="%data_collector.events.class%" public="false">
+        <service id="data_collector.events" class="Symfony\Component\HttpKernel\DataCollector\EventDataCollector" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/events.html.twig" id="events" priority="255" />
             <argument type="service" id="event_dispatcher" on-invalid="ignore" />
         </service>
 
-        <service id="data_collector.logger" class="%data_collector.logger.class%" public="false">
+        <service id="data_collector.logger" class="Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/logger.html.twig" id="logger" priority="255" />
             <tag name="monolog.logger" channel="profiler" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
-        <service id="data_collector.time" class="%data_collector.time.class%" public="false">
+        <service id="data_collector.time" class="Symfony\Component\HttpKernel\DataCollector\TimeDataCollector" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/time.html.twig" id="time" priority="255" />
             <argument type="service" id="kernel" on-invalid="ignore" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
         </service>
 
-        <service id="data_collector.memory" class="%data_collector.memory.class%" public="false">
+        <service id="data_collector.memory" class="Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/memory.html.twig" id="memory" priority="255" />
         </service>
 
-        <service id="data_collector.router" class="%data_collector.router.class%" >
+        <service id="data_collector.router" class="Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector" >
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
             <tag name="data_collector" template="@WebProfiler/Collector/router.html.twig" id="router" priority="255" />
         </service>
 
-        <service id="data_collector.form.extractor" class="%data_collector.form.extractor.class%" />
+        <service id="data_collector.form.extractor" class="Symfony\Component\Form\Extension\DataCollector\FormDataExtractor" />
 
-        <service id="data_collector.form" class="%data_collector.form.class%">
+        <service id="data_collector.form" class="Symfony\Component\Form\Extension\DataCollector\FormDataCollector">
             <tag name="data_collector" template="@WebProfiler/Collector/form.html.twig" id="form" priority="255" />
             <argument type="service" id="data_collector.form.extractor" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -5,21 +5,19 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="debug.event_dispatcher.class">Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher</parameter>
         <parameter key="debug.container.dump">%kernel.cache_dir%/%kernel.container_class%.xml</parameter>
-        <parameter key="debug.controller_resolver.class">Symfony\Component\HttpKernel\Controller\TraceableControllerResolver</parameter>
         <parameter key="debug.error_handler.throw_at">-1</parameter>
     </parameters>
 
     <services>
-        <service id="debug.event_dispatcher" class="%debug.event_dispatcher.class%">
+        <service id="debug.event_dispatcher" class="Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher">
             <tag name="monolog.logger" channel="event" />
             <argument type="service" id="debug.event_dispatcher.parent" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="debug.controller_resolver" class="%debug.controller_resolver.class%">
+        <service id="debug.controller_resolver" class="Symfony\Component\HttpKernel\Controller\TraceableControllerResolver">
             <argument type="service" id="controller_resolver" />
             <argument type="service" id="debug.stopwatch" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -5,13 +5,11 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="debug.debug_handlers_listener.class">Symfony\Component\HttpKernel\EventListener\DebugHandlersListener</parameter>
-        <parameter key="debug.stopwatch.class">Symfony\Component\Stopwatch\Stopwatch</parameter>
         <parameter key="debug.error_handler.throw_at">0</parameter>
     </parameters>
 
     <services>
-        <service id="debug.debug_handlers_listener" class="%debug.debug_handlers_listener.class%">
+        <service id="debug.debug_handlers_listener" class="Symfony\Component\HttpKernel\EventListener\DebugHandlersListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="php" />
             <argument /><!-- Exception handler -->
@@ -22,6 +20,6 @@
             <argument>null</argument><!-- %templating.helper.code.file_link_format% -->
         </service>
 
-        <service id="debug.stopwatch" class="%debug.stopwatch.class%" />
+        <service id="debug.stopwatch" class="Symfony\Component\Stopwatch\Stopwatch" />
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
@@ -4,15 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="esi.class">Symfony\Component\HttpKernel\HttpCache\Esi</parameter>
-        <parameter key="esi_listener.class">Symfony\Component\HttpKernel\EventListener\EsiListener</parameter>
-    </parameters>
-
     <services>
-        <service id="esi" class="%esi.class%" />
+        <service id="esi" class="Symfony\Component\HttpKernel\HttpCache\Esi" />
 
-        <service id="esi_listener" class="%esi_listener.class%">
+        <service id="esi_listener" class="Symfony\Component\HttpKernel\EventListener\EsiListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="esi" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -4,21 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="form.resolved_type_factory.class">Symfony\Component\Form\ResolvedFormTypeFactory</parameter>
-        <parameter key="form.registry.class">Symfony\Component\Form\FormRegistry</parameter>
-        <parameter key="form.factory.class">Symfony\Component\Form\FormFactory</parameter>
-        <parameter key="form.extension.class">Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension</parameter>
-        <parameter key="form.type_guesser.validator.class">Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser</parameter>
-        <parameter key="form.type_extension.form.request_handler.class">Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler</parameter>
-    </parameters>
-
     <services>
         <!-- ResolvedFormTypeFactory -->
-        <service id="form.resolved_type_factory" class="%form.resolved_type_factory.class%" />
+        <service id="form.resolved_type_factory" class="Symfony\Component\Form\ResolvedFormTypeFactory" />
 
         <!-- FormRegistry -->
-        <service id="form.registry" class="%form.registry.class%">
+        <service id="form.registry" class="Symfony\Component\Form\FormRegistry">
             <argument type="collection">
                 <!--
                 We don't need to be able to add more extensions.
@@ -32,13 +23,13 @@
         </service>
 
         <!-- FormFactory -->
-        <service id="form.factory" class="%form.factory.class%">
+        <service id="form.factory" class="Symfony\Component\Form\FormFactory">
             <argument type="service" id="form.registry" />
             <argument type="service" id="form.resolved_type_factory" />
         </service>
 
         <!-- DependencyInjectionExtension -->
-        <service id="form.extension" class="%form.extension.class%" public="false">
+        <service id="form.extension" class="Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension" public="false">
             <argument type="service" id="service_container" />
             <!-- All services with tag "form.type" are inserted here by FormPass -->
             <argument type="collection" />
@@ -49,7 +40,7 @@
         </service>
 
         <!-- ValidatorTypeGuesser -->
-        <service id="form.type_guesser.validator" class="%form.type_guesser.validator.class%">
+        <service id="form.type_guesser.validator" class="Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser">
             <tag name="form.type_guesser" />
             <argument type="service" id="validator.mapping.class_metadata_factory" />
         </service>
@@ -154,7 +145,7 @@
         </service>
 
         <!-- HttpFoundationRequestHandler -->
-        <service id="form.type_extension.form.request_handler" class="%form.type_extension.form.request_handler.class%" public="false" />
+        <service id="form.type_extension.form.request_handler" class="Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler" public="false" />
 
         <!-- FormTypeValidatorExtension -->
         <service id="form.type_extension.form.validator" class="Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
@@ -4,13 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="form.resolved_type_factory.data_collector_proxy.class">Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeFactoryDataCollectorProxy</parameter>
-        <parameter key="form.type_extension.form.data_collector.class">Symfony\Component\Form\Extension\DataCollector\Type\DataCollectorTypeExtension</parameter>
-    </parameters>
-
     <services>
-        <service id="form.resolved_type_factory" class="%form.resolved_type_factory.data_collector_proxy.class%">
+        <service id="form.resolved_type_factory" class="Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeFactoryDataCollectorProxy">
             <argument type="service">
                 <service class="%form.resolved_type_factory.class%" />
             </argument>
@@ -18,7 +13,7 @@
         </service>
 
         <!-- DataCollectorTypeExtension -->
-        <service id="form.type_extension.form.data_collector" class="%form.type_extension.form.data_collector.class%">
+        <service id="form.type_extension.form.data_collector" class="Symfony\Component\Form\Extension\DataCollector\Type\DataCollectorTypeExtension">
             <tag name="form.type_extension" alias="form" />
             <argument type="service" id="data_collector.form" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="form.resolved_type_factory" class="Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeFactoryDataCollectorProxy">
             <argument type="service">
-                <service class="%form.resolved_type_factory.class%" />
+                <service class="Symfony\Component\Form\ResolvedFormTypeFactory" />
             </argument>
             <argument type="service" id="data_collector.form" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_listener.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_listener.xml
@@ -4,12 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="fragment.listener.class">Symfony\Component\HttpKernel\EventListener\FragmentListener</parameter>
-    </parameters>
-
     <services>
-        <service id="fragment.listener" class="%fragment.listener.class%">
+        <service id="fragment.listener" class="Symfony\Component\HttpKernel\EventListener\FragmentListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="uri_signer" />
             <argument>%fragment.path%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -5,29 +5,25 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fragment.handler.class">Symfony\Component\HttpKernel\Fragment\FragmentHandler</parameter>
-        <parameter key="fragment.renderer.inline.class">Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer</parameter>
-        <parameter key="fragment.renderer.hinclude.class">Symfony\Bundle\FrameworkBundle\Fragment\ContainerAwareHIncludeFragmentRenderer</parameter>
         <parameter key="fragment.renderer.hinclude.global_template"></parameter>
-        <parameter key="fragment.renderer.esi.class">Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer</parameter>
         <parameter key="fragment.path">/_fragment</parameter>
     </parameters>
 
     <services>
-        <service id="fragment.handler" class="%fragment.handler.class%">
+        <service id="fragment.handler" class="Symfony\Component\HttpKernel\Fragment\FragmentHandler">
             <argument type="collection" />
             <argument>%kernel.debug%</argument>
             <argument type="service" id="request_stack" />
         </service>
 
-        <service id="fragment.renderer.inline" class="%fragment.renderer.inline.class%">
+        <service id="fragment.renderer.inline" class="Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer">
             <tag name="kernel.fragment_renderer" />
             <argument type="service" id="http_kernel" />
             <argument type="service" id="event_dispatcher" />
             <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
         </service>
 
-        <service id="fragment.renderer.hinclude" class="%fragment.renderer.hinclude.class%">
+        <service id="fragment.renderer.hinclude" class="Symfony\Bundle\FrameworkBundle\Fragment\ContainerAwareHIncludeFragmentRenderer">
             <tag name="kernel.fragment_renderer" />
             <argument type="service" id="service_container" />
             <argument type="service" id="uri_signer" />
@@ -35,7 +31,7 @@
             <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
         </service>
 
-        <service id="fragment.renderer.esi" class="%fragment.renderer.esi.class%">
+        <service id="fragment.renderer.esi" class="Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer">
             <tag name="kernel.fragment_renderer" />
             <argument type="service" id="esi" on-invalid="null" />
             <argument type="service" id="fragment.renderer.inline" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -4,13 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="profiler.class">Symfony\Component\HttpKernel\Profiler\Profiler</parameter>
-        <parameter key="profiler_listener.class">Symfony\Component\HttpKernel\EventListener\ProfilerListener</parameter>
-    </parameters>
-
     <services>
-        <service id="profiler" class="%profiler.class%">
+        <service id="profiler" class="Symfony\Component\HttpKernel\Profiler\Profiler">
             <tag name="monolog.logger" channel="profiler" />
             <argument type="service" id="profiler.storage" />
             <argument type="service" id="logger" on-invalid="null" />
@@ -23,7 +18,7 @@
             <argument>%profiler.storage.lifetime%</argument>
         </service>
 
-        <service id="profiler_listener" class="%profiler_listener.class%">
+        <service id="profiler_listener" class="Symfony\Component\HttpKernel\EventListener\ProfilerListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="profiler" />
             <argument type="service" id="profiler.request_matcher" on-invalid="null" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.xml
@@ -4,12 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="property_accessor.class">Symfony\Component\PropertyAccess\PropertyAccessor</parameter>
-    </parameters>
-
     <services>
-        <service id="property_accessor" class="%property_accessor.class%" >
+        <service id="property_accessor" class="Symfony\Component\PropertyAccess\PropertyAccessor" >
             <argument /> <!-- magicCall, set by the extension -->
             <argument /> <!-- throwExceptionOnInvalidIndex, set by the extension -->
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/request.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/request.xml
@@ -4,12 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="request.add_request_formats_listener.class">Symfony\Component\HttpKernel\EventListener\AddRequestFormatsListener</parameter>
-    </parameters>
-
     <services>
-        <service id="request.add_request_formats_listener" class="%request.add_request_formats_listener.class%">
+        <service id="request.add_request_formats_listener" class="Symfony\Component\HttpKernel\EventListener\AddRequestFormatsListener">
             <tag name="kernel.event_subscriber" />
             <argument/>
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -5,54 +5,45 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="router.class">Symfony\Bundle\FrameworkBundle\Routing\Router</parameter>
-        <parameter key="router.request_context.class">Symfony\Component\Routing\RequestContext</parameter>
-        <parameter key="routing.loader.class">Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader</parameter>
-        <parameter key="routing.resolver.class">Symfony\Component\Config\Loader\LoaderResolver</parameter>
-        <parameter key="routing.loader.xml.class">Symfony\Component\Routing\Loader\XmlFileLoader</parameter>
-        <parameter key="routing.loader.yml.class">Symfony\Component\Routing\Loader\YamlFileLoader</parameter>
-        <parameter key="routing.loader.php.class">Symfony\Component\Routing\Loader\PhpFileLoader</parameter>
         <parameter key="router.options.generator_class">Symfony\Component\Routing\Generator\UrlGenerator</parameter>
         <parameter key="router.options.generator_base_class">Symfony\Component\Routing\Generator\UrlGenerator</parameter>
         <parameter key="router.options.generator_dumper_class">Symfony\Component\Routing\Generator\Dumper\PhpGeneratorDumper</parameter>
         <parameter key="router.options.matcher_class">Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher</parameter>
         <parameter key="router.options.matcher_base_class">Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher</parameter>
         <parameter key="router.options.matcher_dumper_class">Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper</parameter>
-        <parameter key="router.cache_warmer.class">Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer</parameter>
         <parameter key="router.options.matcher.cache_class">%router.cache_class_prefix%UrlMatcher</parameter>
         <parameter key="router.options.generator.cache_class">%router.cache_class_prefix%UrlGenerator</parameter>
-        <parameter key="router_listener.class">Symfony\Component\HttpKernel\EventListener\RouterListener</parameter>
         <parameter key="router.request_context.host">localhost</parameter>
         <parameter key="router.request_context.scheme">http</parameter>
         <parameter key="router.request_context.base_url"></parameter>
     </parameters>
 
     <services>
-        <service id="routing.resolver" class="%routing.resolver.class%" public="false" />
+        <service id="routing.resolver" class="Symfony\Component\Config\Loader\LoaderResolver" public="false" />
 
-        <service id="routing.loader.xml" class="%routing.loader.xml.class%" public="false">
+        <service id="routing.loader.xml" class="Symfony\Component\Routing\Loader\XmlFileLoader" public="false">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
         </service>
 
-        <service id="routing.loader.yml" class="%routing.loader.yml.class%" public="false">
+        <service id="routing.loader.yml" class="Symfony\Component\Routing\Loader\YamlFileLoader" public="false">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
         </service>
 
-        <service id="routing.loader.php" class="%routing.loader.php.class%" public="false">
+        <service id="routing.loader.php" class="Symfony\Component\Routing\Loader\PhpFileLoader" public="false">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
         </service>
 
-        <service id="routing.loader" class="%routing.loader.class%">
+        <service id="routing.loader" class="Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader">
             <tag name="monolog.logger" channel="router" />
             <argument type="service" id="controller_name_converter" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="routing.resolver" />
         </service>
 
-        <service id="router.default" class="%router.class%" public="false">
+        <service id="router.default" class="Symfony\Bundle\FrameworkBundle\Routing\Router" public="false">
             <tag name="monolog.logger" channel="router" />
             <argument type="service" id="service_container" />
             <argument>%router.resource%</argument>
@@ -74,7 +65,7 @@
 
         <service id="router" alias="router.default" />
 
-        <service id="router.request_context" class="%router.request_context.class%" public="false">
+        <service id="router.request_context" class="Symfony\Component\Routing\RequestContext" public="false">
             <argument>%router.request_context.base_url%</argument>
             <argument>GET</argument>
             <argument>%router.request_context.host%</argument>
@@ -83,12 +74,12 @@
             <argument>%request_listener.https_port%</argument>
         </service>
 
-        <service id="router.cache_warmer" class="%router.cache_warmer.class%" public="false">
+        <service id="router.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer" public="false">
             <tag name="kernel.cache_warmer" />
             <argument type="service" id="router" />
         </service>
 
-        <service id="router_listener" class="%router_listener.class%">
+        <service id="router_listener" class="Symfony\Component\HttpKernel\EventListener\RouterListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="router" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -4,13 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="security.secure_random.class">Symfony\Component\Security\Core\Util\SecureRandom</parameter>
-    </parameters>
-
     <services>
         <!-- Pseudo-Random Number Generator -->
-        <service id="security.secure_random" class="%security.secure_random.class%">
+        <service id="security.secure_random" class="Symfony\Component\Security\Core\Util\SecureRandom">
             <tag name="monolog.logger" channel="security" />
             <argument>%kernel.cache_dir%/secure_random.seed</argument>
             <argument type="service" id="logger" on-invalid="ignore" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.xml
@@ -4,22 +4,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="security.csrf.token_generator.class">Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator</parameter>
-        <parameter key="security.csrf.token_storage.class">Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage</parameter>
-        <parameter key="security.csrf.token_manager.class">Symfony\Component\Security\Csrf\CsrfTokenManager</parameter>
-    </parameters>
-
     <services>
-        <service id="security.csrf.token_generator" class="%security.csrf.token_generator.class%" public="false">
+        <service id="security.csrf.token_generator" class="Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator" public="false">
             <argument type="service" id="security.secure_random" />
         </service>
 
-        <service id="security.csrf.token_storage" class="%security.csrf.token_storage.class%" public="false">
+        <service id="security.csrf.token_storage" class="Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage" public="false">
             <argument type="service" id="session" />
         </service>
 
-        <service id="security.csrf.token_manager" class="%security.csrf.token_manager.class%">
+        <service id="security.csrf.token_manager" class="Symfony\Component\Security\Csrf\CsrfTokenManager">
             <argument type="service" id="security.csrf.token_generator" />
             <argument type="service" id="security.csrf.token_storage" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -4,22 +4,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="serializer.class">Symfony\Component\Serializer\Serializer</parameter>
-        <parameter key="serializer.encoder.xml.class">Symfony\Component\Serializer\Encoder\XmlEncoder</parameter>
-        <parameter key="serializer.encoder.json.class">Symfony\Component\Serializer\Encoder\JsonEncoder</parameter>
-    </parameters>
-
     <services>
-        <service id="serializer" class="%serializer.class%" >
+        <service id="serializer" class="Symfony\Component\Serializer\Serializer" >
             <argument type="collection" />
             <argument type="collection" />
         </service>
         <!-- Encoders -->
-        <service id="serializer.encoder.xml" class="%serializer.encoder.xml.class%" public="false" >
+        <service id="serializer.encoder.xml" class="Symfony\Component\Serializer\Encoder\XmlEncoder" public="false" >
             <tag name="serializer.encoder" />
         </service>
-        <service id="serializer.encoder.json" class="%serializer.encoder.json.class%" public="false" >
+        <service id="serializer.encoder.json" class="Symfony\Component\Serializer\Encoder\JsonEncoder" public="false" >
             <tag name="serializer.encoder" />
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -4,36 +4,25 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="event_dispatcher.class">Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher</parameter>
-        <parameter key="http_kernel.class">Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel</parameter>
-        <parameter key="filesystem.class">Symfony\Component\Filesystem\Filesystem</parameter>
-        <parameter key="cache_warmer.class">Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate</parameter>
-        <parameter key="cache_clearer.class">Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer</parameter>
-        <parameter key="file_locator.class">Symfony\Component\HttpKernel\Config\FileLocator</parameter>
-        <parameter key="uri_signer.class">Symfony\Component\HttpKernel\UriSigner</parameter>
-        <parameter key="request_stack.class">Symfony\Component\HttpFoundation\RequestStack</parameter>
-    </parameters>
-
     <services>
-        <service id="event_dispatcher" class="%event_dispatcher.class%">
+        <service id="event_dispatcher" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher">
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="http_kernel" class="%http_kernel.class%">
+        <service id="http_kernel" class="Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel">
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="service_container" />
             <argument type="service" id="controller_resolver" />
             <argument type="service" id="request_stack" />
         </service>
 
-        <service id="request_stack" class="%request_stack.class%" />
+        <service id="request_stack" class="Symfony\Component\HttpFoundation\RequestStack" />
 
-        <service id="cache_warmer" class="%cache_warmer.class%">
+        <service id="cache_warmer" class="Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate">
             <argument type="collection" />
         </service>
 
-        <service id="cache_clearer" class="%cache_clearer.class%">
+        <service id="cache_clearer" class="Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer">
             <argument type="collection" />
         </service>
 
@@ -52,14 +41,14 @@
 
         <service id="kernel" synthetic="true" />
 
-        <service id="filesystem" class="%filesystem.class%"></service>
+        <service id="filesystem" class="Symfony\Component\Filesystem\Filesystem"></service>
 
-        <service id="file_locator" class="%file_locator.class%">
+        <service id="file_locator" class="Symfony\Component\HttpKernel\Config\FileLocator">
             <argument type="service" id="kernel" />
             <argument>%kernel.root_dir%/Resources</argument>
         </service>
 
-        <service id="uri_signer" class="%uri_signer.class%">
+        <service id="uri_signer" class="Symfony\Component\HttpKernel\UriSigner">
             <argument>%kernel.secret%</argument>
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -5,59 +5,49 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="session.class">Symfony\Component\HttpFoundation\Session\Session</parameter>
-        <parameter key="session.flashbag.class">Symfony\Component\HttpFoundation\Session\Flash\FlashBag</parameter>
-        <parameter key="session.attribute_bag.class">Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag</parameter>
-        <parameter key="session.storage.metadata_bag.class">Symfony\Component\HttpFoundation\Session\Storage\MetadataBag</parameter>
         <parameter key="session.metadata.storage_key">_sf2_meta</parameter>
-        <parameter key="session.storage.native.class">Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage</parameter>
-        <parameter key="session.storage.php_bridge.class">Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage</parameter>
-        <parameter key="session.storage.mock_file.class">Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage</parameter>
-        <parameter key="session.handler.native_file.class">Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler</parameter>
-        <parameter key="session.handler.write_check.class">Symfony\Component\HttpFoundation\Session\Storage\Handler\WriteCheckSessionHandler</parameter>
-        <parameter key="session_listener.class">Symfony\Bundle\FrameworkBundle\EventListener\SessionListener</parameter>
     </parameters>
 
     <services>
-        <service id="session" class="%session.class%">
+        <service id="session" class="Symfony\Component\HttpFoundation\Session\Session">
             <argument type="service" id="session.storage" />
             <argument type="service" id="session.attribute_bag" />
             <argument type="service" id="session.flash_bag" />
         </service>
 
-        <service id="session.storage.metadata_bag" class="%session.storage.metadata_bag.class%" public="false">
+        <service id="session.storage.metadata_bag" class="Symfony\Component\HttpFoundation\Session\Flash\FlashBag" public="false">
             <argument>%session.metadata.storage_key%</argument>
             <argument>%session.metadata.update_threshold%</argument>
         </service>
 
-        <service id="session.storage.native" class="%session.storage.native.class%">
+        <service id="session.storage.native" class="Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage">
             <argument>%session.storage.options%</argument>
             <argument type="service" id="session.handler" />
             <argument type="service" id="session.storage.metadata_bag" />
         </service>
 
-        <service id="session.storage.php_bridge" class="%session.storage.php_bridge.class%">
+        <service id="session.storage.php_bridge" class="Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage">
             <argument type="service" id="session.handler" />
             <argument type="service" id="session.storage.metadata_bag" />
         </service>
 
-        <service id="session.flash_bag" class="%session.flashbag.class%" public="false" />
+        <service id="session.flash_bag" class="Symfony\Component\HttpFoundation\Session\Flash\FlashBag" public="false" />
 
-        <service id="session.attribute_bag" class="%session.attribute_bag.class%" public="false" />
+        <service id="session.attribute_bag" class="Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag" public="false" />
 
-        <service id="session.storage.mock_file" class="%session.storage.mock_file.class%" public="false">
+        <service id="session.storage.mock_file" class="Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage" public="false">
             <argument>%kernel.cache_dir%/sessions</argument>
             <argument>MOCKSESSID</argument>
             <argument type="service" id="session.storage.metadata_bag" />
         </service>
 
-        <service id="session.handler.native_file" class="%session.handler.native_file.class%" public="false">
+        <service id="session.handler.native_file" class="Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler" public="false">
             <argument>%session.save_path%</argument>
         </service>
 
-        <service id="session.handler.write_check" class="%session.handler.write_check.class%" public="false" />
+        <service id="session.handler.write_check" class="Symfony\Component\HttpFoundation\Session\Storage\Handler\WriteCheckSessionHandler" public="false" />
 
-        <service id="session_listener" class="%session_listener.class%">
+        <service id="session_listener" class="Symfony\Bundle\FrameworkBundle\EventListener\SessionListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="service_container" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
@@ -4,57 +4,45 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="templating.engine.delegating.class">Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine</parameter>
-        <parameter key="templating.name_parser.class">Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser</parameter>
-        <parameter key="templating.filename_parser.class">Symfony\Bundle\FrameworkBundle\Templating\TemplateFilenameParser</parameter>
-        <parameter key="templating.cache_warmer.template_paths.class">Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplatePathsCacheWarmer</parameter>
-        <parameter key="templating.locator.class">Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator</parameter>
-        <parameter key="templating.loader.filesystem.class">Symfony\Bundle\FrameworkBundle\Templating\Loader\FilesystemLoader</parameter>
-        <parameter key="templating.loader.cache.class">Symfony\Component\Templating\Loader\CacheLoader</parameter>
-        <parameter key="templating.loader.chain.class">Symfony\Component\Templating\Loader\ChainLoader</parameter>
-        <parameter key="templating.finder.class">Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinder</parameter>
-    </parameters>
-
     <services>
-        <service id="templating.engine.delegating" class="%templating.engine.delegating.class%" public="false">
+        <service id="templating.engine.delegating" class="Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine" public="false">
             <argument type="service" id="service_container" />
             <argument type="collection" /> <!-- engines -->
         </service>
 
-        <service id="templating.name_parser" class="%templating.name_parser.class%">
+        <service id="templating.name_parser" class="Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser">
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="templating.filename_parser" class="%templating.filename_parser.class%" />
+        <service id="templating.filename_parser" class="Symfony\Bundle\FrameworkBundle\Templating\TemplateFilenameParser" />
 
-        <service id="templating.locator" class="%templating.locator.class%" public="false">
+        <service id="templating.locator" class="Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator" public="false">
             <argument type="service" id="file_locator" />
             <argument>%kernel.cache_dir%</argument>
         </service>
 
-        <service id="templating.finder" class="%templating.finder.class%" public="false">
+        <service id="templating.finder" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinder" public="false">
             <argument type="service" id="kernel" />
             <argument type="service" id="templating.filename_parser" />
             <argument>%kernel.root_dir%/Resources</argument>
         </service>
 
-        <service id="templating.cache_warmer.template_paths" class="%templating.cache_warmer.template_paths.class%" public="false">
+        <service id="templating.cache_warmer.template_paths" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplatePathsCacheWarmer" public="false">
             <tag name="kernel.cache_warmer" priority="20" />
             <argument type="service" id="templating.finder" />
             <argument type="service" id="templating.locator" />
         </service>
 
-        <service id="templating.loader.filesystem" class="%templating.loader.filesystem.class%" public="false">
+        <service id="templating.loader.filesystem" class="Symfony\Bundle\FrameworkBundle\Templating\Loader\FilesystemLoader" public="false">
             <argument type="service" id="templating.locator" />
         </service>
 
-        <service id="templating.loader.cache" class="%templating.loader.cache.class%" public="false">
+        <service id="templating.loader.cache" class="Symfony\Component\Templating\Loader\CacheLoader" public="false">
             <argument type="service" id="templating.loader.wrapped" />
             <argument>%templating.loader.cache.path%</argument>
         </service>
 
-        <service id="templating.loader.chain" class="%templating.loader.chain.class%" public="false">
+        <service id="templating.loader.chain" class="Symfony\Component\Templating\Loader\ChainLoader" public="false">
         </service>
 
         <service id="templating.loader" alias="templating.loader.filesystem" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_debug.xml
@@ -4,12 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="debug.templating.engine.php.class">Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine</parameter>
-    </parameters>
-
     <services>
-        <service id="debug.templating.engine.php" class="%debug.templating.engine.php.class%" public="false">
+        <service id="debug.templating.engine.php" class="Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine" public="false">
             <argument type="service" id="templating.name_parser" />
             <argument type="service" id="service_container" />
             <argument type="service" id="templating.loader" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -4,28 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="templating.engine.php.class">Symfony\Bundle\FrameworkBundle\Templating\PhpEngine</parameter>
-        <parameter key="templating.helper.slots.class">Symfony\Component\Templating\Helper\SlotsHelper</parameter>
-        <parameter key="templating.helper.assets.class">Symfony\Component\Templating\Helper\CoreAssetsHelper</parameter>
-        <parameter key="templating.helper.actions.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper</parameter>
-        <parameter key="templating.helper.router.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\RouterHelper</parameter>
-        <parameter key="templating.helper.request.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\RequestHelper</parameter>
-        <parameter key="templating.helper.session.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\SessionHelper</parameter>
-        <parameter key="templating.helper.code.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper</parameter>
-        <parameter key="templating.helper.translator.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper</parameter>
-        <parameter key="templating.helper.form.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper</parameter>
-        <parameter key="templating.helper.stopwatch.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\StopwatchHelper</parameter>
-        <parameter key="templating.form.engine.class">Symfony\Component\Form\Extension\Templating\TemplatingRendererEngine</parameter>
-        <parameter key="templating.form.renderer.class">Symfony\Component\Form\FormRenderer</parameter>
-        <parameter key="templating.globals.class">Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables</parameter>
-        <parameter key="templating.asset.path_package.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\PathPackage</parameter>
-        <parameter key="templating.asset.url_package.class">Symfony\Component\Templating\Asset\UrlPackage</parameter>
-        <parameter key="templating.asset.package_factory.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\PackageFactory</parameter>
-    </parameters>
-
     <services>
-        <service id="templating.engine.php" class="%templating.engine.php.class%" public="false">
+        <service id="templating.engine.php" class="Symfony\Bundle\FrameworkBundle\Templating\PhpEngine" public="false">
             <argument type="service" id="templating.name_parser" />
             <argument type="service" id="service_container" />
             <argument type="service" id="templating.loader" />
@@ -33,23 +13,23 @@
             <call method="setCharset"><argument>%kernel.charset%</argument></call>
         </service>
 
-        <service id="templating.helper.slots" class="%templating.helper.slots.class%">
+        <service id="templating.helper.slots" class="Symfony\Component\Templating\Helper\SlotsHelper">
             <tag name="templating.helper" alias="slots" />
         </service>
 
-        <service id="templating.helper.assets" class="%templating.helper.assets.class%">
+        <service id="templating.helper.assets" class="Symfony\Component\Templating\Helper\CoreAssetsHelper">
             <tag name="templating.helper" alias="assets" />
             <argument /> <!-- default package -->
             <argument type="collection" /> <!-- named packages -->
         </service>
 
-        <service id="templating.asset.path_package" class="%templating.asset.path_package.class%" abstract="true">
+        <service id="templating.asset.path_package" class="Symfony\Bundle\FrameworkBundle\Templating\Asset\PathPackage" abstract="true">
             <argument type="service" id="request" />
             <argument /> <!-- version -->
             <argument /> <!-- version format -->
         </service>
 
-        <service id="templating.asset.url_package" class="%templating.asset.url_package.class%" abstract="true">
+        <service id="templating.asset.url_package" class="Symfony\Component\Templating\Asset\UrlPackage" abstract="true">
             <argument /> <!-- base urls -->
             <argument /> <!-- version -->
             <argument /> <!-- version format -->
@@ -61,63 +41,63 @@
             <argument /> <!-- SSL id -->
         </service>
 
-        <service id="templating.asset.package_factory" class="%templating.asset.package_factory.class%">
+        <service id="templating.asset.package_factory" class="Symfony\Bundle\FrameworkBundle\Templating\Asset\PackageFactory">
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="templating.helper.request" class="%templating.helper.request.class%">
+        <service id="templating.helper.request" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\RequestHelper">
             <tag name="templating.helper" alias="request" />
             <argument type="service" id="request_stack" />
         </service>
 
-        <service id="templating.helper.session" class="%templating.helper.session.class%">
+        <service id="templating.helper.session" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\SessionHelper">
             <tag name="templating.helper" alias="session" />
             <argument type="service" id="request_stack" />
         </service>
 
-        <service id="templating.helper.router" class="%templating.helper.router.class%">
+        <service id="templating.helper.router" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\RouterHelper">
             <tag name="templating.helper" alias="router" />
             <argument type="service" id="router" />
         </service>
 
-        <service id="templating.helper.actions" class="%templating.helper.actions.class%">
+        <service id="templating.helper.actions" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper">
             <tag name="templating.helper" alias="actions" />
             <argument type="service" id="fragment.handler" />
         </service>
 
-        <service id="templating.helper.code" class="%templating.helper.code.class%">
+        <service id="templating.helper.code" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper">
             <tag name="templating.helper" alias="code" />
             <argument>%templating.helper.code.file_link_format%</argument>
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>
 
-        <service id="templating.helper.translator" class="%templating.helper.translator.class%">
+        <service id="templating.helper.translator" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper">
             <tag name="templating.helper" alias="translator" />
             <argument type="service" id="translator" />
         </service>
 
-        <service id="templating.helper.form" class="%templating.helper.form.class%">
+        <service id="templating.helper.form" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper">
             <tag name="templating.helper" alias="form" />
             <argument type="service" id="templating.form.renderer" />
         </service>
 
-        <service id="templating.helper.stopwatch" class="%templating.helper.stopwatch.class%">
+        <service id="templating.helper.stopwatch" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\StopwatchHelper">
             <tag name="templating.helper" alias="stopwatch" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
         </service>
 
-        <service id="templating.form.engine" class="%templating.form.engine.class%" public="false">
+        <service id="templating.form.engine" class="Symfony\Component\Form\Extension\Templating\TemplatingRendererEngine" public="false">
             <argument type="service" id="templating.engine.php" />
             <argument>%templating.helper.form.resources%</argument>
         </service>
 
-        <service id="templating.form.renderer" class="%templating.form.renderer.class%" public="false">
+        <service id="templating.form.renderer" class="Symfony\Component\Form\FormRenderer" public="false">
             <argument type="service" id="templating.form.engine" />
             <argument type="service" id="form.csrf_provider" on-invalid="null" />
         </service>
 
-        <service id="templating.globals" class="%templating.globals.class%">
+        <service id="templating.globals" class="Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables">
             <argument type="service" id="service_container" />
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -5,26 +5,22 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="test.client.class">Symfony\Bundle\FrameworkBundle\Client</parameter>
         <parameter key="test.client.parameters" type="collection"></parameter>
-        <parameter key="test.client.history.class">Symfony\Component\BrowserKit\History</parameter>
-        <parameter key="test.client.cookiejar.class">Symfony\Component\BrowserKit\CookieJar</parameter>
-        <parameter key="test.session.listener.class">Symfony\Bundle\FrameworkBundle\EventListener\TestSessionListener</parameter>
     </parameters>
 
     <services>
-        <service id="test.client" class="%test.client.class%" scope="prototype">
+        <service id="test.client" class="Symfony\Bundle\FrameworkBundle\Client" scope="prototype">
             <argument type="service" id="kernel" />
             <argument>%test.client.parameters%</argument>
             <argument type="service" id="test.client.history" />
             <argument type="service" id="test.client.cookiejar" />
         </service>
 
-        <service id="test.client.history" class="%test.client.history.class%" scope="prototype" />
+        <service id="test.client.history" class="Symfony\Component\BrowserKit\History" scope="prototype" />
 
-        <service id="test.client.cookiejar" class="%test.client.cookiejar.class%" scope="prototype" />
+        <service id="test.client.cookiejar" class="Symfony\Component\BrowserKit\CookieJar" scope="prototype" />
 
-        <service id="test.session.listener" class="%test.session.listener.class%">
+        <service id="test.session.listener" class="Symfony\Bundle\FrameworkBundle\EventListener\TestSessionListener">
             <argument type="service" id="service_container" />
             <tag name="kernel.event_subscriber" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -4,39 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="translator.class">Symfony\Bundle\FrameworkBundle\Translation\Translator</parameter>
-        <parameter key="translator.identity.class">Symfony\Component\Translation\IdentityTranslator</parameter>
-        <parameter key="translator.selector.class">Symfony\Component\Translation\MessageSelector</parameter>
-        <parameter key="translation.loader.php.class">Symfony\Component\Translation\Loader\PhpFileLoader</parameter>
-        <parameter key="translation.loader.yml.class">Symfony\Component\Translation\Loader\YamlFileLoader</parameter>
-        <parameter key="translation.loader.xliff.class">Symfony\Component\Translation\Loader\XliffFileLoader</parameter>
-        <parameter key="translation.loader.po.class">Symfony\Component\Translation\Loader\PoFileLoader</parameter>
-        <parameter key="translation.loader.mo.class">Symfony\Component\Translation\Loader\MoFileLoader</parameter>
-        <parameter key="translation.loader.qt.class">Symfony\Component\Translation\Loader\QtFileLoader</parameter>
-        <parameter key="translation.loader.csv.class">Symfony\Component\Translation\Loader\CsvFileLoader</parameter>
-        <parameter key="translation.loader.res.class">Symfony\Component\Translation\Loader\IcuResFileLoader</parameter>
-        <parameter key="translation.loader.dat.class">Symfony\Component\Translation\Loader\IcuDatFileLoader</parameter>
-        <parameter key="translation.loader.ini.class">Symfony\Component\Translation\Loader\IniFileLoader</parameter>
-        <parameter key="translation.loader.json.class">Symfony\Component\Translation\Loader\JsonFileLoader</parameter>
-        <parameter key="translation.dumper.php.class">Symfony\Component\Translation\Dumper\PhpFileDumper</parameter>
-        <parameter key="translation.dumper.xliff.class">Symfony\Component\Translation\Dumper\XliffFileDumper</parameter>
-        <parameter key="translation.dumper.po.class">Symfony\Component\Translation\Dumper\PoFileDumper</parameter>
-        <parameter key="translation.dumper.mo.class">Symfony\Component\Translation\Dumper\MoFileDumper</parameter>
-        <parameter key="translation.dumper.yml.class">Symfony\Component\Translation\Dumper\YamlFileDumper</parameter>
-        <parameter key="translation.dumper.qt.class">Symfony\Component\Translation\Dumper\QtFileDumper</parameter>
-        <parameter key="translation.dumper.csv.class">Symfony\Component\Translation\Dumper\CsvFileDumper</parameter>
-        <parameter key="translation.dumper.ini.class">Symfony\Component\Translation\Dumper\IniFileDumper</parameter>
-        <parameter key="translation.dumper.json.class">Symfony\Component\Translation\Dumper\JsonFileDumper</parameter>
-        <parameter key="translation.dumper.res.class">Symfony\Component\Translation\Dumper\IcuResFileDumper</parameter>
-        <parameter key="translation.extractor.php.class">Symfony\Bundle\FrameworkBundle\Translation\PhpExtractor</parameter>
-        <parameter key="translation.loader.class">Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader</parameter>
-        <parameter key="translation.extractor.class">Symfony\Component\Translation\Extractor\ChainExtractor</parameter>
-        <parameter key="translation.writer.class">Symfony\Component\Translation\Writer\TranslationWriter</parameter>
-    </parameters>
-
     <services>
-        <service id="translator.default" class="%translator.class%">
+        <service id="translator.default" class="Symfony\Bundle\FrameworkBundle\Translation\Translator">
             <argument type="service" id="service_container" />
             <argument type="service" id="translator.selector" />
             <argument type="collection" /> <!-- translation loaders -->
@@ -52,104 +21,104 @@
             <tag name="monolog.logger" channel="translation" />
         </service>
 
-        <service id="translator" class="%translator.identity.class%">
+        <service id="translator" class="Symfony\Component\Translation\IdentityTranslator">
             <argument type="service" id="translator.selector" />
         </service>
 
-        <service id="translator.selector" class="%translator.selector.class%" public="false" />
+        <service id="translator.selector" class="Symfony\Component\Translation\MessageSelector" public="false" />
 
-        <service id="translation.loader.php" class="%translation.loader.php.class%">
+        <service id="translation.loader.php" class="Symfony\Component\Translation\Loader\PhpFileLoader">
             <tag name="translation.loader" alias="php" />
         </service>
 
-        <service id="translation.loader.yml" class="%translation.loader.yml.class%">
+        <service id="translation.loader.yml" class="Symfony\Component\Translation\Loader\YamlFileLoader">
             <tag name="translation.loader" alias="yml" />
         </service>
 
-        <service id="translation.loader.xliff" class="%translation.loader.xliff.class%">
+        <service id="translation.loader.xliff" class="Symfony\Component\Translation\Loader\XliffFileLoader">
             <tag name="translation.loader" alias="xlf" legacy-alias="xliff" />
         </service>
 
-        <service id="translation.loader.po" class="%translation.loader.po.class%">
+        <service id="translation.loader.po" class="Symfony\Component\Translation\Loader\PoFileLoader">
             <tag name="translation.loader" alias="po" />
         </service>
 
-        <service id="translation.loader.mo" class="%translation.loader.mo.class%">
+        <service id="translation.loader.mo" class="Symfony\Component\Translation\Loader\MoFileLoader">
             <tag name="translation.loader" alias="mo" />
         </service>
 
-        <service id="translation.loader.qt" class="%translation.loader.qt.class%">
+        <service id="translation.loader.qt" class="Symfony\Component\Translation\Loader\QtFileLoader">
             <tag name="translation.loader" alias="ts" />
         </service>
 
-        <service id="translation.loader.csv" class="%translation.loader.csv.class%">
+        <service id="translation.loader.csv" class="Symfony\Component\Translation\Loader\CsvFileLoader">
             <tag name="translation.loader" alias="csv" />
         </service>
 
-        <service id="translation.loader.res" class="%translation.loader.res.class%">
+        <service id="translation.loader.res" class="Symfony\Component\Translation\Loader\IcuResFileLoader">
             <tag name="translation.loader" alias="res" />
         </service>
 
-        <service id="translation.loader.dat" class="%translation.loader.dat.class%">
+        <service id="translation.loader.dat" class="Symfony\Component\Translation\Loader\IcuDatFileLoader">
             <tag name="translation.loader" alias="dat" />
         </service>
 
-        <service id="translation.loader.ini" class="%translation.loader.ini.class%">
+        <service id="translation.loader.ini" class="Symfony\Component\Translation\Loader\IniFileLoader">
             <tag name="translation.loader" alias="ini" />
         </service>
 
-        <service id="translation.loader.json" class="%translation.loader.json.class%">
+        <service id="translation.loader.json" class="Symfony\Component\Translation\Loader\JsonFileLoader">
             <tag name="translation.loader" alias="json" />
         </service>
 
-        <service id="translation.dumper.php" class="%translation.dumper.php.class%">
+        <service id="translation.dumper.php" class="Symfony\Component\Translation\Dumper\PhpFileDumper">
             <tag name="translation.dumper" alias="php" />
         </service>
 
-        <service id="translation.dumper.xliff" class="%translation.dumper.xliff.class%">
+        <service id="translation.dumper.xliff" class="Symfony\Component\Translation\Dumper\XliffFileDumper">
             <tag name="translation.dumper" alias="xlf" />
         </service>
 
-        <service id="translation.dumper.po" class="%translation.dumper.po.class%">
+        <service id="translation.dumper.po" class="Symfony\Component\Translation\Dumper\PoFileDumper">
             <tag name="translation.dumper" alias="po" />
         </service>
 
-        <service id="translation.dumper.mo" class="%translation.dumper.mo.class%">
+        <service id="translation.dumper.mo" class="Symfony\Component\Translation\Dumper\MoFileDumper">
             <tag name="translation.dumper" alias="mo" />
         </service>
 
-        <service id="translation.dumper.yml" class="%translation.dumper.yml.class%">
+        <service id="translation.dumper.yml" class="Symfony\Component\Translation\Dumper\YamlFileDumper">
             <tag name="translation.dumper" alias="yml" />
         </service>
 
-        <service id="translation.dumper.qt" class="%translation.dumper.qt.class%">
+        <service id="translation.dumper.qt" class="Symfony\Component\Translation\Dumper\QtFileDumper">
             <tag name="translation.dumper" alias="ts" />
         </service>
 
-        <service id="translation.dumper.csv" class="%translation.dumper.csv.class%">
+        <service id="translation.dumper.csv" class="Symfony\Component\Translation\Dumper\CsvFileDumper">
             <tag name="translation.dumper" alias="csv" />
         </service>
 
-        <service id="translation.dumper.ini" class="%translation.dumper.ini.class%">
+        <service id="translation.dumper.ini" class="Symfony\Component\Translation\Dumper\IniFileDumper">
             <tag name="translation.dumper" alias="ini" />
         </service>
 
-        <service id="translation.dumper.json" class="%translation.dumper.json.class%">
+        <service id="translation.dumper.json" class="Symfony\Component\Translation\Dumper\JsonFileDumper">
             <tag name="translation.dumper" alias="json" />
         </service>
 
-        <service id="translation.dumper.res" class="%translation.dumper.res.class%">
+        <service id="translation.dumper.res" class="Symfony\Component\Translation\Dumper\IcuResFileDumper">
             <tag name="translation.dumper" alias="res" />
         </service>
 
-        <service id="translation.extractor.php" class="%translation.extractor.php.class%">
+        <service id="translation.extractor.php" class="Symfony\Bundle\FrameworkBundle\Translation\PhpExtractor">
             <tag name="translation.extractor" alias="php" />
         </service>
 
-        <service id="translation.loader" class="%translation.loader.class%"/>
+        <service id="translation.loader" class="Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader"/>
 
-        <service id="translation.extractor" class="%translation.extractor.class%"/>
+        <service id="translation.extractor" class="Symfony\Component\Translation\Extractor\ChainExtractor"/>
 
-        <service id="translation.writer" class="%translation.writer.class%"/>
+        <service id="translation.writer" class="Symfony\Component\Translation\Writer\TranslationWriter"/>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -5,11 +5,12 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <parameter key="validator.class">Symfony\Component\Validator\ValidatorInterface</parameter>
         <parameter key="validator.mapping.cache.prefix" />
     </parameters>
 
     <services>
-        <service id="validator" class="Symfony\Component\Validator\Validator\ValidatorInterface" factory-service="validator.builder" factory-method="getValidator" />
+        <service id="validator" class="%validator.class%" factory-service="validator.builder" factory-method="getValidator" />
 
         <service id="validator.builder" class="Symfony\Component\Validator\ValidatorBuilderInterface" factory-class="Symfony\Component\Validator\Validation" factory-method="createValidatorBuilder">
             <call method="setConstraintValidatorFactory">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="validator" class="Symfony\Component\Validator\ValidatorInterface" factory-service="validator.builder" factory-method="getValidator" />
+        <service id="validator" class="Symfony\Component\Validator\Validator\ValidatorInterface" factory-service="validator.builder" factory-method="getValidator" />
 
         <service id="validator.builder" class="Symfony\Component\Validator\ValidatorBuilderInterface" factory-class="Symfony\Component\Validator\Validation" factory-method="createValidatorBuilder">
             <call method="setConstraintValidatorFactory">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -5,20 +5,13 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="validator.class">Symfony\Component\Validator\ValidatorInterface</parameter>
-        <parameter key="validator.builder.class">Symfony\Component\Validator\ValidatorBuilderInterface</parameter>
-        <parameter key="validator.builder.factory.class">Symfony\Component\Validator\Validation</parameter>
-        <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache</parameter>
         <parameter key="validator.mapping.cache.prefix" />
-        <parameter key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory</parameter>
-        <parameter key="validator.expression.class">Symfony\Component\Validator\Constraints\ExpressionValidator</parameter>
-        <parameter key="validator.email.class">Symfony\Component\Validator\Constraints\EmailValidator</parameter>
     </parameters>
 
     <services>
-        <service id="validator" class="%validator.class%" factory-service="validator.builder" factory-method="getValidator" />
+        <service id="validator" class="Symfony\Component\Validator\ValidatorInterface" factory-service="validator.builder" factory-method="getValidator" />
 
-        <service id="validator.builder" class="%validator.builder.class%" factory-class="%validator.builder.factory.class%" factory-method="createValidatorBuilder">
+        <service id="validator.builder" class="Symfony\Component\Validator\ValidatorBuilderInterface" factory-class="Symfony\Component\Validator\Validation" factory-method="createValidatorBuilder">
             <call method="setConstraintValidatorFactory">
                 <argument type="service" id="validator.validator_factory" />
             </call>
@@ -32,21 +25,21 @@
 
         <service id="validator.mapping.class_metadata_factory" alias="validator" public="false" />
 
-        <service id="validator.mapping.cache.apc" class="%validator.mapping.cache.apc.class%" public="false">
+        <service id="validator.mapping.cache.apc" class="Symfony\Component\Validator\Mapping\Cache\ApcCache" public="false">
             <argument>%validator.mapping.cache.prefix%</argument>
         </service>
 
-        <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">
+        <service id="validator.validator_factory" class="Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory" public="false">
             <argument type="service" id="service_container" />
             <argument type="collection" />
         </service>
 
-        <service id="validator.expression" class="%validator.expression.class%">
+        <service id="validator.expression" class="Symfony\Component\Validator\Constraints\ExpressionValidator">
             <argument type="service" id="property_accessor" />
             <tag name="validator.constraint_validator" alias="validator.expression" />
         </service>
 
-        <service id="validator.email" class="%validator.email.class%">
+        <service id="validator.email" class="Symfony\Component\Validator\Constraints\EmailValidator">
             <argument></argument>
             <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -4,37 +4,29 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="controller_resolver.class">Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver</parameter>
-        <parameter key="controller_name_converter.class">Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser</parameter>
-        <parameter key="response_listener.class">Symfony\Component\HttpKernel\EventListener\ResponseListener</parameter>
-        <parameter key="streamed_response_listener.class">Symfony\Component\HttpKernel\EventListener\StreamedResponseListener</parameter>
-        <parameter key="locale_listener.class">Symfony\Component\HttpKernel\EventListener\LocaleListener</parameter>
-    </parameters>
-
     <services>
-        <service id="controller_name_converter" class="%controller_name_converter.class%" public="false">
+        <service id="controller_name_converter" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver" public="false">
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="controller_resolver" class="%controller_resolver.class%" public="false">
+        <service id="controller_resolver" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser" public="false">
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="service_container" />
             <argument type="service" id="controller_name_converter" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
-        <service id="response_listener" class="%response_listener.class%">
+        <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener">
             <tag name="kernel.event_subscriber" />
             <argument>%kernel.charset%</argument>
         </service>
 
-        <service id="streamed_response_listener" class="%streamed_response_listener.class%">
+        <service id="streamed_response_listener" class="Symfony\Component\HttpKernel\EventListener\StreamedResponseListener">
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="locale_listener" class="%locale_listener.class%">
+        <service id="locale_listener" class="Symfony\Component\HttpKernel\EventListener\LocaleListener">
             <tag name="kernel.event_subscriber" />
             <argument>%kernel.default_locale%</argument>
             <argument type="service" id="router" on-invalid="ignore" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggingTranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggingTranslatorPassTest.php
@@ -41,7 +41,7 @@ class LoggingTranslatorPassTest extends \PHPUnit_Framework_TestCase
 
         $definition->expects($this->once())
             ->method('getClass')
-            ->will($this->returnValue("%translator.class%"));
+            ->will($this->returnValue("Symfony\Bundle\FrameworkBundle\Translation\Translator"));
 
         $parameterBag->expects($this->once())
             ->method('resolveValue')

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
@@ -4,12 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="data_collector.security.class">Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector</parameter>
-    </parameters>
-
     <services>
-        <service id="data_collector.security" class="%data_collector.security.class%" public="false">
+        <service id="data_collector.security" class="Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector" public="false">
             <tag name="data_collector" template="@Security/Collector/security.html.twig" id="security" />
             <argument type="service" id="security.context" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -5,52 +5,24 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="security.context.class">Symfony\Component\Security\Core\SecurityContext</parameter>
-
-        <parameter key="security.user_checker.class">Symfony\Component\Security\Core\User\UserChecker</parameter>
-
-        <parameter key="security.encoder_factory.generic.class">Symfony\Component\Security\Core\Encoder\EncoderFactory</parameter>
         <parameter key="security.encoder.digest.class">Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder</parameter>
         <parameter key="security.encoder.plain.class">Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder</parameter>
         <parameter key="security.encoder.pbkdf2.class">Symfony\Component\Security\Core\Encoder\Pbkdf2PasswordEncoder</parameter>
         <parameter key="security.encoder.bcrypt.class">Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder</parameter>
 
-        <parameter key="security.user.provider.in_memory.class">Symfony\Component\Security\Core\User\InMemoryUserProvider</parameter>
-        <parameter key="security.user.provider.in_memory.user.class">Symfony\Component\Security\Core\User\User</parameter>
-        <parameter key="security.user.provider.chain.class">Symfony\Component\Security\Core\User\ChainUserProvider</parameter>
-
         <parameter key="security.authentication.trust_resolver.class">Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver</parameter>
         <parameter key="security.authentication.trust_resolver.anonymous_class">Symfony\Component\Security\Core\Authentication\Token\AnonymousToken</parameter>
         <parameter key="security.authentication.trust_resolver.rememberme_class">Symfony\Component\Security\Core\Authentication\Token\RememberMeToken</parameter>
 
-        <parameter key="security.authentication.manager.class">Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager</parameter>
-
         <parameter key="security.authentication.session_strategy.class">Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy</parameter>
-
         <parameter key="security.access.decision_manager.class">Symfony\Component\Security\Core\Authorization\AccessDecisionManager</parameter>
 
-        <parameter key="security.access.simple_role_voter.class">Symfony\Component\Security\Core\Authorization\Voter\RoleVoter</parameter>
-        <parameter key="security.access.authenticated_voter.class">Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter</parameter>
-        <parameter key="security.access.role_hierarchy_voter.class">Symfony\Component\Security\Core\Authorization\Voter\RoleHierarchyVoter</parameter>
-        <parameter key="security.access.expression_voter.class">Symfony\Component\Security\Core\Authorization\Voter\ExpressionVoter</parameter>
-
-        <parameter key="security.firewall.class">Symfony\Component\Security\Http\Firewall</parameter>
-        <parameter key="security.firewall.map.class">Symfony\Bundle\SecurityBundle\Security\FirewallMap</parameter>
-        <parameter key="security.firewall.context.class">Symfony\Bundle\SecurityBundle\Security\FirewallContext</parameter>
         <parameter key="security.matcher.class">Symfony\Component\HttpFoundation\RequestMatcher</parameter>
         <parameter key="security.expression_matcher.class">Symfony\Component\HttpFoundation\ExpressionRequestMatcher</parameter>
-
-        <parameter key="security.role_hierarchy.class">Symfony\Component\Security\Core\Role\RoleHierarchy</parameter>
-
-        <parameter key="security.http_utils.class">Symfony\Component\Security\Http\HttpUtils</parameter>
-
-        <parameter key="security.validator.user_password.class">Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator</parameter>
-
-        <parameter key="security.expression_language.class">Symfony\Component\Security\Core\Authorization\ExpressionLanguage</parameter>
     </parameters>
 
     <services>
-        <service id="security.context" class="%security.context.class%">
+        <service id="security.context" class="Symfony\Component\Security\Core\SecurityContext">
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authorization_checker" />
         </service>
@@ -65,7 +37,7 @@
         <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" />
 
         <!-- Authentication related services -->
-        <service id="security.authentication.manager" class="%security.authentication.manager.class%" public="false">
+        <service id="security.authentication.manager" class="Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager" public="false">
             <argument type="collection" />
             <argument>%security.authentication.manager.erase_credentials%</argument>
             <call method="setEventDispatcher">
@@ -73,16 +45,16 @@
             </call>
         </service>
 
-        <service id="security.authentication.trust_resolver" class="%security.authentication.trust_resolver.class%" public="false">
+        <service id="security.authentication.trust_resolver" class="Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver" public="false">
             <argument>%security.authentication.trust_resolver.anonymous_class%</argument>
             <argument>%security.authentication.trust_resolver.rememberme_class%</argument>
         </service>
 
-        <service id="security.authentication.session_strategy" class="%security.authentication.session_strategy.class%" public="false">
+        <service id="security.authentication.session_strategy" class="Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy" public="false">
             <argument>%security.authentication.session_strategy.strategy%</argument>
         </service>
 
-        <service id="security.encoder_factory.generic" class="%security.encoder_factory.generic.class%" public="false">
+        <service id="security.encoder_factory.generic" class="Symfony\Component\Security\Core\Encoder\EncoderFactory" public="false">
             <argument type="collection"></argument>
         </service>
 
@@ -94,40 +66,40 @@
 
         <service id="security.password_encoder" alias="security.user_password_encoder.generic"></service>
 
-        <service id="security.user_checker" class="%security.user_checker.class%" public="false" />
+        <service id="security.user_checker" class="Symfony\Component\Security\Core\User\UserChecker" public="false" />
 
-        <service id="security.expression_language" class="%security.expression_language.class%" public="false" />
+        <service id="security.expression_language" class="Symfony\Component\Security\Core\Authorization\ExpressionLanguage" public="false" />
 
         <service id="security.authentication_utils" class="Symfony\Component\Security\Http\Authentication\AuthenticationUtils">
             <argument type="service" id="request_stack" />
         </service>
 
         <!-- Authorization related services -->
-        <service id="security.access.decision_manager" class="%security.access.decision_manager.class%" public="false">
+        <service id="security.access.decision_manager" class="Symfony\Component\Security\Core\Authorization\AccessDecisionManager" public="false">
             <argument type="collection"></argument>
         </service>
 
-        <service id="security.role_hierarchy" class="%security.role_hierarchy.class%" public="false">
+        <service id="security.role_hierarchy" class="Symfony\Component\Security\Core\Role\RoleHierarchy" public="false">
             <argument>%security.role_hierarchy.roles%</argument>
         </service>
 
 
         <!-- Security Voters -->
-        <service id="security.access.simple_role_voter" class="%security.access.simple_role_voter.class%" public="false">
+        <service id="security.access.simple_role_voter" class="Symfony\Component\Security\Core\Authorization\Voter\RoleVoter" public="false">
             <tag name="security.voter" priority="245" />
         </service>
 
-        <service id="security.access.authenticated_voter" class="%security.access.authenticated_voter.class%" public="false">
+        <service id="security.access.authenticated_voter" class="Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter" public="false">
             <argument type="service" id="security.authentication.trust_resolver" />
             <tag name="security.voter" priority="250" />
         </service>
 
-        <service id="security.access.role_hierarchy_voter" class="%security.access.role_hierarchy_voter.class%" public="false">
+        <service id="security.access.role_hierarchy_voter" class="Symfony\Component\Security\Core\Authorization\Voter\RoleHierarchyVoter" public="false">
             <argument type="service" id="security.role_hierarchy" />
             <tag name="security.voter" priority="245" />
         </service>
 
-        <service id="security.access.expression_voter" class="%security.access.expression_voter.class%" public="false">
+        <service id="security.access.expression_voter" class="Symfony\Component\Security\Core\Authorization\Voter\ExpressionVoter" public="false">
             <argument type="service" id="security.expression_language" />
             <argument type="service" id="security.authentication.trust_resolver" />
             <argument type="service" id="security.role_hierarchy" on-invalid="null" />
@@ -136,35 +108,35 @@
 
 
         <!-- Firewall related services -->
-        <service id="security.firewall" class="%security.firewall.class%">
+        <service id="security.firewall" class="Symfony\Component\Security\Http\Firewall">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="security.firewall.map" />
             <argument type="service" id="event_dispatcher" />
         </service>
 
-        <service id="security.firewall.map" class="%security.firewall.map.class%" public="false">
+        <service id="security.firewall.map" class="Symfony\Bundle\SecurityBundle\Security\FirewallMap" public="false">
             <argument type="service" id="service_container" />
             <argument type="collection" />
         </service>
 
-        <service id="security.firewall.context" class="%security.firewall.context.class%" abstract="true">
+        <service id="security.firewall.context" class="Symfony\Bundle\SecurityBundle\Security\FirewallContext" abstract="true">
             <argument type="collection" />
             <argument type="service" id="security.exception_listener" />
         </service>
 
         <!-- Provisioning -->
-        <service id="security.user.provider.in_memory" class="%security.user.provider.in_memory.class%" abstract="true" public="false" />
-        <service id="security.user.provider.in_memory.user" class="%security.user.provider.in_memory.user.class%" abstract="true" public="false" />
+        <service id="security.user.provider.in_memory" class="Symfony\Component\Security\Core\User\InMemoryUserProvider" abstract="true" public="false" />
+        <service id="security.user.provider.in_memory.user" class="Symfony\Component\Security\Core\User\User" abstract="true" public="false" />
 
-        <service id="security.user.provider.chain" class="%security.user.provider.chain.class%" abstract="true" public="false" />
+        <service id="security.user.provider.chain" class="Symfony\Component\Security\Core\User\ChainUserProvider" abstract="true" public="false" />
 
-        <service id="security.http_utils" class="%security.http_utils.class%" public="false">
+        <service id="security.http_utils" class="Symfony\Component\Security\Http\HttpUtils" public="false">
             <argument type="service" id="router" on-invalid="null" />
             <argument type="service" id="router" on-invalid="null" />
         </service>
 
         <!-- Validator -->
-        <service id="security.validator.user_password" class="%security.validator.user_password.class%">
+        <service id="security.validator.user_password" class="Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator">
             <tag name="validator.constraint_validator" alias="security.validator.user_password" />
             <argument type="service" id="security.context" />
             <argument type="service" id="security.encoder_factory" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl.xml
@@ -5,36 +5,26 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="security.acl.permission_granting_strategy.class">Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy</parameter>
-
-        <parameter key="security.acl.voter.class">Symfony\Component\Security\Acl\Voter\AclVoter</parameter>
-        <parameter key="security.acl.permission.map.class">Symfony\Component\Security\Acl\Permission\BasicPermissionMap</parameter>
-
-        <parameter key="security.acl.object_identity_retrieval_strategy.class">Symfony\Component\Security\Acl\Domain\ObjectIdentityRetrievalStrategy</parameter>
-        <parameter key="security.acl.security_identity_retrieval_strategy.class">Symfony\Component\Security\Acl\Domain\SecurityIdentityRetrievalStrategy</parameter>
-
-        <parameter key="security.acl.cache.doctrine.class">Symfony\Component\Security\Acl\Domain\DoctrineAclCache</parameter>
-
         <parameter key="security.acl.collection_cache.class">Symfony\Component\Security\Acl\Domain\AclCollectionCache</parameter>
     </parameters>
 
     <services>
-        <service id="security.acl.object_identity_retrieval_strategy" class="%security.acl.object_identity_retrieval_strategy.class%" public="false"></service>
+        <service id="security.acl.object_identity_retrieval_strategy" class="Symfony\Component\Security\Acl\Domain\ObjectIdentityRetrievalStrategy" public="false"></service>
 
-        <service id="security.acl.security_identity_retrieval_strategy" class="%security.acl.security_identity_retrieval_strategy.class%" public="false">
+        <service id="security.acl.security_identity_retrieval_strategy" class="Symfony\Component\Security\Acl\Domain\SecurityIdentityRetrievalStrategy" public="false">
             <argument type="service" id="security.role_hierarchy" />
             <argument type="service" id="security.authentication.trust_resolver" />
         </service>
 
-        <service id="security.acl.permission_granting_strategy" class="%security.acl.permission_granting_strategy.class%" public="false">
+        <service id="security.acl.permission_granting_strategy" class="Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy" public="false">
             <call method="setAuditLogger">
                 <argument type="service" id="security.acl.audit_logger" on-invalid="ignore" />
             </call>
         </service>
 
-        <service id="security.acl.permission.map" class="%security.acl.permission.map.class%" public="false"></service>
+        <service id="security.acl.permission.map" class="Symfony\Component\Security\Acl\Permission\BasicPermissionMap" public="false"></service>
 
-        <service id="security.acl.voter.basic_permissions" class="%security.acl.voter.class%" public="false">
+        <service id="security.acl.voter.basic_permissions" class="Symfony\Component\Security\Acl\Voter\AclVoter" public="false">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.acl.provider" />
             <argument type="service" id="security.acl.object_identity_retrieval_strategy" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
@@ -4,16 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="security.acl.dbal.provider.class">Symfony\Component\Security\Acl\Dbal\MutableAclProvider</parameter>
-        <parameter key="security.acl.dbal.schema.class">Symfony\Component\Security\Acl\Dbal\Schema</parameter>
-        <parameter key="security.acl.dbal.schema_listener.class">Symfony\Bundle\SecurityBundle\EventListener\AclSchemaListener</parameter>
-    </parameters>
-
     <services>
         <service id="security.acl.dbal.connection" alias="database_connection" />
 
-        <service id="security.acl.dbal.provider" class="%security.acl.dbal.provider.class%" public="false">
+        <service id="security.acl.dbal.provider" class="Symfony\Component\Security\Acl\Dbal\MutableAclProvider" public="false">
             <argument type="service" id="security.acl.dbal.connection" />
             <argument type="service" id="security.acl.permission_granting_strategy" />
             <argument type="collection">
@@ -26,7 +20,7 @@
             <argument type="service" id="security.acl.cache" on-invalid="null" />
         </service>
 
-        <service id="security.acl.dbal.schema" class="%security.acl.dbal.schema.class%">
+        <service id="security.acl.dbal.schema" class="Symfony\Component\Security\Acl\Dbal\Schema">
             <argument type="collection">
                 <argument key="class_table_name">%security.acl.dbal.class_table_name%</argument>
                 <argument key="entry_table_name">%security.acl.dbal.entry_table_name%</argument>
@@ -36,19 +30,19 @@
             </argument>
             <argument type="service" id="security.acl.dbal.connection" />
         </service>
-        <service id="security.acl.dbal.schema_listener" class="%security.acl.dbal.schema_listener.class%" public="false">
+        <service id="security.acl.dbal.schema_listener" class="Symfony\Bundle\SecurityBundle\EventListener\AclSchemaListener" public="false">
             <argument type="service" id="security.acl.dbal.schema" />
         </service>
 
         <service id="security.acl.provider" alias="security.acl.dbal.provider" />
 
-        <service id="security.acl.cache.doctrine" class="%security.acl.cache.doctrine.class%" public="false">
+        <service id="security.acl.cache.doctrine" class="Symfony\Component\Security\Acl\Domain\DoctrineAclCache" public="false">
             <argument type="service" id="security.acl.cache.doctrine.cache_impl" />
             <argument type="service" id="security.acl.permission_granting_strategy" />
         </service>
 
         <service id="security.acl.cache.doctrine.cache_impl" alias="doctrine.orm.default_result_cache" public="false" />
 
-        <service id="security.acl.permission.map" class="%security.acl.permission.map.class%" public="false"></service>
+        <service id="security.acl.permission.map" class="Symfony\Component\Security\Acl\Permission\BasicPermissionMap" public="false"></service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -4,53 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="security.authentication.retry_entry_point.class">Symfony\Component\Security\Http\EntryPoint\RetryAuthenticationEntryPoint</parameter>
-
-        <parameter key="security.channel_listener.class">Symfony\Component\Security\Http\Firewall\ChannelListener</parameter>
-
-        <parameter key="security.authentication.form_entry_point.class">Symfony\Component\Security\Http\EntryPoint\FormAuthenticationEntryPoint</parameter>
-        <parameter key="security.authentication.listener.form.class">Symfony\Component\Security\Http\Firewall\UsernamePasswordFormAuthenticationListener</parameter>
-
-        <parameter key="security.authentication.listener.simple_form.class">Symfony\Component\Security\Http\Firewall\SimpleFormAuthenticationListener</parameter>
-
-        <parameter key="security.authentication.listener.simple_preauth.class">Symfony\Component\Security\Http\Firewall\SimplePreAuthenticationListener</parameter>
-
-        <parameter key="security.authentication.listener.basic.class">Symfony\Component\Security\Http\Firewall\BasicAuthenticationListener</parameter>
-        <parameter key="security.authentication.basic_entry_point.class">Symfony\Component\Security\Http\EntryPoint\BasicAuthenticationEntryPoint</parameter>
-
-        <parameter key="security.authentication.listener.digest.class">Symfony\Component\Security\Http\Firewall\DigestAuthenticationListener</parameter>
-        <parameter key="security.authentication.digest_entry_point.class">Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint</parameter>
-
-        <parameter key="security.authentication.listener.x509.class">Symfony\Component\Security\Http\Firewall\X509AuthenticationListener</parameter>
-
-        <parameter key="security.authentication.listener.anonymous.class">Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener</parameter>
-
-        <parameter key="security.authentication.switchuser_listener.class">Symfony\Component\Security\Http\Firewall\SwitchUserListener</parameter>
-
-        <parameter key="security.logout_listener.class">Symfony\Component\Security\Http\Firewall\LogoutListener</parameter>
-        <parameter key="security.logout.handler.session.class">Symfony\Component\Security\Http\Logout\SessionLogoutHandler</parameter>
-        <parameter key="security.logout.handler.cookie_clearing.class">Symfony\Component\Security\Http\Logout\CookieClearingLogoutHandler</parameter>
-        <parameter key="security.logout.success_handler.class">Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler</parameter>
-
-        <parameter key="security.access_listener.class">Symfony\Component\Security\Http\Firewall\AccessListener</parameter>
-        <parameter key="security.access_map.class">Symfony\Component\Security\Http\AccessMap</parameter>
-        <parameter key="security.exception_listener.class">Symfony\Component\Security\Http\Firewall\ExceptionListener</parameter>
-        <parameter key="security.context_listener.class">Symfony\Component\Security\Http\Firewall\ContextListener</parameter>
-
-        <parameter key="security.authentication.provider.dao.class">Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider</parameter>
-        <parameter key="security.authentication.provider.simple.class">Symfony\Component\Security\Core\Authentication\Provider\SimpleAuthenticationProvider</parameter>
-        <parameter key="security.authentication.provider.pre_authenticated.class">Symfony\Component\Security\Core\Authentication\Provider\PreAuthenticatedAuthenticationProvider</parameter>
-
-        <parameter key="security.authentication.provider.anonymous.class">Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider</parameter>
-
-        <parameter key="security.authentication.success_handler.class">Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler</parameter>
-        <parameter key="security.authentication.failure_handler.class">Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler</parameter>
-        <parameter key="security.authentication.simple_success_failure_handler.class">Symfony\Component\Security\Http\Authentication\SimpleAuthenticationHandler</parameter>
-    </parameters>
-
     <services>
-        <service id="security.authentication.listener.anonymous" class="%security.authentication.listener.anonymous.class%" public="false">
+        <service id="security.authentication.listener.anonymous" class="Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener" public="false">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument /> <!-- Key -->
@@ -58,29 +13,29 @@
             <argument type="service" id="security.authentication.manager" />
         </service>
 
-        <service id="security.authentication.provider.anonymous" class="%security.authentication.provider.anonymous.class%" public="false">
+        <service id="security.authentication.provider.anonymous" class="Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider" public="false">
             <argument /> <!-- Key -->
         </service>
 
-        <service id="security.authentication.retry_entry_point" class="%security.authentication.retry_entry_point.class%" public="false">
+        <service id="security.authentication.retry_entry_point" class="Symfony\Component\Security\Http\EntryPoint\RetryAuthenticationEntryPoint" public="false">
             <argument>%request_listener.http_port%</argument>
             <argument>%request_listener.https_port%</argument>
         </service>
 
-        <service id="security.authentication.basic_entry_point" class="%security.authentication.basic_entry_point.class%" public="false" />
+        <service id="security.authentication.basic_entry_point" class="Symfony\Component\Security\Http\EntryPoint\BasicAuthenticationEntryPoint" public="false" />
 
-        <service id="security.authentication.digest_entry_point" class="%security.authentication.digest_entry_point.class%" public="false" />
+        <service id="security.authentication.digest_entry_point" class="Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint" public="false" />
 
-        <service id="security.channel_listener" class="%security.channel_listener.class%" public="false">
+        <service id="security.channel_listener" class="Symfony\Component\Security\Http\Firewall\ChannelListener" public="false">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.access_map" />
             <argument type="service" id="security.authentication.retry_entry_point" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.access_map" class="%security.access_map.class%" public="false" />
+        <service id="security.access_map" class="Symfony\Component\Security\Http\AccessMap" public="false" />
 
-        <service id="security.context_listener" class="%security.context_listener.class%" public="false">
+        <service id="security.context_listener" class="Symfony\Component\Security\Http\Firewall\ContextListener" public="false">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument type="collection"></argument>
@@ -89,21 +44,21 @@
             <argument type="service" id="event_dispatcher" on-invalid="null"/>
         </service>
 
-        <service id="security.logout_listener" class="%security.logout_listener.class%" public="false" abstract="true">
+        <service id="security.logout_listener" class="Symfony\Component\Security\Http\Firewall\LogoutListener" public="false" abstract="true">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.http_utils" />
             <argument type="service" id="security.logout.success_handler" />
             <argument /> <!-- Options -->
         </service>
-        <service id="security.logout.handler.session" class="%security.logout.handler.session.class%" public="false" />
-        <service id="security.logout.handler.cookie_clearing" class="%security.logout.handler.cookie_clearing.class%" public="false" abstract="true" />
+        <service id="security.logout.handler.session" class="Symfony\Component\Security\Http\Logout\SessionLogoutHandler" public="false" />
+        <service id="security.logout.handler.cookie_clearing" class="Symfony\Component\Security\Http\Logout\CookieClearingLogoutHandler" public="false" abstract="true" />
 
-        <service id="security.logout.success_handler" class="%security.logout.success_handler.class%" public="false" abstract="true">
+        <service id="security.logout.success_handler" class="Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler" public="false" abstract="true">
             <argument type="service" id="security.http_utils" />
             <argument>/</argument>
         </service>
 
-        <service id="security.authentication.form_entry_point" class="%security.authentication.form_entry_point.class%" public="false" abstract="true">
+        <service id="security.authentication.form_entry_point" class="Symfony\Component\Security\Http\EntryPoint\FormAuthenticationEntryPoint" public="false" abstract="true">
             <argument type="service" id="http_kernel" />
         </service>
 
@@ -127,7 +82,7 @@
             <argument /> <!-- Provider-shared Key -->
         </service>
 
-        <service id="security.authentication.success_handler" class="%security.authentication.success_handler.class%" abstract="true" public="false">
+        <service id="security.authentication.success_handler" class="Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler" abstract="true" public="false">
             <argument type="service" id="security.http_utils" />
             <argument type="collection" /> <!-- Options -->
         </service>
@@ -137,7 +92,7 @@
             <argument type="collection" /> <!-- Options -->
         </service>
 
-        <service id="security.authentication.failure_handler" class="%security.authentication.failure_handler.class%" abstract="true" public="false">
+        <service id="security.authentication.failure_handler" class="Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler" abstract="true" public="false">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="http_kernel" />
             <argument type="service" id="security.http_utils" />
@@ -146,18 +101,18 @@
         </service>
 
         <service id="security.authentication.listener.form"
-                 class="%security.authentication.listener.form.class%"
+                 class="Symfony\Component\Security\Http\Firewall\UsernamePasswordFormAuthenticationListener"
                  parent="security.authentication.listener.abstract"
                  abstract="true">
         </service>
 
         <service id="security.authentication.listener.simple_form"
-                 class="%security.authentication.listener.simple_form.class%"
+                 class="Symfony\Component\Security\Http\Firewall\SimpleFormAuthenticationListener"
                  parent="security.authentication.listener.abstract"
                  abstract="true">
         </service>
 
-        <service id="security.authentication.simple_success_failure_handler" class="%security.authentication.simple_success_failure_handler.class%" public="false" abstract="true">
+        <service id="security.authentication.simple_success_failure_handler" class="Symfony\Component\Security\Http\Authentication\SimpleAuthenticationHandler" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument /> <!-- Authenticator -->
             <argument type="service" id="security.authentication.success_handler" />
@@ -165,7 +120,7 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.listener.simple_preauth" class="%security.authentication.listener.simple_preauth.class%" public="false" abstract="true">
+        <service id="security.authentication.listener.simple_preauth" class="Symfony\Component\Security\Http\Firewall\SimplePreAuthenticationListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
@@ -174,7 +129,7 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.listener.x509" class="%security.authentication.listener.x509.class%" public="false" abstract="true">
+        <service id="security.authentication.listener.x509" class="Symfony\Component\Security\Http\Firewall\X509AuthenticationListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
@@ -195,7 +150,7 @@
             <argument type="service" id="event_dispatcher" on-invalid="null"/>
         </service>
 
-        <service id="security.authentication.listener.basic" class="%security.authentication.listener.basic.class%" public="false" abstract="true">
+        <service id="security.authentication.listener.basic" class="Symfony\Component\Security\Http\Firewall\BasicAuthenticationListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
@@ -204,7 +159,7 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.listener.digest" class="%security.authentication.listener.digest.class%" public="false" abstract="true">
+        <service id="security.authentication.listener.digest" class="Symfony\Component\Security\Http\Firewall\DigestAuthenticationListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument /> <!-- User Provider -->
@@ -213,7 +168,7 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.provider.dao" class="%security.authentication.provider.dao.class%" abstract="true" public="false">
+        <service id="security.authentication.provider.dao" class="Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider" abstract="true" public="false">
             <argument /> <!-- User Provider -->
             <argument type="service" id="security.user_checker" />
             <argument /> <!-- Provider-shared Key -->
@@ -221,18 +176,18 @@
             <argument>%security.authentication.hide_user_not_found%</argument>
         </service>
 
-        <service id="security.authentication.provider.simple" class="%security.authentication.provider.simple.class%" abstract="true" public="false">
+        <service id="security.authentication.provider.simple" class="Symfony\Component\Security\Core\Authentication\Provider\SimpleAuthenticationProvider" abstract="true" public="false">
             <argument /> <!-- Simple Authenticator -->
             <argument /> <!-- User Provider -->
             <argument /> <!-- Provider-shared Key -->
         </service>
 
-        <service id="security.authentication.provider.pre_authenticated" class="%security.authentication.provider.pre_authenticated.class%" abstract="true" public="false">
+        <service id="security.authentication.provider.pre_authenticated" class="Symfony\Component\Security\Core\Authentication\Provider\PreAuthenticatedAuthenticationProvider" abstract="true" public="false">
             <argument /> <!-- User Provider -->
             <argument type="service" id="security.user_checker" />
         </service>
 
-        <service id="security.exception_listener" class="%security.exception_listener.class%" public="false" abstract="true">
+        <service id="security.exception_listener" class="Symfony\Component\Security\Http\Firewall\ExceptionListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.trust_resolver" />
@@ -244,7 +199,7 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.switchuser_listener" class="%security.authentication.switchuser_listener.class%" public="false" abstract="true">
+        <service id="security.authentication.switchuser_listener" class="Symfony\Component\Security\Http\Firewall\SwitchUserListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument /> <!-- User Provider -->
@@ -257,7 +212,7 @@
             <argument type="service" id="event_dispatcher" on-invalid="null"/>
         </service>
 
-        <service id="security.access_listener" class="%security.access_listener.class%" public="false">
+        <service id="security.access_listener" class="Symfony\Component\Security\Http\Firewall\AccessListener" public="false">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument type="service" id="security.access.decision_manager" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
@@ -4,20 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="security.authentication.provider.rememberme.class">Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider</parameter>
-
-        <parameter key="security.authentication.listener.rememberme.class">Symfony\Component\Security\Http\Firewall\RememberMeListener</parameter>
-        <parameter key="security.rememberme.token.provider.in_memory.class">Symfony\Component\Security\Core\Authentication\RememberMe\InMemoryTokenProvider</parameter>
-
-        <parameter key="security.authentication.rememberme.services.persistent.class">Symfony\Component\Security\Http\RememberMe\PersistentTokenBasedRememberMeServices</parameter>
-        <parameter key="security.authentication.rememberme.services.simplehash.class">Symfony\Component\Security\Http\RememberMe\TokenBasedRememberMeServices</parameter>
-
-        <parameter key="security.rememberme.response_listener.class">Symfony\Component\Security\Http\RememberMe\ResponseListener</parameter>
-    </parameters>
-
     <services>
-        <service id="security.authentication.listener.rememberme" class="%security.authentication.listener.rememberme.class%" public="false" abstract="true">
+        <service id="security.authentication.listener.rememberme" class="Symfony\Component\Security\Http\Firewall\RememberMeListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.rememberme" />
@@ -27,11 +15,11 @@
             <argument /> <!-- Catch exception flag set in RememberMeFactory -->
         </service>
 
-        <service id="security.authentication.provider.rememberme" class="%security.authentication.provider.rememberme.class%" abstract="true" public="false">
+        <service id="security.authentication.provider.rememberme" class="Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider" abstract="true" public="false">
             <argument type="service" id="security.user_checker" />
         </service>
 
-        <service id="security.rememberme.token.provider.in_memory" class="%security.rememberme.token.provider.in_memory.class%" public="false"/>
+        <service id="security.rememberme.token.provider.in_memory" class="Symfony\Component\Security\Core\Authentication\RememberMe\InMemoryTokenProvider" public="false"/>
 
         <service id="security.authentication.rememberme.services.abstract" abstract="true" public="false">
             <tag name="monolog.logger" channel="security" />
@@ -43,19 +31,19 @@
         </service>
 
         <service id="security.authentication.rememberme.services.persistent"
-                 class="%security.authentication.rememberme.services.persistent.class%"
+                 class="Symfony\Component\Security\Http\RememberMe\PersistentTokenBasedRememberMeServices"
                  parent="security.authentication.rememberme.services.abstract"
                  abstract="true">
             <argument type="service" id="security.secure_random" />
         </service>
 
         <service id="security.authentication.rememberme.services.simplehash"
-                 class="%security.authentication.rememberme.services.simplehash.class%"
+                 class="Symfony\Component\Security\Http\RememberMe\TokenBasedRememberMeServices"
                  parent="security.authentication.rememberme.services.abstract"
                  abstract="true">
         </service>
 
-        <service id="security.rememberme.response_listener" class="%security.rememberme.response_listener.class%">
+        <service id="security.rememberme.response_listener" class="Symfony\Component\Security\Http\RememberMe\ResponseListener">
             <tag name="kernel.event_subscriber" />
         </service>
     </services>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
@@ -4,19 +4,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="templating.helper.logout_url.class">Symfony\Bundle\SecurityBundle\Templating\Helper\LogoutUrlHelper</parameter>
-        <parameter key="templating.helper.security.class">Symfony\Bundle\SecurityBundle\Templating\Helper\SecurityHelper</parameter>
-    </parameters>
-
     <services>
-        <service id="templating.helper.logout_url" class="%templating.helper.logout_url.class%">
+        <service id="templating.helper.logout_url" class="Symfony\Bundle\SecurityBundle\Templating\Helper\LogoutUrlHelper">
             <tag name="templating.helper" alias="logout_url" />
             <argument type="service" id="service_container" />
             <argument type="service" id="router" />
         </service>
 
-        <service id="templating.helper.security" class="%templating.helper.security.class%">
+        <service id="templating.helper.security" class="Symfony\Bundle\SecurityBundle\Templating\Helper\SecurityHelper">
             <tag name="templating.helper" alias="security" />
             <argument type="service" id="security.context" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
@@ -4,18 +4,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="twig.extension.logout_url.class">Symfony\Bundle\SecurityBundle\Twig\Extension\LogoutUrlExtension</parameter>
-        <parameter key="twig.extension.security.class">Symfony\Bridge\Twig\Extension\SecurityExtension</parameter>
-    </parameters>
-
     <services>
-        <service id="twig.extension.logout_url" class="%twig.extension.logout_url.class%" public="false">
+        <service id="twig.extension.logout_url" class="Symfony\Bundle\SecurityBundle\Twig\Extension\LogoutUrlExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="templating.helper.logout_url" />
         </service>
 
-        <service id="twig.extension.security" class="%twig.extension.security.class%" public="false">
+        <service id="twig.extension.security" class="Symfony\Bridge\Twig\Extension\SecurityExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="security.context" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/debug.xml
@@ -4,12 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="debug.templating.engine.twig.class">Symfony\Bundle\TwigBundle\Debug\TimedTwigEngine</parameter>
-    </parameters>
-
     <services>
-        <service id="debug.templating.engine.twig" class="%debug.templating.engine.twig.class%" public="false">
+        <service id="debug.templating.engine.twig" class="Symfony\Bundle\TwigBundle\Debug\TimedTwigEngine" public="false">
             <argument type="service" id="twig" />
             <argument type="service" id="templating.name_parser" />
             <argument type="service" id="templating.locator" />

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -4,32 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="twig.class">Twig_Environment</parameter>
-        <parameter key="twig.loader.filesystem.class">Symfony\Bundle\TwigBundle\Loader\FilesystemLoader</parameter>
-        <parameter key="twig.loader.chain.class">Twig_Loader_Chain</parameter>
-        <parameter key="templating.engine.twig.class">Symfony\Bundle\TwigBundle\TwigEngine</parameter>
-        <parameter key="twig.cache_warmer.class">Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheCacheWarmer</parameter>
-        <parameter key="twig.extension.trans.class">Symfony\Bridge\Twig\Extension\TranslationExtension</parameter>
-        <parameter key="twig.extension.assets.class">Symfony\Bundle\TwigBundle\Extension\AssetsExtension</parameter>
-        <parameter key="twig.extension.actions.class">Symfony\Bundle\TwigBundle\Extension\ActionsExtension</parameter>
-        <parameter key="twig.extension.code.class">Symfony\Bridge\Twig\Extension\CodeExtension</parameter>
-        <parameter key="twig.extension.routing.class">Symfony\Bridge\Twig\Extension\RoutingExtension</parameter>
-        <parameter key="twig.extension.yaml.class">Symfony\Bridge\Twig\Extension\YamlExtension</parameter>
-        <parameter key="twig.extension.form.class">Symfony\Bridge\Twig\Extension\FormExtension</parameter>
-        <parameter key="twig.extension.httpkernel.class">Symfony\Bridge\Twig\Extension\HttpKernelExtension</parameter>
-        <parameter key="twig.extension.debug.stopwatch.class">Symfony\Bridge\Twig\Extension\StopwatchExtension</parameter>
-        <parameter key="twig.extension.expression.class">Symfony\Bridge\Twig\Extension\ExpressionExtension</parameter>
-        <parameter key="twig.form.engine.class">Symfony\Bridge\Twig\Form\TwigRendererEngine</parameter>
-        <parameter key="twig.form.renderer.class">Symfony\Bridge\Twig\Form\TwigRenderer</parameter>
-        <parameter key="twig.translation.extractor.class">Symfony\Bridge\Twig\Translation\TwigExtractor</parameter>
-        <parameter key="twig.exception_listener.class">Symfony\Component\HttpKernel\EventListener\ExceptionListener</parameter>
-        <parameter key="twig.controller.exception.class">Symfony\Bundle\TwigBundle\Controller\ExceptionController</parameter>
-        <parameter key="twig.controller.preview_error.class">Symfony\Bundle\TwigBundle\Controller\PreviewErrorController</parameter>
-    </parameters>
-
     <services>
-        <service id="twig" class="%twig.class%">
+        <service id="twig" class="Twig_Environment">
             <argument type="service" id="twig.loader" />
             <argument>%twig.options%</argument>
             <call method="addGlobal">
@@ -38,104 +14,104 @@
             </call>
         </service>
 
-        <service id="twig.cache_warmer" class="%twig.cache_warmer.class%" public="false">
+        <service id="twig.cache_warmer" class="Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheCacheWarmer" public="false">
             <tag name="kernel.cache_warmer" />
             <argument type="service" id="service_container" />
             <argument type="service" id="templating.finder" />
         </service>
 
-        <service id="twig.loader.filesystem" class="%twig.loader.filesystem.class%" public="false">
+        <service id="twig.loader.filesystem" class="Symfony\Bundle\TwigBundle\Loader\FilesystemLoader" public="false">
             <argument type="service" id="templating.locator" />
             <argument type="service" id="templating.name_parser" />
             <tag name="twig.loader"/>
         </service>
 
-        <service id="twig.loader.chain" class="%twig.loader.chain.class%" public="false"/>
+        <service id="twig.loader.chain" class="Twig_Loader_Chain" public="false"/>
 
         <service id="twig.loader" alias="twig.loader.filesystem" />
 
-        <service id="templating.engine.twig" class="%templating.engine.twig.class%" public="false">
+        <service id="templating.engine.twig" class="Symfony\Bundle\TwigBundle\TwigEngine" public="false">
             <argument type="service" id="twig" />
             <argument type="service" id="templating.name_parser" />
             <argument type="service" id="templating.locator" />
         </service>
 
-        <service id="twig.extension.trans" class="%twig.extension.trans.class%" public="false">
+        <service id="twig.extension.trans" class="Symfony\Bridge\Twig\Extension\TranslationExtension" public="false">
             <argument type="service" id="translator" />
         </service>
 
-        <service id="twig.extension.assets" class="%twig.extension.assets.class%" public="false">
+        <service id="twig.extension.assets" class="Symfony\Bundle\TwigBundle\Extension\AssetsExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="service_container" />
             <argument type="service" id="router.request_context" on-invalid="null" />
         </service>
 
-        <service id="twig.extension.actions" class="%twig.extension.actions.class%" public="false">
+        <service id="twig.extension.actions" class="Symfony\Bundle\TwigBundle\Extension\ActionsExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="twig.extension.code" class="%twig.extension.code.class%" public="false">
+        <service id="twig.extension.code" class="Symfony\Bridge\Twig\Extension\CodeExtension" public="false">
             <tag name="twig.extension" />
             <argument>%templating.helper.code.file_link_format%</argument>
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>
 
-        <service id="twig.extension.routing" class="%twig.extension.routing.class%" public="false">
+        <service id="twig.extension.routing" class="Symfony\Bridge\Twig\Extension\RoutingExtension" public="false">
             <argument type="service" id="router" />
         </service>
 
-        <service id="twig.extension.yaml" class="%twig.extension.yaml.class%" public="false">
+        <service id="twig.extension.yaml" class="Symfony\Bridge\Twig\Extension\YamlExtension" public="false">
             <tag name="twig.extension" />
         </service>
 
-        <service id="twig.extension.debug.stopwatch" class="%twig.extension.debug.stopwatch.class%" public="false">
+        <service id="twig.extension.debug.stopwatch" class="Symfony\Bridge\Twig\Extension\StopwatchExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="twig.extension.expression" class="%twig.extension.expression.class%" public="false">
+        <service id="twig.extension.expression" class="Symfony\Bridge\Twig\Extension\ExpressionExtension" public="false">
             <tag name="twig.extension" />
         </service>
 
-        <service id="twig.extension.httpkernel" class="%twig.extension.httpkernel.class%" public="false">
+        <service id="twig.extension.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelExtension" public="false">
             <argument type="service" id="fragment.handler" />
         </service>
 
 
-        <service id="twig.extension.form" class="%twig.extension.form.class%" public="false">
+        <service id="twig.extension.form" class="Symfony\Bridge\Twig\Extension\FormExtension" public="false">
             <argument type="service" id="twig.form.renderer" />
         </service>
 
-        <service id="twig.form.engine" class="%twig.form.engine.class%" public="false">
+        <service id="twig.form.engine" class="Symfony\Bridge\Twig\Form\TwigRendererEngine" public="false">
             <argument>%twig.form.resources%</argument>
         </service>
 
-        <service id="twig.form.renderer" class="%twig.form.renderer.class%" public="false">
+        <service id="twig.form.renderer" class="Symfony\Bridge\Twig\Form\TwigRenderer" public="false">
             <argument type="service" id="twig.form.engine" />
             <argument type="service" id="form.csrf_provider" on-invalid="null" />
         </service>
 
-        <service id="twig.translation.extractor" class="%twig.translation.extractor.class%">
+        <service id="twig.translation.extractor" class="Symfony\Bridge\Twig\Translation\TwigExtractor">
             <argument type="service" id="twig" />
             <tag name="translation.extractor" alias="twig" />
         </service>
 
-        <service id="twig.exception_listener" class="%twig.exception_listener.class%">
+        <service id="twig.exception_listener" class="Symfony\Component\HttpKernel\EventListener\ExceptionListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument>%twig.exception_listener.controller%</argument>
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="twig.controller.exception" class="%twig.controller.exception.class%">
+        <service id="twig.controller.exception" class="Symfony\Bundle\TwigBundle\Controller\ExceptionController">
             <argument type="service" id="twig" />
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="twig.controller.preview_error" class="%twig.controller.preview_error.class%">
+        <service id="twig.controller.preview_error" class="Symfony\Bundle\TwigBundle\Controller\PreviewErrorController">
             <argument type="service" id="http_kernel" />
             <argument>%twig.exception_listener.controller%</argument>
         </service>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/commands.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/commands.xml
@@ -4,18 +4,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="web_profiler.command.import.class">Symfony\Bundle\WebProfilerBundle\Command\ImportCommand</parameter>
-        <parameter key="web_profiler.command.export.class">Symfony\Bundle\WebProfilerBundle\Command\ExportCommand</parameter>
-    </parameters>
-
     <services>
-        <service id="web_profiler.command.import" class="%web_profiler.command.import.class%">
+        <service id="web_profiler.command.import" class="Symfony\Bundle\WebProfilerBundle\Command\ImportCommand">
             <argument type="service" id="profiler" on-invalid="null" />
             <tag name="console.command" />
         </service>
 
-        <service id="web_profiler.command.export" class="%web_profiler.command.export.class%">
+        <service id="web_profiler.command.export" class="Symfony\Bundle\WebProfilerBundle\Command\ExportCommand">
             <argument type="service" id="profiler" on-invalid="null" />
             <tag name="console.command" />
         </service>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -4,15 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="web_profiler.controller.profiler.class">Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController</parameter>
-        <parameter key="web_profiler.controller.router.class">Symfony\Bundle\WebProfilerBundle\Controller\RouterController</parameter>
-        <parameter key="web_profiler.controller.exception.class">Symfony\Bundle\WebProfilerBundle\Controller\ExceptionController</parameter>
-        <parameter key="twig.extension.webprofiler.class">Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension</parameter>
-    </parameters>
-
     <services>
-        <service id="web_profiler.controller.profiler" class="%web_profiler.controller.profiler.class%">
+        <service id="web_profiler.controller.profiler" class="Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController">
             <argument type="service" id="router" on-invalid="null" />
             <argument type="service" id="profiler" on-invalid="null" />
             <argument type="service" id="twig" />
@@ -20,19 +13,19 @@
             <argument>%web_profiler.debug_toolbar.position%</argument>
         </service>
 
-        <service id="web_profiler.controller.router" class="%web_profiler.controller.router.class%">
+        <service id="web_profiler.controller.router" class="Symfony\Bundle\WebProfilerBundle\Controller\RouterController">
             <argument type="service" id="profiler" on-invalid="null" />
             <argument type="service" id="twig" />
             <argument type="service" id="router" on-invalid="null" />
         </service>
 
-        <service id="web_profiler.controller.exception" class="%web_profiler.controller.exception.class%">
+        <service id="web_profiler.controller.exception" class="Symfony\Bundle\WebProfilerBundle\Controller\ExceptionController">
             <argument type="service" id="profiler" on-invalid="null" />
             <argument type="service" id="twig" />
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="twig.extension.webprofiler" class="%twig.extension.webprofiler.class%" public="false">
+        <service id="twig.extension.webprofiler" class="Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension" public="false">
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
@@ -4,12 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="web_profiler.debug_toolbar.class">Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener</parameter>
-    </parameters>
-
     <services>
-        <service id="web_profiler.debug_toolbar" class="%web_profiler.debug_toolbar.class%">
+        <service id="web_profiler.debug_toolbar" class="Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="twig" />
             <argument>%web_profiler.debug_toolbar.intercept_redirects%</argument>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #11881 |
| License | MIT |
| Doc PR | none |

Remove the *.class parameters in all bundle settings.

see: https://github.com/symfony/symfony/issues/11881
