### PR TITLE
[SecurityBundle] remove short array syntax

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -80,13 +80,13 @@ class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
 
         $container->loadFromExtension('security', array(
             'providers' => array(
-                'my_foo' => array('foo' => []),
+                'my_foo' => array('foo' => array()),
             ),
 
             'firewalls' => array(
                 'some_firewall' => array(
                     'pattern' => '/.*',
-                    'http_basic' => [],
+                    'http_basic' => array(),
                 ),
             ),
         ));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The short array syntax was introduced in PHP 5.4 and therefore leads
to failing tests when executed in PHP 5.3 environments.
