### PR TITLE
Add deprecation warning to LegacyPdoSessionHandler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/LegacyPdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/LegacyPdoSessionHandler.php
@@ -76,6 +76,9 @@ class LegacyPdoSessionHandler implements \SessionHandlerInterface
         if (\PDO::ERRMODE_EXCEPTION !== $pdo->getAttribute(\PDO::ATTR_ERRMODE)) {
             throw new \InvalidArgumentException(sprintf('"%s" requires PDO error mode attribute be set to throw Exceptions (i.e. $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION))', __CLASS__));
         }
+
+        trigger_error('"Symfony\Component\HttpFoundation\Session\Storage\Handler\LegacyPdoSessionHandler" is deprecated since version 2.6 and will be removed in 3.0. Use "Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler" instead.', E_USER_DEPRECATED);
+
         $this->pdo = $pdo;
         $dbOptions = array_merge(array(
             'db_id_col' => 'sess_id',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

LegacyPdoSessionHandler has been deprecated in favor of PdoSessionHandler. Trigger an E_USER_DEPRECATED error when the deprecated class is used.

Addresses @fabpot's comment on [#13068](https://github.com/symfony/symfony/pull/13068#issuecomment-67977358).
