### PR TITLE
[2.3] Docblocks should not be followed by a blank line

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -155,7 +155,6 @@ class SecurityExtension extends Extension
      * @param array            $config    An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-
     private function createRoleHierarchy($config, ContainerBuilder $container)
     {
         if (!isset($config['role_hierarchy'])) {

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the Symfony package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php
@@ -16,7 +16,6 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  *
  * @see http://php.net/sessionhandler
  */
-
 if (PHP_VERSION_ID >= 50400) {
     class NativeSessionHandler extends \SessionHandler
     {

--- a/src/Symfony/Component/Process/Tests/NonStopableProcess.php
+++ b/src/Symfony/Component/Process/Tests/NonStopableProcess.php
@@ -7,7 +7,6 @@
  *
  * @example `php NonStopableProcess.php 42` will run the script for 42 seconds
  */
-
 function handleSignal($signal)
 {
     switch ($signal) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

There should be no blank line(s) between phpdocs that document properties, interfaces, classes, functions, or traits. This pull request was a test run of a new php-cs-fixer: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/864.
