### PR TITLE
[Yaml] Improve YAML boolean escaping

### DIFF
--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -72,7 +72,15 @@ class Escaper
      */
     public static function requiresSingleQuoting($value)
     {
-        return self::containsCharRequiresSingleQuoting($value) || self::isValueRequiresSingleQuoting($value);
+        // Determines if the PHP value contains any single characters that would
+        // cause it to require single quoting in YAML.
+        if (preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ \- ? | < > = ! % @ ` ]/x', $value)) {
+            return true;
+        }
+
+        // Determines if a PHP value is entirely composed of a value that would
+        // require single quoting in YAML.
+        return in_array(strtolower($value), array('null', '~', 'true', 'false', 'y', 'n', 'yes', 'no', 'on', 'off'));
     }
 
     /**
@@ -85,31 +93,5 @@ class Escaper
     public static function escapeWithSingleQuotes($value)
     {
         return sprintf("'%s'", str_replace('\'', '\'\'', $value));
-    }
-
-    /**
-     * Determines if a PHP value contains any single characters that would cause
-     * the value to require single quoting in YAML.
-     *
-     * @param  string $value A PHP value
-     * @return bool          True if the value would require single quotes.
-     */
-    private static function containsCharRequiresSingleQuoting($value)
-    {
-        return preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ \- ? | < > = ! % @ ` ]/x', $value);
-    }
-
-    /**
-     * Determines if a PHP value is entirely composed of a value that would
-     * require single quoting in YAML.
-     *
-     * @param  string $value A PHP value
-     * @return bool          True if the value would require single quotes.
-     */
-    private static function isValueRequiresSingleQuoting($value)
-    {
-        // Note that whilst 'y' and 'n' are not supported as valid Booleans,
-        // they are escaped here for interoperability.
-        return in_array(strtolower($value), array('null', '~', 'true', 'false', 'y', 'n', 'yes', 'no', 'on', 'off'));
     }
 }

--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -72,7 +72,7 @@ class Escaper
      */
     public static function requiresSingleQuoting($value)
     {
-        return preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ \- ? | < > = ! % @ ` ]/x', $value);
+        return self::containsCharRequiresSingleQuoting($value) || self::isValueRequiresSingleQuoting($value);
     }
 
     /**
@@ -85,5 +85,29 @@ class Escaper
     public static function escapeWithSingleQuotes($value)
     {
         return sprintf("'%s'", str_replace('\'', '\'\'', $value));
+    }
+
+    /**
+     * Determines if a PHP value contains any single characters that would cause
+     * the value to require single quoting in YAML.
+     *
+     * @param  string $value A PHP value
+     * @return bool          True if the value would require single quotes.
+     */
+    private static function containsCharRequiresSingleQuoting($value)
+    {
+        return preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ \- ? | < > = ! % @ ` ]/x', $value);
+    }
+
+    /**
+     * Determines if a PHP value is entirely composed of a value that would
+     * require require single quoting in YAML.
+     *
+     * @param  string $value A PHP value
+     * @return bool          True if the value would require single quotes.
+     */
+    private static function isValueRequiresSingleQuoting($value)
+    {
+        return in_array(strtolower($value), array('null', '~', 'true', 'false', 'y', 'n', 'yes', 'no', 'on', 'off'));
     }
 }

--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -101,7 +101,7 @@ class Escaper
 
     /**
      * Determines if a PHP value is entirely composed of a value that would
-     * require require single quoting in YAML.
+     * require single quoting in YAML.
      *
      * @param  string $value A PHP value
      * @return bool          True if the value would require single quotes.

--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -108,6 +108,8 @@ class Escaper
      */
     private static function isValueRequiresSingleQuoting($value)
     {
+        // Note that whilst 'y' and 'n' are not supported as valid Booleans,
+        // they are escaped here for interoperability.
         return in_array(strtolower($value), array('null', '~', 'true', 'false', 'y', 'n', 'yes', 'no', 'on', 'off'));
     }
 }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -135,12 +135,10 @@ class Inline
             case Escaper::requiresDoubleQuoting($value):
                 return Escaper::escapeWithDoubleQuotes($value);
             case Escaper::requiresSingleQuoting($value):
+            case preg_match(self::getTimestampRegex(), $value):
                 return Escaper::escapeWithSingleQuotes($value);
             case '' == $value:
                 return "''";
-            case preg_match(self::getTimestampRegex(), $value):
-            case in_array(strtolower($value), array('null', '~', 'true', 'false')):
-                return "'$value'";
             default:
                 return $value;
         }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -190,6 +190,14 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             "'#cfcfcf'" => '#cfcfcf',
             '::form_base.html.twig' => '::form_base.html.twig',
 
+            // Pre-YAML-1.2 booleans
+            "'y'" => 'y',
+            "'n'" => 'n',
+            "'yes'" => 'yes',
+            "'no'" => 'no',
+            "'on'" => 'on',
+            "'off'" => 'off',
+
             '2007-10-30' => mktime(0, 0, 0, 10, 30, 2007),
             '2007-10-30T02:59:43Z' => gmmktime(2, 59, 43, 10, 30, 2007),
             '2007-10-30 02:59:43 Z' => gmmktime(2, 59, 43, 10, 30, 2007),
@@ -256,6 +264,14 @@ class InlineTest extends \PHPUnit_Framework_TestCase
 
             "'-dash'" => '-dash',
             "'-'" => '-',
+
+            // Pre-YAML-1.2 booleans
+            "'y'" => 'y',
+            "'n'" => 'n',
+            "'yes'" => 'yes',
+            "'no'" => 'no',
+            "'on'" => 'on',
+            "'off'" => 'off',
 
             // sequences
             '[foo, bar, false, null, 12]' => array('foo', 'bar', false, null, 12),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13209 |
| License | MIT |
| Doc PR | None |

This PR ensures that PHP [values which would be interpreted as booleans](http://yaml.org/type/bool.html) in older versions of the YAML spec are escaped with single quotes when dumped by the Dumper.

For example, dumping this:

``` php
array(
    'country_code' => 'no',
    'speaks_norwegian' => 'y',
    'heating' => 'on',
)
```

Will produce this YAML:

``` yaml
country_code: 'no'
speaks_norwegian: 'y'
heating: 'on'
```
