### PR TITLE
[2.3] [Console] remove « use » statement for PHP built-in exception classes.

### DIFF
--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Console\Helper;
 
 use Symfony\Component\Console\Output\OutputInterface;
-use InvalidArgumentException;
 
 /**
  * Provides helpers to display table output.
@@ -79,7 +78,7 @@ class TableHelper extends Helper
      *
      * @return TableHelper
      *
-     * @throws InvalidArgumentException when the table layout is not known
+     * @throws \InvalidArgumentException when the table layout is not known
      */
     public function setLayout($layout)
     {
@@ -111,8 +110,7 @@ class TableHelper extends Helper
                 break;
 
             default:
-                throw new InvalidArgumentException(sprintf('Invalid table layout "%s".', $layout));
-                break;
+                throw new \InvalidArgumentException(sprintf('Invalid table layout "%s".', $layout));
         };
 
         return $this;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
