### PR TITLE
[WIP] Add support for parameters and service calls in route conditions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -85,7 +85,7 @@ EOF
             $context->setHost($host);
         }
 
-        $matcher = new TraceableUrlMatcher($router->getRouteCollection(), $context);
+        $matcher = new TraceableUrlMatcher($router->getRouteCollection(), $context, $this->getContainer());
 
         $traces = $matcher->getTraces($input->getArgument('path_info'));
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -70,6 +70,9 @@
             </argument>
             <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
+            <argument type="collection">
+                <argument key="container" type="service" id="service_container" />
+            </argument>
         </service>
 
         <service id="router" alias="router.default" />

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -35,13 +35,16 @@ class Router extends BaseRouter implements WarmableInterface
      * @param mixed              $resource  The main resource to load
      * @param array              $options   An array of options
      * @param RequestContext     $context   The context
+     * @param array              $expressionLanguageCtx Context for expression language component in matcher
      */
-    public function __construct(ContainerInterface $container, $resource, array $options = array(), RequestContext $context = null)
+    public function __construct(ContainerInterface $container, $resource, array $options = array(), RequestContext $context = null,
+                                array $expressionLanguageCtx)
     {
         $this->container = $container;
 
         $this->resource = $resource;
         $this->context = $context ?: new RequestContext();
+        $this->expressionLanguageCtx = $expressionLanguageCtx;
         $this->setOptions($options);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -74,6 +74,14 @@ class Router extends BaseRouter implements WarmableInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getMatcherInstance()
+    {
+        return new $this->options['matcher_class']($this->getRouteCollection(), $this->context, $this->container);
+    }
+
+    /**
      * Replaces placeholders with service container parameter values in:
      * - the route defaults,
      * - the route requirements,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RedirectableUrlMatcherTest.php
@@ -15,15 +15,22 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $dumbContainer;
+
     public function testRedirectWhenNoSlash()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/'));
 
-        $matcher = new RedirectableUrlMatcher($coll, $context = new RequestContext());
+        $matcher = new RedirectableUrlMatcher($coll, $context = new RequestContext(), $this->dumbContainer);
 
         $this->assertEquals(array(
                 '_controller' => 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction',
@@ -43,7 +50,7 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array('_scheme' => 'https')));
 
-        $matcher = new RedirectableUrlMatcher($coll, $context = new RequestContext());
+        $matcher = new RedirectableUrlMatcher($coll, $context = new RequestContext(), $this->dumbContainer);
 
         $this->assertEquals(array(
                 '_controller' => 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction',
@@ -63,7 +70,7 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array(), array(), '', array('https')));
 
-        $matcher = new RedirectableUrlMatcher($coll, $context = new RequestContext());
+        $matcher = new RedirectableUrlMatcher($coll, $context = new RequestContext(), $this->dumbContainer);
 
         $this->assertEquals(array(
                 '_controller' => 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction',

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Controller;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
@@ -30,13 +31,16 @@ class RouterController
     private $twig;
     private $matcher;
     private $routes;
+    private $container;
 
-    public function __construct(Profiler $profiler = null, \Twig_Environment $twig, UrlMatcherInterface $matcher = null, RouteCollection $routes = null)
+    public function __construct(Profiler $profiler = null, \Twig_Environment $twig, UrlMatcherInterface $matcher = null, ContainerInterface $container,
+                                RouteCollection $routes = null)
     {
         $this->profiler = $profiler;
         $this->twig = $twig;
         $this->matcher = $matcher;
         $this->routes = $routes;
+        $this->container = $container;
 
         if (null === $this->routes && $this->matcher instanceof RouterInterface) {
             $this->routes = $matcher->getRouteCollection();
@@ -68,7 +72,7 @@ class RouterController
 
         $context = $this->matcher->getContext();
         $context->setMethod($profile->getMethod());
-        $matcher = new TraceableUrlMatcher($this->routes, $context);
+        $matcher = new TraceableUrlMatcher($this->routes, $context, $this->container);
 
         $request = $profile->getCollector('request');
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="profiler" on-invalid="null" />
             <argument type="service" id="twig" />
             <argument type="service" id="router" on-invalid="null" />
+            <argument type="service" id="service_container" />
         </service>
 
         <service id="web_profiler.controller.exception" class="%web_profiler.controller.exception.class%">

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -24,7 +24,7 @@ class WebProfilerExtensionTest extends TestCase
 {
     private $kernel;
     /**
-     * @var Symfony\Component\DependencyInjection\Container $container
+     * @var Container $container
      */
     private $container;
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -254,7 +254,7 @@ EOF;
         }
 
         if ($route->getCondition()) {
-            $conditions[] = $this->getExpressionLanguage()->compile($route->getCondition(), array('context', 'request'));
+            $conditions[] = $this->getExpressionLanguage()->compile($route->getCondition(), array('context', 'request', 'container'));
         }
 
         $conditions = implode(' && ', $conditions);

--- a/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
@@ -51,7 +51,9 @@ abstract class RedirectableUrlMatcher extends UrlMatcher implements Redirectable
     protected function handleRouteRequirements($pathinfo, $name, Route $route)
     {
         // expression condition
-        if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(), array('context' => $this->context, 'request' => $this->request))) {
+        if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(),
+                array('context' => $this->context, 'request' => $this->request, 'container' => $this->container))) {
+
             return array(self::REQUIREMENT_MISMATCH, null);
         }
 

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -95,7 +95,7 @@ class TraceableUrlMatcher extends UrlMatcher
 
             // check condition
             if ($condition = $route->getCondition()) {
-                if (!$this->getExpressionLanguage()->evaluate($condition, array('context' => $this->context, 'request' => $this->request))) {
+                if (!$this->getExpressionLanguage()->evaluate($condition, array('context' => $this->context, 'request' => $this->request, 'container' => $this->container))) {
                     $this->addTrace(sprintf('Condition "%s" does not evaluate to "true"', $condition), self::ROUTE_ALMOST_MATCHES, $name, $route);
 
                     continue;

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -11,14 +11,13 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\DependencyInjection\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
 /**
@@ -58,22 +57,22 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     protected $expressionLanguageProviders = array();
 
     /**
-     * @var ContainerInterface
+     * @var array
      */
-    protected $container;
+    protected $expressionLanguageCtx;
 
     /**
      * @param RouteCollection $routes  A RouteCollection instance
      * @param RequestContext  $context The context
-     * @param ContainerInterface $container Service container needed for expressionLanguage
+     * @param array $expressionLanguageCtx Context for evaluation of ExpLang expressions
      *
      * @api
      */
-    public function __construct(RouteCollection $routes, RequestContext $context, ContainerInterface $container)
+    public function __construct(RouteCollection $routes, RequestContext $context, array $expressionLanguageCtx)
     {
         $this->routes = $routes;
         $this->context = $context;
-        $this->container = $container;
+        $this->expressionLanguageCtx = $expressionLanguageCtx;
     }
 
     /**
@@ -218,7 +217,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     {
         // expression condition
         if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(),
-                array('context' => $this->context, 'request' => $this->request, 'container' => $this->container))) {
+                array('context' => $this->context, 'request' => $this->request) + $this->expressionLanguageCtx)) {
 
             return array(self::REQUIREMENT_MISMATCH, null);
         }

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -11,13 +11,14 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\DependencyInjection\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
 /**
@@ -57,17 +58,22 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     protected $expressionLanguageProviders = array();
 
     /**
-     * Constructor.
-     *
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
      * @param RouteCollection $routes  A RouteCollection instance
      * @param RequestContext  $context The context
+     * @param ContainerInterface $container Service container needed for expressionLanguage
      *
      * @api
      */
-    public function __construct(RouteCollection $routes, RequestContext $context)
+    public function __construct(RouteCollection $routes, RequestContext $context, ContainerInterface $container)
     {
         $this->routes = $routes;
         $this->context = $context;
+        $this->container = $container;
     }
 
     /**
@@ -211,7 +217,9 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     protected function handleRouteRequirements($pathinfo, $name, Route $route)
     {
         // expression condition
-        if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(), array('context' => $this->context, 'request' => $this->request))) {
+        if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(),
+                array('context' => $this->context, 'request' => $this->request, 'container' => $this->container))) {
+
             return array(self::REQUIREMENT_MISMATCH, null);
         }
 

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -72,6 +72,11 @@ class Router implements RouterInterface, RequestMatcherInterface
     protected $logger;
 
     /**
+     * @var array
+     */
+    protected $expressionLanguageCtx;
+
+    /**
      * @var ExpressionFunctionProviderInterface[]
      */
     private $expressionLanguageProviders = array();
@@ -85,7 +90,8 @@ class Router implements RouterInterface, RequestMatcherInterface
      * @param RequestContext  $context  The context
      * @param LoggerInterface $logger   A logger instance
      */
-    public function __construct(LoaderInterface $loader, $resource, array $options = array(), RequestContext $context = null, LoggerInterface $logger = null)
+    public function __construct(LoaderInterface $loader, $resource, array $options = array(), RequestContext $context = null, LoggerInterface $logger = null,
+                                array $expressionLang)
     {
         $this->loader = $loader;
         $this->resource = $resource;

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -251,7 +251,7 @@ class Router implements RouterInterface, RequestMatcherInterface
         }
 
         if (null === $this->options['cache_dir'] || null === $this->options['matcher_cache_class']) {
-            $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
+            $this->matcher = $this->getMatcherInstance();
             if (method_exists($this->matcher, 'addExpressionLanguageProvider')) {
                 foreach ($this->expressionLanguageProviders as $provider) {
                     $this->matcher->addExpressionLanguageProvider($provider);
@@ -342,5 +342,13 @@ class Router implements RouterInterface, RequestMatcherInterface
     protected function getMatcherDumperInstance()
     {
         return new $this->options['matcher_dumper_class']($this->getRouteCollection());
+    }
+
+    /**
+     * @return UrlMatcherInterface
+     */
+    protected function getMatcherInstance()
+    {
+        return new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -17,12 +17,20 @@ use Symfony\Component\Routing\RequestContext;
 
 class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
 {
+
+    protected $dumbContainer;
+
+    public function setUp()
+    {
+        $this->dumbContainer = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface', array(), '', false);
+    }
+
     public function testRedirectWhenNoSlash()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/'));
 
-        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext()));
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext(), $this->dumbContainer));
         $matcher->expects($this->once())->method('redirect');
         $matcher->match('/foo');
     }
@@ -37,7 +45,7 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $context = new RequestContext();
         $context->setMethod('POST');
-        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, $context));
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, $context, $this->dumbContainer));
         $matcher->match('/foo');
     }
 
@@ -46,7 +54,7 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array('_scheme' => 'https')));
 
-        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext()));
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext(), $this->dumbContainer));
         $matcher
             ->expects($this->once())
             ->method('redirect')
@@ -61,7 +69,7 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array(), array(), '', array('FTP', 'HTTPS')));
 
-        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext()));
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext(), $this->dumbContainer));
         $matcher
             ->expects($this->once())
             ->method('redirect')
@@ -76,7 +84,7 @@ class RedirectableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array(), array(), '', array('https', 'http')));
 
-        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext()));
+        $matcher = $this->getMockForAbstractClass('Symfony\Component\Routing\Matcher\RedirectableUrlMatcher', array($coll, new RequestContext(), $this->dumbContainer));
         $matcher
             ->expects($this->never())
             ->method('redirect')

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -11,21 +11,37 @@
 
 namespace Symfony\Component\Routing\Tests\Matcher;
 
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $dumbContainer;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->dumbContainer = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface', array(), '', false);
+    }
+
     public function testNoMethodSoAllowed()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo'));
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $matcher->match('/foo');
     }
 
@@ -34,7 +50,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array('_method' => 'post')));
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
 
         try {
             $matcher->match('/foo');
@@ -49,7 +65,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array('_method' => 'get')));
 
-        $matcher = new UrlMatcher($coll, new RequestContext('', 'head'));
+        $matcher = new UrlMatcher($coll, new RequestContext('', 'head'), $this->dumbContainer);
         $matcher->match('/foo');
     }
 
@@ -59,7 +75,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll->add('foo1', new Route('/foo', array(), array('_method' => 'post')));
         $coll->add('foo2', new Route('/foo', array(), array('_method' => 'put|delete')));
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
 
         try {
             $matcher->match('/foo');
@@ -74,7 +90,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         // test the patterns are matched and parameters are returned
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo/{bar}'));
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         try {
             $matcher->match('/no-match');
             $this->fail();
@@ -85,17 +101,17 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         // test that defaults are merged
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo/{bar}', array('def' => 'test')));
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => 'foo', 'bar' => 'baz', 'def' => 'test'), $matcher->match('/foo/baz'));
 
         // test that route "method" is ignored if no method is given in the context
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo', array(), array('_method' => 'GET|head')));
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertInternalType('array', $matcher->match('/foo'));
 
         // route does not match with POST method context
-        $matcher = new UrlMatcher($collection, new RequestContext('', 'post'));
+        $matcher = new UrlMatcher($collection, new RequestContext('', 'post'), $this->dumbContainer);
         try {
             $matcher->match('/foo');
             $this->fail();
@@ -103,28 +119,28 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         }
 
         // route does match with GET or HEAD method context
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertInternalType('array', $matcher->match('/foo'));
-        $matcher = new UrlMatcher($collection, new RequestContext('', 'head'));
+        $matcher = new UrlMatcher($collection, new RequestContext('', 'head'), $this->dumbContainer);
         $this->assertInternalType('array', $matcher->match('/foo'));
 
         // route with an optional variable as the first segment
         $collection = new RouteCollection();
         $collection->add('bar', new Route('/{bar}/foo', array('bar' => 'bar'), array('bar' => 'foo|bar')));
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'bar'), $matcher->match('/bar/foo'));
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'foo'), $matcher->match('/foo/foo'));
 
         $collection = new RouteCollection();
         $collection->add('bar', new Route('/{bar}', array('bar' => 'bar'), array('bar' => 'foo|bar')));
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'foo'), $matcher->match('/foo'));
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'bar'), $matcher->match('/'));
 
         // route with only optional variables
         $collection = new RouteCollection();
         $collection->add('bar', new Route('/{foo}/{bar}', array('foo' => 'foo', 'bar' => 'bar'), array()));
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => 'bar', 'foo' => 'foo', 'bar' => 'bar'), $matcher->match('/'));
         $this->assertEquals(array('_route' => 'bar', 'foo' => 'a', 'bar' => 'bar'), $matcher->match('/a'));
         $this->assertEquals(array('_route' => 'bar', 'foo' => 'a', 'bar' => 'b'), $matcher->match('/a/b'));
@@ -137,7 +153,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection->addPrefix('/b');
         $collection->addPrefix('/a');
 
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => 'foo', 'foo' => 'foo'), $matcher->match('/a/b/foo'));
     }
 
@@ -148,7 +164,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection->addPrefix('/b');
         $collection->addPrefix('/{_locale}');
 
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_locale' => 'fr', '_route' => 'foo', 'foo' => 'foo'), $matcher->match('/fr/b/foo'));
     }
 
@@ -157,7 +173,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection = new RouteCollection();
         $collection->add('$péß^a|', new Route('/bar'));
 
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => '$péß^a|'), $matcher->match('/bar'));
     }
 
@@ -167,7 +183,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $chars = '!"$%éà &\'()*+,./:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[]^_`abcdefghijklmnopqrstuvwxyz{|}~-';
         $collection->add('foo', new Route('/{foo}/bar', array(), array('foo' => '['.preg_quote($chars).']+')));
 
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.rawurlencode($chars).'/bar'));
         $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.strtr($chars, array('%' => '%25')).'/bar'));
     }
@@ -177,7 +193,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/{foo}/bar', array(), array('foo' => '.+')));
 
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => 'foo', 'foo' => "\n"), $matcher->match('/'.urlencode("\n").'/bar'), 'linefeed character is matched');
     }
 
@@ -191,7 +207,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $collection->addCollection($collection1);
 
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
 
         $this->assertEquals(array('_route' => 'foo'), $matcher->match('/foo1'));
         $this->setExpectedException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
@@ -204,12 +220,12 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll->add('foo', new Route('/foo/{foo}'));
         $coll->add('bar', new Route('/foo/bar/{foo}'));
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('foo' => 'bar', '_route' => 'bar'), $matcher->match('/foo/bar/bar'));
 
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/{bar}'));
-        $matcher = new UrlMatcher($collection, new RequestContext());
+        $matcher = new UrlMatcher($collection, new RequestContext(), $this->dumbContainer);
         try {
             $matcher->match('/');
             $this->fail();
@@ -222,7 +238,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('test', new Route('/{page}.{_format}', array('page' => 'index', '_format' => 'html')));
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('page' => 'my-page', '_format' => 'xml', '_route' => 'test'), $matcher->match('/my-page.xml'));
     }
 
@@ -231,7 +247,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('test', new Route('/{foo}-{bar}-', array(), array('foo' => '.+', 'bar' => '.+')));
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('foo' => 'text1-text2-text3', 'bar' => 'text4', '_route' => 'test'), $matcher->match('/text1-text2-text3-text4-'));
     }
 
@@ -240,7 +256,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('test', new Route('/{w}{x}{y}{z}.{_format}', array('z' => 'default-z', '_format' => 'html'), array('y' => 'y|Y')));
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         // 'w' eagerly matches as much as possible and the other variables match the remaining chars.
         // This also shows that the variables w-z must all exclude the separating char (the dot '.' in this case) by default requirement.
         // Otherwise they would also consume '.xml' and _format would never match as it's an optional variable.
@@ -259,7 +275,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $coll = new RouteCollection();
         $coll->add('test', new Route('/get{what}', array('what' => 'All')));
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
 
         $this->assertEquals(array('what' => 'All', '_route' => 'test'), $matcher->match('/get'));
         $this->assertEquals(array('what' => 'Sites', '_route' => 'test'), $matcher->match('/getSites'));
@@ -274,7 +290,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $coll = new RouteCollection();
         $coll->add('test', new Route('/get{what}Suffix'));
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
 
         $this->assertEquals(array('what' => 'Sites', '_route' => 'test'), $matcher->match('/getSitesSuffix'));
     }
@@ -283,7 +299,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $coll = new RouteCollection();
         $coll->add('test', new Route('/{page}.{_format}'));
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
 
         $this->assertEquals(array('page' => 'index', '_format' => 'mobile.html', '_route' => 'test'), $matcher->match('/index.mobile.html'));
     }
@@ -295,7 +311,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $coll = new RouteCollection();
         $coll->add('test', new Route('/{page}.{_format}'));
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
 
         $matcher->match('/index.sl/ash');
     }
@@ -307,7 +323,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $coll = new RouteCollection();
         $coll->add('test', new Route('/{page}.{_format}', array(), array('_format' => 'html|xml')));
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
 
         $matcher->match('/do.t.html');
     }
@@ -319,7 +335,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array('_scheme' => 'https')));
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $matcher->match('/foo');
     }
     /**
@@ -329,7 +345,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array(), array(), '', array('https')));
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $matcher->match('/foo');
     }
 
@@ -342,8 +358,36 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $route = new Route('/foo');
         $route->setCondition('context.getMethod() == "POST"');
         $coll->add('foo', $route);
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $matcher->match('/foo');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
+    public function testConditionWithParameterFail()
+    {
+        $container = new Container(new ParameterBag(array('foo' => 'foo')));
+        $container->compile();
+        $coll = new RouteCollection();
+        $route = new Route('/foo');
+        $route->setCondition('parameter("foo") == "bar"');
+        $coll->add('foo', $route);
+        $matcher = new UrlMatcher($coll, new RequestContext(), $container);
+        $matcher->match('/foo');
+    }
+
+    public function testConditionWithParameterSuccess()
+    {
+        $container = new Container(new ParameterBag(array('foo' => 'bar')));
+        $container->set('bar', (object)array('foo' => 'foo'));
+        $container->compile();
+        $coll = new RouteCollection();
+        $route = new Route('/foo');
+        $route->setCondition('parameter("foo") == "bar" && service("bar").foo == "foo"');
+        $coll->add('foo', $route);
+        $matcher = new UrlMatcher($coll, new RequestContext(), $container);
+        $this->assertNotNull($matcher->match('/foo'));
     }
 
     public function testDecodeOnce()
@@ -351,7 +395,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/{foo}'));
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('foo' => 'bar%23', '_route' => 'foo'), $matcher->match('/foo/bar%2523'));
     }
 
@@ -367,7 +411,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $coll->addCollection($subColl);
 
-        $matcher = new UrlMatcher($coll, new RequestContext());
+        $matcher = new UrlMatcher($coll, new RequestContext(), $this->dumbContainer);
         $this->assertEquals(array('_route' => 'bar'), $matcher->match('/new'));
     }
 
@@ -376,7 +420,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/{foo}', array(), array(), array(), '{locale}.example.com'));
 
-        $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'));
+        $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'), $this->dumbContainer);
         $this->assertEquals(array('foo' => 'bar', '_route' => 'foo', 'locale' => 'en'), $matcher->match('/foo/bar'));
     }
 
@@ -387,10 +431,10 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll->add('bar', new Route('/bar/{foo}', array(), array(), array(), '{locale}.example.net'));
         $coll->setHost('{locale}.example.com');
 
-        $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'));
+        $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'), $this->dumbContainer);
         $this->assertEquals(array('foo' => 'bar', '_route' => 'foo', 'locale' => 'en'), $matcher->match('/foo/bar'));
 
-        $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'));
+        $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'), $this->dumbContainer);
         $this->assertEquals(array('foo' => 'bar', '_route' => 'bar', 'locale' => 'en'), $matcher->match('/bar/bar'));
     }
 
@@ -402,7 +446,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/{foo}', array(), array(), array(), '{locale}.example.com'));
 
-        $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'example.com'));
+        $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'example.com'), $this->dumbContainer);
         $matcher->match('/foo/bar');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

See http://symfony.com/doc/2.7/book/routing.html#completely-customized-route-matching-with-conditions for reference on route conditions. This feature adds ability to use `parameter()` and `service()` functions in route conditions just like in container configuration.

Although I don't like injecting container in all those places, I'm not aware of better solution. What do you think and/or maybe you have better ideas how to do it?

TODO: fix tests, fix Symfony\Component\Routing\Router compatibility issues - probably it's better to make UrlMatcher unaware of container and instead just use a context array for ExpLang and pass it there (so there's no static coupling from UrlMatcher to Symfony's container)
