### PR TITLE
[FrameworkBundle] Allow custom services for validator mapping cache.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -442,7 +442,12 @@ class Configuration implements ConfigurationInterface
                     ->info('validation configuration')
                     ->canBeEnabled()
                     ->children()
-                        ->scalarNode('cache')->end()
+                        ->scalarNode('cache')
+                            ->beforeNormalization()
+                                // Can be removed in 3.0, once ApcCache support is dropped
+                                ->ifString()->then(function ($v) { return 'apc' === $v ? 'validator.mapping.cache.apc' : $v; })
+                            ->end()
+                        ->end()
                         ->booleanNode('enable_annotations')->defaultFalse()->end()
                         ->arrayNode('static_method')
                             ->defaultValue(array('loadValidatorMetadata'))

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -716,7 +716,7 @@ class FrameworkExtension extends Extension
                 'validator_'.hash('sha256', $container->getParameter('kernel.root_dir'))
             );
 
-            $validatorBuilder->addMethodCall('setMetadataCache', array(new Reference('validator.mapping.cache.'.$config['cache'])));
+            $validatorBuilder->addMethodCall('setMetadataCache', array(new Reference($config['cache'])));
         }
 
         switch ($config['api']) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12803 |
| License | MIT |
| Doc PR | - |
#9892 introduced `DoctrineCache`, but it's not really used by the FrameworkBundle. This was overlooked, therefore I think it should go into 2.5.

This PR will let us to configure a service id, instead of a driver name. The only exception is apc, which is converted to `validator.mapping.cache.apc` to keep BC.

Examples:

``` yaml
framework:
    validation:
        cache: apc # converted to validator.mapping.cache.apc
```

``` yaml
framework:
    validation:
        cache: my_custom_cache_service
```

It would be nice to be able to provide a doctrine service id, instead of `CacheInterface` implementation. It could be automatically decorated with `DoctrineCache`:

``` yaml
framework:
    validation:
        cache:
            doctrine: my_doctrine_cache_service # could be provided by DoctrineCacheBundle
```

I'll work on it next.
