### PR TITLE
[FrameworkBundle] update debug commands references

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -123,7 +123,7 @@ EOF
         $helper->describe($output, $object, $options);
 
         if (!$input->getArgument('name') && $input->isInteractive()) {
-            $output->writeln('To search for a service, re-run this command with a search term. <comment>container:debug log</comment>');
+            $output->writeln('To search for a service, re-run this command with a search term. <comment>debug:container log</comment>');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Dumps the ContainerBuilder to a cache file so that it can be used by
- * debugging tools such as the container:debug console command.
+ * debugging tools such as the debug:container console command.
  *
  * @author Ryan Weaver <ryan@thatsquality.com>
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -51,7 +51,7 @@
         "symfony/finder": "For using the translation loader and cache warmer",
         "symfony/form": "For using forms",
         "symfony/validator": "For using validation",
-        "symfony/yaml": "For using the config:debug and yaml:lint commands",
+        "symfony/yaml": "For using the debug:config and yaml:lint commands",
         "doctrine/cache": "For using alternative cache drivers"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12939 |
| License | MIT |
| Doc PR |  |

With #11627, both the `ContainerDebugCommand` name and the
`ConfigDebugCommand` name have been moved to the `debug` namespace.
Thus, references should be updated accordingly.
