### PR TITLE
[FrameworkBundle] Fixed Translation loader.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -136,6 +136,13 @@ EOF
             ? new DiffOperation($currentCatalogue, $extractedCatalogue)
             : new MergeOperation($currentCatalogue, $extractedCatalogue);
 
+        // Exit if no messages found.
+        if (count($operation->getDomains()) < 1) {
+            $output->writeln("\n <error>No translation found.</error>");
+
+            return;
+        }
+
         // show compiled list of messages
         if ($input->getOption('dump-messages') === true) {
             foreach ($operation->getDomains() as $domain) {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -47,6 +47,10 @@ class TranslationLoader
      */
     public function loadMessages($directory, MessageCatalogue $catalogue)
     {
+        if (!is_dir($directory)) {
+            return;
+        }
+
         foreach ($this->loaders as $format => $loader) {
             // load any existing translation files
             $finder = new Finder();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This patch verifies that the directory to load translations exists in `FrameworkBundle/Translation/TranslationLoader.php` and stop the command if there are no translation found.

**Before, when loading messages** :
- _of a bundle_
  ![capture d ecran 2014-12-20 a 14 38 05](https://cloud.githubusercontent.com/assets/667519/5514999/e179392a-8855-11e4-8fe1-916bac8c546b.png)
- _of an app folder_
  ![capture d ecran 2014-12-20 a 14 37 44](https://cloud.githubusercontent.com/assets/667519/5515000/e17bd9a0-8855-11e4-8f55-c32d92039f7c.png)

**After** :
- _of a bundle_
  ![capture d ecran 2014-12-20 a 14 39 12](https://cloud.githubusercontent.com/assets/667519/5515001/fe65d2aa-8855-11e4-9d5a-2a81bdb2a6e4.png)
- _of an app folder_
  ![capture d ecran 2014-12-20 a 14 41 34](https://cloud.githubusercontent.com/assets/667519/5515006/63aaceae-8856-11e4-8f0e-1e2fc2cf93c9.png)
