### PR TITLE
[Form] add back model_timezone and view_timezone options

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,13 +1,20 @@
 CHANGELOG
 =========
 
+2.6.2
+-----
+
+* Added back the `model_timezone` and `view_timezone` options for `TimeType`, `DateType`
+  and `BirthdayType`
+
 2.6.0
 -----
 
  * added "html5" option to Date, Time and DateTimeFormType to be able to
    enable/disable HTML5 input date when widget option is "single_text"
  * added "label_format" option with possible placeholders "%name%" and "%id%"
- * [BC BREAK] drop support for model_timezone and view_timezone options in TimeType, DateType and BirthdayType
+ * [BC BREAK] drop support for model_timezone and view_timezone options in TimeType, DateType and BirthdayType,
+   update to 2.6.2 to get back support for these options
 
 2.5.0
 ------

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -197,6 +197,8 @@ class TimeType extends AbstractType
             'input' => 'datetime',
             'with_minutes' => true,
             'with_seconds' => false,
+            'model_timezone' => null,
+            'view_timezone' => null,
             'empty_value' => $emptyValue, // deprecated
             'placeholder' => $placeholder,
             'html5' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -60,6 +60,8 @@ class DateTypeTest extends TestCase
     public function testSubmitFromSingleTextDateTimeWithDefaultFormat()
     {
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'datetime',
         ));
@@ -74,6 +76,8 @@ class DateTypeTest extends TestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'datetime',
         ));
@@ -88,6 +92,8 @@ class DateTypeTest extends TestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'string',
         ));
@@ -102,6 +108,8 @@ class DateTypeTest extends TestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'timestamp',
         ));
@@ -118,6 +126,8 @@ class DateTypeTest extends TestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'array',
         ));
@@ -137,6 +147,8 @@ class DateTypeTest extends TestCase
     public function testSubmitFromText()
     {
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'text',
         ));
 
@@ -157,6 +169,8 @@ class DateTypeTest extends TestCase
     public function testSubmitFromChoice()
     {
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -177,6 +191,8 @@ class DateTypeTest extends TestCase
     public function testSubmitFromChoiceEmpty()
     {
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
             'required' => false,
         ));
@@ -196,6 +212,8 @@ class DateTypeTest extends TestCase
     public function testSubmitFromInputDateTimeDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'datetime',
@@ -210,6 +228,8 @@ class DateTypeTest extends TestCase
     public function testSubmitFromInputStringDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'string',
@@ -224,6 +244,8 @@ class DateTypeTest extends TestCase
     public function testSubmitFromInputTimestampDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'timestamp',
@@ -240,6 +262,8 @@ class DateTypeTest extends TestCase
     public function testSubmitFromInputRawDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'array',
@@ -358,10 +382,25 @@ class DateTypeTest extends TestCase
 
     public function testSetDataWithDifferentNegativeUTCTimezoneDateTime()
     {
-        date_default_timezone_set('Pacific/Tahiti');
-
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Pacific/Tahiti',
+            'input' => 'string',
+            'widget' => 'single_text',
+        ));
+
+        $form->setData('2010-06-02');
+
+        $this->assertEquals('01.06.2010', $form->getViewData());
+    }
+
+    public function testSetDataWithDifferentTimezonesDateTime()
+    {
+        $form = $this->factory->create('date', null, array(
+            'format' => \IntlDateFormatter::MEDIUM,
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Pacific/Tahiti',
             'input' => 'datetime',
             'widget' => 'single_text',
         ));
@@ -371,7 +410,7 @@ class DateTypeTest extends TestCase
         $form->setData($dateTime);
 
         $this->assertDateTimeEquals($dateTime, $form->getData());
-        $this->assertEquals('02.06.2010', $form->getViewData());
+        $this->assertEquals('01.06.2010', $form->getViewData());
     }
 
     public function testSetDataWithDifferentPositiveUTCTimezoneDateTime()
@@ -520,6 +559,8 @@ class DateTypeTest extends TestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
         ));
 
@@ -533,6 +574,8 @@ class DateTypeTest extends TestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -550,6 +593,8 @@ class DateTypeTest extends TestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -567,6 +612,8 @@ class DateTypeTest extends TestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -18,25 +18,18 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class TimeTypeTest extends TestCase
 {
-    private $defaultTimezone;
-
     protected function setUp()
     {
         IntlTestHelper::requireIntl($this);
 
         parent::setUp();
-
-        $this->defaultTimezone = date_default_timezone_get();
-    }
-
-    protected function tearDown()
-    {
-        date_default_timezone_set($this->defaultTimezone);
     }
 
     public function testSubmitDateTime()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'datetime',
         ));
 
@@ -56,6 +49,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitString()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'string',
         ));
 
@@ -73,6 +68,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitTimestamp()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'timestamp',
         ));
 
@@ -92,6 +89,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitArray()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'array',
         ));
 
@@ -109,6 +108,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitDatetimeSingleText()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'widget' => 'single_text',
         ));
@@ -122,6 +123,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitDatetimeSingleTextWithoutMinutes()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'widget' => 'single_text',
             'with_minutes' => false,
@@ -136,6 +139,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitArraySingleText()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'array',
             'widget' => 'single_text',
         ));
@@ -154,6 +159,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitArraySingleTextWithoutMinutes()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'array',
             'widget' => 'single_text',
             'with_minutes' => false,
@@ -172,6 +179,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitArraySingleTextWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'array',
             'widget' => 'single_text',
             'with_seconds' => true,
@@ -192,6 +201,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitStringSingleText()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -205,6 +216,8 @@ class TimeTypeTest extends TestCase
     public function testSubmitStringSingleTextWithoutMinutes()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'string',
             'widget' => 'single_text',
             'with_minutes' => false,
@@ -219,6 +232,8 @@ class TimeTypeTest extends TestCase
     public function testSetDataWithoutMinutes()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'with_minutes' => false,
         ));
@@ -231,6 +246,8 @@ class TimeTypeTest extends TestCase
     public function testSetDataWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'with_seconds' => true,
         ));
@@ -240,23 +257,53 @@ class TimeTypeTest extends TestCase
         $this->assertEquals(array('hour' => 3, 'minute' => 4, 'second' => 5), $form->getViewData());
     }
 
-    public function testSetDataWithTimezoneDateTime()
+    public function testSetDataDifferentTimezones()
     {
-        date_default_timezone_set('Asia/Hong_Kong');
-
         $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Asia/Hong_Kong',
+            'input' => 'string',
+            'with_seconds' => true,
+        ));
+
+        $dateTime = new \DateTime('2013-01-01 12:04:05');
+        $dateTime->setTimezone(new \DateTimeZone('America/New_York'));
+
+        $form->setData($dateTime->format('H:i:s'));
+
+        $outputTime = clone $dateTime;
+        $outputTime->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        $displayedData = array(
+            'hour' => (int) $outputTime->format('H'),
+            'minute' => (int) $outputTime->format('i'),
+            'second' => (int) $outputTime->format('s'),
+        );
+
+        $this->assertEquals($displayedData, $form->getViewData());
+    }
+
+    public function testSetDataDifferentTimezonesDateTime()
+    {
+        $form = $this->factory->create('time', null, array(
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'datetime',
             'with_seconds' => true,
         ));
 
-        $dateTime = new \DateTime('12:04:05', new \DateTimeZone('America/New_York'));
+        $dateTime = new \DateTime('12:04:05');
+        $dateTime->setTimezone(new \DateTimeZone('America/New_York'));
 
         $form->setData($dateTime);
 
+        $outputTime = clone $dateTime;
+        $outputTime->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
         $displayedData = array(
-            'hour' => 12,
-            'minute' => 4,
-            'second' => 5,
+            'hour' => (int) $outputTime->format('H'),
+            'minute' => (int) $outputTime->format('i'),
+            'second' => (int) $outputTime->format('s'),
         );
 
         $this->assertDateTimeEquals($dateTime, $form->getData());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13224 |
| License | MIT |
| Doc PR | symfony/symfony-docs#4763 ~~TODO (deprecate the `model_timezone` and `view_timezone` options)~~ |

This reverts #12404.
