### PR TITLE
Test show FieldEntry serialization Bug

### DIFF
--- a/src/Symfony/Component/Security/Acl/Tests/Domain/FieldEntryTest.php
+++ b/src/Symfony/Component/Security/Acl/Tests/Domain/FieldEntryTest.php
@@ -40,6 +40,37 @@ class FieldEntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($ace->isAuditFailure(), $uAce->isAuditFailure());
     }
 
+    public function testSerializeUnserializeMoreAceWithSameSecurityIdentity()
+    {
+        $sid = $this->getSid();
+
+        $aceFirst = $this->getAce(null, $sid);
+        $aceSecond = $this->getAce(null, $sid);
+
+        $serializedFirst = serialize(array($aceFirst, $aceSecond));
+        list($uAceFirst, $uAceSecond) = unserialize($serializedFirst);
+
+        $this->assertNull($uAceFirst->getAcl());
+        $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAceFirst->getSecurityIdentity());
+        $this->assertEquals($aceFirst->getId(), $uAceFirst->getId());
+        $this->assertEquals($aceFirst->getField(), $uAceFirst->getField());
+        $this->assertEquals($aceFirst->getMask(), $uAceFirst->getMask());
+        $this->assertEquals($aceFirst->getStrategy(), $uAceFirst->getStrategy());
+        $this->assertEquals($aceFirst->isGranting(), $uAceFirst->isGranting());
+        $this->assertEquals($aceFirst->isAuditSuccess(), $uAceFirst->isAuditSuccess());
+        $this->assertEquals($aceFirst->isAuditFailure(), $uAceFirst->isAuditFailure());
+
+        $this->assertNull($uAceSecond->getAcl());
+        $this->assertInstanceOf('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface', $uAceSecond->getSecurityIdentity());
+        $this->assertEquals($aceSecond->getId(), $uAceSecond->getId());
+        $this->assertEquals($aceSecond->getField(), $uAceSecond->getField());
+        $this->assertEquals($aceSecond->getMask(), $uAceSecond->getMask());
+        $this->assertEquals($aceSecond->getStrategy(), $uAceSecond->getStrategy());
+        $this->assertEquals($aceSecond->isGranting(), $uAceSecond->isGranting());
+        $this->assertEquals($aceSecond->isAuditSuccess(), $uAceSecond->isAuditSuccess());
+        $this->assertEquals($aceSecond->isAuditFailure(), $uAceSecond->isAuditFailure());
+    }
+
     protected function getAce($acl = null, $sid = null)
     {
         if (null === $acl) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no] |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This commit show problem with serialize Acl with many FieldEntry objects contains same sid.
