### PR TITLE
Deprecate the translator implementation in the Validator component

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -977,6 +977,22 @@ UPGRADE FROM 2.x to 3.0
    $plural = $violation->getPlural();
    ```
 
+ * The class `Symfony\Component\Validator\DefaultTranslator` was removed. You
+   should use `Symfony\Component\Translation\IdentityTranslator` instead.
+
+   Before:
+
+   ```php
+   $translator = new \Symfony\Component\Validator\DefaultTranslator();
+   ```
+
+   After:
+
+   ```php
+   $translator = new \Symfony\Component\Translation\IdentityTranslator();
+   $translator->setLocale('en');
+   ```
+
 ### Yaml
 
  * The ability to pass file names to `Yaml::parse()` has been removed.

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.7.0
+-----
+
+ * deprecated `DefaultTranslator` in favor of `Symfony\Component\Translation\IdentityTranslator`
+
 2.6.0
 -----
 

--- a/src/Symfony/Component/Validator/DefaultTranslator.php
+++ b/src/Symfony/Component/Validator/DefaultTranslator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator;
 
+trigger_error('The class '.__NAMESPACE__.'\DefaultTranslator is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Translation\IdentityTranslator instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Exception\BadMethodCallException;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
@@ -42,6 +44,8 @@ use Symfony\Component\Validator\Exception\InvalidArgumentException;
  * locales. Instead, it implements a subset of the capabilities of
  * {@link \Symfony\Component\Translation\Translator} and can be used in places
  * where translation is not required by default but should be optional.
+ *
+ * @deprecated since version 2.7, to be removed in 3.0. Use Symfony\Component\Translation\IdentityTranslator instead.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */

--- a/src/Symfony/Component/Validator/Tests/Validator/LegacyValidator2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/LegacyValidator2Dot5ApiTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Validator\Tests\Validator;
 
+use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\LegacyExecutionContextFactory;
-use Symfony\Component\Validator\DefaultTranslator;
 use Symfony\Component\Validator\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validator\LegacyValidator;
 
@@ -30,7 +30,10 @@ class LegacyValidator2Dot5ApiTest extends Abstract2Dot5ApiTest
 
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
-        $contextFactory = new LegacyExecutionContextFactory($metadataFactory, new DefaultTranslator());
+        $translator = new IdentityTranslator();
+        $translator->setLocale('en');
+
+        $contextFactory = new LegacyExecutionContextFactory($metadataFactory, $translator);
         $validatorFactory = new ConstraintValidatorFactory();
 
         return new LegacyValidator($contextFactory, $metadataFactory, $validatorFactory, $objectInitializers);

--- a/src/Symfony/Component/Validator/Tests/Validator/LegacyValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/LegacyValidatorLegacyApiTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Validator\Tests\Validator;
 
+use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\LegacyExecutionContextFactory;
-use Symfony\Component\Validator\DefaultTranslator;
 use Symfony\Component\Validator\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validator\LegacyValidator;
 
@@ -30,7 +30,10 @@ class LegacyValidatorLegacyApiTest extends AbstractLegacyApiTest
 
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
-        $contextFactory = new LegacyExecutionContextFactory($metadataFactory, new DefaultTranslator());
+        $translator = new IdentityTranslator();
+        $translator->setLocale('en');
+
+        $contextFactory = new LegacyExecutionContextFactory($metadataFactory, $translator);
         $validatorFactory = new ConstraintValidatorFactory();
 
         return new LegacyValidator($contextFactory, $metadataFactory, $validatorFactory, $objectInitializers);

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidator2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidator2Dot5ApiTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Validator\Tests\Validator;
 
+use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
-use Symfony\Component\Validator\DefaultTranslator;
 use Symfony\Component\Validator\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validator\RecursiveValidator;
 
@@ -21,7 +21,10 @@ class RecursiveValidator2Dot5ApiTest extends Abstract2Dot5ApiTest
 {
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
-        $contextFactory = new ExecutionContextFactory(new DefaultTranslator());
+        $translator = new IdentityTranslator();
+        $translator->setLocale('en');
+
+        $contextFactory = new ExecutionContextFactory($translator);
         $validatorFactory = new ConstraintValidatorFactory();
 
         return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $objectInitializers);

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Validator\Tests;
 
+use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
-use Symfony\Component\Validator\DefaultTranslator;
 use Symfony\Component\Validator\MetadataFactoryInterface;
 use Symfony\Component\Validator\Tests\Fixtures\Entity;
 use Symfony\Component\Validator\Tests\Validator\AbstractLegacyApiTest;
@@ -23,7 +23,10 @@ class ValidatorTest extends AbstractLegacyApiTest
 {
     protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = array())
     {
-        return new LegacyValidator($metadataFactory, new ConstraintValidatorFactory(), new DefaultTranslator(), 'validators', $objectInitializers);
+        $translator = new IdentityTranslator();
+        $translator->setLocale('en');
+
+        return new LegacyValidator($metadataFactory, new ConstraintValidatorFactory(), $translator, 'validators', $objectInitializers);
     }
 
     /**

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/translation": "~2.0,>=2.0.5|~3.0.0"
+        "symfony/translation": "~2.4|~3.0.0"
     },
     "require-dev": {
         "symfony/http-foundation": "~2.1|~3.0.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The Translation component already provides an implementation which only deals with replacing parameters in the message without translating it.
Duplicating the logic in the Validator component is not needed (and it is the wrong place for it).
