### PR TITLE
[FrameworkBundle] Use security.token_storage service in Controller::getUser()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -293,7 +293,7 @@ class Controller extends ContainerAware
     }
 
     /**
-     * Get a user from the Security Context.
+     * Get a user from the Security Token Storage.
      *
      * @return mixed
      *
@@ -303,15 +303,16 @@ class Controller extends ContainerAware
      */
     public function getUser()
     {
-        if (!$this->container->has('security.context')) {
+        if (!$this->container->has('security.token_storage')) {
             throw new \LogicException('The SecurityBundle is not registered in your application.');
         }
 
-        if (null === $token = $this->container->get('security.context')->getToken()) {
+        if (null === $token = $this->container->get('security.token_storage')->getToken()) {
             return;
         }
 
         if (!is_object($user = $token->getUser())) {
+            // e.g. anonymous authentication
             return;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -13,9 +13,13 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\User;
 
 class ControllerTest extends TestCase
 {
@@ -37,10 +41,99 @@ class ControllerTest extends TestCase
         $container->expects($this->at(0))->method('get')->will($this->returnValue($requestStack));
         $container->expects($this->at(1))->method('get')->will($this->returnValue($kernel));
 
-        $controller = new Controller();
+        $controller = new TestController();
         $controller->setContainer($container);
 
         $response = $controller->forward('a_controller');
         $this->assertEquals('xml--fr', $response->getContent());
+    }
+
+    public function testGetUser()
+    {
+        $user = new User('user', 'pass');
+        $token = new UsernamePasswordToken($user, 'pass', 'default', array('ROLE_USER'));
+
+        $controller = new TestController();
+        $controller->setContainer($this->getContainerWithTokenStorage($token));
+
+        $this->assertSame($controller->getUser(), $user);
+    }
+
+    public function testGetUserAnonymousUserConvertedToNull()
+    {
+        $token = new AnonymousToken('default', 'anon.');
+
+        $controller = new TestController();
+        $controller->setContainer($this->getContainerWithTokenStorage($token));
+
+        $this->assertNull($controller->getUser());
+    }
+
+    public function testGetUserWithEmptyTokenStorage()
+    {
+        $controller = new TestController();
+        $controller->setContainer($this->getContainerWithTokenStorage(null));
+
+        $this->assertNull($controller->getUser());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The SecurityBundle is not registered in your application.
+     */
+    public function testGetUserWithEmptyContainer()
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('security.token_storage')
+            ->will($this->returnValue(false));
+
+        $controller = new TestController();
+        $controller->setContainer($container);
+
+        $controller->getUser();
+    }
+
+    /**
+     * @param $token
+     * @return ContainerInterface
+     */
+    private function getContainerWithTokenStorage($token = null)
+    {
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage');
+        $tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->will($this->returnValue($token));
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('security.token_storage')
+            ->will($this->returnValue(true));
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with('security.token_storage')
+            ->will($this->returnValue($tokenStorage));
+
+        return $container;
+    }
+}
+
+class TestController extends Controller
+{
+    public function forward($controller, array $path = array(), array $query = array())
+    {
+        return parent::forward($controller, $path, $query);
+    }
+
+    public function getUser()
+    {
+        return parent::getUser();
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Replace deprecated `security.context` with `security.token_storage` service.
