### PR TITLE
[TwigBundle] added missing @deprecated tags

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Node/RenderNode.php
+++ b/src/Symfony/Bundle/TwigBundle/Node/RenderNode.php
@@ -15,6 +15,8 @@ namespace Symfony\Bundle\TwigBundle\Node;
  * Represents a render node.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.2, to be removed in 3.0.
  */
 class RenderNode extends \Twig_Node
 {

--- a/src/Symfony/Bundle/TwigBundle/TokenParser/RenderTokenParser.php
+++ b/src/Symfony/Bundle/TwigBundle/TokenParser/RenderTokenParser.php
@@ -17,6 +17,8 @@ use Symfony\Bundle\TwigBundle\Node\RenderNode;
  * Token Parser for the render tag.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.2, to be removed in 3.0.
  */
 class RenderTokenParser extends \Twig_TokenParser
 {


### PR DESCRIPTION
The `Symfony\Bundle\TwigBundle\Extension\ActionsExtension` class has been deprecated in Symfony 2.2 but we forgot to deprecate the related classes.
