### PR TITLE
Replace usages of the deprecated TypeTestCase by the new one

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Form\Type;
 
-use Symfony\Component\Form\Tests\FormPerformanceTestCase;
+use Symfony\Component\Form\Test\FormPerformanceTestCase;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bridge\Doctrine\Tests\DoctrineOrmTestCase;

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Doctrine\Tests\Form\Type;
 
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\GroupableEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;

--- a/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\Propel1\Tests\Fixtures\Item;
 use Symfony\Bridge\Propel1\Form\PropelExtension;
 use Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItemI18n;
 use Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItem;
-use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 
 class TranslationCollectionTypeTest extends TypeTestCase
 {

--- a/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class CompoundFormPerformanceTest extends \Symfony\Component\Form\Tests\FormPerformanceTestCase
+class CompoundFormPerformanceTest extends \Symfony\Component\Form\Test\FormPerformanceTestCase
 {
     /**
      * Create a compound form multiple times, as happens in a collection form.

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -12,9 +12,10 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class CountryTypeTest extends TypeTestCase
+class CountryTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -12,9 +12,10 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class CurrencyTypeTest extends TypeTestCase
+class CurrencyTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -12,9 +12,10 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class DateTimeTypeTest extends TypeTestCase
+class DateTimeTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -13,9 +13,10 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class DateTypeTest extends TypeTestCase
+class DateTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class IntegerTypeTest extends TypeTestCase
+class IntegerTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -12,9 +12,10 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class LanguageTypeTest extends TypeTestCase
+class LanguageTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -12,9 +12,10 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class LocaleTypeTest extends TypeTestCase
+class LocaleTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class MoneyTypeTest extends TypeTestCase
+class MoneyTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class NumberTypeTest extends TypeTestCase
+class NumberTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
+
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class SubmitTypeTest extends TypeTestCase
+class SubmitTypeTest extends TestCase
 {
     public function testCreateSubmitButtonInstances()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -13,9 +13,10 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class TimeTypeTest extends TypeTestCase
+class TimeTypeTest extends TestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-class UrlTypeTest extends TypeTestCase
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
+
+class UrlTypeTest extends TestCase
 {
     public function testSubmitAddsDefaultProtocolIfNoneIsIncluded()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I'm applying this in 2.3 to make merging branches easier. This is especially needed for 2.7 because of deprecation warnings added in #13060
