### PR TITLE
[Console] Define isVerbose(), etc. methods in OutputInterface

### DIFF
--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -76,6 +76,42 @@ interface OutputInterface
     public function getVerbosity();
 
     /**
+     * Returns whether verbosity is quiet (-q)
+     *
+     * @return bool true if verbosity is set to VERBOSITY_QUIET, false otherwise
+     *
+     * @api
+     */
+    public function isQuiet();
+
+    /**
+     * Returns whether verbosity is verbose (-v)
+     *
+     * @return bool true if verbosity is set to VERBOSITY_VERBOSE, false otherwise
+     *
+     * @api
+     */
+    public function isVerbose();
+
+    /**
+     * Returns whether verbosity is very verbose (-vv)
+     *
+     * @return bool true if verbosity is set to VERBOSITY_VERY_VERBOSE, false otherwise
+     *
+     * @api
+     */
+    public function isVeryVerbose();
+
+    /**
+     * Returns whether verbosity is debug (-vvv)
+     *
+     * @return bool true if verbosity is set to VERBOSITY_DEBUG, false otherwise
+     *
+     * @api
+     */
+    public function isDebug();
+
+    /**
      * Sets the decorated flag.
      *
      * @param bool $decorated Whether to decorate the messages

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -79,8 +79,6 @@ interface OutputInterface
      * Returns whether verbosity is quiet (-q)
      *
      * @return bool true if verbosity is set to VERBOSITY_QUIET, false otherwise
-     *
-     * @api
      */
     public function isQuiet();
 
@@ -88,8 +86,6 @@ interface OutputInterface
      * Returns whether verbosity is verbose (-v)
      *
      * @return bool true if verbosity is set to VERBOSITY_VERBOSE, false otherwise
-     *
-     * @api
      */
     public function isVerbose();
 
@@ -97,8 +93,6 @@ interface OutputInterface
      * Returns whether verbosity is very verbose (-vv)
      *
      * @return bool true if verbosity is set to VERBOSITY_VERY_VERBOSE, false otherwise
-     *
-     * @api
      */
     public function isVeryVerbose();
 
@@ -106,8 +100,6 @@ interface OutputInterface
      * Returns whether verbosity is debug (-vvv)
      *
      * @return bool true if verbosity is set to VERBOSITY_DEBUG, false otherwise
-     *
-     * @api
      */
     public function isDebug();
 


### PR DESCRIPTION
Could / should the `Symfony\Component\Console\Output\OutputInterface` define the methods `isQuiet()`, `isVerbose()`, `isVeryVerbose()` and `isDebug()`?

Because the Interface already defines the verbosity constants and the `getVerbosity()` method, it will probalby be the right place to do so...

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
