### PR TITLE
[TwigBundle] removed the Container dependency on ActionsExtension

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -27,6 +27,10 @@ class ExtensionPass implements CompilerPassInterface
             $container->getDefinition('twig.loader.filesystem')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
         }
 
+        if ($container->has('fragment.handler')) {
+            $container->getDefinition('twig.extension.actions')->addTag('twig.extension');
+        }
+
         if ($container->has('translator')) {
             $container->getDefinition('twig.extension.trans')->addTag('twig.extension');
         }

--- a/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
@@ -12,8 +12,8 @@
 namespace Symfony\Bundle\TwigBundle\Extension;
 
 use Symfony\Bundle\TwigBundle\TokenParser\RenderTokenParser;
-use Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 
 /**
  * Twig extension for Symfony actions helper.
@@ -24,16 +24,26 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ActionsExtension extends \Twig_Extension
 {
-    private $container;
+    private $handler;
 
     /**
-     * Constructor.
+     * @param FragmentHandler|ContainerInterface $handler
      *
-     * @param ContainerInterface $container The service container
+     * @deprecated Passing a ContainerInterface as a first argument is deprecated as of 2.7 and will be removed in 3.0.
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct($handler)
     {
-        $this->container = $container;
+        if ($handler instanceof FragmentHandler) {
+            $this->handler = $handler;
+        } elseif ($handler instanceof ContainerInterface) {
+            trigger_error(sprintf('The ability to pass a ContainerInterface instance as a first argument to %s was deprecated in 2.7 and will be removed in 3.0. Please, pass a FragmentHandler instance instead.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->handler = $handler->get('fragment.handler');
+        } else {
+            throw new \BadFunctionCallException(sprintf('%s takes a FragmentHandler or a ContainerInterface object as its first argument.', __METHOD__));
+        }
+
+        $this->handler = $handler;
     }
 
     /**
@@ -42,11 +52,14 @@ class ActionsExtension extends \Twig_Extension
      * @param string $uri     A URI
      * @param array  $options An array of options
      *
-     * @see ActionsHelper::render()
+     * @see FragmentHandler::render()
      */
     public function renderUri($uri, array $options = array())
     {
-        return $this->container->get('templating.helper.actions')->render($uri, $options);
+        $strategy = isset($options['strategy']) ? $options['strategy'] : 'inline';
+        unset($options['strategy']);
+
+        return $this->handler->render($uri, $strategy, $options);
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -71,8 +71,7 @@
         </service>
 
         <service id="twig.extension.actions" class="%twig.extension.actions.class%" public="false">
-            <tag name="twig.extension" />
-            <argument type="service" id="service_container" />
+            <argument type="service" id="fragment.handler" />
         </service>
 
         <service id="twig.extension.code" class="%twig.extension.code.class%" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | fixes #11876 partially |
| License | MIT |
| Doc PR | n/a |

This PR removes the injection of the container into the actions extension, and decouple this extension from FrameworkBundle (it was part of #13143 but as it is now totally independent, I've created a new PR).
