### PR TITLE
[Validator] add german translation for checkDNS option

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -302,6 +302,10 @@
                 <source>An empty file is not allowed.</source>
                 <target>Eine leere Datei ist nicht erlaubt.</target>
             </trans-unit>
+            <trans-unit id="79">
+                <source>The host could not be resolved.</source>
+                <target>Der Hostname konnte nicht aufgelöst werden.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets |  |
| License | MIT |

German translation for the `checkDNS` option introduced in #12956.
