### PR TITLE
[TwigBundle] update required minimum TwigBridge version

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/twig-bridge": "~2.2",
+        "symfony/twig-bridge": "~2.3,>=2.3.10",
         "symfony/http-kernel": "~2.1"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

To be able to use `Twig_SimpleFunction` in `AssetsExtension`, Twig has
to be present in version 1.12 or higher. The TwigBridge only enforces
this Twig version as of version 2.3.10.
