### PR TITLE
[HttpFoundation] Prevent XSS in JsonResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -120,6 +120,11 @@ class JsonResponse extends Response
             $this->headers->set('Content-Type', 'application/json');
         }
 
+        // Prevent XSS attack
+        if (!$this->headers->has('X-Content-Type-Options')) {
+            $this->headers->set('X-Content-Type-Options', 'nosniff');
+        }
+
         return $this->setContent($this->data);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -182,4 +182,11 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
     {
         JsonResponse::create("\xB1\x31");
     }
+
+    public function testXContentTypeOptionsHeader()
+    {
+        $response = new JsonResponse(array('test' => true));
+
+        $this->assertSame('nosniff', $response->headers->get('X-Content-Type-Options'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

FYI https://www.owasp.org/index.php/REST_Security_Cheat_Sheet#Send_security_headers
