### PR TITLE
[Console] Return command also if alias matches name exactly

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -554,7 +554,7 @@ class Application
             $commandList = $this->commands;
             $commands = array_filter($commands, function ($nameOrAlias) use ($commandList, $commands) {
                 if ($nameOrAlias === $name) {
-                  return true;
+                    return true;
                 }
 
                 $commandName = $commandList[$nameOrAlias]->getName();

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -553,6 +553,10 @@ class Application
         if (count($commands) > 1) {
             $commandList = $this->commands;
             $commands = array_filter($commands, function ($nameOrAlias) use ($commandList, $commands) {
+                if ($nameOrAlias === $name) {
+                  return true;
+                }
+
                 $commandName = $commandList[$nameOrAlias]->getName();
 
                 return $commandName === $nameOrAlias || !in_array($commandName, $commands);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Previously there was thrown an InvalidArgumentException if the entered
command was amibigious - even if an alias matched exactly.
