### PR TITLE
[2.5] [Validator] marks TraversalStrategy::STOP_RECURSION constant internal

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/TraversalStrategy.php
+++ b/src/Symfony/Component/Validator/Mapping/TraversalStrategy.php
@@ -53,6 +53,7 @@ class TraversalStrategy
      *
      * @deprecated This constant was added for backwards compatibility only.
      *             It will be removed in Symfony 3.0.
+     * @internal
      */
     const STOP_RECURSION = 8;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This constant has been introduced for the BC layer and will be removed in 3.0.
