### PR TITLE
[DependencyInjection] Support DefinitionDecorator in ContainerBuilder

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection;
 use Symfony\Component\DependencyInjection\Compiler\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -913,6 +914,14 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     {
         if ($definition->isSynthetic()) {
             throw new RuntimeException(sprintf('You have requested a synthetic service ("%s"). The DIC does not know how to construct this service.', $id));
+        }
+
+        // If the definition is a decorator, manually run the corresponding pass
+        // to complete it.
+        if ($definition instanceof DefinitionDecorator) {
+            $pass = new ResolveDefinitionTemplatesPass();
+            $pass->process($this);
+            $definition = $this->getDefinition($id);
         }
 
         if ($tryProxy && $definition->isLazy()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
@@ -793,6 +794,21 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertTrue($classInList);
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService()
+     */
+    public function testGetWithDecoratorDefinition()
+    {
+        $builder = new ContainerBuilder();
+
+        $builder->register('parent', 'stdClass')->setProperty('foo', 'moo');
+        $builder->setDefinition('child', new DefinitionDecorator('parent'));
+
+        $child = $builder->get('child');
+        $this->assertInternalType('object', $child);
+        $this->assertEquals('moo', $child->foo);
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (I guess?) |
| Fixed tickets | #10034 |
| License | MIT |
| Doc PR |  |

This is a possible fix for https://github.com/symfony/symfony/issues/10034. It is pretty ugly, looking for feedback.

I would prefer to run it so that only $definition has to be changed instead of the whole container, a public method on that Pass that just updates a specific definition would be nice?
