### PR TITLE
[TwigBundle] always load the exception listener if the templating.engines is not present

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
@@ -28,9 +28,11 @@ class ExceptionListenerPass implements CompilerPassInterface
         }
 
         // register the exception controller only if Twig is enabled
-        $engines = $container->getParameter('templating.engines');
-        if (!in_array('twig', $engines)) {
-            $container->removeDefinition('twig.exception_listener');
+        if ($container->hasParameter('templating.engines')) {
+            $engines = $container->getParameter('templating.engines');
+            if (!in_array('twig', $engines)) {
+                $container->removeDefinition('twig.exception_listener');
+            }
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | fixes #11876 partially |
| License | MIT |
| Doc PR | n/a |

This PR removes (partially) the dependency of TwigBundle on FrameworkBundle. If FrameworkBundle is not registered, the Twig exception listener is always registered (this change was part of #13143 but as it is now totally independent, I've created a new PR).
