### PR TITLE
[DependencyInjection] force ExpressionLanguage version >= 2.6

### DIFF
--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -23,6 +23,9 @@
         "symfony/config": "~2.2",
         "symfony/expression-language": "~2.6"
     },
+    "conflict": {
+        "symfony/expression-language": "<2.6"
+    },
     "suggest": {
         "symfony/yaml": "",
         "symfony/config": "",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13176 |
| License | MIT |
| Doc PR |  |

The DependencyInjection component requires the ExpressionLanguage
component to be present in version 2.6 or higher to be able to use
expressions in service configurations since Symfony 2.6.
