### PR TITLE
[VarDumper] increase debug.max_items to 2500

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/Configuration.php
@@ -34,7 +34,7 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('max_items')
                     ->info('Max number of displayed items past the first level, -1 means no limit')
                     ->min(-1)
-                    ->defaultValue(250)
+                    ->defaultValue(2500)
                 ->end()
                 ->integerNode('max_string_length')
                     ->info('Max length of displayed strings, -1 means no limit')

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -80,7 +80,7 @@ abstract class AbstractCloner implements ClonerInterface
         ':stream-context' => 'Symfony\Component\VarDumper\Caster\ResourceCaster::castStreamContext',
     );
 
-    protected $maxItems = 250;
+    protected $maxItems = 2500;
     protected $maxString = -1;
 
     private $casters = array();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I see others (and me) hit the 250 limit too many times. The component is able to handle way more items.
