### PR TITLE
[WebProfilerBundle] Avoid missing method when using __invoke on a controller

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -4,10 +4,14 @@
     {% set request_handler %}
         {% if collector.controller.class is defined %}
             {% set link = collector.controller.file|file_link(collector.controller.line) %}
-            <span class="sf-toolbar-info-class sf-toolbar-info-with-next-pointer">{{ collector.controller.class|abbr_class }}</span>
-            <span class="sf-toolbar-info-method" onclick="{% if link %}window.location='{{link|e('js')}}';window.event.stopPropagation();return false;{% endif %}">
-                {{ collector.controller.method }}
-            </span>
+            {% if collector.controller.method %}
+                <span class="sf-toolbar-info-class sf-toolbar-info-with-next-pointer">{{ collector.controller.class|abbr_class }}</span>
+                <span class="sf-toolbar-info-method" onclick="{% if link %}window.location='{{link|e('js')}}';window.event.stopPropagation();return false;{% endif %}">
+                    {{ collector.controller.method }}
+                </span>
+            {% else %}
+                <span class="sf-toolbar-info-class" onclick="{% if link %}window.location='{{link|e('js')}}';window.event.stopPropagation();return false;{% endif %}">{{ collector.controller.class|abbr_class }}</span>
+            {% endif %}
         {% else %}
             <span class="sf-toolbar-info-class">{{ collector.controller }}</span>
         {% endif %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

2.6 added support for using `__invoke` on controllers, but the profiler toolbar still expects a method name, leading to:

![image](https://cloud.githubusercontent.com/assets/1784740/5412993/4553c4da-820a-11e4-899c-50ef9f330cdd.png)

This PR changes it to only include the method section/double dots if the method name is included (and the `link` is moved to the class name).
