### PR TITLE
[Debug] use ternary operator to simplify the getClassLoader() method in DebugClassLoader class.

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -65,11 +65,7 @@ class DebugClassLoader
      */
     public function getClassLoader()
     {
-        if ($this->wasFinder) {
-            return $this->classLoader[0];
-        } else {
-            return $this->classLoader;
-        }
+        return $this->wasFinder ? $this->classLoader[0] : $this->classLoader;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
