### PR TITLE
[TwigBundle] Moved the setting of the default escaping strategy from the Twig engine to the Twig environment

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -124,7 +124,9 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->fixXmlConfig('path')
             ->children()
-                ->scalarNode('autoescape')->end()
+                ->variableNode('autoescape')
+                    ->defaultValue(array('Symfony\Bundle\TwigBundle\TwigDefaultEscapingStrategy', 'guess'))
+                ->end()
                 ->scalarNode('autoescape_service')->defaultNull()->end()
                 ->scalarNode('autoescape_service_method')->defaultNull()->end()
                 ->scalarNode('base_template_class')->example('Twig_Template')->end()

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -109,12 +109,9 @@ class TwigExtension extends Extension
         }
 
         if (isset($config['autoescape_service']) && isset($config['autoescape_service_method'])) {
-            $container->findDefinition('templating.engine.twig')->addMethodCall('setDefaultEscapingStrategy', array(array(new Reference($config['autoescape_service']), $config['autoescape_service_method'])));
-
-            unset($config['autoescape_service'], $config['autoescape_service_method']);
-        } elseif (!isset($config['autoescape'])) {
-            $container->findDefinition('templating.engine.twig')->addMethodCall('setDefaultEscapingStrategy', array(array(new Reference('templating.engine.twig'), 'guessDefaultEscapingStrategy')));
+            $config['autoescape'] = array(new Reference($config['autoescape_service']), $config['autoescape_service_method']);
         }
+        unset($config['autoescape_service'], $config['autoescape_service_method']);
 
         $container->setParameter('twig.options', $config);
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -95,7 +95,8 @@ class TwigExtensionTest extends TestCase
         $this->loadFromFile($container, 'customTemplateEscapingGuesser', $format);
         $this->compileContainer($container);
 
-        $this->assertTemplateEscapingGuesserDefinition($container, 'my_project.some_bundle.template_escaping_guesser', 'guess');
+        $options = $container->getParameter('twig.options');
+        $this->assertEquals(array(new Reference('my_project.some_bundle.template_escaping_guesser'), 'guess'), $options['autoescape']);
     }
 
     /**
@@ -108,7 +109,8 @@ class TwigExtensionTest extends TestCase
         $this->loadFromFile($container, 'empty', $format);
         $this->compileContainer($container);
 
-        $this->assertTemplateEscapingGuesserDefinition($container, 'templating.engine.twig', 'guessDefaultEscapingStrategy');
+        $options = $container->getParameter('twig.options');
+        $this->assertEquals(array('Symfony\Bundle\TwigBundle\TwigDefaultEscapingStrategy', 'guess'), $options['autoescape']);
     }
 
     public function testGlobalsWithDifferentTypesAndValues()
@@ -218,19 +220,5 @@ class TwigExtensionTest extends TestCase
         }
 
         $loader->load($file.'.'.$format);
-    }
-
-    private function assertTemplateEscapingGuesserDefinition(ContainerBuilder $container, $serviceId, $serviceMethod)
-    {
-        $def = $container->getDefinition('templating.engine.twig');
-
-        $this->assertCount(1, $def->getMethodCalls());
-
-        foreach ($def->getMethodCalls() as $call) {
-            if ('setDefaultEscapingStrategy' === $call[0]) {
-                $this->assertSame($serviceId, (string) $call[1][0][0]);
-                $this->assertSame($serviceMethod, $call[1][0][1]);
-            }
-        }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/TwigDefaultEscapingStrategy.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigDefaultEscapingStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TwigDefaultEscapingStrategy
+{
+    public static function guess($filename)
+    {
+        // remove .twig
+        $filename = substr($filename, 0, -5);
+
+        // get the format
+        $format = substr($filename, strrpos($filename, '.') + 1);
+
+        if ('js' === $format) {
+            return 'js';
+        }
+
+        if ('txt' === $format) {
+            return false;
+        }
+
+        return 'html';
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -41,28 +41,21 @@ class TwigEngine extends BaseEngine implements EngineInterface
         $this->locator = $locator;
     }
 
+    /**
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Inject the escaping
+     *             strategy on Twig_Environment instead
+     */
     public function setDefaultEscapingStrategy($strategy)
     {
         $this->environment->getExtension('escaper')->setDefaultStrategy($strategy);
     }
 
+    /**
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use TwigDefaultEscapingStrategy instead.
+     */
     public function guessDefaultEscapingStrategy($filename)
     {
-        // remove .twig
-        $filename = substr($filename, 0, -5);
-
-        // get the format
-        $format = substr($filename, strrpos($filename, '.') + 1);
-
-        if ('js' === $format) {
-            return 'js';
-        }
-
-        if ('txt' === $format) {
-            return false;
-        }
-
-        return 'html';
+        return TwigDefaultEscapingStrategy::guess($filename);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11773 |
| License | MIT |
| Doc PR | n/a |

The default escaping strategy was set on the Twig Engine and not the Twig Environment. That's a problem under some circumstances (like what #11773 describes), but it's also much better to set everything on the Twig  Environment directly.
