### PR TITLE
[2.5] Use $this->iniSet() in tests

### DIFF
--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -62,17 +62,14 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
     public function testUnsilencing()
     {
         ob_start();
-        $bak = array(
-            ini_set('log_errors', 0),
-            ini_set('display_errors', 1),
-        );
+
+        $this->iniSet('log_errors', 0);
+        $this->iniSet('display_errors', 1);
 
         // See below: this will fail with parse error
         // but this should not be @-silenced.
         @class_exists(__NAMESPACE__.'\TestingUnsilencing', true);
 
-        ini_set('log_errors', $bak[0]);
-        ini_set('display_errors', $bak[1]);
         $output = ob_get_clean();
 
         $this->assertStringMatchesFormat('%aParse error%a', $output);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Conversion for 2.3 was done in #13195.

Only one test in 2.5 where replacing `ini_set()` with `$this->iniSet()` was needed. Other uses were class wide and in isolated tests.
