### PR TITLE
[Form][WebProfiler] Fixed issue#10054 : cannot report form data when "allow_add" is true in a field

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -542,7 +542,7 @@
 
         {% if data.submitted_data is defined %}
         <h3>
-            <a class="toggle-button" data-toggle-target-id="{{ data.id }}-submitted_data" href="#">
+            <a class="toggle-button"{% if data.id is defined %} data-toggle-target-id="{{ data.id }}-submitted_data"{% endif %} href="#">
                 Submitted Data
                 <span class="toggle-icon"></span>
             </a>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -420,7 +420,7 @@
             {% else %}
                 <div class="toggle-icon empty"></div>
             {% endif %}
-            {{ name|default('(no name)') }} {% if data.type is not empty %}[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]{% endif %}
+            {{ name|default('(no name)') }} {% if data.type is defined and data.type is not empty %}[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]{% endif %}
             {% if data.errors is defined and data.errors|length > 0 %}
             <div class="badge-error">{{ data.errors|length }}</div>
             {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -420,7 +420,7 @@
             {% else %}
                 <div class="toggle-icon empty"></div>
             {% endif %}
-            {{ name|default('(no name)') }} {% if data.type is defined and data.type is not empty %}[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]{% endif %}
+            {{ name|default('(no name)') }} {% if data.type is not empty %}[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]{% endif %}
             {% if data.errors is defined and data.errors|length > 0 %}
             <div class="badge-error">{{ data.errors|length }}</div>
             {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -414,7 +414,7 @@
 
 {% macro form_tree_entry(name, data, expanded) %}
     <li>
-        <div class="tree-inner" data-tab-target-id="{{ data.id }}-details">
+        <div class="tree-inner" {% if data.id is defined %}data-tab-target-id="{{ data.id }}-details"{% endif %}>
             {% if data.children is not empty %}
                 <a class="toggle-button" data-toggle-target-id="{{ data.id }}-children" href="#"><span class="toggle-icon"></span></a>
             {% else %}
@@ -548,7 +548,7 @@
             </a>
         </h3>
 
-        <div id="{{ data.id }}-submitted_data">
+        <div{% if data.id is defined %} id="{{ data.id }}-submitted_data"{% endif %}>
         {% if data.submitted_data.norm is defined %}
             <table>
                 <tr>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10054 |
| License | MIT |
| Doc PR | @WebProfilerBundle:Collector:form.html.twig, without checking if data.type is defined on line 423, web profiler crash to report form data when "allow_add" is true. |
