### PR TITLE
[Yaml] Removed the ability to parse a file in Yaml::parse()

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/YamlTest.php
+++ b/src/Symfony/Component/Yaml/Tests/YamlTest.php
@@ -22,13 +22,4 @@ class YamlTest extends \PHPUnit_Framework_TestCase
         $parsed = Yaml::parse($yml);
         $this->assertEquals($data, $parsed);
     }
-
-    public function testParseFromFile()
-    {
-        $filename = __DIR__.'/Fixtures/index.yml';
-        $contents = file_get_contents($filename);
-        $parsedByFilename = Yaml::parse($filename);
-        $parsedByContents = Yaml::parse($contents);
-        $this->assertEquals($parsedByFilename, $parsedByContents);
-    }
 }

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -34,11 +34,7 @@ class Yaml
      *   print_r($array);
      *  </code>
      *
-     * As this method accepts both plain strings and file names as an input,
-     * you must validate the input before calling this method. Passing a file
-     * as an input is a deprecated feature and will be removed in 3.0.
-     *
-     * @param string $input                  Path to a YAML file or a string containing YAML
+     * @param string $input                  A string containing YAML
      * @param bool   $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
      * @param bool   $objectSupport          True if object support is enabled, false otherwise
      *
@@ -46,36 +42,13 @@ class Yaml
      *
      * @throws ParseException If the YAML is not valid
      *
-     * @deprecated The ability to pass file names to Yaml::parse() was deprecated in 2.2 and will be removed in 3.0. Please, pass the contents of the file instead.
-     *
      * @api
      */
     public static function parse($input, $exceptionOnInvalidType = false, $objectSupport = false)
     {
-        // if input is a file, process it
-        $file = '';
-        if (strpos($input, "\n") === false && is_file($input)) {
-            trigger_error('The ability to pass file names to Yaml::parse() was deprecated in 2.2 and will be removed in 3.0. Please, pass the contents of the file instead.', E_USER_DEPRECATED);
-
-            if (false === is_readable($input)) {
-                throw new ParseException(sprintf('Unable to parse "%s" as the file is not readable.', $input));
-            }
-
-            $file = $input;
-            $input = file_get_contents($file);
-        }
-
         $yaml = new Parser();
 
-        try {
-            return $yaml->parse($input, $exceptionOnInvalidType, $objectSupport);
-        } catch (ParseException $e) {
-            if ($file) {
-                $e->setParsedFile($file);
-            }
-
-            throw $e;
-        }
+        return $yaml->parse($input, $exceptionOnInvalidType, $objectSupport);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
