### PR TITLE
[2.7] [Bridge] [Swiftmailer] adds deprecation notice on MessageDataCollector class.

### DIFF
--- a/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
+++ b/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\Swiftmailer\DataCollector;
 
+trigger_error(__CLASS__.' class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Bundle\SwiftmailerBundle\DataCollector\MessageDataCollector class from SwiftmailerBundle instead. Require symfony/swiftmailer-bundle package to download SwiftmailerBundle with Composer.', E_USER_DEPRECATED);
+
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
