### PR TITLE
[FrameworkBundle] added a test router for the built-in web server

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -68,8 +68,8 @@ router script using <info>--router</info> option:
 
   <info>%command.full_name% --router=app/config/router.php</info>
 
-Specifing a router script is required when the used environment is not "dev" or
-"prod".
+Specifing a router script is required when the used environment is not "dev",
+"prod", or "test".
 
 See also: http://www.php.net/manual/en/features.commandline.webserver.php
 EOF

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_test.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_test.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * This file implements rewrite rules for PHP built-in web server.
+ *
+ * See: http://www.php.net/manual/en/features.commandline.webserver.php
+ *
+ * If you have custom directory layout, then you have to write your own router
+ * and pass it as a value to 'router' option of server:run command.
+ *
+ * @author: Michał Pipa <michal.pipa.xsolve@gmail.com>
+ * @author: Albert Jessurum <ajessu@gmail.com>
+ */
+
+if (is_file($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$_SERVER['SCRIPT_NAME'])) {
+    return false;
+}
+
+$_SERVER = array_merge($_SERVER, $_ENV);
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app_test.php';
+
+require 'app_test.php';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9995 |
| License | MIT |
| Doc PR | n/a |
#9995 describes a very valid use case.

Not sure if this should be merged into 2.7 only... now that I think about it, probably :)
