### PR TITLE
[CssSelector] Use the correct cssselect library name in docblocks.

### DIFF
--- a/src/Symfony/Component/CssSelector/CssSelector.php
+++ b/src/Symfony/Component/CssSelector/CssSelector.php
@@ -24,7 +24,7 @@ use Symfony\Component\CssSelector\XPath\Translator;
  *
  * $xpath = CssSelector::toXpath('h1.foo');
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * Copyright (c) 2007-2012 Ian Bicking and contributors. See AUTHORS

--- a/src/Symfony/Component/CssSelector/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/CssSelector/Exception/ExceptionInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Exception;
 /**
  * Interface for exceptions.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Exception/ExpressionErrorException.php
+++ b/src/Symfony/Component/CssSelector/Exception/ExpressionErrorException.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Exception;
 /**
  * ParseException is thrown when a CSS selector syntax is not valid.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Exception/InternalErrorException.php
+++ b/src/Symfony/Component/CssSelector/Exception/InternalErrorException.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Exception;
 /**
  * ParseException is thrown when a CSS selector syntax is not valid.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Exception/ParseException.php
+++ b/src/Symfony/Component/CssSelector/Exception/ParseException.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Exception;
 /**
  * ParseException is thrown when a CSS selector syntax is not valid.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
+++ b/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
@@ -16,7 +16,7 @@ use Symfony\Component\CssSelector\Parser\Token;
 /**
  * ParseException is thrown when a CSS selector syntax is not valid.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/AbstractNode.php
+++ b/src/Symfony/Component/CssSelector/Node/AbstractNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Abstract base node class.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/AttributeNode.php
+++ b/src/Symfony/Component/CssSelector/Node/AttributeNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a "<selector>[<namespace>|<attribute> <operator> <value>]" node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/ClassNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ClassNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a "<selector>.<name>" node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/CombinedSelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/CombinedSelectorNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a combined node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/ElementNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ElementNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a "<namespace>|<element>" node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/FunctionNode.php
+++ b/src/Symfony/Component/CssSelector/Node/FunctionNode.php
@@ -16,7 +16,7 @@ use Symfony\Component\CssSelector\Parser\Token;
 /**
  * Represents a "<selector>:<name>(<arguments>)" node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/HashNode.php
+++ b/src/Symfony/Component/CssSelector/Node/HashNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a "<selector>#<id>" node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/NegationNode.php
+++ b/src/Symfony/Component/CssSelector/Node/NegationNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a "<selector>:not(<identifier>)" node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/NodeInterface.php
+++ b/src/Symfony/Component/CssSelector/Node/NodeInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Interface for nodes.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/PseudoNode.php
+++ b/src/Symfony/Component/CssSelector/Node/PseudoNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a "<selector>:<identifier>" node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/SelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/SelectorNode.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a "<selector>(::|:)<pseudoElement>" node.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Node/Specificity.php
+++ b/src/Symfony/Component/CssSelector/Node/Specificity.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Node;
 /**
  * Represents a node specificity.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @see http://www.w3.org/TR/selectors/#specificity

--- a/src/Symfony/Component/CssSelector/Parser/Handler/CommentHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/CommentHandler.php
@@ -17,7 +17,7 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
 /**
  * CSS selector comment handler.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Handler/HandlerInterface.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/HandlerInterface.php
@@ -17,7 +17,7 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
 /**
  * CSS selector handler interface.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Handler/HashHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/HashHandler.php
@@ -20,7 +20,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
 /**
  * CSS selector comment handler.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Handler/IdentifierHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/IdentifierHandler.php
@@ -20,7 +20,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
 /**
  * CSS selector comment handler.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Handler/NumberHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/NumberHandler.php
@@ -19,7 +19,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
 /**
  * CSS selector comment handler.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Handler/StringHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/StringHandler.php
@@ -22,7 +22,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
 /**
  * CSS selector comment handler.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Handler/WhitespaceHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/WhitespaceHandler.php
@@ -18,7 +18,7 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
 /**
  * CSS selector whitespace handler.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -18,7 +18,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\Tokenizer;
 /**
  * CSS selector parser.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/ParserInterface.php
+++ b/src/Symfony/Component/CssSelector/Parser/ParserInterface.php
@@ -16,7 +16,7 @@ use Symfony\Component\CssSelector\Node\SelectorNode;
 /**
  * CSS selector parser interface.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Reader.php
+++ b/src/Symfony/Component/CssSelector/Parser/Reader.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Parser;
 /**
  * CSS selector reader.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/ClassParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/ClassParser.php
@@ -19,7 +19,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
 /**
  * CSS selector class parser shortcut.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/ElementParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/ElementParser.php
@@ -18,7 +18,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
 /**
  * CSS selector element parser shortcut.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/EmptyStringParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/EmptyStringParser.php
@@ -22,7 +22,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  * - The parser fails to parse an empty string.
  * - In the previous version, an empty string matches each tags.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
@@ -19,7 +19,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
 /**
  * CSS selector hash parser shortcut.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Token.php
+++ b/src/Symfony/Component/CssSelector/Parser/Token.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Parser;
 /**
  * CSS selector token.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -17,7 +17,7 @@ use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
 /**
  * CSS selector token stream.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/Tokenizer.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/Tokenizer.php
@@ -19,7 +19,7 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
 /**
  * CSS selector tokenizer.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerEscaping.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerEscaping.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Parser\Tokenizer;
 /**
  * CSS selector tokenizer escaping applier.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\Parser\Tokenizer;
 /**
  * CSS selector tokenizer patterns builder.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/README.md
+++ b/src/Symfony/Component/CssSelector/README.md
@@ -36,10 +36,9 @@ names are lower-cased, the following extra pseudo-classes are supported:
 Resources
 ---------
 
-This component is a port of the Python lxml library, which is copyright Infrae
-and distributed under the BSD license.
-
-Current code is a port of https://github.com/SimonSapin/cssselect/releases/tag/v0.7.1
+This component is a port of the Python cssselect library
+[v0.7.1](https://github.com/SimonSapin/cssselect/releases/tag/v0.7.1),
+which is distributed under the BSD license.
 
 You can run the unit tests with the following command:
 

--- a/src/Symfony/Component/CssSelector/XPath/Extension/AbstractExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/AbstractExtension.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\XPath\Extension;
 /**
  * XPath expression translator abstract extension.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/Extension/AttributeMatchingExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/AttributeMatchingExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
 /**
  * XPath expression translator attribute extension.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/Extension/CombinationExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/CombinationExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
 /**
  * XPath expression translator combination extension.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/ExtensionInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\XPath\Extension;
 /**
  * XPath expression translator extension interface.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
@@ -21,7 +21,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
 /**
  * XPath expression translator function extension.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
 /**
  * XPath expression translator HTML extension.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
 /**
  * XPath expression translator node extension.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
 /**
  * XPath expression translator pseudo-class extension.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -21,7 +21,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
 /**
  * XPath expression translator interface.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/TranslatorInterface.php
+++ b/src/Symfony/Component/CssSelector/XPath/TranslatorInterface.php
@@ -16,7 +16,7 @@ use Symfony\Component\CssSelector\Node\SelectorNode;
 /**
  * XPath expression translator interface.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>

--- a/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\CssSelector\XPath;
 /**
  * XPath expression translator interface.
  *
- * This component is a port of the Python cssselector library,
+ * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #11894 |
| License | MIT |
| Doc PR | - |

As suggested in #11894, the original python library is called [cssselect](https://github.com/SimonSapin/cssselect), not cssselector.

I also updated the README, as the cssselect was extracted as an independent library and it's no longer part of lxml.
