### PR TITLE
Fixes Issue #13184 - incremental output getters now return empty strings

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -499,6 +499,11 @@ class Process
         $data = $this->getOutput();
 
         $latest = substr($data, $this->incrementalOutputOffset);
+
+        if (false === $latest) {
+            return '';
+        }
+
         $this->incrementalOutputOffset = strlen($data);
 
         return $latest;
@@ -559,6 +564,11 @@ class Process
         $data = $this->getErrorOutput();
 
         $latest = substr($data, $this->incrementalErrorOutputOffset);
+
+        if (false === $latest) {
+            return '';
+        }
+        
         $this->incrementalErrorOutputOffset = strlen($data);
 
         return $latest;

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -568,7 +568,7 @@ class Process
         if (false === $latest) {
             return '';
         }
-        
+
         $this->incrementalErrorOutputOffset = strlen($data);
 
         return $latest;

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -314,7 +314,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         while ($p->isRunning()) {
             if ('R' === file_get_contents($lock)) {
-                if(!$shouldWrite) {
+                if (!$shouldWrite) {
                     $this->assertLessThanOrEqual(1, preg_match_all('/ERROR/', $p->getIncrementalOutput(), $matches));
                     $shouldWrite = true;
                 } else {
@@ -383,7 +383,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         while ($p->isRunning()) {
             if ('R' === file_get_contents($lock)) {
-                if(!$shouldWrite) {
+                if (!$shouldWrite) {
                     $this->assertLessThanOrEqual(1, preg_match_all('/foo/', $p->getIncrementalOutput(), $matches));
                     $shouldWrite = true;
                 } else {

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -299,6 +299,37 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         unlink($lock);
     }
 
+    public function testGetEmptyIncrementalErrorOutput()
+    {
+        // use a lock file to toggle between writing ("W") and reading ("R") the
+        // output stream
+        $lock = tempnam(sys_get_temp_dir(), get_class($this).'Lock');
+        file_put_contents($lock, 'W');
+
+        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { if (\'W\' === file_get_contents('.var_export($lock, true).')) { file_put_contents(\'php://stderr\', \'ERROR\'); $n++; file_put_contents('.var_export($lock, true).', \'R\'); } usleep(100); }')));
+
+        $p->start();
+
+        $shouldWrite = false;
+
+        while ($p->isRunning()) {
+            if ('R' === file_get_contents($lock)) {
+                if(!$shouldWrite) {
+                    $this->assertLessThanOrEqual(1, preg_match_all('/ERROR/', $p->getIncrementalOutput(), $matches));
+                    $shouldWrite = true;
+                } else {
+                    $this->assertSame('', $p->getIncrementalOutput());
+
+                    file_put_contents($lock, 'W');
+                    $shouldWrite = false;
+                }
+            }
+            usleep(100);
+        }
+
+        unlink($lock);
+    }
+
     public function testFlushErrorOutput()
     {
         $p = $this->getProcess(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }')));
@@ -330,6 +361,37 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
             if ('R' === file_get_contents($lock)) {
                 $this->assertLessThanOrEqual(1, preg_match_all('/foo/', $p->getIncrementalOutput(), $matches));
                 file_put_contents($lock, 'W');
+            }
+            usleep(100);
+        }
+
+        unlink($lock);
+    }
+
+    public function testGetEmptyIncrementalOutput()
+    {
+        // use a lock file to toggle between writing ("W") and reading ("R") the
+        // output stream
+        $lock = tempnam(sys_get_temp_dir(), get_class($this).'Lock');
+        file_put_contents($lock, 'W');
+
+        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { if (\'W\' === file_get_contents('.var_export($lock, true).')) { echo \' foo \'; $n++; file_put_contents('.var_export($lock, true).', \'R\'); } usleep(100); }')));
+
+        $p->start();
+
+        $shouldWrite = false;
+
+        while ($p->isRunning()) {
+            if ('R' === file_get_contents($lock)) {
+                if(!$shouldWrite) {
+                    $this->assertLessThanOrEqual(1, preg_match_all('/foo/', $p->getIncrementalOutput(), $matches));
+                    $shouldWrite = true;
+                } else {
+                    $this->assertSame('', $p->getIncrementalOutput());
+
+                    file_put_contents($lock, 'W');
+                    $shouldWrite = false;
+                }
             }
             usleep(100);
         }


### PR DESCRIPTION
fixed Issue #13184

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | Issue #13184 |
| License | MIT |
| Doc PR | [`Symfony\Component\Process\Process::getIncrementalOutput()`](http://api.symfony.com/2.6/Symfony/Component/Process/Process.html#method_getIncrementalOutput), [`Symfony\Component\Process\Process::getIncrementalErrorOutput()`](http://api.symfony.com/2.6/Symfony/Component/Process/Process.html#method_getIncrementalErrorOutput) |
