### PR TITLE
[Console] added possibility to choose right answers for a ConfirmationQuestion

### DIFF
--- a/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
+++ b/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
@@ -21,42 +21,42 @@ class ConfirmationQuestion extends Question
     /**
      * Constructor.
      *
-     * @param string $question     The question to ask to the user
-     * @param bool   $default      The default answer to return, true or false
-     * @param array  $rightAnswers All the answers equivalent to "yes" (only first letter will be taken into account)
+     * @param string $question       The question to ask to the user
+     * @param bool   $default        The default answer to return, true or false
+     * @param array  $correctAnswers All the answers equivalent to "yes" (only first letter will be taken into account)
      */
-    public function __construct($question, $default = true, $rightAnswers = ['y'])
+    public function __construct($question, $default = true, array $correctAnswers = array('y'))
     {
         parent::__construct($question, (bool) $default);
 
-        $rightAnswers = array_map(function ($value) {
+        $correctAnswers = array_map(function ($value) {
                 return strtolower($value[0]);
-            }, $rightAnswers);
+            }, $correctAnswers);
 
-        $this->setNormalizer($this->getDefaultNormalizer($rightAnswers));
+        $this->setNormalizer($this->getDefaultNormalizer($correctAnswers));
     }
 
     /**
      * Returns the default answer normalizer.
      *
-     * @param array $rightAnswers
+     * @param array $correctAnswers
      *
      * @return callable
      */
-    private function getDefaultNormalizer(array $rightAnswers)
+    private function getDefaultNormalizer(array $correctAnswers)
     {
         $default = $this->getDefault();
 
-        return function ($answer) use ($default, $rightAnswers) {
+        return function ($answer) use ($default, $correctAnswers) {
             if (is_bool($answer)) {
                 return $answer;
             }
 
             if (false === $default) {
-                return $answer && in_array(strtolower($answer[0]), $rightAnswers);
+                return $answer && in_array(strtolower($answer[0]), $correctAnswers);
             }
 
-            return !$answer || in_array(strtolower($answer[0]), $rightAnswers);
+            return !$answer || in_array(strtolower($answer[0]), $correctAnswers);
         };
     }
 }

--- a/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
+++ b/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
@@ -21,35 +21,42 @@ class ConfirmationQuestion extends Question
     /**
      * Constructor.
      *
-     * @param string $question The question to ask to the user
-     * @param bool   $default  The default answer to return, true or false
+     * @param string $question     The question to ask to the user
+     * @param bool   $default      The default answer to return, true or false
+     * @param array  $rightAnswers All the answers equivalent to "yes" (only first letter will be taken into account)
      */
-    public function __construct($question, $default = true)
+    public function __construct($question, $default = true, $rightAnswers = ['y'])
     {
         parent::__construct($question, (bool) $default);
 
-        $this->setNormalizer($this->getDefaultNormalizer());
+        $rightAnswers = array_map(function ($value) {
+                return strtolower($value[0]);
+            }, $rightAnswers);
+
+        $this->setNormalizer($this->getDefaultNormalizer($rightAnswers));
     }
 
     /**
      * Returns the default answer normalizer.
      *
+     * @param array $rightAnswers
+     *
      * @return callable
      */
-    private function getDefaultNormalizer()
+    private function getDefaultNormalizer(array $rightAnswers)
     {
         $default = $this->getDefault();
 
-        return function ($answer) use ($default) {
+        return function ($answer) use ($default, $rightAnswers) {
             if (is_bool($answer)) {
                 return $answer;
             }
 
             if (false === $default) {
-                return $answer && 'y' === strtolower($answer[0]);
+                return $answer && in_array(strtolower($answer[0]), $rightAnswers);
             }
 
-            return !$answer || 'y' === strtolower($answer[0]);
+            return !$answer || in_array(strtolower($answer[0]), $rightAnswers);
         };
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -158,9 +158,9 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
         $question = new ConfirmationQuestion('Do you like French fries?', false);
         $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
-        $question = new ConfirmationQuestion('Do you like French fries?', false, ['y', 'o']);
+        $question = new ConfirmationQuestion('Do you like French fries?', false, array('y', 'o'));
         $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
-        $question = new ConfirmationQuestion('Do you like French fries?', false, ['yes', 'oui']);
+        $question = new ConfirmationQuestion('Do you like French fries?', false, array('yes', 'oui'));
         $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
 
         $dialog->setInputStream($this->getInputStream("n\nno\n"));

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -153,10 +153,14 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         $question = new ConfirmationQuestion('Do you like French fries?', false);
         $this->assertFalse($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
 
-        $dialog->setInputStream($this->getInputStream("y\nyes\n"));
+        $dialog->setInputStream($this->getInputStream("y\nyes\nY\no\n"));
         $question = new ConfirmationQuestion('Do you like French fries?', false);
         $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
         $question = new ConfirmationQuestion('Do you like French fries?', false);
+        $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
+        $question = new ConfirmationQuestion('Do you like French fries?', false, ['y', 'o']);
+        $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
+        $question = new ConfirmationQuestion('Do you like French fries?', false, ['yes', 'oui']);
         $this->assertTrue($dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
 
         $dialog->setInputStream($this->getInputStream("n\nno\n"));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

With this pull request, the ConfirmationQuestion can accept one (or many) answer(s) like 'o', 'oui' (in french) or 'si' (in spanish) or anything else, it's up to you !
Default value is still 'y' (yes)
