### PR TITLE
avoid fatal error when using form_enctype

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/FormEnctypeNode.php
+++ b/src/Symfony/Bridge/Twig/Node/FormEnctypeNode.php
@@ -23,6 +23,7 @@ class FormEnctypeNode extends SearchAndRenderBlockNode
     {
         parent::compile($compiler);
 
+        $compiler->raw(";\n");
         $compiler->write('trigger_error(\'The helper form_enctype(form) is deprecated since version 2.3 and will be removed in 3.0. Use form_start(form) instead.\', E_USER_DEPRECATED)');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12824, #12825 |
| License | MIT |
| Doc PR |  |

There seems to have been changes that crossed each other and a missing test... This is reverting #8731 as meanwhile, the line to output the deprecation was uncommented, breaking all twig templates that use form_enctype with a fatal php error.
