### PR TITLE
[Debug] split tests for deprecated interfaces

### DIFF
--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -23,22 +23,6 @@ use Symfony\Component\Debug\Exception\ContextErrorException;
  */
 class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var int Error reporting level before running tests.
-     */
-    protected $errorReporting;
-
-    public function setUp()
-    {
-        $this->errorReporting = error_reporting(E_ALL | E_STRICT);
-        $this->iniSet('display_errors', '1');
-    }
-
-    public function tearDown()
-    {
-        error_reporting($this->errorReporting);
-    }
-
     public function testRegister()
     {
         $handler = ErrorHandler::register();
@@ -373,8 +357,10 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testDeprecatedInterface()
+    public function testLegacyInterface()
     {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
         try {
             $handler = ErrorHandler::register(0);
             $this->assertFalse($handler->handle(0, 'foo', 'foo.php', 12, array()));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Splitting tests for deprecated interfaces in "Legacy" prefixed test classes/methods should be done for every component.
Let's start by this simple one. To anyone: help welcomed for the other components.
