### PR TITLE
[Filesystem] enforce umask while testing

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class FilesystemTest extends \PHPUnit_Framework_TestCase
 {
+    private $umask;
+
     /**
      * @var string
      */
@@ -47,6 +49,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        $this->umask = umask(0);
         $this->filesystem = new Filesystem();
         $this->workspace = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.time().rand(0, 1000);
         mkdir($this->workspace, 0777, true);
@@ -56,6 +59,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->clean($this->workspace);
+        umask($this->umask);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Having a predictable umask (but not the usual one) should help (TDD for #13222).
When merging in 2.5, the patch should be moved to the new `FilesystemTestCase`
