### PR TITLE
[2.7] Print deprecation summary at end of tests

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -6,6 +6,86 @@ if (PHP_VERSION_ID >= 50400 && gc_enabled()) {
     gc_disable();
 }
 
+/**
+ * Catch deprecation notices and print a summary report at the end of the test suite
+ *
+ * @internal
+ */
+class DeprecationErrorHandler
+{
+    private static $isRegistered = false;
+
+    public static function register()
+    {
+        if (self::$isRegistered) {
+            return;
+        }
+        $deprecations = array(0);
+        $oldErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context) use (&$deprecations) {
+            if (E_USER_DEPRECATED !== $type) {
+                return PHPUnit_Util_ErrorHandler::handleError($type, $msg, $file, $line, $context);
+            }
+
+            ++$deprecations[0];
+            $trace = debug_backtrace(PHP_VERSION_ID >= 50400 ? DEBUG_BACKTRACE_IGNORE_ARGS : false);
+
+            $i = count($trace);
+            while (isset($trace[--$i]['class']) && ('ReflectionMethod' === $trace[$i]['class'] || 0 === strpos($trace[$i]['class'], 'PHPUnit_'))) {
+                // No-op
+            }
+
+            if (isset($trace[$i]['class'])) {
+                if (isset($deprecations[$trace[$i]['class']][$trace[$i]['function']][$msg])) {
+                    ++$deprecations[$trace[$i]['class']][$trace[$i]['function']][$msg];
+                } else {
+                    $deprecations[$trace[$i]['class']][$trace[$i]['function']][$msg] = 1;
+                }
+            }
+        });
+
+        if (null !== $oldErrorHandler) {
+            restore_error_handler();
+            if (array('PHPUnit_Util_ErrorHandler', 'handleError') === $oldErrorHandler) {
+                restore_error_handler();
+                self::register();
+            }
+        } else {
+            self::$isRegistered = true;
+            register_shutdown_function(function () use (&$deprecations) {
+                if ($deprecations[0]) {
+                    if (function_exists('posix_isatty') && @posix_isatty(STDOUT)) {
+                        echo "\n\x1B[43;30mDeprecation notices ($deprecations[0]):\x1B[0m\n";
+                    } else {
+                        echo "\nDeprecation notices ($deprecations[0]):\n";
+                    }
+
+                    foreach ($deprecations as $class => $notices) {
+                        if (0 !== $class) {
+                            echo "\n{$class}\n";
+                            foreach ($notices as $method => $notices) {
+                                echo "  ->{$method}()\n";
+                                foreach ($notices as $msg => $freq) {
+                                    echo "      {$msg}: $freq\n";
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    if (function_exists('posix_isatty') && @posix_isatty(STDOUT)) {
+                        echo "\n\x1B[42;30mNo deprecation notice\x1B[0m\n";
+                    } else {
+                        echo "\nNo deprecation notice\n";
+                    }
+                }
+            });
+        }
+    }
+}
+
+if (class_exists('PHPUnit_Util_ErrorHandler')) {
+    DeprecationErrorHandler::register();
+}
+
 $loader = require_once __DIR__.'/vendor/autoload.php';
 
 use Doctrine\Common\Annotations\AnnotationRegistry;

--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -160,8 +160,12 @@ class Client extends BaseClient
             $profilerCode = '$kernel->getContainer()->get(\'profiler\')->enable();';
         }
 
+        $errorReporting = error_reporting();
+
         $code = <<<EOF
 <?php
+
+error_reporting($errorReporting);
 
 if ('$autoloader') {
     require_once '$autoloader';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12973 |
| License | MIT |
| Doc PR | - |

This will show deprecations in the logs of the tests, but still allow them to be green.
This is not done on each component on purpose.
This is the first step to make 2.7 free from any deprecation notice.
Next steps are:
1. remove all deprecation warnings that are related to 2.7 _wrongly_ using deprecated interfaces. That will still leave notices related to BC layers.
2. isolate all tests related to BC layers in their own "Legacy"-prefixed test classes.
3. switch `off` then `on` again deprecations using `error_reporting` in setUp/tearDown for each of these legacy- test classes
4. revert this PR and put back error_reporting to E_ALL in every phpunit.xml.dist file

This process will:
- make tests green again,
- ensure over time that "pure" 2.7 API does not rely on deprecated one
- ensure over time that the 2.7 BC-layer keeps working
