### PR TITLE
[2.3] [Security] Fixed The AuthenticationProviderInterface Alignment

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
@@ -24,12 +24,12 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
  */
 interface AuthenticationProviderInterface extends AuthenticationManagerInterface
 {
-     /**
-      * Checks whether this provider supports the given token.
-      *
-      * @param TokenInterface $token A TokenInterface instance
-      *
-      * @return bool true if the implementation supports the Token, false otherwise
-      */
-     public function supports(TokenInterface $token);
+    /**
+     * Checks whether this provider supports the given token.
+     *
+     * @param TokenInterface $token A TokenInterface instance
+     *
+     * @return bool true if the implementation supports the Token, false otherwise
+     */
+    public function supports(TokenInterface $token);
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the AuthenticationProviderInterface alignment.

Everything was indented by one too many spaces.
