### PR TITLE
[WIP] [HttpFoundation] Added the ability of mapping stream wrapper protocols when using X-Sendfile

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -189,6 +189,10 @@ class BinaryFileResponse extends Response
             // Use X-Sendfile, do not send any content.
             $type = $request->headers->get('X-Sendfile-Type');
             $path = $this->file->getRealPath();
+            // Fall back to scheme://path for stream wrapped locations.
+            if (empty($path)) {
+              $path = $this->file->getPathname();
+            }
             if (strtolower($type) == 'x-accel-redirect') {
                 // Do X-Accel-Mapping substitutions.
                 foreach (explode(',', $request->headers->get('X-Accel-Mapping', '')) as $mapping) {

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -191,7 +191,7 @@ class BinaryFileResponse extends Response
             $path = $this->file->getRealPath();
             // Fall back to scheme://path for stream wrapped locations.
             if (empty($path)) {
-              $path = $this->file->getPathname();
+                $path = $this->file->getPathname();
             }
             if (strtolower($type) == 'x-accel-redirect') {
                 // Do X-Accel-Mapping substitutions.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12990 |
| License | MIT |
| Doc PR | ~ |
- [ ] Testcase for serving stream wrapped files using X-sendfile
