### PR TITLE
[Validator] Add deprecated logs on addViolation() and addViolationAt() methods

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -188,7 +188,7 @@ class ExecutionContext implements ExecutionContextInterface
         // You should use buildViolation() instead.
         if (func_num_args() > 2) {
             throw new BadMethodCallException(
-                'The parameters $invalidValue, $pluralization and $code are '.
+                'The parameters $invalidValue, $plural and $code are '.
                 'not supported anymore as of Symfony 2.5. Please use '.
                 'buildViolation() instead or enable the legacy mode.'
             );
@@ -321,8 +321,6 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function validate($value, $subPath = '', $groups = null, $traverse = false, $deep = false)
     {
-        trigger_error('ExecutionContext::validate() is deprecated since version 2.5 and will be removed in 3.0. Use ExecutionContext::getValidator() together with inContext() instead.', E_USER_DEPRECATED);
-
         throw new BadMethodCallException(
             'validate() is not supported anymore as of Symfony 2.5. '.
             'Please use getValidator() instead or enable the legacy mode.'
@@ -334,8 +332,6 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function validateValue($value, $constraints, $subPath = '', $groups = null)
     {
-        trigger_error('ExecutionContext::validateValue() is deprecated since version 2.5 and will be removed in 3.0. Use ExecutionContext::getValidator() together with inContext() instead.', E_USER_DEPRECATED);
-
         throw new BadMethodCallException(
             'validateValue() is not supported anymore as of Symfony 2.5. '.
             'Please use getValidator() instead or enable the legacy mode.'

--- a/src/Symfony/Component/Validator/Context/LegacyExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/LegacyExecutionContext.php
@@ -58,6 +58,8 @@ class LegacyExecutionContext extends ExecutionContext
     public function addViolation($message, array $parameters = array(), $invalidValue = null, $plural = null, $code = null)
     {
         if (func_num_args() > 2) {
+            trigger_error('The parameters $invalidValue, $plural and $code of '.__METHOD__.' are deprecated since version 2.5 and will be removed in 3.0. Please use buildViolation() instead.', E_USER_DEPRECATED);
+
             $this
                 ->buildViolation($message, $parameters)
                 ->setInvalidValue($invalidValue)
@@ -77,6 +79,11 @@ class LegacyExecutionContext extends ExecutionContext
      */
     public function addViolationAt($subPath, $message, array $parameters = array(), $invalidValue = null, $plural = null, $code = null)
     {
+        trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Please use buildViolation() instead.',
+            E_USER_DEPRECATED
+        );
+
         if (func_num_args() > 2) {
             $this
                 ->buildViolation($message, $parameters)
@@ -102,6 +109,8 @@ class LegacyExecutionContext extends ExecutionContext
      */
     public function validate($value, $subPath = '', $groups = null, $traverse = false, $deep = false)
     {
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use getValidator() together with inContext() instead.', E_USER_DEPRECATED);
+
         if (is_array($value)) {
             // The $traverse flag is ignored for arrays
             $constraint = new Valid(array('traverse' => true, 'deep' => $deep));
@@ -138,6 +147,8 @@ class LegacyExecutionContext extends ExecutionContext
      */
     public function validateValue($value, $constraints, $subPath = '', $groups = null)
     {
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use getValidator() together with inContext() instead.', E_USER_DEPRECATED);
+
         return $this
             ->getValidator()
             ->inContext($this)
@@ -151,6 +162,8 @@ class LegacyExecutionContext extends ExecutionContext
      */
     public function getMetadataFactory()
     {
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use getValidator() together with getMetadataFor() or hasMetadataFor instead.', E_USER_DEPRECATED);
+
         return $this->metadataFactory;
     }
 }

--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -92,6 +92,10 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function addViolation($message, array $params = array(), $invalidValue = null, $plural = null, $code = null)
     {
+        if (func_num_args() > 2) {
+            trigger_error('The parameters $invalidValue, $plural and $code of '.__METHOD__.' are deprecated since version 2.5 and will be removed in 3.0. Please use buildViolation() of the new validation API instead.', E_USER_DEPRECATED);
+        }
+
         if (null === $plural) {
             $translatedMessage = $this->translator->trans($message, $params, $this->translationDomain);
         } else {
@@ -120,6 +124,11 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function addViolationAt($subPath, $message, array $parameters = array(), $invalidValue = null, $plural = null, $code = null)
     {
+        trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Please use buildViolation() of the new validation API instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->globalContext->getViolations()->add(new ConstraintViolation(
             null === $plural
                 ? $this->translator->trans($message, $parameters, $this->translationDomain)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12686, #12688 |
| License | MIT |
| Doc PR |  |

This replaces https://github.com/symfony/symfony/pull/12714 by adding the deprecation warnings in the right class and updating them to match our standards.
