### PR TITLE
[HttpKernel] Add deprecation log for Kernel::isClassInActiveBundle()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -214,6 +214,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     public function isClassInActiveBundle($class)
     {
+        trigger_error('Symfony\\Component\\HttpKernel\\Kernel::isClassInActiveBundle() is deprecated since version 2.6 and will be removed in version 3.0.', E_USER_DEPRECATED);
+
         foreach ($this->getBundles() as $bundle) {
             if (0 === strpos($class, $bundle->getNamespace())) {
                 return true;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #11652 |
| License | MIT |
| Doc PR | \- (Not mentioned in the docs) |

See #11869 and #12854 
