### PR TITLE
[2.6] Made help information of commands more consistent

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -41,23 +41,23 @@ class ServerStartCommand extends ServerCommand
             ->setHelp(<<<EOF
 The <info>%command.name%</info> runs PHP's built-in web server:
 
-  <info>%command.full_name%</info>
+  <info>php %command.full_name%</info>
 
 To change the default bind address and the default port use the <info>address</info> argument:
 
-  <info>%command.full_name% 127.0.0.1:8080</info>
+  <info>php %command.full_name% 127.0.0.1:8080</info>
 
 To change the default document root directory use the <info>--docroot</info> option:
 
-  <info>%command.full_name% --docroot=htdocs/</info>
+  <info>php %command.full_name% --docroot=htdocs/</info>
 
 If you have a custom document root directory layout, you can specify your own
 router script using the <info>--router</info> option:
 
-  <info>%command.full_name% --router=app/config/router.php</info>
+  <info>php %command.full_name% --router=app/config/router.php</info>
 
-Specifying a router script is required when the used environment is not "dev" or
-"prod".
+Specifying a router script is required when the used environment is not <comment>"dev"</comment> or
+<comment>"prod"</comment>.
 
 See also: http://www.php.net/manual/en/features.commandline.webserver.php
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStopCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStopCommand.php
@@ -36,11 +36,11 @@ class ServerStopCommand extends ServerCommand
             ->setHelp(<<<EOF
 The <info>%command.name%</info> stops PHP's built-in web server:
 
-  <info>%command.full_name%</info>
+  <info>php %command.full_name%</info>
 
 To change the default bind address and the default port use the <info>address</info> argument:
 
-  <info>%command.full_name% 127.0.0.1:8080</info>
+  <info>php %command.full_name% 127.0.0.1:8080</info>
 
 EOF
             )

--- a/src/Symfony/Bundle/SecurityBundle/Command/SetAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/SetAclCommand.php
@@ -59,20 +59,22 @@ class SetAclCommand extends ContainerAwareCommand
 The <info>%command.name%</info> command sets ACL.
 The ACL system must have been initialized with the <info>init:acl</info> command.
 
-To set <comment>VIEW</comment> and <comment>EDIT</comment> permissions for the user <comment>kevin</comment> on the instance of <comment>Acme\MyClass</comment> having the identifier <comment>42</comment>:
+To set <comment>VIEW</comment> and <comment>EDIT</comment> permissions for the user <comment>kevin</comment> on the instance of
+<comment>Acme\MyClass</comment> having the identifier <comment>42</comment>:
 
-<info>php %command.full_name% --user=Symfony/Component/Security/Core/User/User:kevin VIEW EDIT Acme/MyClass:42</info>
+  <info>php %command.full_name% --user=Symfony/Component/Security/Core/User/User:kevin VIEW EDIT Acme/MyClass:42</info>
 
 Note that you can use <comment>/</comment> instead of <comment>\\ </comment>for the namespace delimiter to avoid any
 problem.
 
 To set permissions for a role, use the <info>--role</info> option:
 
-<info>php %command.full_name% --role=ROLE_USER VIEW Acme/MyClass:1936</info>
+  <info>php %command.full_name% --role=ROLE_USER VIEW Acme/MyClass:1936</info>
 
 To set permissions at the class scope, use the <info>--class-scope</info> option:
 
-<info>php %command.full_name% --class-scope --user=Symfony/Component/Security/Core/User/User:anne OWNER Acme/MyClass:42</info>
+  <info>php %command.full_name% --class-scope --user=Symfony/Component/Security/Core/User/User:anne OWNER Acme/MyClass:42</info>
+  
 EOF
             )
             ->addArgument('arguments', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'A list of permissions and object identities (class name and ID separated by a column)')


### PR DESCRIPTION
Just like https://github.com/symfony/symfony/pull/13231, but then for commands added in 2.6
