### PR TITLE
Fixed deprecation version

### DIFF
--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -46,7 +46,7 @@ class Yaml
      *
      * @throws ParseException If the YAML is not valid
      *
-     * @deprecated The ability to pass file names to Yaml::parse() was deprecated in 2.7 and will be removed in 3.0. Please, pass the contents of the file instead.
+     * @deprecated The ability to pass file names to Yaml::parse() was deprecated in 2.2 and will be removed in 3.0. Please, pass the contents of the file instead.
      *
      * @api
      */
@@ -55,7 +55,7 @@ class Yaml
         // if input is a file, process it
         $file = '';
         if (strpos($input, "\n") === false && is_file($input)) {
-            trigger_error('The ability to pass file names to Yaml::parse() was deprecated in 2.7 and will be removed in 3.0. Please, pass the contents of the file instead.', E_USER_DEPRECATED);
+            trigger_error('The ability to pass file names to Yaml::parse() was deprecated in 2.2 and will be removed in 3.0. Please, pass the contents of the file instead.', E_USER_DEPRECATED);
 
             if (false === is_readable($input)) {
                 throw new ParseException(sprintf('Unable to parse "%s" as the file is not readable.', $input));


### PR DESCRIPTION
Passing a file to `Yaml::parse()` is deprecated since 2.2 if I understand http://symfony.com/blog/security-release-symfony-2-0-22-and-2-1-7-released correctly.

| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |
