### PR TITLE
No global state for isolated tests and other fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
     - if [ "$components" = "no" ]; then COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install; fi;
 
 script:
-    - if [ "$components" = "no" ]; then ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo "Running {} tests"; phpunit --exclude-group tty,benchmark,intl-data {};'; fi;
-    - if [ "$components" = "no" ]; then echo "Running tests requiring tty"; phpunit --group tty; fi;
-    - if [ "$components" = "high" ]; then find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist | sed 's#\(.*\)/.*#\1#' | parallel --gnu --keep-order 'echo "Running {} tests"; cd {}; COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install; phpunit --exclude-group tty,benchmark,intl-data;'; fi;
-    - if [ "$components" = "low" ]; then find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist | sed 's#\(.*\)/.*#\1#' | parallel --gnu --keep-order -j50% 'echo "Running {} tests"; cd {}; COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev --prefer-lowest --prefer-stable update; phpunit --exclude-group tty,benchmark,intl-data;'; fi;
+    - if [ "$components" = "no" ]; then ls -d src/Symfony/*/* | parallel --gnu --keep-order 'echo -e "\\nRunning {} tests"; phpunit --exclude-group tty,benchmark,intl-data {} || (echo -e "\\e[41mKO\\e[0m {}" && $(exit 1));'; fi;
+    - if [ "$components" = "no" ]; then echo -e "\\nRunning tests requiring tty"; phpunit --group tty || (echo -e "\\e[41mKO\\e[0m tty group" && $(exit 1)); fi;
+    - if [ "$components" = "high" ]; then find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist | sed 's#\(.*\)/.*#\1#' | parallel --gnu --keep-order -j25% 'echo -e "\\nRunning {} tests"; cd {}; COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev update; phpunit --exclude-group tty,benchmark,intl-data || (echo -e "\\e[41mKO\\e[0m {}" && $(exit 1));'; fi;
+    - if [ "$components" = "low" ]; then find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist | sed 's#\(.*\)/.*#\1#' | parallel --gnu --keep-order -j25% 'echo -e "\\nRunning {} tests"; cd {}; COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev --prefer-lowest --prefer-stable update; phpunit --exclude-group tty,benchmark,intl-data || (echo -e "\\e[41mKO\\e[0m {}" && $(exit 1));'; fi;

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/common": "~2.2",
-        "twig/twig": "~1.12",
+        "doctrine/common": "~2.3",
+        "twig/twig": "~1.12,>=1.12.3",
         "psr/log": "~1.0"
     },
     "replace": {

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/DefaultCsrfProviderTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/DefaultCsrfProviderTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\Extension\Csrf\CsrfProvider\DefaultCsrfProvider;
 
 /**
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class DefaultCsrfProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,6 +25,7 @@ class DefaultCsrfProviderTest extends \PHPUnit_Framework_TestCase
     {
         ini_set('session.save_handler', 'files');
         ini_set('session.save_path', sys_get_temp_dir());
+        ini_set('error_reporting', -1 & ~E_USER_DEPRECATED);
     }
 
     protected function setUp()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
  * @author Drak <drak@zikula.org>
  *
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeSessionHandlerTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandle
  * @author Drak <drak@zikula.org>
  *
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class NativeSessionHandlerTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NullSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NullSessionHandlerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
  * @author Drak <drak@zikula.org>
  *
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class NullSessionHandlerTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
  * These tests require separate processes.
  *
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
  * These tests require separate processes.
  *
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class PhpBridgeSessionStorageTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -96,6 +96,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testIsActivePhp54()
     {
@@ -122,6 +123,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      * @expectedException \LogicException
      */
     public function testSetActivePhp54()
@@ -135,6 +137,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testName()
     {
@@ -159,6 +162,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      * @expectedException \LogicException
      */
     public function testNameExceptionPhp54()
@@ -173,6 +177,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testId()
     {
@@ -197,6 +202,7 @@ class AbstractProxyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      * @expectedException \LogicException
      */
     public function testIdExceptionPhp54()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
  * @author Drak <drak@zikula.org>
  *
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class SessionHandlerProxyTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
@@ -36,6 +36,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
      * time zone, this test would use it too if not running in a separated process.
      *
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testFormatWithTimezoneFromEnvironmentVariable()
     {

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/intl": ">=2.3"
+        "symfony/intl": "~2.3"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Locale\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

By default, phpunit preserves global state for isolated processes. This made the tests break on my laptop.
Other tweaks included.
In branch 2.5, `src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php` also misses the `@preserveGlobalState disabled` annotation. Please add it when merging
