### PR TITLE
bug #12893 [DependencyInjection] Normalize path values with realpath.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1372,6 +1372,8 @@ EOF;
 
     private function export($value)
     {
+        $originalValue = $value;
+        $value = (is_string($value) && (is_dir($value) || is_file($value)) && !in_array($value, array('.', '..'))) ? realpath($value) : $value;
         if (null !== $this->targetDirRegex && is_string($value) && preg_match($this->targetDirRegex, $value, $matches, PREG_OFFSET_CAPTURE)) {
             $prefix = $matches[0][1] ? var_export(substr($value, 0, $matches[0][1]), true).'.' : '';
             $suffix = $matches[0][1] + strlen($matches[0][0]);
@@ -1389,6 +1391,6 @@ EOF;
             return $dirname;
         }
 
-        return var_export($value, true);
+        return var_export($originalValue, true);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -93,10 +93,24 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $container->setParameter('bar', dirname(__FILE__));
         $container->setParameter('baz', '%bar%/PhpDumperTest.php');
         $container->setParameter('buz', dirname(dirname(__DIR__)));
+        $container->setParameter('baz_dir_with_dots', dirname(__FILE__).'/../'.basename(dirname(__FILE__)));
+        $container->setParameter('baz_file_with_dots', dirname(__FILE__).'/../'.basename(dirname(__FILE__)).'/PhpDumperTest.php');
         $container->compile();
 
         $dumper = new PhpDumper($container);
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services12.php', $dumper->dump(array('file' => __FILE__)), '->dump() dumps __DIR__ relative strings');
+    }
+
+    public function testDumpRelativeDirAndKeepValuesWhichNotMatchTargetDirRegex()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('baz_dir_with_dots', dirname(__FILE__).'/../'.basename(dirname(__FILE__)));
+        $container->setParameter('baz_file_with_dots', dirname(__FILE__).'/../'.basename(dirname(__FILE__)).'/PhpDumperTest.php');
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dumpedString = $dumper->dump(array('file' => '/foo/bar'));
+        $this->assertEquals(str_replace('%path%', dirname(__FILE__), file_get_contents(self::$fixturesPath.'/php/services13.php')), $dumpedString, '->dump() dumps __DIR__ relative strings and keep values which not match target dir regex');
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -24,10 +24,6 @@ class ProjectServiceContainer extends Container
      */
     public function __construct()
     {
-        $dir = __DIR__;
-        for ($i = 1; $i <= 5; ++$i) {
-            $this->targetDirs[$i] = $dir = dirname($dir);
-        }
         $this->parameters = $this->getDefaultParameters();
 
         $this->services =
@@ -38,24 +34,8 @@ class ProjectServiceContainer extends Container
 
         $this->scopes = array();
         $this->scopeChildren = array();
-        $this->methodMap = array(
-            'test' => 'getTestService',
-        );
 
         $this->aliases = array();
-    }
-
-    /**
-     * Gets the 'test' service.
-     *
-     * This service is shared.
-     * This method always returns the same instance of the service.
-     *
-     * @return \stdClass A stdClass instance.
-     */
-    protected function getTestService()
-    {
-        return $this->services['test'] = new \stdClass(('wiz'.$this->targetDirs[1]), array(('wiz'.$this->targetDirs[1]) => $this->targetDirs[2]));
     }
 
     /**
@@ -109,12 +89,8 @@ class ProjectServiceContainer extends Container
     protected function getDefaultParameters()
     {
         return array(
-            'foo' => ('wiz'.$this->targetDirs[1]),
-            'bar' => __DIR__,
-            'baz' => (__DIR__.'/PhpDumperTest.php'),
-            'buz' => $this->targetDirs[2],
-            'baz_dir_with_dots' => __DIR__,
-            'baz_file_with_dots' => (__DIR__.'/PhpDumperTest.php'),
+            'baz_dir_with_dots' => '%path%/../Dumper',
+            'baz_file_with_dots' => '%path%/../Dumper/PhpDumperTest.php',
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12893 |
| License | MIT |
| Doc PR |  |

As mentioned in #12893 the PhpDumper currently produces paths like

```
'kernel.cache_dir' => (dirname(dirname(dirname(__DIR__))).'/app/../var/cache/de_'),
```

if the cache directory is outside the AppKernel root. With this PR this path would appear as

```
'kernel.cache_dir' => __DIR__,
```

which sould be equivalent. Since this path does not contain the enviroment part, even if it was outside AppKernel root, there is no more need to fix it from warmup to real cache path (which does not work with relative paths currently).

E.g. other path like session.save_path are written as

```
'session.save_path' => (__DIR__.'/sessions'), 
```

instead of

```
'session.save_path' => (dirname(dirname(dirname(__DIR__))).'/app/../var/cache/de_/sessions'),
```

With this change the path values are normalized with realpath, before matching them against the targetDirRegex, which was in turn generated after passing the 'dir' option to realpath. So the path values have a better chance to match the regex.

I'm not sure if the change has a negative effect in other cases. Could it be a reasonable solution?
