### PR TITLE
[Console] Allowing the user answering key or value of the autocompleterValues

### DIFF
--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -135,6 +135,10 @@ class Question
      */
     public function setAutocompleterValues($values)
     {
+        if (is_array($values) && $this->isAssoc($values)) {
+            $values = array_merge(array_keys($values), array_values($values));
+        }
+
         if (null !== $values && !is_array($values)) {
             if (!$values instanceof \Traversable || $values instanceof \Countable) {
                 throw new \InvalidArgumentException('Autocompleter values can be either an array, `null` or an object implementing both `Countable` and `Traversable` interfaces.');
@@ -234,5 +238,10 @@ class Question
     public function getNormalizer()
     {
         return $this->normalizer;
+    }
+
+    protected function isAssoc($array)
+    {
+        return (bool) count(array_filter(array_keys($array), 'is_string'));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11116 |
| License | MIT |
| Doc PR | ~ |

**Before**:
![capture d ecran 2014-12-05 a 01 07 54](https://cloud.githubusercontent.com/assets/667519/5308827/ebaec496-7c1b-11e4-8872-5ed1f3642836.png)

**After**:
![capture d ecran 2014-12-07 a 01 56 13](https://cloud.githubusercontent.com/assets/667519/5329554/493e8602-7db4-11e4-9667-ef4c8826317c.png)

NB: As we want the user to be able to type either "env_1" or "Launch this and that", I offered autocompletion too on the values of the autocompletedValues.
