### PR TITLE
[Filesystem] [Keep executable permission] use octal notation.

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -71,7 +71,7 @@ class Filesystem
 
             if (is_executable($originFile)) {
                 // User Executable | Group Executable | Other Executable
-                chmod($targetFile, fileperms($targetFile) | 0x0040 | 0x0008 | 0x0001);
+                chmod($targetFile, fileperms($targetFile) | 0100 | 0010 | 0001);
             }
 
             if (stream_is_local($originFile) && $bytesCopied !== filesize($originFile)) {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -69,9 +69,8 @@ class Filesystem
                 throw new IOException(sprintf('Failed to copy "%s" to "%s".', $originFile, $targetFile), 0, null, $originFile);
             }
 
-            if (is_executable($originFile)) {
-                // User Executable | Group Executable | Other Executable
-                chmod($targetFile, fileperms($targetFile) | 0100 | 0010 | 0001);
+            if (is_file($originFile)) {
+                $this->chmod($targetFile, fileperms($originFile));
             }
 
             if (stream_is_local($originFile) && $bytesCopied !== filesize($originFile)) {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -996,26 +996,13 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertSame('bar', file_get_contents($filename));
     }
 
-    public function testCopyShouldKeepExecutionPermission()
+    public function testCopyShouldKeepPermission()
     {
         $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';
         $targetFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_target_file';
 
         file_put_contents($sourceFilePath, 'SOURCE FILE');
         chmod($sourceFilePath, 0755);
-
-        $this->filesystem->copy($sourceFilePath, $targetFilePath);
-
-        $this->assertFilePermissions(755, $targetFilePath);
-    }
-
-    public function testCopyShouldNotKeepWritePermissionOtherThanCurrentUser()
-    {
-        $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';
-        $targetFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_target_file';
-
-        file_put_contents($sourceFilePath, 'SOURCE FILE');
-        chmod($sourceFilePath, 0777);
 
         $this->filesystem->copy($sourceFilePath, $targetFilePath);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #12653 |
| Tests pass? | yes |
| License | MIT |

Use octal notation as @stof suggested in https://github.com/symfony/symfony/pull/12653/files#r22431992
