### PR TITLE
Fix a web profiler form issue with fields added to the form after the form was built

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -420,7 +420,7 @@
             {% else %}
                 <div class="toggle-icon empty"></div>
             {% endif %}
-            {{ name|default('(no name)') }} {% if data.type is not empty %}[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]{% endif %}
+            {{ name|default('(no name)') }} {% if data.type_class is defined and data.type is defined %}[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]{% endif %}
             {% if data.errors is defined and data.errors|length > 0 %}
             <div class="badge-error">{{ data.errors|length }}</div>
             {% endif %}
@@ -440,7 +440,7 @@
     <div class="tree-details" {% if data.id is defined %} id="{{ data.id }}-details"{% endif %}>
         <h2>
             {{ name|default('(no name)') }}
-            {% if data.type_class is defined %}
+            {% if data.type_class is defined and data.type is defined %}
             <span class="form-type">[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]</span>
             {% endif %}
         </h2>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no, but not because of this PR |
| Fixed tickets | #13155 |
| License | MIT |
| Doc PR | - |

This also make the check consistent with a similar check in this template made further down:
- check for `data.type_class`, instead of `data.type`
- check if `data.type_class` is defined rather than if it's empty

The problem doesn't exist in 2.5.
