### PR TITLE
Adds more context about what Symfony/Debug is for

### DIFF
--- a/src/Symfony/Component/Debug/README.md
+++ b/src/Symfony/Component/Debug/README.md
@@ -1,7 +1,7 @@
 Debug Component
 ===============
 
-Debug provides tools to make debugging easier.
+Debug provides tools to make debugging easier by using a standard common-sense set of debug flags and output handlers for web and CLI.
 
 Enabling all debug tools is as easy as calling the `enable()` method on the
 main `Debug` class:


### PR DESCRIPTION
The context of "making debugging easier" is too vague for people who aren't already familiar with this, many full-blown debugging tools also "make debugging easier". Hopefully this improves the docs.
