### PR TITLE
[Security] Delete old session on auth strategy migrate

### DIFF
--- a/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
@@ -47,7 +47,7 @@ class SessionAuthenticationStrategy implements SessionAuthenticationStrategyInte
                 return;
 
             case self::MIGRATE:
-                $request->getSession()->migrate();
+                $request->getSession()->migrate(true);
 
                 return;
 

--- a/src/Symfony/Component/Security/Tests/Http/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Session/SessionAuthenticationStrategyTest.php
@@ -47,7 +47,7 @@ class SessionAuthenticationStrategyTest extends \PHPUnit_Framework_TestCase
     public function testSessionIsMigrated()
     {
         $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
-        $session->expects($this->once())->method('migrate');
+        $session->expects($this->once())->method('migrate')->with($this->equalTo(true));
 
         $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE);
         $strategy->onAuthentication($this->getRequest($session), $this->getToken());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13026 |
| License | MIT |
| Doc PR |  |

As identified by @austinh in #13026 there are two sessions after authentication, since the previous session is migrated to a new one by `session_regenerate_id`. This PR ensures the old session is been deleted immediately on migration. 
I can't see any drawbacks, but if the change would break BC, another approach would be to add a new strategy like `switch` to enable instant deletion of the old session.
