### PR TITLE
[2.6] [SecurityBundle] use TokenStorageInterface instead of deprecated SecurityContextInterface in SecurityDataCollector and added unit tests suite.

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -11,10 +11,11 @@
 
 namespace Symfony\Bundle\SecurityBundle\DataCollector;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * SecurityDataCollector.
@@ -23,11 +24,16 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
  */
 class SecurityDataCollector extends DataCollector
 {
-    private $context;
+    private $tokenStorage;
 
-    public function __construct(SecurityContextInterface $context = null)
+    /**
+     * Constructor.
+     *
+     * @param TokenStorageInterface|null $tokenStorage
+     */
+    public function __construct(TokenStorageInterface $tokenStorage = null)
     {
-        $this->context = $context;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -35,7 +41,7 @@ class SecurityDataCollector extends DataCollector
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
-        if (null === $this->context) {
+        if (null === $this->tokenStorage) {
             $this->data = array(
                 'enabled' => false,
                 'authenticated' => false,
@@ -43,7 +49,7 @@ class SecurityDataCollector extends DataCollector
                 'user' => '',
                 'roles' => array(),
             );
-        } elseif (null === $token = $this->context->getToken()) {
+        } elseif (null === $token = $this->tokenStorage->getToken()) {
             $this->data = array(
                 'enabled' => true,
                 'authenticated' => false,
@@ -57,7 +63,7 @@ class SecurityDataCollector extends DataCollector
                 'authenticated' => $token->isAuthenticated(),
                 'token_class' => get_class($token),
                 'user' => $token->getUsername(),
-                'roles' => array_map(function ($role) { return $role->getRole();}, $token->getRoles()),
+                'roles' => array_map(function (RoleInterface $role) { return $role->getRole();}, $token->getRoles()),
             );
         }
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
@@ -11,7 +11,7 @@
     <services>
         <service id="data_collector.security" class="%data_collector.security.class%" public="false">
             <tag name="data_collector" template="@Security/Collector/security.html.twig" id="security" />
-            <argument type="service" id="security.context" on-invalid="ignore" />
+            <argument type="service" id="security.token_storage" on-invalid="ignore" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DataCollector;
+
+use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Role\Role;
+
+class SecurityDataCollectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCollectWhenSecurityIsDisabled()
+    {
+        $collector = new SecurityDataCollector();
+        $collector->collect($this->getRequest(), $this->getResponse());
+
+        $this->assertSame('security', $collector->getName());
+        $this->assertFalse($collector->isEnabled());
+        $this->assertFalse($collector->isAuthenticated());
+        $this->assertNull($collector->getTokenClass());
+        $this->assertCount(0, $collector->getRoles());
+        $this->assertEmpty($collector->getUser());
+    }
+
+    /** @dataProvider provideTokenStorage */
+    public function testCollectWhenAuthenticationTokenIsNull($tokenStorage)
+    {
+        $collector = new SecurityDataCollector($tokenStorage);
+        $collector->collect($this->getRequest(), $this->getResponse());
+
+        $this->assertTrue($collector->isEnabled());
+        $this->assertFalse($collector->isAuthenticated());
+        $this->assertNull($collector->getTokenClass());
+        $this->assertCount(0, $collector->getRoles());
+        $this->assertEmpty($collector->getUser());
+    }
+
+    public function provideTokenStorage()
+    {
+        return array(
+            array(new TokenStorage()),
+            array($this->getMock('Symfony\Component\Security\Core\SecurityContextInterface')),
+        );
+    }
+
+    /** @dataProvider provideRoles */
+    public function testCollectAuthenticationTokenAndRoles(array $roles, array $normalizedRoles)
+    {
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken('hhamon', 'P4$$w0rD', 'provider', $roles));
+
+        $collector = new SecurityDataCollector($tokenStorage);
+        $collector->collect($this->getRequest(), $this->getResponse());
+
+        $this->assertTrue($collector->isEnabled());
+        $this->assertTrue($collector->isAuthenticated());
+        $this->assertSame('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', $collector->getTokenClass());
+        $this->assertSame($normalizedRoles, $collector->getRoles());
+        $this->assertSame('hhamon', $collector->getUser());
+    }
+
+    public function provideRoles()
+    {
+        return array(
+            array(
+                array('ROLE_USER'),
+                array('ROLE_USER'),
+            ),
+            array(
+                array(new Role('ROLE_USER')),
+                array('ROLE_USER'),
+            ),
+        );
+    }
+
+    private function getRequest()
+    {
+        return $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+    private function getResponse()
+    {
+        return $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
