### PR TITLE
[2.5] Made help information of commands more consistent

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -32,11 +32,10 @@ class ConfigDebugCommand extends AbstractConfigCommand
         $this
             ->setName('config:debug')
             ->setDefinition(array(
-                new InputArgument('name', InputArgument::OPTIONAL, 'The Bundle name or the extension alias'),
+                new InputArgument('name', InputArgument::OPTIONAL, 'The bundle name or the extension alias'),
             ))
             ->setDescription('Dumps the current configuration for an extension')
             ->setHelp(<<<EOF
-
 The <info>%command.name%</info> command dumps the current configuration for an
 extension/bundle.
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -48,7 +48,7 @@ Either the extension alias or bundle name can be used:
   <info>php %command.full_name% framework</info>
   <info>php %command.full_name% FrameworkBundle</info>
 
-With the <info>format</info> option specifies the format of the configuration,
+With the <info>--format</info> option specifies the format of the configuration,
 this is either <comment>yaml</comment> or <comment>xml</comment>.
 When the option is not provided, <comment>yaml</comment> is used.
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -61,7 +61,7 @@ class RouterDebugCommand extends ContainerAwareCommand
 The <info>%command.name%</info> displays the configured routes:
 
   <info>php %command.full_name%</info>
-
+  
 EOF
             )
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -60,7 +60,9 @@ class RouterMatchCommand extends ContainerAwareCommand
 The <info>%command.name%</info> shows which routes match a given request and which don't and for what reason:
 
   <info>php %command.full_name% /foo</info>
-  or
+  
+or
+
   <info>php %command.full_name% /foo --method POST --scheme https --host symfony.com --verbose</info>
 
 EOF

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -54,19 +54,19 @@ templates and translation files of a given bundle.
 
 You can display information about bundle translations in a specific locale:
 
-<info>php %command.full_name% en AcmeDemoBundle</info>
+  <info>php %command.full_name% en AcmeDemoBundle</info>
 
 You can also specify a translation domain for the search:
 
-<info>php %command.full_name% --domain=messages en AcmeDemoBundle</info>
+  <info>php %command.full_name% --domain=messages en AcmeDemoBundle</info>
 
 You can only display missing messages:
 
-<info>php %command.full_name% --only-missing en AcmeDemoBundle</info>
+  <info>php %command.full_name% --only-missing en AcmeDemoBundle</info>
 
 You can only display unused messages:
 
-<info>php %command.full_name% --only-unused en AcmeDemoBundle</info>
+  <info>php %command.full_name% --only-unused en AcmeDemoBundle</info>
 
 EOF
             )

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -43,20 +43,20 @@ the first encountered syntax error.
 
 You can validate the syntax of a file:
 
-<info>php %command.full_name% filename</info>
+  <info>php %command.full_name% filename</info>
 
 Or of a whole directory:
 
-<info>php %command.full_name% dirname</info>
-<info>php %command.full_name% dirname --format=json</info>
+  <info>php %command.full_name% dirname</info>
+  <info>php %command.full_name% dirname --format=json</info>
 
 Or all YAML files in a bundle:
 
-<info>php %command.full_name% @AcmeDemoBundle</info>
+  <info>php %command.full_name% @AcmeDemoBundle</info>
 
 You can also pass the YAML contents from STDIN:
 
-<info>cat filename | php %command.full_name%</info>
+  <info>cat filename | php %command.full_name%</info>
 
 EOF
             )

--- a/src/Symfony/Bundle/TwigBundle/Command/DebugCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/DebugCommand.php
@@ -37,15 +37,15 @@ class DebugCommand extends ContainerAwareCommand
 The <info>%command.name%</info> command outputs a list of twig functions,
 filters, globals and tests. Output can be filtered with an optional argument.
 
-<info>php %command.full_name%</info>
+  <info>php %command.full_name%</info>
 
 The command lists all functions, filters, etc.
 
-<info>php %command.full_name% date</info>
+  <info>php %command.full_name% date</info>
 
 The command lists everything that contains the word date.
 
-<info>php %command.full_name% --format=json</info>
+  <info>php %command.full_name% --format=json</info>
 
 The command lists everything in a machine readable json format.
 EOF

--- a/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
@@ -56,10 +56,10 @@ class LintCommand extends BaseLintCommand implements ContainerAwareInterface
             ->setHelp(
                 $this->getHelp().<<<EOF
 
-
 Or all template files in a bundle:
 
-<info>php %command.full_name% @AcmeDemoBundle</info>
+  <info>php %command.full_name% @AcmeDemoBundle</info>
+  
 EOF
             )
         ;


### PR DESCRIPTION
Follow up of https://github.com/symfony/symfony/pull/13231 for commands added in 2.4 and 2.5
