### PR TITLE
[2.6] cleanup deprecated uses

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -338,6 +339,23 @@ class XmlDescriptor extends Descriptor
 
         if ($definition->getFactoryMethod()) {
             $serviceXML->setAttribute('factory-method', $definition->getFactoryMethod());
+        }
+
+        if ($factory = $definition->getFactory()) {
+            $serviceXML->appendChild($factoryXML = $dom->createElement('factory'));
+
+            if (is_array($factory)) {
+                if ($factory[0] instanceof Reference) {
+                    $factoryXML->setAttribute('service', (string) $factory[0]);
+                } elseif ($factory[0] instanceof Definition) {
+                    throw new \InvalidArgumentException('Factory is not describable.');
+                } else {
+                    $factoryXML->setAttribute('class', $factory[0]);
+                }
+                $factoryXML->setAttribute('method', $factory[1]);
+            } else {
+                $factoryXML->setAttribute('function', $factory);
+            }
         }
 
         $serviceXML->setAttribute('scope', $definition->getScope());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -98,8 +99,7 @@ class ObjectsProvider
                 ->setLazy(true)
                 ->setSynchronized(true)
                 ->setAbstract(true)
-                ->setFactoryClass('Full\\Qualified\\FactoryClass')
-                ->setFactoryMethod('get'),
+                ->setFactory(array('Full\\Qualified\\FactoryClass', 'get')),
             'definition_2' => $definition2
                 ->setPublic(false)
                 ->setSynthetic(true)
@@ -110,8 +110,7 @@ class ObjectsProvider
                 ->addTag('tag1', array('attr1' => 'val1', 'attr2' => 'val2'))
                 ->addTag('tag1', array('attr3' => 'val3'))
                 ->addTag('tag2')
-                ->setFactoryService('factory.service')
-                ->setFactoryMethod('get'),
+                ->setFactory(array(new Reference('factory.service'), 'get')),
         );
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
@@ -2,6 +2,8 @@
 <container>
   <alias id="alias_1" service="service_1" public="true"/>
   <alias id="alias_2" service="service_2" public="false"/>
-  <definition id="definition_1" class="Full\Qualified\Class1" factory-class="Full\Qualified\FactoryClass" factory-method="get" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file=""/>
+  <definition id="definition_1" class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file="">
+    <factory class="Full\Qualified\FactoryClass" method="get"/>
+  </definition>
   <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
@@ -2,8 +2,11 @@
 <container>
   <alias id="alias_1" service="service_1" public="true"/>
   <alias id="alias_2" service="service_2" public="false"/>
-  <definition id="definition_1" class="Full\Qualified\Class1" factory-class="Full\Qualified\FactoryClass" factory-method="get" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file=""/>
-  <definition id="definition_2" class="Full\Qualified\Class2" factory-service="factory.service" factory-method="get" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+  <definition id="definition_1" class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file="">
+    <factory class="Full\Qualified\FactoryClass" method="get"/>
+  </definition>
+  <definition id="definition_2" class="Full\Qualified\Class2" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+    <factory service="factory.service" method="get"/>
     <tags>
       <tag name="tag1">
         <parameter name="attr1">val1</parameter>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container>
-  <definition id="definition_2" class="Full\Qualified\Class2" factory-service="factory.service" factory-method="get" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+  <definition id="definition_2" class="Full\Qualified\Class2" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+    <factory service="factory.service" method="get"/>
     <tags>
       <tag name="tag1">
         <parameter name="attr1">val1</parameter>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container>
   <tag name="tag1">
-    <definition id="definition_2" class="Full\Qualified\Class2" factory-service="factory.service" factory-method="get" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file"/>
+    <definition id="definition_2" class="Full\Qualified\Class2" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+      <factory service="factory.service" method="get"/>
+    </definition>
   </tag>
   <tag name="tag2">
-    <definition id="definition_2" class="Full\Qualified\Class2" factory-service="factory.service" factory-method="get" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file"/>
+    <definition id="definition_2" class="Full\Qualified\Class2" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+      <factory service="factory.service" method="get"/>
+    </definition>
   </tag>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definition class="Full\Qualified\Class1" factory-class="Full\Qualified\FactoryClass" factory-method="get" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file=""/>
+<definition class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file="">
+  <factory class="Full\Qualified\FactoryClass" method="get"/>
+</definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definition class="Full\Qualified\Class2" factory-service="factory.service" factory-method="get" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+<definition class="Full\Qualified\Class2" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+  <factory service="factory.service" method="get"/>
   <tags>
     <tag name="tag1">
       <parameter name="attr1">val1</parameter>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
@@ -26,8 +26,10 @@ class GlobalVariablesTest extends TestCase
         $this->globals = new GlobalVariables($this->container);
     }
 
-    public function testGetSecurity()
+    public function testLegacyGetSecurity()
     {
+        $this->iniSet('error_reporting', -1 & E_USER_DEPRECATED);
+
         $securityContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
 
         $this->assertNull($this->globals->getSecurity());

--- a/src/Symfony/Component/Debug/README.md
+++ b/src/Symfony/Component/Debug/README.md
@@ -24,7 +24,7 @@ if ('cli' !== php_sapi_name()) {
 } elseif (!ini_get('log_errors') || ini_get('error_log')) {
     ini_set('display_errors', 1);
 }
-ErrorHandler::register($errorReportingLevel);
+ErrorHandler::register();
 ```
 
 Note that the `Debug::enable()` call also registers the debug class loader

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -74,15 +74,15 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
             if ($definition->getFactoryService()) {
                 $this->processArguments(array(new Reference($definition->getFactoryService())));
             }
+            if (is_array($definition->getFactory())) {
+                $this->processArguments($definition->getFactory());
+            }
 
             if (!$this->onlyConstructorArguments) {
                 $this->processArguments($definition->getMethodCalls());
                 $this->processArguments($definition->getProperties());
                 if ($definition->getConfigurator()) {
                     $this->processArguments(array($definition->getConfigurator()));
-                }
-                if ($definition->getFactory()) {
-                    $this->processArguments(array($definition->getFactory()));
                 }
             }
         }
@@ -115,6 +115,9 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
                 $this->processArguments($argument->getMethodCalls());
                 $this->processArguments($argument->getProperties());
 
+                if (is_array($argument->getFactory())) {
+                    $this->processArguments($argument->getFactory());
+                }
                 if ($argument->getFactoryService()) {
                     $this->processArguments(array(new Reference($argument->getFactoryService())));
                 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -144,6 +144,10 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             return false;
         }
 
+        if (count($ids) > 1 && is_array($factory = $definition->getFactory()) && ($factory[0] instanceof Reference || $factory[0] instanceof Definition)) {
+            return false;
+        }
+
         if (count($ids) > 1 && $definition->getFactoryService()) {
             return false;
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -81,11 +81,9 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $def->setArguments($parentDef->getArguments());
         $def->setMethodCalls($parentDef->getMethodCalls());
         $def->setProperties($parentDef->getProperties());
-        if (null !== $parentDef->getFactoryMethod()) {
-            $def->setFactoryClass($parentDef->getFactoryClass());
-            $def->setFactoryMethod($parentDef->getFactoryMethod());
-            $def->setFactoryService($parentDef->getFactoryService());
-        }
+        $def->setFactoryClass($parentDef->getFactoryClass());
+        $def->setFactoryMethod($parentDef->getFactoryMethod());
+        $def->setFactoryService($parentDef->getFactoryService());
         $def->setFactory($parentDef->getFactory());
         $def->setConfigurator($parentDef->getConfigurator());
         $def->setFile($parentDef->getFile());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AnalyzeServiceReferencesPassTest.php
@@ -87,7 +87,7 @@ class AnalyzeServiceReferencesPassTest extends \PHPUnit_Framework_TestCase
         ;
 
         $factory = new Definition();
-        $factory->setFactoryService('a');
+        $factory->setFactory(array(new Reference('a'), 'a'));
 
         $container
             ->register('b')
@@ -124,13 +124,11 @@ class AnalyzeServiceReferencesPassTest extends \PHPUnit_Framework_TestCase
 
         $container
             ->register('foo', 'stdClass')
-            ->setFactoryClass('stdClass')
-            ->setFactoryMethod('getInstance');
+            ->setFactory(array('stdClass', 'getInstance'));
 
         $container
             ->register('bar', 'stdClass')
-            ->setFactoryService('foo')
-            ->setFactoryMethod('getInstance');
+            ->setFactory(array(new Reference('foo'), 'getInstance'));
 
         $graph = $this->process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
@@ -53,13 +53,11 @@ class CheckCircularReferencesPassTest extends \PHPUnit_Framework_TestCase
 
         $container
             ->register('a', 'stdClass')
-            ->setFactoryService('b')
-            ->setFactoryMethod('getInstance');
+            ->setFactory(array(new Reference('b'), 'getInstance'));
 
         $container
             ->register('b', 'stdClass')
-            ->setFactoryService('a')
-            ->setFactoryMethod('getInstance');
+            ->setFactory(array(new Reference('a'), 'getInstance'));
 
         $this->process($container);
     }
@@ -88,8 +86,7 @@ class CheckCircularReferencesPassTest extends \PHPUnit_Framework_TestCase
 
         $container
             ->register('b', 'stdClass')
-            ->setFactoryService('c')
-            ->setFactoryMethod('getInstance');
+            ->setFactory(array(new Reference('c'), 'getInstance'));
 
         $container->register('c')->addArgument(new Reference('a'));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -118,7 +118,7 @@ class InlineServiceDefinitionsPassTest extends \PHPUnit_Framework_TestCase
         $b = $container
             ->register('b')
             ->setPublic(false)
-            ->setFactoryService('a')
+            ->setFactory(array(new Reference('a'), 'a'))
         ;
 
         $container
@@ -142,7 +142,7 @@ class InlineServiceDefinitionsPassTest extends \PHPUnit_Framework_TestCase
         $container
             ->register('b')
             ->setPublic(false)
-            ->setFactoryService('a')
+            ->setFactory(array(new Reference('a'), 'a'))
         ;
 
         $container
@@ -168,12 +168,12 @@ class InlineServiceDefinitionsPassTest extends \PHPUnit_Framework_TestCase
         $container
             ->register('b')
             ->setPublic(false)
-            ->setFactoryService('a')
+            ->setFactory(array(new Reference('a'), 'a'))
         ;
 
         $inlineFactory = new Definition();
         $inlineFactory->setPublic(false);
-        $inlineFactory->setFactoryService('b');
+        $inlineFactory->setFactory(array(new Reference('b'), 'b'));
 
         $container
             ->register('foo')

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveUnusedDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveUnusedDefinitionsPassTest.php
@@ -86,14 +86,12 @@ class RemoveUnusedDefinitionsPassTest extends \PHPUnit_Framework_TestCase
 
         $container
             ->register('foo', 'stdClass')
-            ->setFactoryClass('stdClass')
-            ->setFactoryMethod('getInstance')
+            ->setFactory(array('stdClass', 'getInstance'))
             ->setPublic(false);
 
         $container
             ->register('bar', 'stdClass')
-            ->setFactoryService('foo')
-            ->setFactoryMethod('getInstance')
+            ->setFactory(array(new Reference('foo'), 'getInstance'))
             ->setPublic(false);
 
         $container

--- a/src/Symfony/Component/DependencyInjection/Tests/LegacyContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LegacyContainerBuilderTest.php
@@ -16,6 +16,11 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class LegacyContainerBuilderTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        $this->iniSet('error_reporting', -1 & E_USER_DEPRECATED);
+    }
+
     /**
      * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -242,7 +242,7 @@ class DateTimeType extends AbstractType
 
         // Don't add some defaults in order to preserve the defaults
         // set in DateType and TimeType
-        $resolver->setOptional(array(
+        $resolver->setDefined(array(
             'empty_value', // deprecated
             'placeholder',
             'years',

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -165,7 +165,7 @@ class FormType extends BaseType
 
         // If data is given, the form is locked to that data
         // (independent of its value)
-        $resolver->setOptional(array(
+        $resolver->setDefined(array(
             'data',
         ));
 

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.1",
         "symfony/intl": "~2.3",
-        "symfony/options-resolver": "~2.1",
+        "symfony/options-resolver": "~2.6",
         "symfony/property-access": "~2.3"
     },
     "require-dev": {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/LegacyPdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/LegacyPdoSessionHandlerTest.php
@@ -19,6 +19,8 @@ class LegacyPdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $this->iniSet('error_reporting', -1 & E_USER_DEPRECATED);
+
         if (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers())) {
             $this->markTestSkipped('This test requires SQLite support in your environment');
         }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Tests\DataCollector;
 
-use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 
 class LoggerDataCollectorTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SurrogateListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SurrogateListenerTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class EsiListenerTest extends \PHPUnit_Framework_TestCase
+class SurrogateListenerTest extends \PHPUnit_Framework_TestCase
 {
     public function testFilterDoesNothingForSubRequests()
     {

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -274,21 +274,21 @@ EOF;
         $this->assertEquals($expected, $output);
     }
 
-    public function testIsClassInActiveBundleFalse()
+    public function testLegacyIsClassInActiveBundleFalse()
     {
         $kernel = $this->getKernelMockForIsClassInActiveBundleTest();
 
         $this->assertFalse($kernel->isClassInActiveBundle('Not\In\Active\Bundle'));
     }
 
-    public function testIsClassInActiveBundleFalseNoNamespace()
+    public function testLegacyIsClassInActiveBundleFalseNoNamespace()
     {
         $kernel = $this->getKernelMockForIsClassInActiveBundleTest();
 
         $this->assertFalse($kernel->isClassInActiveBundle('NotNamespacedClass'));
     }
 
-    public function testIsClassInActiveBundleTrue()
+    public function testLegacyIsClassInActiveBundleTrue()
     {
         $kernel = $this->getKernelMockForIsClassInActiveBundleTest();
 
@@ -297,6 +297,8 @@ EOF;
 
     protected function getKernelMockForIsClassInActiveBundleTest()
     {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
         $bundle = new FooBarBundle();
 
         $kernel = $this->getKernel(array('getBundles'));

--- a/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
@@ -14,10 +14,7 @@ namespace Symfony\Component\OptionsResolver\Tests;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
 
-/**
- * @deprecated Deprecated since Symfony 2.6, to be removed in Symfony 3.0.
- */
-class OptionsResolverTest extends \PHPUnit_Framework_TestCase
+class LegacyOptionsResolverTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var OptionsResolver
@@ -26,6 +23,8 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
         $this->resolver = new OptionsResolver();
     }
 
@@ -701,5 +700,17 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
             'one' => '1',
             'three' => '3',
         ), $clone->resolve());
+    }
+
+    public function testOverloadReturnsThis()
+    {
+        $this->assertSame($this->resolver, $this->resolver->overload('foo', 'bar'));
+    }
+
+    public function testOverloadCallsSet()
+    {
+        $this->resolver->overload('foo', 'bar');
+
+        $this->assertSame(array('foo' => 'bar'), $this->resolver->resolve());
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsTest.php
@@ -14,10 +14,7 @@ namespace Symfony\Component\OptionsResolver\Tests;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @deprecated Deprecated since Symfony 2.6, to be removed in Symfony 3.0.
- */
-class OptionsTest extends \PHPUnit_Framework_TestCase
+class LegacyOptionsTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var OptionsResolver
@@ -26,6 +23,8 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $this->iniSet('error_reporting', -1 & E_USER_DEPRECATED);
+
         $this->options = new OptionsResolver();
     }
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -114,22 +114,6 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // overload()
-    ////////////////////////////////////////////////////////////////////////////
-
-    public function testOverloadReturnsThis()
-    {
-        $this->assertSame($this->resolver, $this->resolver->overload('foo', 'bar'));
-    }
-
-    public function testOverloadCallsSet()
-    {
-        $this->resolver->overload('foo', 'bar');
-
-        $this->assertSame(array('foo' => 'bar'), $this->resolver->resolve());
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
     // lazy setDefault()
     ////////////////////////////////////////////////////////////////////////////
 

--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -70,8 +70,6 @@ class SecurityContext implements SecurityContextInterface
     }
 
     /**
-     * @deprecated Deprecated since version 2.6, to be removed in 3.0. Use TokenStorageInterface::getToken() instead.
-     *
      * {@inheritdoc}
      */
     public function getToken()
@@ -80,8 +78,6 @@ class SecurityContext implements SecurityContextInterface
     }
 
     /**
-     * @deprecated Deprecated since version 2.6, to be removed in 3.0. Use TokenStorageInterface::setToken() instead.
-     *
      * {@inheritdoc}
      */
     public function setToken(TokenInterface $token = null)
@@ -90,8 +86,6 @@ class SecurityContext implements SecurityContextInterface
     }
 
     /**
-     * @deprecated Deprecated since version 2.6, to be removed in 3.0. Use AuthorizationCheckerInterface::isGranted() instead.
-     *
      * {@inheritdoc}
      */
     public function isGranted($attributes, $object = null)

--- a/src/Symfony/Component/Security/Tests/Core/LegacySecurityContextInterfaceTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/LegacySecurityContextInterfaceTest.php
@@ -14,15 +14,15 @@ namespace Symfony\Component\Security\Tests\Core;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Security;
 
-class SecurityContextInterfaceTest extends \PHPUnit_Framework_TestCase
+class LegacySecurityContextInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Test if the BC Layer is working as intended
-     *
-     * @deprecated Deprecated since version 2.6, to be removed in 3.0.
      */
     public function testConstantSync()
     {
+        $this->iniSet('error_reporting', -1 & E_USER_DEPRECATED);
+
         $this->assertSame(Security::ACCESS_DENIED_ERROR, SecurityContextInterface::ACCESS_DENIED_ERROR);
         $this->assertSame(Security::AUTHENTICATION_ERROR, SecurityContextInterface::AUTHENTICATION_ERROR);
         $this->assertSame(Security::LAST_USERNAME, SecurityContextInterface::LAST_USERNAME);

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -273,14 +273,6 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     /**
      * https://github.com/symfony/symfony/issues/11604.
      */
-    public function testGetMemberMetadatasReturnsEmptyArrayWithoutConfiguredMetadata()
-    {
-        $this->assertCount(0, $this->metadata->getMemberMetadatas('foo'), '->getMemberMetadatas() returns an empty collection if no metadata is configured for the given property');
-    }
-
-    /**
-     * https://github.com/symfony/symfony/issues/11604.
-     */
     public function testGetPropertyMetadataReturnsEmptyArrayWithoutConfiguredMetadata()
     {
         $this->assertCount(0, $this->metadata->getPropertyMetadata('foo'), '->getPropertyMetadata() returns an empty collection if no metadata is configured for the given property');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I wish again we could find a way to make deprecation authors do this job.
This is especially visible here: trying to use the new factory declaration enlightens holes in the implementation.
