### PR TITLE
Remove hardcoded exception message on the container set function.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -197,7 +197,7 @@ class Container implements IntrospectableContainerInterface
     public function set($id, $service, $scope = self::SCOPE_CONTAINER)
     {
         if (self::SCOPE_PROTOTYPE === $scope) {
-            throw new InvalidArgumentException(sprintf('You cannot set service "%s" of scope "prototype".', $id));
+            throw new InvalidArgumentException(sprintf('You cannot set service "%s" of scope "%s".', $id, self::SCOPE_PROTOTYPE));
         }
 
         $id = strtolower($id);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

[DependencyInjection] Replaced hardcoded 'prototype' string with the 'PROTOTYPE' constant on the InvalidArgumentException, when using
the 'set' function on the Container with 'prototype' scope.
