### PR TITLE
[FrameworkBundle] skip compiler pass if interface doesn't exist

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
@@ -25,6 +25,11 @@ class LoggingTranslatorPass implements CompilerPassInterface
             return;
         }
 
+        // skip if the symfony/translation version is lower than 2.6
+        if (!interface_exists('Symfony\Component\Translation\TranslatorBagInterface')) {
+            return;
+        }
+
         if ($container->getParameter('translator.logging')) {
             $translatorAlias = $container->getAlias('translator');
             $definition = $container->getDefinition((string) $translatorAlias);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12813 |
| License | MIT |
| Doc PR |  |

The FrameworkBundle doesn't depend on the `symfony/translation`
component and therefore does not enforce a high enough version of this
package. Thus, with `symfony/translation` versions before `2.6`, the
`translator` service does exist, but the `TranslatorBagInterface` is
not present.
