### PR TITLE
[Security][acl] Fixed Sql Server error 1785: Multiple Cascade paths.

### DIFF
--- a/src/Symfony/Component/Security/Acl/Dbal/DefaultTables.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/DefaultTables.php
@@ -113,4 +113,4 @@ class DefaultTables implements TablesInterface
         $table->setPrimaryKey(array('id'));
         $table->addUniqueIndex(array('identifier', 'username'));
     }
-} 
+}

--- a/src/Symfony/Component/Security/Acl/Dbal/DefaultTables.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/DefaultTables.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Symfony\Component\Security\Acl\Dbal;
+
+/**
+ * @author <daniel@headdev.com.br>
+ */
+class DefaultTables implements TablesInterface
+{
+    private $schema;
+
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * Adds the class table to the schema.
+     */
+    public function addClassTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('class_table_name'));
+        $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
+        $table->addColumn('class_type', 'string', array('length' => 200));
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('class_type'));
+    }
+
+    /**
+     * Adds the entry table to the schema.
+     */
+    public function addEntryTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('entry_table_name'));
+
+        $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
+        $table->addColumn('class_id', 'integer', array('unsigned' => true));
+        $table->addColumn('object_identity_id', 'integer', array('unsigned' => true, 'notnull' => false));
+        $table->addColumn('field_name', 'string', array('length' => 50, 'notnull' => false));
+        $table->addColumn('ace_order', 'smallint', array('unsigned' => true));
+        $table->addColumn('security_identity_id', 'integer', array('unsigned' => true));
+        $table->addColumn('mask', 'integer');
+        $table->addColumn('granting', 'boolean');
+        $table->addColumn('granting_strategy', 'string', array('length' => 30));
+        $table->addColumn('audit_success', 'boolean');
+        $table->addColumn('audit_failure', 'boolean');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('class_id', 'object_identity_id', 'field_name', 'ace_order'));
+        $table->addIndex(array('class_id', 'object_identity_id', 'security_identity_id'));
+
+        $table->addForeignKeyConstraint($this->schema->getTable($this->schema->getOptions('class_table_name')), array('class_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+        $table->addForeignKeyConstraint($this->schema->getTable($this->schema->getOptions('oid_table_name')), array('object_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+        $table->addForeignKeyConstraint($this->schema->getTable($this->schema->getOptions('sid_table_name')), array('security_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+    }
+
+    /**
+     * Adds the object identity table to the schema.
+     */
+    public function addObjectIdentitiesTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('oid_table_name'));
+
+        $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
+        $table->addColumn('class_id', 'integer', array('unsigned' => true));
+        $table->addColumn('object_identifier', 'string', array('length' => 100));
+        $table->addColumn('parent_object_identity_id', 'integer', array('unsigned' => true, 'notnull' => false));
+        $table->addColumn('entries_inheriting', 'boolean');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('object_identifier', 'class_id'));
+        $table->addIndex(array('parent_object_identity_id'));
+
+        $table->addForeignKeyConstraint($table, array('parent_object_identity_id'), array('id'));
+    }
+
+    /**
+     * Adds the object identity relation table to the schema.
+     */
+    public function addObjectIdentityAncestorsTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('oid_ancestors_table_name'));
+
+        $table->addColumn('object_identity_id', 'integer', array('unsigned' => true));
+        $table->addColumn('ancestor_id', 'integer', array('unsigned' => true));
+
+        $table->setPrimaryKey(array('object_identity_id', 'ancestor_id'));
+
+        $oidTable = $this->schema->getTable($this->schema->getOptions('oid_table_name'));
+        $table->addForeignKeyConstraint($oidTable, array('object_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+        $table->addForeignKeyConstraint($oidTable, array('ancestor_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+    }
+
+    /**
+     * Adds the security identity table to the schema.
+     */
+    public function addSecurityIdentitiesTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('sid_table_name'));
+
+        $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
+        $table->addColumn('identifier', 'string', array('length' => 200));
+        $table->addColumn('username', 'boolean');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('identifier', 'username'));
+    }
+} 

--- a/src/Symfony/Component/Security/Acl/Dbal/MssqlTables.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MssqlTables.php
@@ -113,4 +113,4 @@ class MssqlTables implements TablesInterface
         $table->setPrimaryKey(array('id'));
         $table->addUniqueIndex(array('identifier', 'username'));
     }
-} 
+}

--- a/src/Symfony/Component/Security/Acl/Dbal/MssqlTables.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MssqlTables.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Symfony\Component\Security\Acl\Dbal;
+
+/**
+ * @author Daniel Oliveira <daniel@headdev.com.br>
+ */
+class MssqlTables implements TablesInterface
+{
+    private $schema;
+
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * Adds the class table to the schema.
+     */
+    public function addClassTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('class_table_name'));
+        $table->addColumn('id', 'integer', array('autoincrement' => 'auto'));
+        $table->addColumn('class_type', 'string', array('length' => 200));
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('class_type'));
+    }
+
+    /**
+     * Adds the entry table to the schema.
+     */
+    public function addEntryTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('entry_table_name'));
+
+        $table->addColumn('id', 'integer', array('autoincrement' => 'auto'));
+        $table->addColumn('class_id', 'integer', array('unsigned' => true));
+        $table->addColumn('object_identity_id', 'integer', array('notnull' => false));
+        $table->addColumn('field_name', 'string', array('length' => 50, 'notnull' => false));
+        $table->addColumn('ace_order', 'smallint', array('unsigned' => true));
+        $table->addColumn('security_identity_id', 'integer', array('unsigned' => true));
+        $table->addColumn('mask', 'integer');
+        $table->addColumn('granting', 'boolean');
+        $table->addColumn('granting_strategy', 'string', array('length' => 30));
+        $table->addColumn('audit_success', 'boolean');
+        $table->addColumn('audit_failure', 'boolean');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('class_id', 'object_identity_id', 'field_name', 'ace_order'));
+        $table->addIndex(array('class_id', 'object_identity_id', 'security_identity_id'));
+
+        $table->addForeignKeyConstraint($this->schema->getTable($this->schema->getOptions('class_table_name')), array('class_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+        $table->addForeignKeyConstraint($this->schema->getTable($this->schema->getOptions('oid_table_name')), array('object_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+        $table->addForeignKeyConstraint($this->schema->getTable($this->schema->getOptions('sid_table_name')), array('security_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+    }
+
+    /**
+     * Adds the object identity table to the schema.
+     */
+    public function addObjectIdentitiesTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('oid_table_name'));
+
+        $table->addColumn('id', 'integer', array('autoincrement' => 'auto'));
+        $table->addColumn('class_id', 'integer', array('unsigned' => true));
+        $table->addColumn('object_identifier', 'string', array('length' => 100));
+        $table->addColumn('parent_object_identity_id', 'integer', array('notnull' => false));
+        $table->addColumn('entries_inheriting', 'boolean');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('object_identifier', 'class_id'));
+        $table->addIndex(array('parent_object_identity_id'));
+
+        $table->addForeignKeyConstraint($table, array('parent_object_identity_id'), array('id'));
+    }
+
+    /**
+     * Adds the object identity relation table to the schema.
+     */
+    public function addObjectIdentityAncestorsTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('oid_ancestors_table_name'));
+
+        $table->addColumn('object_identity_id', 'integer', array('unsigned' => true));
+        $table->addColumn('ancestor_id', 'integer', array('unsigned' => true));
+
+        $table->setPrimaryKey(array('object_identity_id', 'ancestor_id'));
+
+        $oidTable = $this->schema->getTable($this->schema->getOptions('oid_table_name'));
+        $table->addForeignKeyConstraint($oidTable, array('object_identity_id'), array('id'));
+        $table->addForeignKeyConstraint($oidTable, array('ancestor_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
+    }
+
+    /**
+     * Adds the security identity table to the schema.
+     */
+    public function addSecurityIdentitiesTable()
+    {
+        $table = $this->schema->createTable($this->schema->getOptions('sid_table_name'));
+
+        $table->addColumn('id', 'integer', array('autoincrement' => 'auto'));
+        $table->addColumn('identifier', 'string', array('length' => 200));
+        $table->addColumn('username', 'boolean');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('identifier', 'username'));
+    }
+} 

--- a/src/Symfony/Component/Security/Acl/Dbal/Schema.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/Schema.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Connection;
  * The schema used for the ACL system.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Daniel Oliveira <daniel@headdev.com.br>
  */
 final class Schema extends BaseSchema
 {
@@ -37,11 +38,21 @@ final class Schema extends BaseSchema
 
         $this->options = $options;
 
-        $this->addClassTable();
-        $this->addSecurityIdentitiesTable();
-        $this->addObjectIdentitiesTable();
-        $this->addObjectIdentityAncestorsTable();
-        $this->addEntryTable();
+        switch ($connection->getDatabasePlatform()->getName()) {
+
+            case 'mssql':
+                $schemaStrategy = new MssqlTables($this);
+                break;
+            default:
+                $schemaStrategy = new DefaultTables($this);
+                break;
+        }
+
+        $schemaStrategy->addClassTable();
+        $schemaStrategy->addSecurityIdentitiesTable();
+        $schemaStrategy->addObjectIdentitiesTable();
+        $schemaStrategy->addObjectIdentityAncestorsTable();
+        $schemaStrategy->addEntryTable();
     }
 
     /**
@@ -61,94 +72,11 @@ final class Schema extends BaseSchema
     }
 
     /**
-     * Adds the class table to the schema.
+     * @param $key
+     * @return mixed
      */
-    protected function addClassTable()
+    public function getOptions($key)
     {
-        $table = $this->createTable($this->options['class_table_name']);
-        $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
-        $table->addColumn('class_type', 'string', array('length' => 200));
-        $table->setPrimaryKey(array('id'));
-        $table->addUniqueIndex(array('class_type'));
-    }
-
-    /**
-     * Adds the entry table to the schema.
-     */
-    protected function addEntryTable()
-    {
-        $table = $this->createTable($this->options['entry_table_name']);
-
-        $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
-        $table->addColumn('class_id', 'integer', array('unsigned' => true));
-        $table->addColumn('object_identity_id', 'integer', array('unsigned' => true, 'notnull' => false));
-        $table->addColumn('field_name', 'string', array('length' => 50, 'notnull' => false));
-        $table->addColumn('ace_order', 'smallint', array('unsigned' => true));
-        $table->addColumn('security_identity_id', 'integer', array('unsigned' => true));
-        $table->addColumn('mask', 'integer');
-        $table->addColumn('granting', 'boolean');
-        $table->addColumn('granting_strategy', 'string', array('length' => 30));
-        $table->addColumn('audit_success', 'boolean');
-        $table->addColumn('audit_failure', 'boolean');
-
-        $table->setPrimaryKey(array('id'));
-        $table->addUniqueIndex(array('class_id', 'object_identity_id', 'field_name', 'ace_order'));
-        $table->addIndex(array('class_id', 'object_identity_id', 'security_identity_id'));
-
-        $table->addForeignKeyConstraint($this->getTable($this->options['class_table_name']), array('class_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
-        $table->addForeignKeyConstraint($this->getTable($this->options['oid_table_name']), array('object_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
-        $table->addForeignKeyConstraint($this->getTable($this->options['sid_table_name']), array('security_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
-    }
-
-    /**
-     * Adds the object identity table to the schema.
-     */
-    protected function addObjectIdentitiesTable()
-    {
-        $table = $this->createTable($this->options['oid_table_name']);
-
-        $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
-        $table->addColumn('class_id', 'integer', array('unsigned' => true));
-        $table->addColumn('object_identifier', 'string', array('length' => 100));
-        $table->addColumn('parent_object_identity_id', 'integer', array('unsigned' => true, 'notnull' => false));
-        $table->addColumn('entries_inheriting', 'boolean');
-
-        $table->setPrimaryKey(array('id'));
-        $table->addUniqueIndex(array('object_identifier', 'class_id'));
-        $table->addIndex(array('parent_object_identity_id'));
-
-        $table->addForeignKeyConstraint($table, array('parent_object_identity_id'), array('id'));
-    }
-
-    /**
-     * Adds the object identity relation table to the schema.
-     */
-    protected function addObjectIdentityAncestorsTable()
-    {
-        $table = $this->createTable($this->options['oid_ancestors_table_name']);
-
-        $table->addColumn('object_identity_id', 'integer', array('unsigned' => true));
-        $table->addColumn('ancestor_id', 'integer', array('unsigned' => true));
-
-        $table->setPrimaryKey(array('object_identity_id', 'ancestor_id'));
-
-        $oidTable = $this->getTable($this->options['oid_table_name']);
-        $table->addForeignKeyConstraint($oidTable, array('object_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
-        $table->addForeignKeyConstraint($oidTable, array('ancestor_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
-    }
-
-    /**
-     * Adds the security identity table to the schema.
-     */
-    protected function addSecurityIdentitiesTable()
-    {
-        $table = $this->createTable($this->options['sid_table_name']);
-
-        $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
-        $table->addColumn('identifier', 'string', array('length' => 200));
-        $table->addColumn('username', 'boolean');
-
-        $table->setPrimaryKey(array('id'));
-        $table->addUniqueIndex(array('identifier', 'username'));
+        return $this->options[$key];
     }
 }

--- a/src/Symfony/Component/Security/Acl/Dbal/TablesInterface.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/TablesInterface.php
@@ -15,7 +15,6 @@ namespace Symfony\Component\Security\Acl\Dbal;
  */
 interface TablesInterface
 {
-
     /**
      * Adds the class table to the schema.
      */
@@ -39,4 +38,4 @@ interface TablesInterface
      * Adds the security identity table to the schema.
      */
     public function addSecurityIdentitiesTable();
-} 
+}

--- a/src/Symfony/Component/Security/Acl/Dbal/TablesInterface.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/TablesInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Symfony\Component\Security\Acl\Dbal;
+
+/**
+ * @author Daniel Oliveira <daniel@headdev.com.br>
+ */
+interface TablesInterface
+{
+
+    /**
+     * Adds the class table to the schema.
+     */
+    public function addClassTable();
+
+    /**
+     * Adds the entry table to the schema.
+     */
+    public function addEntryTable();
+    /**
+     * Adds the object identity table to the schema.
+     */
+    public function addObjectIdentitiesTable();
+
+    /**
+     * Adds the object identity relation table to the schema.
+     */
+    public function addObjectIdentityAncestorsTable();
+
+    /**
+     * Adds the security identity table to the schema.
+     */
+    public function addSecurityIdentitiesTable();
+} 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7560 |
| License | MIT |
| Doc PR | - |

This commit fixed the "sql server error 1785" when try creating constraint FOREIGN KEY with multiple cascade paths and UNSIGNED type that is not support for him  to perform  `php app/console acl:init`.
