### PR TITLE
[2.7] [SecurityBundle] fixes SecurityDataCollector::getInheritedRoles() documentation.

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -114,7 +114,7 @@ class SecurityDataCollector extends DataCollector
     /**
      * Gets the inherited roles of the user.
      *
-     * @return string The inherited roles
+     * @return array The inherited roles
      */
     public function getInheritedRoles()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
