### PR TITLE
[Doctrine] [Bridge] Add a "repository" option to the uniqueEntity validator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Employee.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Employee.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/** @Entity */
+class Employee extends Person
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Person.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Person.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\InheritanceType;
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"person" = "Person", "employee" = "Employee"})
+ */
+class Person
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="string") */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -16,6 +16,8 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\Employee;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\Person;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity;
@@ -134,6 +136,8 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
             $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity'),
             $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity'),
             $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity'),
+            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\Person'),
+            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\Employee'),
         ));
     }
 
@@ -458,5 +462,36 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
         $entity = new SingleIntIdEntity(1, null);
 
         $this->validator->validate($entity, $constraint);
+    }
+
+    public function testValidateInheritanceUniqueness()
+    {
+        $constraint = new UniqueEntity(array(
+            'message' => 'myMessage',
+            'fields' => array('name'),
+            'em' => self::EM_NAME,
+            'repository' => 'Symfony\Bridge\Doctrine\Tests\Fixtures\Person',
+        ));
+
+        $entity1 = new Person(1, 'Foo');
+        $entity2 = new Employee(2, 'Foo');
+
+        $this->validator->validate($entity1, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->em->persist($entity1);
+        $this->em->flush();
+
+        $this->validator->validate($entity1, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->validator->validate($entity2, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->atPath('property.path.name')
+            ->setInvalidValue('Foo')
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -26,6 +26,7 @@ class UniqueEntity extends Constraint
     public $message = 'This value is already used.';
     public $service = 'doctrine.orm.validator.unique';
     public $em = null;
+    public $repository = null;
     public $repositoryMethod = 'findBy';
     public $fields = array();
     public $errorPath = null;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kind of |
| New feature? | yes, but debatable |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | No |
| Fixed tickets | #12573, #4087 |
| License | MIT |

See #12573 for more explanations.

I made a pull request for the 2.7 branch, as pragmatically, this is a new feature. But IMO, it's questionable, as it is an easy-pick for older branches and solves what might be considered as a bug, or at least induces one. This could easily be merged into 2.3 without any bad behavior.

The new repository option expects an entity path, in order to select its repository.
This allows to use properly the `UniqueEntity` constraint on hierarchical (inheritance) entities, using the root class repository in order to check the uniqueness, and not just the child repository.

Given this inheritance scheme:

```
User
 ├─ Customer
 └─ Society
```

The code below is now sufficient in order order to check username uniqueness in both `Customer` & `Society` entities, when trying to register a `Customer`.

``` php
#ACME\UserBundle\Entity\User.php
/**
 * @ORM\Entity
 *
 * @UniqueEntity(fields="username", repository="ACME\UserBundle\Entity\User")
 *
 */
class User { ... }
```

Not specifiying the repository option will not cause any issue, and keep the same behavior as before.
## Further:

The above case, IMO, might be the most used one, and it seems perhaps redondant to specify the current class as the repository to use for the constraint. Maybe we could imagine a `current` value for the `repository` option, auto-detecting the class on which the constraint is bound. (feasible ??)

Some other values could be considered in this way:
- `current`: As described above, will detect the exact class on which the constraint was bound, and use its repository.
- `root`: Will search for the top-level entity (User) and automatically use its repository.
- `real`: the current behavior. Is the default value for the repository option (or null).

For 3.0, I think the default value should be `current`.
## Discuss:
- For now, the `repository` option name is disputable, as it expects an entity path in order to load its repository, and not the repository itself. Should it be renamed ?
- If I define my Repositories as service, would I be able to somehow define a service for this as well ? (suggested by @itar)
