### PR TITLE
Escape annotation in docblock.

### DIFF
--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -101,7 +101,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      *
      * The resource name must follow the following pattern:
      *
-     *     @BundleName/path/to/a/file.something
+     *     @<BundleName>/path/to/a/file.something
      *
      * where BundleName is the name of the bundle
      * and the remaining part is the relative path in the bundle.


### PR DESCRIPTION
as already done in the [HttpKernel](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/HttpKernel/Kernel.php#L259) to avoid problems with non-imported annotations.

| Q | A |
| --- | --- |
| Fixed tickets | --- |
| License | MIT |
