### PR TITLE
Don't add Accept-Range header on unsafe HTTP requests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -170,7 +170,11 @@ class BinaryFileResponse extends Response
     public function prepare(Request $request)
     {
         $this->headers->set('Content-Length', $this->file->getSize());
-        $this->headers->set('Accept-Ranges', 'bytes');
+
+        if (!$this->headers->has('Accept-Ranges')) {
+            // Only accept ranges on safe HTTP methods
+            $this->headers->set('Accept-Ranges', $request->isMethodSafe() ? 'bytes' : 'none');
+        }
 
         if (!$this->headers->has('Content-Type')) {
             $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -208,21 +208,22 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertFileNotExists($path);
     }
 
-    /**
-     *
-     */
     public function testAcceptRangeOnUnsafeMethods()
     {
         $request = Request::create('/', 'POST');
         $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif');
         $response->prepare($request);
-        $this->assertEquals('none', $response->headers->get('Accept-Ranges'));
 
-        // Don't override when already set
+        $this->assertEquals('none', $response->headers->get('Accept-Ranges'));
+    }
+
+    public function testAcceptRangeNotOverriden()
+    {
         $request = Request::create('/', 'POST');
         $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif');
         $response->headers->set('Accept-Ranges', 'foo');
         $response->prepare($request);
+
         $this->assertEquals('foo', $response->headers->get('Accept-Ranges'));
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -208,6 +208,24 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertFileNotExists($path);
     }
 
+    /**
+     *
+     */
+    public function testAcceptRangeOnUnsafeMethods()
+    {
+        $request = Request::create('/', 'POST');
+        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif');
+        $response->prepare($request);
+        $this->assertEquals('none', $response->headers->get('Accept-Ranges'));
+
+        // Don't override when already set
+        $request = Request::create('/', 'POST');
+        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif');
+        $response->headers->set('Accept-Ranges', 'foo');
+        $response->prepare($request);
+        $this->assertEquals('foo', $response->headers->get('Accept-Ranges'));
+    }
+
     public function getSampleXAccelMappings()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12556 |
| License | MIT |
| Doc PR | N/A |
