### PR TITLE
[Form][Translator] Added `choice_label_format` option

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -79,7 +79,16 @@
                 {{- block('choice_widget_options') -}}
             </optgroup>
         {%- else -%}
-            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
+            {%- set choice_label = choice.label -%}
+            {%- if options.choice_label_format is defined and options.choice_label_format is not empty -%}
+                {%- set choice_label = options.choice_label_format|replace({
+                    '%value%': choice.value,
+                    '%choice%': choice.label,
+                    '%name%': name,
+                    '%id%': id,
+                }) -%}
+            {%- endif -%}
+            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_label|trans({}, translation_domain) }}</option>
         {%- endif -%}
     {% endfor %}
 {%- endblock choice_widget_options %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -83,7 +83,7 @@
             {%- if choice_label_format is defined and choice_label_format is not empty -%}
                 {%- set choice_label = choice_label_format|replace({
                     '%value%': choice.value,
-                    '%choice%': choice.label,
+                    '%choice%': choice_label,
                     '%name%': name,
                     '%id%': id,
                 }) -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -80,8 +80,8 @@
             </optgroup>
         {%- else -%}
             {%- set choice_label = choice.label -%}
-            {%- if options.choice_label_format is defined and options.choice_label_format is not empty -%}
-                {%- set choice_label = options.choice_label_format|replace({
+            {%- if choice_label_format is defined and choice_label_format is not empty -%}
+                {%- set choice_label = choice_label_format|replace({
                     '%value%': choice.value,
                     '%choice%': choice.label,
                     '%name%': name,

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_options.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_options.html.php
@@ -6,6 +6,12 @@
             <?php echo $formHelper->block($form, 'choice_widget_options', array('choices' => $choice)) ?>
         </optgroup>
     <?php else: ?>
-        <option value="<?php echo $view->escape($choice->value) ?>"<?php if ($is_selected($choice->value, $value)): ?> selected="selected"<?php endif?>><?php echo $view->escape($translatorHelper->trans($choice->label, array(), $translation_domain)) ?></option>
+        <?php
+        $choiceLabel = $choice->label;
+        if (isset($choice_label_format)) {
+            $choiceLabel = strtr($choice_label_format, array('%name%' => $name, '%id%' => $id, '%value%' => $choice->value, '%choice%' => $choice->label));
+        }
+        ?>
+        <option value="<?php echo $view->escape($choice->value) ?>"<?php if ($is_selected($choice->value, $value)): ?> selected="selected"<?php endif?>><?php echo $view->escape($translatorHelper->trans($choiceLabel, array(), $translation_domain)) ?></option>
     <?php endif ?>
 <?php endforeach ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -45,6 +45,7 @@ abstract class BaseType extends AbstractType
         $blockName = $options['block_name'] ?: $form->getName();
         $translationDomain = $options['translation_domain'];
         $labelFormat = $options['label_format'];
+        $choiceLabelFormat = $options['choice_label_format'];
 
         if ($view->parent) {
             if ('' !== ($parentFullName = $view->parent->vars['full_name'])) {
@@ -63,6 +64,10 @@ abstract class BaseType extends AbstractType
 
             if (!$labelFormat) {
                 $labelFormat = $view->parent->vars['label_format'];
+            }
+
+            if (!$choiceLabelFormat) {
+                $choiceLabelFormat = $view->parent->vars['choice_label_format'];
             }
         } else {
             $id = $name;
@@ -93,6 +98,7 @@ abstract class BaseType extends AbstractType
             'disabled' => $form->isDisabled(),
             'label' => $options['label'],
             'label_format' => $labelFormat,
+            'choice_label_format' => $choiceLabelFormat,
             'multipart' => false,
             'attr' => $options['attr'],
             'block_prefixes' => $blockPrefixes,
@@ -118,6 +124,7 @@ abstract class BaseType extends AbstractType
             'disabled' => false,
             'label' => null,
             'label_format' => null,
+            'choice_label_format' => null,
             'attr' => array(),
             'translation_domain' => null,
             'auto_initialize' => true,

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -385,6 +385,94 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
+    public function testChoiceLabelFormatName()
+    {
+        $form = $this->factory->createNamedBuilder('myform')
+            ->add('myfield', 'choice', array(
+                'choices' => array(
+                    'choice1',
+                    'choice2',
+                )
+            ))
+            ->getForm();
+        $view = $form->get('myfield')->createView();
+        $html = $this->renderLabel($view, null, array('choicelabel_format' => 'form.%name%.choices.%choice%'));
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="myform_myfield"]
+    [.="[trans]form.myfield.choices.choice1[/trans]"]
+'
+        );
+    }
+
+    public function testChoiceLabelFormatId()
+    {
+        $form = $this->factory->createNamedBuilder('myform')
+            ->add('myfield', 'text')
+            ->getForm();
+        $view = $form->get('myfield')->createView();
+        $html = $this->renderLabel($view, null, array(
+            'choice_label_format' => 'myform.%id%.choices.%choice%',
+            'choices' => array(
+                'choice1',
+                'choice2',
+            )
+        ));
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="myform_myfield"]
+    [.="[trans]myform.myform_myfield.choices.choice1[/trans]"]
+'
+        );
+    }
+
+    public function testChoiceLabelFormatAsFormOption()
+    {
+        $options = array('choice_label_format' => 'form.%name%.choices.%choice%');
+
+        $form = $this->factory->createNamedBuilder('myform', 'form', null, $options)
+            ->add('myfield', 'choice', array(
+                'choice1',
+                'choice2',
+            ))
+            ->getForm();
+        $view = $form->get('myfield')->createView();
+        $html = $this->renderLabel($view);
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="myform_myfield"]
+    [.="[trans]form.myfield.choices.choice1[/trans]"]
+'
+        );
+    }
+
+    public function testChoiceLabelFormatOverriddenOption()
+    {
+        $options = array('choice_label_format' => 'otherform.choices.%name%.%choice%');
+
+        $form = $this->factory->createNamedBuilder('myform', 'form', null, $options)
+            ->add('myfield', 'choice', array(
+                'choice_label_format' => 'myform.choices.%name%.%choice%',
+                'choices' => array(
+                    'choice1',
+                    'choice2',
+                ),
+            ))
+            ->getForm();
+        $view = $form->get('myfield')->createView();
+        $html = $this->renderLabel($view);
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="myform_myfield"]
+    [.="[trans]myform.choices.myfield.choice1[/trans]"]
+'
+        );
+    }
+
     public function testErrors()
     {
         $form = $this->factory->createNamed('name', 'text');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | unsure (see https://github.com/symfony/symfony/pull/12882#issuecomment-66195601) |
| Fixed tickets | #12880 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/4602 |
### What this adds...

Inspired by the recently added `label_format` option, I wondered if this was worth merging.
Basically, these changes allow us to do this:

``` php
<?php
$builder->add('gender', 'choice', array(
  // ...
  'choice_label_format' => 'my_form.choices.%name%.%choice%'
));
```

My reason for adding it to the `BaseType` (just like the `label_format` option) is that you could then also define this option on the form itself during construction. It might seem odd to do this but consider the convenience of doing this (within a framework project):

``` php
<?php
$searchForm = $this->createForm(new SearchType(), null, [
  'label_format' => 'docs_search.form.fields.%name%',
  'choice_label_format' => 'docs_search.form.choices.%name%.%choice%'
]);
```
