### PR TITLE
[Security] Fixed typo in SecurityContext PHPDoc

### DIFF
--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -41,7 +41,7 @@ class SecurityContext implements SecurityContextInterface
     private $authorizationChecker;
 
     /**
-     * For backwords compatibility, the signature of sf <2.6 still works
+     * For backwards compatibility, the signature of sf <2.6 still works
      *
      * @param TokenStorageInterface|AuthenticationManagerInterface         $tokenStorage
      * @param AuthorizationCheckerInterface|AccessDecisionManagerInterface $authorizationChecker


### PR DESCRIPTION
Fixes a simple typo.
