### PR TITLE
[EventDispatcher] Fixed #12845 adding a listener to an event that is currently being dispatched

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -224,6 +224,9 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     {
         $skipped = false;
         foreach ($this->dispatcher->getListeners($eventName) as $listener) {
+            if (!$listener instanceof WrappedListener) { // #12845: a new listener was added during dispatch.
+                continue;
+            }
             // Unwrap listener
             $this->dispatcher->removeListener($eventName, $listener);
             $this->dispatcher->addListener($eventName, $listener->getWrappedListener());

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -75,6 +75,24 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $kernel->handle($request);
     }
 
+    public function testAddListenerNested()
+    {
+        $called1 = false;
+        $called2 = false;
+        $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $dispatcher->addListener('my-event', function () use ($dispatcher, &$called1, &$called2) {
+            $called1 = true;
+            $dispatcher->addListener('my-event', function () use (&$called2) {
+                $called2 = true;
+            });
+        });
+        $dispatcher->dispatch('my-event');
+        $this->assertTrue($called1);
+        $this->assertFalse($called2);
+        $dispatcher->dispatch('my-event');
+        $this->assertTrue($called2);
+    }
+
     protected function getHttpKernel($dispatcher, $controller)
     {
         $resolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');


### PR DESCRIPTION
[EventDispatcher] Fixed adding listener when event is currently being dispatched

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12845 |
| License | MIT |
