### PR TITLE
[FrameworkBundle] Fixed cache clear command with relative file refs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -150,10 +150,10 @@ EOF
         }
 
         // fix references to cached files with the real cache directory name
-        $search = array($warmupDir, str_replace('\\', '\\\\', $warmupDir));
-        $replace = str_replace('\\', '/', $realCacheDir);
+        $search = sprintf('/(dirname\(.+?)(%s)/', preg_quote(basename($warmupDir)));
+        $replace = sprintf('$1%s', preg_quote(basename($realCacheDir)));
         foreach (Finder::create()->files()->in($warmupDir) as $file) {
-            $content = str_replace($search, $replace, file_get_contents($file));
+            $content = preg_replace($search, $replace, file_get_contents($file));
             file_put_contents($file, $content);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12893 |
| License | MIT |
| Doc PR | - |

It's a quick fix for the clear cache command issue. Maybe it is not the best solution, but works for me and maybe worth merging until somebody can come up something better.
