### PR TITLE
[Console] terminals are not interactive on Travis

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -972,7 +972,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester = new ApplicationTester($application);
         $tester->run(array('command' => 'help'));
 
-        $this->assertTrue($tester->getInput()->isInteractive());
         $this->assertFalse($tester->getInput()->hasParameterOption(array('--no-interaction', '-n')));
 
         $inputStream = $application->getHelperSet()->get('question')->getInputStream();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

You cannot assume that the input is always interactive when the tests
for the `Application` class are executed. The expected value depends
on the terminal being interactive.
