### PR TITLE
[FrameworkBundle] Container parameters in Route#condition

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -1,0 +1,17 @@
+UPGRADE FROM 2.6 to 2.7
+=======================
+
+### Router
+
+ * Route conditions now support container parameters which
+   can be injected into condition using `%parameter%` notation.
+   Due to the fact that it works by replacing all parameters
+   with their corresponding values before passing condition
+   expression for compilation there can be BC breaks where you
+   could already have used percentage symbols. Single percentage symbol
+   usage is not affected in any way. Conflicts may occur where
+   you might have used `%` as a modulo operator, here's an example:
+   `foo%bar%2` which would be compiled to `$foo % $bar % 2` in 2.6
+   but in 2.7 you would get an error if `bar` parameter
+   doesn't exist or unexpected result otherwise.
+ 

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Routing;
 
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\Router as BaseRouter;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Routing;
 
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\Router as BaseRouter;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -95,6 +96,7 @@ class Router extends BaseRouter implements WarmableInterface
 
             $route->setPath($this->resolve($route->getPath()));
             $route->setHost($this->resolve($route->getHost()));
+            $route->setCondition($this->resolve($route->getCondition()));
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -28,16 +28,18 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 '_locale' => 'en|es',
-            )
+            ), array(), '', array(), array(), '"%foo%" == "bar"'
         ));
 
         $sc = $this->getServiceContainer($routes);
         $sc->setParameter('locale', 'es');
+        $sc->setParameter('foo', 'bar');
 
         $router = new Router($sc, 'foo');
 
         $this->assertSame('/en', $router->generate('foo', array('_locale' => 'en')));
         $this->assertSame('/', $router->generate('foo', array('_locale' => 'es')));
+        $this->assertSame('"bar" == "bar"', $router->getRouteCollection()->get('foo')->getCondition());
     }
 
     public function testDefaultsPlaceholders()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/http-foundation": "~2.4.9|~2.5,>=2.5.4",
         "symfony/http-kernel": "~2.6",
         "symfony/filesystem": "~2.3",
-        "symfony/routing": "~2.2",
+        "symfony/routing": "~2.5",
         "symfony/security-core": "~2.6",
         "symfony/security-csrf": "~2.6",
         "symfony/stopwatch": "~2.3",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Adds ability to use parameters in route conditions like you can use them in container definitions:

``` php
contact:
    path:     /contact
    defaults: { _controller: AcmeDemoBundle:Main:contact }
    condition: "request.headers.get('User-Agent') matches '%allowed_user_agents%'"
```

As you could see replacement of the placeholder happens before ExpressionLanguage will tokenize and compile the expression so it looks kinda ad-hoc and primitive. This means a BC break for us, because some of conditions out there that had percentage symbol might be invalid now, f.e.: `10%var_name%2`\- without the patch this will be currently compiled to `10 % $var_name % 2`, with the patch it will try to replace `%var_name%` with a parameter. The same goes for percentage symbols inside string literals. 

This PR is a different implementation of #12869 which is I think is too overcomplicated for this feature.
