### PR TITLE
[FrameworkBundle] Fix dependency on ExtensionInterface over implementation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
  * A console command for dumping available configuration reference.
@@ -73,7 +73,7 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         return $extension;
     }
 
-    public function validateConfiguration(Extension $extension, $configuration)
+    public function validateConfiguration(ExtensionInterface $extension, $configuration)
     {
         if (!$configuration) {
             throw new \LogicException(sprintf('The extension with alias "%s" does not have its getConfiguration() method setup', $extension->getAlias()));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no (but anyway, they didn't pass previously) |
| Fixed tickets | #13084 |
| License | MIT |

When implementing `ExtensionInterface` through classes not inheriting the core `Extension`, the command `config:dump` throws.
This bug was introduced in 2.5 and could be fixed up to 2.7 with the same patch.
