### PR TITLE
[Form] Remove a redundant test

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -278,37 +278,6 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->assertSame($valid, $form->isValid());
     }
 
-    /**
-     * @dataProvider provideBoolean
-     */
-    public function testValidateTokenOnBindIfRootAndCompoundUsesTypeClassAsIntentionIfEmptyFormName($valid)
-    {
-        $this->csrfProvider->expects($this->once())
-            ->method('isCsrfTokenValid')
-            ->with('Symfony\Component\Form\Extension\Core\Type\FormType', 'token')
-            ->will($this->returnValue($valid));
-
-        $form = $this->factory
-            ->createNamedBuilder('', 'form', null, array(
-                'csrf_field_name' => 'csrf',
-                'csrf_provider' => $this->csrfProvider,
-                'compound' => true,
-            ))
-            ->add('child', 'text')
-            ->getForm();
-
-        $form->submit(array(
-            'child' => 'foobar',
-            'csrf' => 'token',
-        ));
-
-        // Remove token from data
-        $this->assertSame(array('child' => 'foobar'), $form->getData());
-
-        // Validate accordingly
-        $this->assertSame($valid, $form->isValid());
-    }
-
     public function testFailIfRootAndCompoundAndTokenMissing()
     {
         $this->csrfProvider->expects($this->never())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

As a result of changing `bind()` to `submit()` in #13161, the `testValidateTokenOnBindIfRootAndCompoundUsesTypeClassAsIntentionIfEmptyFormName()` is exactly the same as `testValidateTokenOnSubmitIfRootAndCompoundUsesTypeClassAsIntentionIfEmptyFormName()`. This makes the form tests to fail on 2.5 branch, as after a merge csrf provider is used instead of the token manager.
