### PR TITLE
[FrameworkBundle] forward error reporting level to insulated Client

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -160,8 +160,12 @@ class Client extends BaseClient
             $profilerCode = '$kernel->getContainer()->get(\'profiler\')->enable();';
         }
 
+        $errorReporting = error_reporting();
+
         $code = <<<EOF
 <?php
+
+error_reporting($errorReporting);
 
 if ('$autoloader') {
     require_once '$autoloader';

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -102,9 +102,12 @@ class Client extends BaseClient
         $r = new \ReflectionClass('\\Symfony\\Component\\ClassLoader\\ClassLoader');
         $requirePath = str_replace("'", "\\'", $r->getFileName());
         $symfonyPath = str_replace("'", "\\'", realpath(__DIR__.'/../../..'));
+        $errorReporting = error_reporting();
 
         $code = <<<EOF
 <?php
+
+error_reporting($errorReporting);
 
 require_once '$requirePath';
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Especially if deprecation notices are silenced on the main php instance, we should also silence them in the insulated Client
