### PR TITLE
[FrameworkBundle] fix cache:clear command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -74,6 +74,7 @@ EOF
         } else {
             // the warmup cache dir name must have the same length than the real one
             // to avoid the many problems in serialized resources files
+            $realCacheDir = realpath($realCacheDir);
             $warmupDir = substr($realCacheDir, 0, -1).'_';
 
             if ($filesystem->exists($warmupDir)) {
@@ -165,12 +166,14 @@ EOF
      */
     protected function getTempKernel(KernelInterface $parent, $namespace, $parentClass, $warmupDir)
     {
-        $rootDir = $parent->getRootDir();
+        $cacheDir = var_export($warmupDir, true);
+        $rootDir = var_export(realpath($parent->getRootDir()), true);
+        $logDir = var_export(realpath($parent->getLogDir()), true);
         // the temp kernel class name must have the same length than the real one
         // to avoid the many problems in serialized resources files
         $class = substr($parentClass, 0, -1).'_';
         // the temp kernel name must be changed too
-        $name = substr($parent->getName(), 0, -1).'_';
+        $name = var_export(substr($parent->getName(), 0, -1).'_', true);
         $code = <<<EOF
 <?php
 
@@ -180,17 +183,22 @@ namespace $namespace
     {
         public function getCacheDir()
         {
-            return '$warmupDir';
+            return $cacheDir;
         }
 
         public function getName()
         {
-            return '$name';
+            return $name;
         }
 
         public function getRootDir()
         {
-            return '$rootDir';
+            return $rootDir;
+        }
+
+        public function getLogDir()
+        {
+            return $logDir;
         }
 
         protected function buildContainer()

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -586,12 +586,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
         return array_merge(
             array(
-                'kernel.root_dir' => $this->rootDir,
+                'kernel.root_dir' => realpath($this->rootDir) ?: $this->rootDir,
                 'kernel.environment' => $this->environment,
                 'kernel.debug' => $this->debug,
                 'kernel.name' => $this->name,
-                'kernel.cache_dir' => $this->getCacheDir(),
-                'kernel.logs_dir' => $this->getLogDir(),
+                'kernel.cache_dir' => realpath($this->getCacheDir()) ?: $this->getCacheDir(),
+                'kernel.logs_dir' => realpath($this->getLogDir()) ?: $this->getLogDir(),
                 'kernel.bundles' => $bundles,
                 'kernel.charset' => $this->getCharset(),
                 'kernel.container_class' => $this->getContainerClass(),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12893 |
| License | MIT |
| Doc PR | - |

Reading comment on #12893 stating that using absolute paths works around the pb, I tried using realpath(),
and it works!
Pending work on #12955 can be done quietly now.
