### PR TITLE
[DebugBundle] enable the DumpDataCollectorPass

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DebugBundle.php
+++ b/src/Symfony/Bundle/DebugBundle/DebugBundle.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\DebugBundle;
 
+use Symfony\Bundle\DebugBundle\DependencyInjection\Compiler\DumpDataCollectorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\VarDumper;
@@ -38,5 +40,15 @@ class DebugBundle extends Bundle
                 $handler($var);
             });
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DumpDataCollectorPass());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I forget to activate the `DumpDataCollectorPass` in #13009.
