### PR TITLE
fix ocramius/proxy-manager dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "monolog/monolog": "~1.3",
         "propel/propel1": "~1.6",
         "ircmaxell/password-compat": "~1.0",
-        "ocramius/proxy-manager": "~0.3.1",
+        "ocramius/proxy-manager": "~0.4",
         "egulias/email-validator": "~1.2"
     },
     "autoload": {

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/dependency-injection": "~2.3",
-        "ocramius/proxy-manager": "~0.3.1"
+        "ocramius/proxy-manager": "~0.4"
     },
     "require-dev": {
         "symfony/config": "~2.3"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Symfony 2.5 and higher requires ocramius/proxy-manager 0.4.0 or
higher.
