### PR TITLE
[Serializer] Add circular reference handling to the PropertyNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
-use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 
 /**
@@ -38,64 +37,15 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
  */
 class GetSetMethodNormalizer extends AbstractNormalizer
 {
-    protected $circularReferenceLimit = 1;
-    protected $circularReferenceHandler;
-
-    /**
-     * Set circular reference limit.
-     *
-     * @param $circularReferenceLimit limit of iterations for the same object
-     *
-     * @return self
-     */
-    public function setCircularReferenceLimit($circularReferenceLimit)
-    {
-        $this->circularReferenceLimit = $circularReferenceLimit;
-
-        return $this;
-    }
-
-    /**
-     * Set circular reference handler.
-     *
-     * @param callable $circularReferenceHandler
-     *
-     * @return self
-     *
-     * @throws InvalidArgumentException
-     */
-    public function setCircularReferenceHandler($circularReferenceHandler)
-    {
-        if (!is_callable($circularReferenceHandler)) {
-            throw new InvalidArgumentException('The given circular reference handler is not callable.');
-        }
-
-        $this->circularReferenceHandler = $circularReferenceHandler;
-
-        return $this;
-    }
-
     /**
      * {@inheritdoc}
+     *
+     * @throws CircularReferenceException
      */
     public function normalize($object, $format = null, array $context = array())
     {
-        $objectHash = spl_object_hash($object);
-
-        if (isset($context['circular_reference_limit'][$objectHash])) {
-            if ($context['circular_reference_limit'][$objectHash] >= $this->circularReferenceLimit) {
-                unset($context['circular_reference_limit'][$objectHash]);
-
-                if ($this->circularReferenceHandler) {
-                    return call_user_func($this->circularReferenceHandler, $object);
-                }
-
-                throw new CircularReferenceException(sprintf('A circular reference has been detected (configured limit: %d).', $this->circularReferenceLimit));
-            }
-
-            $context['circular_reference_limit'][$objectHash]++;
-        } else {
-            $context['circular_reference_limit'][$objectHash] = 1;
+        if ($this->isCircularReference($object, $context)) {
+            return $this->handleCircularReference($object);
         }
 
         $reflectionObject = new \ReflectionObject($object);

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/PropertyCircularReferenceDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/PropertyCircularReferenceDummy.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class PropertyCircularReferenceDummy
+{
+    public $me;
+
+    public function __construct()
+    {
+        $this->me = $this;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/PropertySiblingHolder.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/PropertySiblingHolder.php
@@ -14,44 +14,26 @@ namespace Symfony\Component\Serializer\Tests\Fixtures;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class SiblingHolder
+class PropertySiblingHolder
 {
-    private $sibling0;
-    private $sibling1;
-    private $sibling2;
+    public $sibling0;
+    public $sibling1;
+    public $sibling2;
 
     public function __construct()
     {
-        $sibling = new Sibling();
+        $sibling = new PropertySibling();
 
         $this->sibling0 = $sibling;
         $this->sibling1 = $sibling;
         $this->sibling2 = $sibling;
-    }
-
-    public function getSibling0()
-    {
-        return $this->sibling0;
-    }
-
-    public function getSibling1()
-    {
-        return $this->sibling1;
-    }
-
-    public function getSibling2()
-    {
-        return $this->sibling2;
     }
 }
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class Sibling
+class PropertySibling
 {
-    public function getCoopTilleuls()
-    {
-        return 'Les-Tilleuls.coop';
-    }
+    public $coopTilleuls = 'Les-Tilleuls.coop';
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | n/a |

Move circular references handling to `AbstractNormalizer` and use it in `PropertyNormalizer`.
