### PR TITLE
[PropertyAccess] Added test to verify #5775 is fixed

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/Ticket5775Object.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/Ticket5775Object.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class Ticket5775Object
+{
+    private $property;
+
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    private function setProperty()
+    {
+    }
+
+    public function __set($property, $value)
+    {
+        $this->$property = $value;
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Author;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Magician;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\MagicianCall;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\Ticket5775Object;
 
 class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
 {
@@ -378,5 +379,14 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $propertyAccessor->setValue($object, 'magicProperty', 'foobar');
 
         $this->assertEquals('foobar', $object->getMagicProperty());
+    }
+
+    public function testTicket5755()
+    {
+        $object = new Ticket5775Object();
+
+        $this->propertyAccessor->setValue($object, 'property', 'foobar');
+
+        $this->assertEquals('foobar', $object->getProperty());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5775 |
| License | MIT |
| Doc PR |  |

Added regression test to verify #5775 has been fixed some time ago, so that it can be closed.
