### PR TITLE
[FrameworkBundle][Logging Translator] skip if param "translator.logging" doesn't exist.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
@@ -30,7 +30,7 @@ class LoggingTranslatorPass implements CompilerPassInterface
             return;
         }
 
-        if ($container->getParameter('translator.logging')) {
+        if ($container->hasParameter('translator.logging') && $container->getParameter('translator.logging')) {
             $translatorAlias = $container->getAlias('translator');
             $definition = $container->getDefinition((string) $translatorAlias);
             $class = $container->getParameterBag()->resolveValue($definition->getClass());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #12989 |
| Tests pass? | yes |
| License | MIT |
