### PR TITLE
[Yaml] Update README.md

### DIFF
--- a/src/Symfony/Component/Yaml/README.md
+++ b/src/Symfony/Component/Yaml/README.md
@@ -6,7 +6,7 @@ YAML implements most of the YAML 1.2 specification.
 ```php
 use Symfony\Component\Yaml\Yaml;
 
-$array = Yaml::parse($file);
+$array = Yaml::parse(file_get_contents(filename));
 
 print Yaml::dump($array);
 ```


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets |  |
| License | MIT |

The ability to pass file names to Yaml::parse() was deprecated in 2.2 and will be removed in 3.0. So show an up-to-date example.
