### PR TITLE
[HttpKernel] fix DumpDataCollectorTest after CS changes

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -30,7 +30,7 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('dump', $collector->getName());
 
         $collector->dump($data);
-        $line = __LINE__;
+        $line = __LINE__ - 1;
         $this->assertSame(1, $collector->getDumpsCount());
 
         $dump = $collector->getDumps('html');
@@ -63,7 +63,7 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $data = new Data(array(array(456)));
         $collector = new DumpDataCollector();
         $collector->dump($data);
-        $line = __LINE__;
+        $line = __LINE__ - 1;
 
         ob_start();
         $collector = null;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Modify the expected line value which was affected by the move of the
`__LINE__` constant in #12872 to make tests pass again.
