### PR TITLE
[Form] Add further timezone tests for date type

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -355,9 +355,63 @@ class DateTypeTest extends TypeTestCase
         ));
     }
 
-    public function testSetDataWithDifferentTimezoneDateTime()
+    public function testSetDataWithDifferentNegativeUTCTimezoneDateTime()
     {
         date_default_timezone_set('Pacific/Tahiti');
+
+        $form = $this->factory->create('date', null, array(
+            'format' => \IntlDateFormatter::MEDIUM,
+            'input' => 'datetime',
+            'widget' => 'single_text',
+        ));
+
+        $dateTime = new \DateTime('2010-06-02 America/New_York');
+
+        $form->setData($dateTime);
+
+        $this->assertDateTimeEquals($dateTime, $form->getData());
+        $this->assertEquals('02.06.2010', $form->getViewData());
+    }
+
+    public function testSetDataWithDifferentPositiveUTCTimezoneDateTime()
+    {
+        date_default_timezone_set('Pacific/Tahiti');
+
+        $form = $this->factory->create('date', null, array(
+            'format' => \IntlDateFormatter::MEDIUM,
+            'input' => 'datetime',
+            'widget' => 'single_text',
+        ));
+
+        $dateTime = new \DateTime('2010-06-02 Australia/Melbourne');
+
+        $form->setData($dateTime);
+
+        $this->assertDateTimeEquals($dateTime, $form->getData());
+        $this->assertEquals('02.06.2010', $form->getViewData());
+    }
+
+    public function testSetDataWithSamePositiveUTCTimezoneDateTime()
+    {
+        date_default_timezone_set('Australia/Melbourne');
+
+        $form = $this->factory->create('date', null, array(
+            'format' => \IntlDateFormatter::MEDIUM,
+            'input' => 'datetime',
+            'widget' => 'single_text',
+        ));
+
+        $dateTime = new \DateTime('2010-06-02 Australia/Melbourne');
+
+        $form->setData($dateTime);
+
+        $this->assertDateTimeEquals($dateTime, $form->getData());
+        $this->assertEquals('02.06.2010', $form->getViewData());
+    }
+
+    public function testSetDataWithSameNegativeUTCTimezoneDateTime()
+    {
+        date_default_timezone_set('America/New_York');
 
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no (failing tests added) |
| Fixed tickets | Adds tests for bug in #12808 |
| License | MIT |
| Doc PR | ~ |
#12404 removed the timezone options from DateType and TimeType, however the tests don't cover all cases and there was a bug introduced as per #12808.

This PR adds tests for the expected behaviour but will not fix the bug.

Unfortunately, it seems that the tests are being skipped in the form component on Travis (and have been for a year) - probably due to the ICU version being changed.
