### PR TITLE
Fix the implementation of deprecated Locale classes

### DIFF
--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Locale;
 
-use Symfony\Component\Icu\IcuData;
 use Symfony\Component\Intl\Intl;
 
 /**
@@ -173,7 +172,7 @@ class Locale extends \Locale
      */
     public static function getIcuDataDirectory()
     {
-        return IcuData::getResourceDirectory();
+        return Intl::getDataDirectory();
     }
 
     /**

--- a/src/Symfony/Component/Locale/Stub/StubLocale.php
+++ b/src/Symfony/Component/Locale/Stub/StubLocale.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Locale\Stub;
 
-use Symfony\Component\Icu\IcuData;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Locale\Locale;
 
@@ -86,7 +85,7 @@ class StubLocale extends Locale
 
     public static function getDataDirectory()
     {
-        return IcuData::getResourceDirectory();
+        return Intl::getDataDirectory();
     }
 
     private static function prepareCurrencies($locale)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The ICU component does not exist anymore, but the BC layer was still referencing it.
