### PR TITLE
[2.5] Fixed the proxy-manager version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "monolog/monolog": "~1.3",
         "propel/propel1": "~1.6",
         "ircmaxell/password-compat": "~1.0",
-        "ocramius/proxy-manager": ">=0.3.1,<0.6-dev",
+        "ocramius/proxy-manager": "~1.0",
         "egulias/email-validator": "~1.2"
     },
     "autoload": {

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/dependency-injection": "~2.3",
-        "ocramius/proxy-manager": "~1.0"
+        "ocramius/proxy-manager": "~0.5|~1.0"
     },
     "require-dev": {
         "symfony/config": "~2.3"

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/dependency-injection": "~2.3",
-        "ocramius/proxy-manager": ">=0.3.1,<0.6-dev"
+        "ocramius/proxy-manager": "~1.0"
     },
     "require-dev": {
         "symfony/config": "~2.3"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the `ocramius/proxy-manager` version constraint in the 2.5 branch.

The upcoming `1.0.x` is currently similar enough to `0.5.x` that our tests still pass, and there are no breaking changes planned before the final 1.0.0 release, so the `"~1.0"` move should be safe. Note that there are already 3 beta tags on that repo, so it's pretty stable.

---

This accompanies #12779 on the 2.3 branch.
