### PR TITLE
[travis] reorder matrix + prevent "Killed" jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 language: php
 
-php:
-    - 5.3.3
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - hhvm-nightly
-
 matrix:
-    allow_failures:
-        - php: hhvm-nightly
     include:
-        - php: 5.5
-          env: components=high
         - php: 5.3.3
           env: components=low
+        - php: 5.6
+          env: components=high
+        - php: 5.3.3
+        - php: 5.3
+        - php: 5.4
+        - php: 5.5
+        - php: 5.6
+        - php: hhvm-nightly
+    allow_failures:
+        - php: hhvm-nightly
+    fast_finish: true
 
 services: mongodb
 
@@ -26,12 +25,12 @@ env:
 before_install:
     - travis_retry sudo apt-get install parallel
     - composer self-update
-    - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi;
-    - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then phpenv config-rm xdebug.ini; fi;
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ] && [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then pecl install -f memcached-2.1.0; fi;
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then php -i; fi;
     - sudo locale-gen fr_FR.UTF-8 && sudo update-locale
 #    - if [ "$TRAVIS_PHP_VERSION" != "5.3.3" ]; then phpunit --self-update; fi;
 
@@ -42,4 +41,4 @@ script:
     - if [ "$components" = "no" ]; then ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark,intl-data {};'; fi;
     - if [ "$components" = "no" ]; then echo "Running tests requiring tty"; phpunit --group tty; fi;
     - if [ "$components" = "high" ]; then find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist | sed 's#\(.*\)/.*#\1#' | parallel --gnu --keep-order 'echo "Running {} tests"; cd {}; COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install; phpunit --exclude-group tty,benchmark,intl-data;'; fi;
-    - if [ "$components" = "low" ]; then find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist | sed 's#\(.*\)/.*#\1#' | parallel --gnu --keep-order 'echo "Running {} tests"; cd {}; COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev --prefer-lowest --prefer-stable update; phpunit --exclude-group tty,benchmark,intl-data;'; fi;
+    - if [ "$components" = "low" ]; then find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist | sed 's#\(.*\)/.*#\1#' | parallel --gnu --keep-order -j50% 'echo "Running {} tests"; cd {}; COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev --prefer-lowest --prefer-stable update; phpunit --exclude-group tty,benchmark,intl-data;'; fi;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The new --prefer-lowest matrix line fails randomly with ["Killed" message](http://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error).
Lets try reducing concurrency on this one.
The matrix is also reordered so that the slowest lines are started first.
