### PR TITLE
[OptionsResolver] Added Ability to filter by regex the allowed values

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -893,7 +893,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
                     continue;
                 }
 
-                if (preg_match('/^(\/)(.*)(\/)$/', $allowedValue)) {
+                if (preg_match('/^\/.+\/([imsxeAESUXu])?$/i', $allowedValue)) {
                     $isRegex = true;
                     if (preg_match($allowedValue, $value)) {
                         $success = true;

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -873,7 +873,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
         // Validate the value of the resolved option
         if (isset($this->allowedValues[$option])) {
-            $success = false;
+            $success = $isRegex = false;
             $printableAllowedValues = array();
 
             foreach ($this->allowedValues[$option] as $allowedValue) {
@@ -885,9 +885,21 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
                     // Don't include closures in the exception message
                     continue;
-                } elseif ($value === $allowedValue) {
+                }
+
+                if($value === $allowedValue){
                     $success = true;
-                    break;
+
+                    continue;
+                }
+
+                if(preg_match('/^(\/)(.*)(\/)$/', $allowedValue)){
+                    $isRegex = true;
+                    if(preg_match($allowedValue, $value)){
+                        $success = true;
+
+                        continue;
+                    }
                 }
 
                 $printableAllowedValues[] = $allowedValue;
@@ -901,10 +913,19 @@ class OptionsResolver implements Options, OptionsResolverInterface
                 );
 
                 if (count($printableAllowedValues) > 0) {
-                    $message .= sprintf(
-                        ' Accepted values are: %s.',
-                        $this->formatValues($printableAllowedValues)
-                    );
+                    $formatValue = $this->formatValues($printableAllowedValues);
+                    if($isRegex){
+                        $message .= sprintf(
+                            ' Accepted values must match the regular expression: %s.',
+                            $formatValue
+                        );
+                    }else{
+                        $message .= sprintf(
+                            ' Accepted values are: %s.',
+                            $formatValue
+                        );
+                    }
+
                 }
 
                 throw new InvalidOptionsException($message);

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -887,15 +887,15 @@ class OptionsResolver implements Options, OptionsResolverInterface
                     continue;
                 }
 
-                if($value === $allowedValue){
+                if ($value === $allowedValue) {
                     $success = true;
 
                     continue;
                 }
 
-                if(preg_match('/^(\/)(.*)(\/)$/', $allowedValue)){
+                if (preg_match('/^(\/)(.*)(\/)$/', $allowedValue)) {
                     $isRegex = true;
-                    if(preg_match($allowedValue, $value)){
+                    if (preg_match($allowedValue, $value)) {
                         $success = true;
 
                         continue;
@@ -914,18 +914,17 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
                 if (count($printableAllowedValues) > 0) {
                     $formatValue = $this->formatValues($printableAllowedValues);
-                    if($isRegex){
+                    if ($isRegex) {
                         $message .= sprintf(
                             ' Accepted values must match the regular expression: %s.',
                             $formatValue
                         );
-                    }else{
+                    } else {
                         $message .= sprintf(
                             ' Accepted values are: %s.',
                             $formatValue
                         );
                     }
-
                 }
 
                 throw new InvalidOptionsException($message);

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -268,6 +268,83 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         ), $this->resolver->resolve($options));
     }
 
+    public function testResolveSucceedsIfOptionValueAllowedRegex()
+    {
+        $this->resolver->setDefaults(array(
+                'one'   => '1',
+                'two'   => 'two',
+                'three' => 'three',
+                'four'  => '4'
+            ));
+
+        $this->resolver->setAllowedValues(array(
+                'one'   => '/\d+/',
+                'two'   => '/\w/',
+                'three' => '/t+h+r+e+e/',
+                'four'  => '/((q|c)+(uatr)+(e|o))/'
+            ));
+
+        $options = array(
+            'four'  => 'quatre'
+        );
+
+        $this->assertEquals(array(
+                'one'   => '1',
+                'two'   => 'two',
+                'three' => 'three',
+                'four'  => 'quatre'
+            ), $this->resolver->resolve($options));
+
+        $options = array(
+            'four'  => 'cuatro'
+        );
+
+        $this->assertEquals(array(
+                'one'   => '1',
+                'two'   => 'two',
+                'three' => 'three',
+                'four'  => 'cuatro'
+            ), $this->resolver->resolve($options));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage Accepted values must match the regular expression: "/[-0-9a-zA-Z.+_]+@[-0-9a-zA-Z.+_]+\.[a-zA-Z]{2,4}/"
+     */
+    public function testResolveFailsIfOptionValueNotAllowedRegex()
+    {
+        $this->resolver->setDefaults(array(
+                'email' => 'default@email.com',
+            ));
+
+        $this->resolver->setAllowedValues(array(
+                'email' => '/[-0-9a-zA-Z.+_]+@[-0-9a-zA-Z.+_]+\.[a-zA-Z]{2,4}/',
+            ));
+
+        $this->resolver->resolve(array(
+                'email' => 'invalid@email',
+            ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage Accepted values must match the regular expression: "/(https?)+(:\/\/symfony.com)(.*)/"
+     */
+    public function testResolveFailsIfOptionValueNotAllowedRegex2()
+    {
+        $this->resolver->setDefaults(array(
+                'symfony-website' => 'http://symfony.com'
+            ));
+
+        $this->resolver->setAllowedValues(array(
+                'symfony-website' => '/(https?)+(:\/\/symfony.com)(.*)/',
+            ));
+
+        $this->resolver->resolve(array(
+                'symfony-website' => 'https://twig.com',
+            ));
+    }
+
     public function testResolveSucceedsIfOptionalWithAllowedValuesNotSet()
     {
         $this->resolver->setRequired(array(

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -274,36 +274,36 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
                 'one'   => '1',
                 'two'   => 'two',
                 'three' => 'three',
-                'four'  => '4'
+                'four'  => '4',
             ));
 
         $this->resolver->setAllowedValues(array(
                 'one'   => '/\d+/',
                 'two'   => '/\w/',
                 'three' => '/t+h+r+e+e/',
-                'four'  => '/((q|c)+(uatr)+(e|o))/'
+                'four'  => '/((q|c)+(uatr)+(e|o))/',
             ));
 
         $options = array(
-            'four'  => 'quatre'
+            'four'  => 'quatre',
         );
 
         $this->assertEquals(array(
                 'one'   => '1',
                 'two'   => 'two',
                 'three' => 'three',
-                'four'  => 'quatre'
+                'four'  => 'quatre',
             ), $this->resolver->resolve($options));
 
         $options = array(
-            'four'  => 'cuatro'
+            'four'  => 'cuatro',
         );
 
         $this->assertEquals(array(
                 'one'   => '1',
                 'two'   => 'two',
                 'three' => 'three',
-                'four'  => 'cuatro'
+                'four'  => 'cuatro',
             ), $this->resolver->resolve($options));
     }
 
@@ -333,7 +333,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolveFailsIfOptionValueNotAllowedRegex2()
     {
         $this->resolver->setDefaults(array(
-                'symfony-website' => 'http://symfony.com'
+                'symfony-website' => 'http://symfony.com',
             ));
 
         $this->resolver->setAllowedValues(array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | WIP |
- [ ] document the BC breaks

I had the idea to develop this feature further to a presentation focused on the OptionsResolver component, it appeared to be a need expressed by many people.

Example of use:
$resolver->setDefaults(array(
'email' => 'default@email.com',
));

$resolver->setAllowedValues(array(
'email' => '/[-0-9a-zA-Z.+]+@[-0-9a-zA-Z.+]+.[a-zA-Z]{2,4}/',
));

$resolver->resolve(array(
'email' => 'invalid@email',
));

this code will throw this exception :
The option "email" with value "invalid@email" is invalid. Accepted values must match the regular expression: "/[-0-9a-zA-Z.+]+@[-0-9a-zA-Z.+]+.[a-zA-Z]{2,4}/".
