### PR TITLE
Adding note about the PdoSessionHandler BC break

### DIFF
--- a/UPGRADE-2.6.md
+++ b/UPGRADE-2.6.md
@@ -106,6 +106,20 @@ HttpFoundation
 --------------
 
  * The `PdoSessionHandler` to store sessions in a database changed significantly.
+   This introduced a **backwards-compatability** break in the schema of the
+   session table. The following changes must be made to your session table:
+
+   - Add a new integer column called `sess_lifetime`. Assuming you have the
+     default column and table names, in MySQL this would be:
+       ALTER TABLE `session` ADD `sess_lifetime` INT NOT NULL ;
+   - Change the data column (default: `sess_value`) to be a Blob type. In
+     MySQL this would be:
+      ALTER TABLE `session` CHANGE `sess_value` `session_value` BLOB NOT NULL;
+
+   There is also an [issue](https://github.com/symfony/symfony/issues/12834)
+   that affects Windows servers.
+
+   The changes to the `PdoSessionHandler` are:
    - By default, it now implements session locking to prevent loss of data by concurrent access to the same session.
      - It does so using a transaction between opening and closing a session. For this reason, it's not
        recommended to use the same database connection that you also use for your application logic.

--- a/UPGRADE-2.6.md
+++ b/UPGRADE-2.6.md
@@ -1,6 +1,12 @@
 UPGRADE FROM 2.5 to 2.6
 =======================
 
+Known Backwards-Compatability Breaks
+------------------------------------
+
+* If you use the `PdoSessionHandler`, the session table now has a different
+  schema and must be modified. Look below for more details.
+
 Form
 ----
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12833 |
| License | MIT |
| Doc PR | symfony/symfony-docs#4609 |

Hi guys!

This adds an UPGRADE note about the PdoSessionHandler BC break in 2.6. I also added a section on top, which might be more controversial that highlights the BC breaks. That's because this document is long, and much of it is telling you about deprecated features. But what I first want to know is - what will break?

I'm also still interested in maybe adding the old PdoSessionHandler to 2.6 and allowing you to use that one to keep BC (still a BC break, but you could choose to use the old one). 

Thanks!
