### PR TITLE
[FrameworkBundle] Fixed Translation loader and update translation command.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -116,6 +116,13 @@ EOF
             ? new DiffOperation($currentCatalogue, $extractedCatalogue)
             : new MergeOperation($currentCatalogue, $extractedCatalogue);
 
+        // Exit if no messages found.
+        if (!count($operation->getDomains())) {
+            $output->writeln("\n<comment>No translation found.</comment>");
+
+            return;
+        }
+
         // show compiled list of messages
         if ($input->getOption('dump-messages') === true) {
             foreach ($operation->getDomains() as $domain) {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -47,6 +47,10 @@ class TranslationLoader
      */
     public function loadMessages($directory, MessageCatalogue $catalogue)
     {
+        if (!is_dir($directory)) {
+            return;
+        }
+
         foreach ($this->loaders as $format => $loader) {
             // load any existing translation files
             $finder = new Finder();

--- a/src/Symfony/Component/Translation/Writer/TranslationWriter.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriter.php
@@ -67,6 +67,10 @@ class TranslationWriter
         // get the right dumper
         $dumper = $this->dumpers[$format];
 
+        if (isset($options['path']) && !is_dir($options['path'])) {
+            mkdir($options['path'], 0777, true);
+        }
+
         // save
         $dumper->dump($catalogue, $options);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This patch verifies that the directory to load translations exists in `FrameworkBundle/Translation/TranslationLoader.php` and stop the command if there are no translation found.

**Before, when loading messages** :
![capture d ecran 2014-12-20 a 14 55 52](https://cloud.githubusercontent.com/assets/667519/5515053/09f4655c-8859-11e4-8231-fc6587ace5eb.png)

**After, when loading messages** :
![capture d ecran 2014-12-20 a 15 01 36](https://cloud.githubusercontent.com/assets/667519/5515056/216a9fbc-8859-11e4-87a2-9e452df708a5.png)

---

**Before, when writing messages** :
![capture d ecran 2014-12-20 a 14 57 50](https://cloud.githubusercontent.com/assets/667519/5515058/508c3184-8859-11e4-9456-f8e47190d3cd.png)

**After, when writing messages** :
![capture d ecran 2014-12-20 a 15 03 47](https://cloud.githubusercontent.com/assets/667519/5515062/711f61d2-8859-11e4-8d15-d27700ac0a0f.png)

---

**Before when loading message and there was no messages found**:
![capture d ecran 2014-12-20 a 15 05 36](https://cloud.githubusercontent.com/assets/667519/5515065/afe422a4-8859-11e4-9d2d-8f8399555462.png)

**After when loading message and there was no messages found**:
![capture d ecran 2014-12-20 a 15 06 48](https://cloud.githubusercontent.com/assets/667519/5515070/da0247dc-8859-11e4-8cd7-127435441ffd.png)
