### PR TITLE
Update ExceptionController.php

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\TwigBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
-use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
Changed namespace of used FlattenException from HttpKernel to Debug, because SF 2.6 call the showAction with a Symfony\Component\Debug\Exception\FlattenException

The Problem can be reproduced when you use the /app_dev.php/_error/500 example taken from 
http://symfony.com/doc/current/cookbook/controller/error_pages.html
