### PR TITLE
[2.3] [HttpFoundation] Fixed the testStarted method name

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -211,7 +211,7 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testStartedOutside()
+    public function testStarted()
     {
         $storage = $this->getStorage();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
##### This pull request fixes the testStarted method name.

The incorrect method name was introduced by https://github.com/symfony/symfony/commit/b9d3c92ca9a2c02373f014deea03aee9d278e692#diff-b3a49132e88c1d218317fd4bf46e389dL211.
