### PR TITLE
Clarify a comment

### DIFF
--- a/src/Symfony/Component/Form/Extension/DataCollector/EventListener/DataCollectorListener.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/EventListener/DataCollectorListener.php
@@ -76,8 +76,7 @@ class DataCollectorListener implements EventSubscriberInterface
             $this->dataCollector->collectSubmittedData($event->getForm());
 
             // Assemble a form tree
-            // This is done again in collectViewVariables(), but that method
-            // is not guaranteed to be called (i.e. when no view is created)
+            // This is done again after the view is built, but we need it here as the view is not always created.
             $this->dataCollector->buildPreliminaryFormTree($event->getForm());
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The previous comment was lying since [`collectViewVariables()`](https://github.com/symfony/symfony/blob/cffb64fd931d167c905f9bbecdb400e71cb3c850/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php#L165) doesn't really call the [`buildPreliminaryFormTree()`](https://github.com/symfony/symfony/blob/cffb64fd931d167c905f9bbecdb400e71cb3c850/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php#L186) nor the [`buildFinalFormTree()`](https://github.com/symfony/symfony/blob/cffb64fd931d167c905f9bbecdb400e71cb3c850/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php#L196).
