### PR TITLE
Fix phpdoc and coding standards

### DIFF
--- a/src/Symfony/Bridge/Doctrine/RegistryInterface.php
+++ b/src/Symfony/Bridge/Doctrine/RegistryInterface.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Doctrine;
 
 use Doctrine\Common\Persistence\ManagerRegistry as ManagerRegistryInterface;
-use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 
 /**

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -25,7 +25,7 @@ class RegisterEventListenersAndSubscribersPassTest extends \PHPUnit_Framework_Te
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testExceptionOnAbstractTaggedSubscriber()
     {
@@ -41,7 +41,7 @@ class RegisterEventListenersAndSubscribersPassTest extends \PHPUnit_Framework_Te
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testExceptionOnAbstractTaggedListener()
     {

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Doctrine\Tests\Form\Type;
 
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\GroupableEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -22,7 +22,6 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
-use Symfony\Component\Validator\Validator;
 use Doctrine\ORM\Tools\SchemaTool;
 
 /**

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
@@ -11,9 +11,7 @@
 
 namespace Symfony\Bridge\ProxyManager\Tests\LazyProxy\Instantiator;
 
-use ProxyManager\Proxy\LazyLoadingInterface;
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Templating;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\SecurityContext;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheWarmerPass;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FragmentRendererPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FragmentRendererPassTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FragmentRendererPass;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SerializerPass;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslatorPass;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TimedPhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TimedPhpEngineTest.php
@@ -12,9 +12,6 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
 
 use Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine;
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\Templating\TemplateNameParser;
-use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
 class TimedPhpEngineTest extends TestCase

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -11,12 +11,24 @@
 
 namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigLoaderPass;
 
 class TwigLoaderPassTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $builder;
+    /**
+     * @var Definition
+     */
+    private $chainLoader;
+    /**
+     * @var TwigLoaderPass
+     */
+    private $pass;
+
     public function setUp()
     {
         $this->builder = $this->getMock(

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -13,9 +13,7 @@ namespace Symfony\Bundle\TwigBundle\Tests\Loader;
 
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader;
-use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
-use Symfony\Component\Templating\TemplateNameParserInterface;
 
 class FilesystemLoaderTest extends TestCase
 {

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -24,7 +24,7 @@ class WebProfilerExtensionTest extends TestCase
 {
     private $kernel;
     /**
-     * @var Symfony\Component\DependencyInjection\Container
+     * @var \Symfony\Component\DependencyInjection\Container
      */
     private $container;
 

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\BrowserKit\Tests;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\CookieJar;
-use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
 
 class SpecialResponse extends Response

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -192,7 +192,7 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $val The value that the closure must return
      *
-     * @return Closure
+     * @return \Closure
      */
     protected function returnClosure($val)
     {

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use Symfony\Component\Config\Tests\Definition\Builder\NodeBuilder as CustomNodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 require __DIR__.'/../../Fixtures/Builder/NodeBuilder.php';
 require __DIR__.'/../../Fixtures/Builder/BarNodeDefinition.php';

--- a/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Config\Tests\Loader;
 
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
-use Symfony\Component\Config\Exception\FileLoaderImportCircularReferenceException;
 
 class FileLoaderTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1083,10 +1083,10 @@ class Application
      * Finds alternative of $name among $collection,
      * if nothing is found in $collection, try in $abbrevs.
      *
-     * @param string               $name       The string
-     * @param array|\Traversable   $collection The collection
-     * @param array                $abbrevs    The abbreviations
-     * @param Closure|string|array $callback   The callable to transform collection item before comparison
+     * @param string             $name       The string
+     * @param array|\Traversable $collection The collection
+     * @param array              $abbrevs    The abbreviations
+     * @param callable           $callback   The callable to transform collection item before comparison
      *
      * @return array A sorted array of similar string
      */

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -16,7 +16,6 @@ require_once __DIR__.'/Fixtures/includes/ProjectExtension.php';
 
 use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\DependencyInjection\Alias;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container12.php
@@ -1,7 +1,6 @@
 <?php
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 
 $container = new ContainerBuilder();
 $container->

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Loader;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -18,7 +18,7 @@ class BooleanToStringTransformerTest extends \PHPUnit_Framework_TestCase
     const TRUE_VALUE = '1';
 
     /**
-     * @var boolToStringTransformer
+     * @var BooleanToStringTransformer
      */
     protected $transformer;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Form;
-
 class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     public function testContainsNoChildByDefault()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\PropertyAccess\PropertyPath;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\FixedDataTransformer;

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
 use Symfony\Component\Form\Extension\Validator\Constraints\FormValidator;
 use Symfony\Component\Form\SubmitButtonBuilder;
-use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest;

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
@@ -12,11 +12,6 @@
 namespace Symfony\Component\Form\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class FooSubType extends AbstractType
 {

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooSubTypeWithParentInstance.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooSubTypeWithParentInstance.php
@@ -12,11 +12,6 @@
 namespace Symfony\Component\Form\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class FooSubTypeWithParentInstance extends AbstractType
 {

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
@@ -12,11 +12,6 @@
 namespace Symfony\Component\Form\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class FooType extends AbstractType
 {

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Form\Guess\TypeGuess;
-use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\FooType;
 use Symfony\Component\Form\Tests\Fixtures\FooSubType;
 use Symfony\Component\Form\Tests\Fixtures\FooSubTypeWithParentInstance;

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Form\Tests;
 use Symfony\Component\Form\ResolvedFormType;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\Form;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**

--- a/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
@@ -11,11 +11,8 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\File\MimeType;
 
-use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\FileBinaryMimeTypeGuesser;
-use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
-use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
 
 class MimeTypeTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Flash;
 
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 
 /**
  * FlashBagTest.
@@ -22,7 +21,7 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 class FlashBagTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Symfony\Component\HttpFoundation\SessionFlash\FlashBagInterface
+     * @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface
      */
     private $bag;
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -28,7 +28,7 @@ class MockFileSessionStorageTest extends \PHPUnit_Framework_TestCase
     private $sessionDir;
 
     /**
-     * @var FileMockSessionStorage
+     * @var MockFileSessionStorage
      */
     protected $storage;
 

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Bundle;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\ExtensionPresentBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionAbsentBundle\ExtensionAbsentBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Command\FooCommand;

--- a/src/Symfony/Component/HttpKernel/Tests/CacheClearer/ChainCacheClearerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheClearer/ChainCacheClearerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Tests\CacheClearer;
 
-use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer;
 
 class ChainCacheClearerTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
@@ -11,9 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\CacheWarmer;
 
-use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
-use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
 
 class CacheWarmerAggregateTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests;
 
 use Symfony\Component\HttpKernel\Client;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\Cookie;

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests\Controller;
 
 use Symfony\Component\HttpKernel\Controller\ControllerResolver;
-use Symfony\Component\HttpKernel\Tests\Logger;
 use Symfony\Component\HttpFoundation\Request;
 
 class ControllerResolverTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
-use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests;
 
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -15,7 +15,6 @@ use Symfony\Component\Intl\Data\Bundle\Reader\BundleReaderInterface;
 use Symfony\Component\Intl\Data\Util\ArrayAccessibleResourceBundle;
 use Symfony\Component\Intl\Data\Bundle\Compiler\GenrbCompiler;
 use Symfony\Component\Intl\Data\Util\LocaleScanner;
-use Symfony\Component\Intl\Region;
 
 /**
  * The rule for compiling the region bundle.
@@ -136,7 +135,7 @@ class RegionDataGenerator extends AbstractDataGenerator
     }
 
     /**
-     * @param $localeBundle
+     * @param ArrayAccessibleResourceBundle $localeBundle
      *
      * @return array
      */

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Intl\Tests\DateFormatter;
 
 use Symfony\Component\Intl\DateFormatter\IntlDateFormatter;
 use Symfony\Component\Intl\Globals\IntlGlobals;
-use Symfony\Component\Intl\Intl;
 
 /**
  * Test case for IntlDateFormatter implementations.

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Intl\Tests\NumberFormatter;
 
 use Symfony\Component\Intl\Globals\IntlGlobals;
-use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Locale;
 use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
 use Symfony\Component\Intl\Util\IntlTestHelper;

--- a/src/Symfony/Component/Locale/Tests/LocaleTest.php
+++ b/src/Symfony/Component/Locale/Tests/LocaleTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Locale\Tests;
 
-use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Locale\Locale;
 

--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -154,7 +154,7 @@ class SimpleProcessTest extends AbstractProcessTest
             $process->run(function () use ($process) {
                 $process->stop();
             });
-        } catch (RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $this->fail('A call to stop() is not expected to cause wait() to throw a RuntimeException');
         }
     }
@@ -170,7 +170,7 @@ class SimpleProcessTest extends AbstractProcessTest
                     $process->signal(defined('SIGKILL') ? SIGKILL : 9);
                 }
             });
-        } catch (RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $this->fail('A call to signal() is not expected to cause wait() to throw a RuntimeException');
         }
     }
@@ -186,7 +186,7 @@ class SimpleProcessTest extends AbstractProcessTest
                     $process->signal(defined('SIGTERM') ? SIGTERM : 15);
                 }
             });
-        } catch (RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $this->fail('A call to signal() is not expected to cause wait() to throw a RuntimeException');
         }
     }

--- a/src/Symfony/Component/Security/Acl/Model/MutableAclProviderInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/MutableAclProviderInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Acl\Model;
 
+use Symfony\Component\Security\Acl\Exception\AclAlreadyExistsException;
+
 /**
  * Provides support for creating and storing ACL instances.
  *

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -113,7 +113,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
      * @param UserInterface  $user  The user
      * @param TokenInterface $token The token
      *
-     * @return Role[] The user roles
+     * @return array The user roles
      */
     private function getRoles(UserInterface $user, TokenInterface $token)
     {

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/AuthenticationTrustResolverTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Security\Tests\Core\Authentication;
 
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 
 class AuthenticationTrustResolverTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/ChannelListenerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Tests\Http\Firewall;
 
 use Symfony\Component\Security\Http\Firewall\ChannelListener;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
 
 class ChannelListenerTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Security/Tests/Http/Logout/DefaultLogoutSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Logout/DefaultLogoutSuccessHandlerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Tests\Http\Logout;
 
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler;
 
 class DefaultLogoutSuccessHandlerTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Tests\Http\RememberMe;
 
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
-use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Tests\Http\RememberMe;
 
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
-use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
@@ -21,7 +21,7 @@ interface DecoderInterface
     /**
      * Decodes a string into PHP data.
      *
-     * @param scalar $data    Data to decode
+     * @param string $data    Data to decode
      * @param string $format  Format name
      * @param array  $context options that decoders have access to.
      *

--- a/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
@@ -25,7 +25,7 @@ interface EncoderInterface
      * @param string $format  Format name
      * @param array  $context options that normalizers/encoders have access to.
      *
-     * @return scalar
+     * @return string|bool|int|float|null
      */
     public function encode($data, $format, array $context = array());
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -22,6 +22,9 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
  */
 class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, DecoderInterface, NormalizationAwareInterface
 {
+    /**
+     * @var \DOMDocument
+     */
     private $dom;
     private $format;
     private $rootNodeName = 'response';
@@ -164,7 +167,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      *
      * @return bool
      */
-    final protected function appendXMLString($node, $val)
+    final protected function appendXMLString(\DOMNode $node, $val)
     {
         if (strlen($val) > 0) {
             $frag = $this->dom->createDocumentFragment();
@@ -178,12 +181,12 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
     }
 
     /**
-     * @param DOMNode $node
-     * @param string  $val
+     * @param \DOMNode $node
+     * @param string   $val
      *
      * @return bool
      */
-    final protected function appendText($node, $val)
+    final protected function appendText(\DOMNode $node, $val)
     {
         $nodeText = $this->dom->createTextNode($val);
         $node->appendChild($nodeText);
@@ -192,12 +195,12 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
     }
 
     /**
-     * @param DOMNode $node
-     * @param string  $val
+     * @param \DOMNode $node
+     * @param string   $val
      *
      * @return bool
      */
-    final protected function appendCData($node, $val)
+    final protected function appendCData(\DOMNode $node, $val)
     {
         $nodeText = $this->dom->createCDATASection($val);
         $node->appendChild($nodeText);
@@ -206,12 +209,12 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
     }
 
     /**
-     * @param DOMNode             $node
-     * @param DOMDocumentFragment $fragment
+     * @param \DOMNode             $node
+     * @param \DOMDocumentFragment $fragment
      *
      * @return bool
      */
-    final protected function appendDocumentFragment($node, $fragment)
+    final protected function appendDocumentFragment(\DOMNode $node, $fragment)
     {
         if ($fragment instanceof \DOMDocumentFragment) {
             $node->appendChild($fragment);
@@ -239,11 +242,11 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
     /**
      * Parse the input SimpleXmlElement into an array.
      *
-     * @param SimpleXmlElement $node xml to parse
+     * @param \SimpleXmlElement $node xml to parse
      *
      * @return array
      */
-    private function parseXml($node)
+    private function parseXml(\SimpleXMLElement $node)
     {
         $data = array();
         if ($node->attributes()) {
@@ -290,7 +293,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
     /**
      * Parse the data and convert it to DOMElements.
      *
-     * @param DOMNode      $parentNode
+     * @param \DOMElement  $parentNode
      * @param array|object $data            data
      * @param string       $xmlRootNodeName
      *
@@ -298,7 +301,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      *
      * @throws UnexpectedValueException
      */
-    private function buildXml($parentNode, $data, $xmlRootNodeName = null)
+    private function buildXml(\DOMElement $parentNode, $data, $xmlRootNodeName = null)
     {
         $append = true;
 
@@ -358,14 +361,14 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
     /**
      * Selects the type of node to create and appends it to the parent.
      *
-     * @param DOMNode      $parentNode
+     * @param \DOMNode     $parentNode
      * @param array|object $data
      * @param string       $nodeName
      * @param string       $key
      *
      * @return bool
      */
-    private function appendNode($parentNode, $data, $nodeName, $key = null)
+    private function appendNode(\DOMNode $parentNode, $data, $nodeName, $key = null)
     {
         $node = $this->dom->createElement($nodeName);
         if (null !== $key) {
@@ -395,12 +398,12 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
     /**
      * Tests the value being passed and decide what sort of element to create.
      *
-     * @param DOMNode $node
-     * @param mixed   $val
+     * @param \DOMNode $node
+     * @param mixed    $val
      *
      * @return bool
      */
-    private function selectNodeType($node, $val)
+    private function selectNodeType(\DOMNode $node, $val)
     {
         if (is_array($val)) {
             return $this->buildXml($node, $val);

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
@@ -27,12 +27,12 @@ interface DenormalizableInterface
      * It is important to understand that the denormalize() call should denormalize
      * recursively all child objects of the implementor.
      *
-     * @param DenormalizerInterface $denormalizer The denormalizer is given so that you
-     *                                            can use it to denormalize objects contained within this object.
-     * @param array|scalar          $data         The data from which to re-create the object.
-     * @param string|null           $format       The format is optionally given to be able to denormalize differently
-     *                                            based on different input formats.
-     * @param array                 $context      options for denormalizing
+     * @param DenormalizerInterface            $denormalizer The denormalizer is given so that you
+     *                                                       can use it to denormalize objects contained within this object.
+     * @param array|string|bool|int|float|null $data         The data from which to re-create the object.
+     * @param string|null                      $format       The format is optionally given to be able to denormalize differently
+     *                                                       based on different input formats.
+     * @param array                            $context      options for denormalizing
      */
     public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = array());
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
@@ -33,7 +33,7 @@ interface NormalizableInterface
      *                                        based on different output formats.
      * @param array               $context    Options for normalizing this object
      *
-     * @return array|scalar
+     * @return array|string|bool|int|float|null
      */
     public function normalize(NormalizerInterface $normalizer, $format = null, array $context = array());
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -25,7 +25,7 @@ interface NormalizerInterface
      * @param string $format  format the normalization result will be encoded as
      * @param array  $context Context options for the normalizer
      *
-     * @return array|scalar
+     * @return array|string|bool|int|float|null
      */
     public function normalize($object, $format = null, array $context = array());
 

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -218,7 +218,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
      * @param string $format  format name, present to give the option to normalizers to act differently based on formats
      * @param array  $context The context data for this particular normalization
      *
-     * @return array|scalar
+     * @return array|string|bool|int|float|null
      *
      * @throws LogicException
      * @throws UnexpectedValueException

--- a/src/Symfony/Component/Templating/Tests/Loader/ChainLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/ChainLoaderTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Templating\Tests\Loader;
 
 use Symfony\Component\Templating\Loader\ChainLoader;
 use Symfony\Component\Templating\Loader\FilesystemLoader;
-use Symfony\Component\Templating\Storage\FileStorage;
 use Symfony\Component\Templating\TemplateReference;
 
 class ChainLoaderTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Templating/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/FilesystemLoaderTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Templating\Tests\Loader;
 
 use Symfony\Component\Templating\Loader\FilesystemLoader;
-use Symfony\Component\Templating\Storage\FileStorage;
 use Symfony\Component\Templating\TemplateReference;
 
 class FilesystemLoaderTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Templating/Tests/Storage/FileStorageTest.php
+++ b/src/Symfony/Component/Templating/Tests/Storage/FileStorageTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Templating\Tests\Storage;
 
-use Symfony\Component\Templating\Storage\Storage;
 use Symfony\Component\Templating\Storage\FileStorage;
 
 class FileStorageTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Templating/Tests/Storage/StringStorageTest.php
+++ b/src/Symfony/Component/Templating/Tests/Storage/StringStorageTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Templating\Tests\Storage;
 
-use Symfony\Component\Templating\Storage\Storage;
 use Symfony\Component\Templating\Storage\StringStorage;
 
 class StringStorageTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
+++ b/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
@@ -55,18 +55,18 @@ class PluralizationRulesTest  extends \PHPUnit_Framework_TestCase
      *
      * As it is impossible to have this ever complete we should try as hard as possible to have it almost complete.
      *
-     * @return type
+     * @return array
      */
     public function successLangcodes()
     {
         return array(
-        array('1' , array('ay','bo', 'cgg','dz','id', 'ja', 'jbo', 'ka','kk','km','ko','ky')),
-        array('2' , array('nl', 'fr', 'en', 'de', 'de_GE')),
-        array('3' , array('be','bs','cs','hr')),
-        array('4' , array('cy','mt', 'sl')),
-        array('5' , array()),
-        array('6' , array('ar')),
-      );
+            array('1', array('ay','bo', 'cgg','dz','id', 'ja', 'jbo', 'ka','kk','km','ko','ky')),
+            array('2', array('nl', 'fr', 'en', 'de', 'de_GE')),
+            array('3', array('be','bs','cs','hr')),
+            array('4', array('cy','mt', 'sl')),
+            array('5', array()),
+            array('6', array('ar')),
+        );
     }
 
     /**
@@ -80,13 +80,13 @@ class PluralizationRulesTest  extends \PHPUnit_Framework_TestCase
     public function failingLangcodes()
     {
         return array(
-        array('1' , array('fa')),
-        array('2' , array('jbo')),
-        array('3' , array('cbs')),
-        array('4' , array('gd','kw')),
-        array('5' , array('ga')),
-        array('6' , array()),
-      );
+            array('1', array('fa')),
+            array('2', array('jbo')),
+            array('3', array('cbs')),
+            array('4', array('gd','kw')),
+            array('5', array('ga')),
+            array('6', array()),
+        );
     }
 
     /**
@@ -112,7 +112,7 @@ class PluralizationRulesTest  extends \PHPUnit_Framework_TestCase
     {
         $matrix = array();
         foreach ($langCodes as $langCode) {
-            for ($count = 0; $count<200; $count++) {
+            for ($count = 0; $count < 200; $count++) {
                 $plural = PluralizationRules::get($count, $langCode);
                 $matrix[$langCode][$count] = $plural;
             }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataFactoryTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Tests\Mapping;
 
-use Symfony\Component\Validator\Tests\Fixtures\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
 use Symfony\Component\Validator\Mapping\ClassMetadata;

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Validator\Tests\Mapping;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use Symfony\Component\Validator\Exception\GroupDefinitionException;
-use Symfony\Component\Validator\Tests\Fixtures\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\PropertyConstraint;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -182,7 +182,7 @@ class Inline
     /**
      * Parses a scalar to a YAML string.
      *
-     * @param scalar $scalar
+     * @param string $scalar
      * @param string $delimiters
      * @param array  $stringDelimiters
      * @param int    &$i

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Yaml\Tests;
 
-use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Dumper;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This removes the unused use statements which were not catched by PHP-CS-Fixer because of string occurences. It also fixes some invalid phpdoc (scalar is not recognized as a valid type for instance).

This is complementary to https://github.com/symfony/symfony/pull/13134
