### PR TITLE
[Console][Table] Fix cell padding with multi-byte

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -41,7 +41,7 @@ abstract class Helper implements HelperInterface
     }
 
     /**
-     * Returns the length of a string, using mb_strlen if it is available.
+     * Returns the length of a string, using mb_strwidth if it is available.
      *
      * @param string $string The string to check its length
      *

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -387,8 +387,8 @@ class TableHelper extends Helper
         $width = $this->getColumnWidth($column);
 
         // str_pad won't work properly with multi-byte strings, we need to fix the padding
-        if (function_exists('mb_strlen') && false !== $encoding = mb_detect_encoding($cell)) {
-            $width += strlen($cell) - mb_strlen($cell, $encoding);
+        if (function_exists('mb_strwidth') && false !== $encoding = mb_detect_encoding($cell)) {
+            $width += strlen($cell) - mb_strwidth($cell, $encoding);
         }
 
         $width += $this->strlen($cell) - $this->computeLengthWithoutDecoration($cell);

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -235,7 +235,7 @@ TABLE
 
     public function testRenderMultiByte()
     {
-        if (!function_exists('mb_strlen')) {
+        if (!function_exists('mb_strwidth')) {
             $this->markTestSkipped('The "mbstring" extension is not available');
         }
 
@@ -254,6 +254,33 @@ TABLE
 +------+
 | 1234 |
 +------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public function testRenderFullWidthCharacters()
+    {
+        if (!function_exists('mb_strwidth')) {
+            $this->markTestSkipped('The "mbstring" extension is not available');
+        }
+
+        $table = new TableHelper();
+        $table
+            ->setHeaders(array('あいうえお'))
+            ->setRows(array(array(1234567890)))
+            ->setLayout(TableHelper::LAYOUT_DEFAULT)
+        ;
+        $table->render($output = $this->getOutputStream());
+
+        $expected =
+            <<<TABLE
++------------+
+| あいうえお |
++------------+
+| 1234567890 |
++------------+
 
 TABLE;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

When the `TableHelper` dealing with East Asian text, it renders wrong widths. This fixes that problem.
