### PR TITLE
[DX][Profiler] Show the inherited roles in the web profiler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
@@ -12,6 +12,7 @@
         <service id="data_collector.security" class="%data_collector.security.class%" public="false">
             <tag name="data_collector" template="@Security/Collector/security.html.twig" id="security" />
             <argument type="service" id="security.context" on-invalid="ignore" />
+            <argument type="service" id="security.role_hierarchy" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -67,6 +67,12 @@
                 <th>Roles</th>
                 <td>{{ collector.roles|yaml_encode }}</td>
             </tr>
+            {% if collector.supportsRoleHierarchy %}
+            <tr>
+                <th>Inherited Roles</th>
+                <td>{{ collector.inheritedRoles|yaml_encode }}</td>
+            </tr>
+            {% endif %}
             {% if collector.tokenClass != null %}
             <tr>
                 <th>Token class</th>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12892 |
| License | MIT |
| Doc PR | - |

Given the following role hierarchy configuration 

``` php
security:
    role_hierarchy:
        ROLE_SUPER_ADMIN: [ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]
        ROLE_ADMIN:       [ROLE_EMPLOYEE]
        ROLE_EMPLOYEE:    [ROLE_SALES]
```

If you were checking the user roles in the web profiler as an user with the assigned 
role `ROLE_ADMIN` you saw only the following output.

![bildschirmfoto 2014-12-08 um 12 31 25](https://cloud.githubusercontent.com/assets/2010989/5338601/26fd4c90-7ed6-11e4-961b-12103ddddf50.png)

This was kind of tricky since pages where you were checking `is_granted('ROLE_EMPLOYEE')`
granted access. Debugging was hard for newcomers to the project if they did not understand
the role hierarchy.

With this adjustment you will see the assigned roles as well as the inherited roles separately as 
follows:

![bildschirmfoto 2014-12-08 um 12 23 59](https://cloud.githubusercontent.com/assets/2010989/5338622/5b0ffc58-7ed6-11e4-9863-27c9105897df.png)
