### PR TITLE
Update FormEnctypeNode.php to fix 12824

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/FormEnctypeNode.php
+++ b/src/Symfony/Bridge/Twig/Node/FormEnctypeNode.php
@@ -23,6 +23,6 @@ class FormEnctypeNode extends SearchAndRenderBlockNode
     {
         parent::compile($compiler);
 
-        $compiler->write('trigger_error(\'The helper form_enctype(form) is deprecated since version 2.3 and will be removed in 3.0. Use form_start(form) instead.\', E_USER_DEPRECATED)');
+        $compiler->write('; trigger_error(\'The helper form_enctype(form) is deprecated since version 2.3 and will be removed in 3.0. Use form_start(form) instead.\', E_USER_DEPRECATED)');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12824 |
| License | MIT |
| Doc PR |  |

I found that in #8731 the semi-colon was actually removed because of a problem with using the sandbox.
Which is properly why this was no longer noticed.

This is the simplest way to fix the syntax error.
