### PR TITLE
[Serializer] Name converter support

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -59,3 +59,27 @@ Form
             }
         }
    ```
+
+Serializer
+----------
+
+ * The `setCamelizedAttributes()` method of the
+   `Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer` and
+   `Symfony\Component\Serializer\Normalizer\PropertyNormalizer` classes is marked
+   as deprecated in favor of the new NameConverter system.
+
+   Before:
+
+   ```php
+   $normalizer->setCamelizedAttributes(array('foo_bar', 'bar_foo'));
+   ```
+
+   After:
+
+   ```php
+   use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+   use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+
+   $nameConverter = new CamelCaseToSnakeCaseNameConverter(array('fooBar', 'barFoo'));
+   $normalizer = new GetSetMethodNormalizer(null, $nameConverter);
+   ```

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,11 +1,26 @@
 CHANGELOG
 =========
 
+2.7.0
+-----
+
+ * added support for serialization and deserialization groups including
+   annotations, XML and YAML mapping.
+ * added `AbstractNormalizer` to factorise code and ease normalizers development
+ * added circular references handling for `PropertyNormalizer`
+ * added support for a context key called `object_to_populate` in `AbstractNormalizer`
+   to reuse existing objects in the deserialization process
+ * added `NameConverterInterface` and `CamelCaseToSnakeCaseNameConverter`
+ * [DEPRECATION] `GetSetMethodNormalizer::setCamelizedAttributes()` and
+   `PropertyNormalizer::setCamelizedAttributes()` are replaced by
+   `CamelCaseToSnakeCaseNameConverter`
+
 2.6.0
 -----
 
  * added a new serializer: `PropertyNormalizer`. Like `GetSetMethodNormalizer`,
    this normalizer will map an object's properties to an array.
+ * added circular references handling for `GetSetMethodNormalizer`
 
 2.5.0
 -----

--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\NameConverter;
+
+/**
+ * CamelCase to Underscore name converter.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
+{
+    /**
+     * @var array|null
+     */
+    private $attributes;
+    /**
+     * @var bool
+     */
+    private $lowerCamelCase;
+
+    /**
+     * @param null|array $attributes     The list of attributes to rename or null for all attributes.
+     * @param bool       $lowerCamelCase Use lowerCamelCase style.
+     */
+    public function __construct(array $attributes = null, $lowerCamelCase = true)
+    {
+        $this->attributes = $attributes;
+        $this->lowerCamelCase = $lowerCamelCase;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($propertyName)
+    {
+        if (null === $this->attributes || in_array($propertyName, $this->attributes)) {
+            $snakeCasedName = '';
+
+            $len = strlen($propertyName);
+            for ($i = 0; $i < $len; $i++) {
+                if (ctype_upper($propertyName[$i])) {
+                    $snakeCasedName .= '_'.strtolower($propertyName[$i]);
+                } else {
+                    $snakeCasedName .= strtolower($propertyName[$i]);
+                }
+            }
+
+            return $snakeCasedName;
+        }
+
+        return $propertyName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($propertyName)
+    {
+        $camelCasedName = preg_replace_callback('/(^|_|\.)+(.)/', function ($match) {
+            return ('.' === $match[1] ? '_' : '').strtoupper($match[2]);
+        }, $propertyName);
+
+        if ($this->lowerCamelCase) {
+            $camelCasedName = lcfirst($camelCasedName);
+        }
+
+        if (null === $this->attributes || in_array($camelCasedName, $this->attributes)) {
+            return $this->lowerCamelCase ? lcfirst($camelCasedName) : $camelCasedName;
+        }
+
+        return $propertyName;
+    }
+}

--- a/src/Symfony/Component/Serializer/NameConverter/NameConverterInterface.php
+++ b/src/Symfony/Component/Serializer/NameConverter/NameConverterInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\NameConverter;
+
+/**
+ * Defines the interface for property name converters.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface NameConverterInterface
+{
+    /**
+     * Converts a property name to its normalized value.
+     *
+     * @param string $propertyName
+     * @return string
+     */
+    public function normalize($propertyName);
+
+    /**
+     * Converts a property name to its denormalized value.
+     *
+     * @param string $propertyName
+     * @return string
+     */
+    public function denormalize($propertyName);
+}

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -77,6 +77,10 @@ class GetSetMethodNormalizer extends AbstractNormalizer
                     $attributeValue = $this->serializer->normalize($attributeValue, $format, $context);
                 }
 
+                if ($this->nameConverter) {
+                    $attributeName = $this->nameConverter->normalize($attributeName);
+                }
+
                 $attributes[$attributeName] = $attributeValue;
             }
         }
@@ -102,7 +106,11 @@ class GetSetMethodNormalizer extends AbstractNormalizer
             $ignored = in_array($attribute, $this->ignoredAttributes);
 
             if ($allowed && !$ignored) {
-                $setter = 'set'.$this->formatAttribute($attribute);
+                if ($this->nameConverter) {
+                    $attribute = $this->nameConverter->denormalize($attribute);
+                }
+
+                $setter = 'set'.ucfirst($attribute);
 
                 if (method_exists($object, $setter)) {
                     $object->$setter($value);

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -71,7 +71,12 @@ class PropertyNormalizer extends AbstractNormalizer
                 $attributeValue = $this->serializer->normalize($attributeValue, $format, $context);
             }
 
-            $attributes[$property->name] = $attributeValue;
+            $propertyName = $property->name;
+            if ($this->nameConverter) {
+                $propertyName = $this->nameConverter->normalize($propertyName);
+            }
+
+            $attributes[$propertyName] = $attributeValue;
         }
 
         return $attributes;
@@ -91,7 +96,9 @@ class PropertyNormalizer extends AbstractNormalizer
         $object = $this->instantiateObject($data, $class, $context, $reflectionClass, $allowedAttributes);
 
         foreach ($data as $propertyName => $value) {
-            $propertyName = lcfirst($this->formatAttribute($propertyName));
+            if ($this->nameConverter) {
+                $propertyName = $this->nameConverter->denormalize($propertyName);
+            }
 
             $allowed = $allowedAttributes === false || in_array($propertyName, $allowedAttributes);
             $ignored = in_array($propertyName, $this->ignoredAttributes);

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\NameConverter;
+
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class CamelCaseToSnakeCaseNameConverterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider attributeProvider
+     */
+    public function testNormalize($underscored, $lowerCamelCased)
+    {
+        $nameConverter = new CamelCaseToSnakeCaseNameConverter();
+        $this->assertEquals($nameConverter->normalize($lowerCamelCased), $underscored);
+    }
+
+    /**
+     * @dataProvider attributeProvider
+     */
+    public function testDenormalize($underscored, $lowerCamelCased)
+    {
+        $nameConverter = new CamelCaseToSnakeCaseNameConverter();
+        $this->assertEquals($nameConverter->denormalize($underscored), $lowerCamelCased);
+    }
+
+    public function attributeProvider()
+    {
+        return array(
+            array('coop_tilleuls', 'coopTilleuls'),
+            array('_kevin_dunglas', '_kevinDunglas'),
+            array('this_is_a_test', 'thisIsATest'),
+        );
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -102,6 +102,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
             array('camel_case' => 'camelCase'),
             __NAMESPACE__.'\GetSetDummy'
         );
+
         $this->assertEquals('camelCase', $obj->getCamelCase());
     }
 
@@ -110,27 +111,46 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new GetSetDummy(), $this->normalizer->denormalize(null, __NAMESPACE__.'\GetSetDummy'));
     }
 
-    /**
-     * @dataProvider attributeProvider
-     */
-    public function testFormatAttribute($attribute, $camelizedAttributes, $result)
+    public function testCamelizedAttributesNormalize()
     {
-        $r = new \ReflectionObject($this->normalizer);
-        $m = $r->getMethod('formatAttribute');
-        $m->setAccessible(true);
+        $obj = new GetCamelizedDummy('dunglas.fr');
+        $obj->setFooBar('les-tilleuls.coop');
+        $obj->setBar_foo('lostinthesupermarket.fr');
 
-        $this->normalizer->setCamelizedAttributes($camelizedAttributes);
-        $this->assertEquals($m->invoke($this->normalizer, $attribute, $camelizedAttributes), $result);
+        $this->normalizer->setCamelizedAttributes(array('kevin_dunglas'));
+        $this->assertEquals($this->normalizer->normalize($obj), array(
+            'kevin_dunglas' => 'dunglas.fr',
+            'fooBar' => 'les-tilleuls.coop',
+            'bar_foo' => 'lostinthesupermarket.fr',
+        ));
+
+        $this->normalizer->setCamelizedAttributes(array('foo_bar'));
+        $this->assertEquals($this->normalizer->normalize($obj), array(
+            'kevinDunglas' => 'dunglas.fr',
+            'foo_bar' => 'les-tilleuls.coop',
+            'bar_foo' => 'lostinthesupermarket.fr',
+        ));
     }
 
-    public function attributeProvider()
+    public function testCamelizedAttributesDenormalize()
     {
-        return array(
-            array('attribute_test', array('attribute_test'),'AttributeTest'),
-            array('attribute_test', array('any'),'attribute_test'),
-            array('attribute', array('attribute'),'Attribute'),
-            array('attribute', array(), 'attribute'),
-        );
+        $obj = new GetCamelizedDummy('dunglas.fr');
+        $obj->setFooBar('les-tilleuls.coop');
+        $obj->setBar_foo('lostinthesupermarket.fr');
+
+        $this->normalizer->setCamelizedAttributes(array('kevin_dunglas'));
+        $this->assertEquals($this->normalizer->denormalize(array(
+            'kevin_dunglas' => 'dunglas.fr',
+            'fooBar' => 'les-tilleuls.coop',
+            'bar_foo' => 'lostinthesupermarket.fr',
+        ), __NAMESPACE__.'\GetCamelizedDummy'), $obj);
+
+        $this->normalizer->setCamelizedAttributes(array('foo_bar'));
+        $this->assertEquals($this->normalizer->denormalize(array(
+            'kevinDunglas' => 'dunglas.fr',
+            'foo_bar' => 'les-tilleuls.coop',
+            'bar_foo' => 'lostinthesupermarket.fr',
+        ), __NAMESPACE__.'\GetCamelizedDummy'), $obj);
     }
 
     public function testConstructorDenormalize()
@@ -542,5 +562,42 @@ class GetConstructorOptionalArgsDummy
     public function otherMethod()
     {
         throw new \RuntimeException("Dummy::otherMethod() should not be called");
+    }
+}
+
+class GetCamelizedDummy
+{
+    private $kevinDunglas;
+    private $fooBar;
+    private $bar_foo;
+
+    public function __construct($kevinDunglas = null)
+    {
+        $this->kevinDunglas = $kevinDunglas;
+    }
+
+    public function getKevinDunglas()
+    {
+        return $this->kevinDunglas;
+    }
+
+    public function setFooBar($fooBar)
+    {
+        $this->fooBar = $fooBar;
+    }
+
+    public function getFooBar()
+    {
+        return $this->fooBar;
+    }
+
+    public function setBar_foo($bar_foo)
+    {
+        $this->bar_foo = $bar_foo;
+    }
+
+    public function getBar_foo()
+    {
+        return $this->bar_foo;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -74,27 +74,46 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('value', $obj->getCamelCase());
     }
 
-    /**
-     * @dataProvider attributeProvider
-     */
-    public function testFormatAttribute($attribute, $camelizedAttributes, $result)
+    public function testCamelizedAttributesNormalize()
     {
-        $r = new \ReflectionObject($this->normalizer);
-        $m = $r->getMethod('formatAttribute');
-        $m->setAccessible(true);
+        $obj = new PropertyCamelizedDummy('dunglas.fr');
+        $obj->fooBar = 'les-tilleuls.coop';
+        $obj->bar_foo = 'lostinthesupermarket.fr';
 
-        $this->normalizer->setCamelizedAttributes($camelizedAttributes);
-        $this->assertEquals($m->invoke($this->normalizer, $attribute, $camelizedAttributes), $result);
+        $this->normalizer->setCamelizedAttributes(array('kevin_dunglas'));
+        $this->assertEquals($this->normalizer->normalize($obj), array(
+            'kevin_dunglas' => 'dunglas.fr',
+            'fooBar' => 'les-tilleuls.coop',
+            'bar_foo' => 'lostinthesupermarket.fr',
+        ));
+
+        $this->normalizer->setCamelizedAttributes(array('foo_bar'));
+        $this->assertEquals($this->normalizer->normalize($obj), array(
+            'kevinDunglas' => 'dunglas.fr',
+            'foo_bar' => 'les-tilleuls.coop',
+            'bar_foo' => 'lostinthesupermarket.fr',
+        ));
     }
 
-    public function attributeProvider()
+    public function testCamelizedAttributesDenormalize()
     {
-        return array(
-            array('attribute_test', array('attribute_test'),'AttributeTest'),
-            array('attribute_test', array('any'),'attribute_test'),
-            array('attribute', array('attribute'),'Attribute'),
-            array('attribute', array(), 'attribute'),
-        );
+        $obj = new PropertyCamelizedDummy('dunglas.fr');
+        $obj->fooBar = 'les-tilleuls.coop';
+        $obj->bar_foo = 'lostinthesupermarket.fr';
+
+        $this->normalizer->setCamelizedAttributes(array('kevin_dunglas'));
+        $this->assertEquals($this->normalizer->denormalize(array(
+            'kevin_dunglas' => 'dunglas.fr',
+            'fooBar' => 'les-tilleuls.coop',
+            'bar_foo' => 'lostinthesupermarket.fr',
+        ), __NAMESPACE__.'\PropertyCamelizedDummy'), $obj);
+
+        $this->normalizer->setCamelizedAttributes(array('foo_bar'));
+        $this->assertEquals($this->normalizer->denormalize(array(
+            'kevinDunglas' => 'dunglas.fr',
+            'foo_bar' => 'les-tilleuls.coop',
+            'bar_foo' => 'lostinthesupermarket.fr',
+        ), __NAMESPACE__.'\PropertyCamelizedDummy'), $obj);
     }
 
     public function testConstructorDenormalize()
@@ -358,5 +377,17 @@ class PropertyConstructorDummy
     public function getBar()
     {
         return $this->bar;
+    }
+}
+
+class PropertyCamelizedDummy
+{
+    private $kevinDunglas;
+    public $fooBar;
+    public $bar_foo;
+
+    public function __construct($kevinDunglas = null)
+    {
+        $this->kevinDunglas = $kevinDunglas;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12212 |
| License | MIT |
| Doc PR | symfony/symfony-docs#4692 |

This PR adds support for custom property naming strategies to the serializer and provides a built-in NameConverter using this new system: (CamelCase to underscore).
It handles normalization and denormalization (convert `fooBar` to `foo_bar` when serializing, then from `foo_bar` to `fooBar` when deserializing). It also has a flag to convert only some attributes.

The `setCamelizedAttributes()` is deprecated in favor of this new method (more flexible, allows to rename all attributes of a class and support deserialization) and now uses it internally.
