### PR TITLE
[2.6] [Security] Fixed ExpressionVoter - addExpressionLanguageProvider

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
@@ -15,6 +15,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -41,6 +42,11 @@ class ExpressionVoter implements VoterInterface
         $this->expressionLanguage = $expressionLanguage;
         $this->trustResolver = $trustResolver;
         $this->roleHierarchy = $roleHierarchy;
+    }
+
+    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
+    {
+        $this->expressionLanguage->registerProvider($provider);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | --- |
| Fixed tickets | --- |
| License | MIT |
| Doc PR | --- |

Fix missing addExpressionLanguageProvider in [ExpressionVoter](https://github.com/symfony/symfony/blob/2.6/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php), used by [AddExpressionLanguageProvidersPass](https://github.com/symfony/symfony/blob/2.6/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php) to add expression providers.
