### PR TITLE
URL manipulations as a Twig extension

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 2.7.0
 -----
 
- * added an HttpFoundation extension (provides the `absolute_url` function)
+ * added an HttpFoundation extension (provides the `absolute_url` and the `relative_path` functions)
 
 2.5.0
 -----

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.7.0
+-----
+
+ * added an HttpFoundation extension (provides the `absolute_url` function)
+
 2.5.0
 -----
 

--- a/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Asset\Packages;
+
+/**
+ * Twig extension for the Symfony HttpFoundation component.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HttpFoundationExtension extends \Twig_Extension
+{
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('absolute_url', array($this, 'generateAbsoluteUrl')),
+        );
+    }
+
+    /**
+     * Returns the absolute URL for the given path.
+     *
+     * This method returns the path unchanged if no request is available.
+     *
+     * @param string $path The path
+     *
+     * @return string The absolute URL
+     */
+    public function generateAbsoluteUrl($path)
+    {
+        if (false !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
+            return $path;
+        }
+
+        if (!$request = $this->requestStack->getMasterRequest()) {
+            return $path;
+        }
+
+        return $request->getUriForPath($path);
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'request';
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use Symfony\Bridge\Twig\Extension\HttpFoundationExtension;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+
+class HttpFoundationExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getGenerateAbsoluteUrlData()
+     */
+    public function testGenerateAbsoluteUrl($expected, $path, $pathinfo)
+    {
+        $stack = new RequestStack();
+        $stack->push(Request::create($pathinfo));
+        $extension = new HttpFoundationExtension($stack);
+
+        $this->assertEquals($expected, $extension->generateAbsoluteUrl($path));
+    }
+
+    public function getGenerateAbsoluteUrlData()
+    {
+        return array(
+            array('http://localhost/foo.png', '/foo.png', '/foo/bar.html'),
+            array('http://localhost/foo/foo.png', 'foo.png', '/foo/bar.html'),
+            array('http://localhost/foo/foo.png', 'foo.png', '/foo/bar'),
+            array('http://localhost/foo/bar/foo.png', 'foo.png', '/foo/bar/'),
+
+            array('http://example.com/baz', 'http://example.com/baz', '/'),
+            array('https://example.com/baz', 'https://example.com/baz', '/'),
+            array('//example.com/baz', '//example.com/baz', '/'),
+        );
+    }
+
+    /**
+     * @dataProvider getGenerateRelativePathData()
+     */
+    public function testGenerateRelativePath($expected, $path, $pathinfo)
+    {
+        if (!method_exists('Symfony\Component\HttpFoundation\Request', 'getRelativeUriForPath')) {
+            $this->markTestSkipped('Your version of Symfony HttpFoundation is too old.');
+        }
+
+        $stack = new RequestStack();
+        $stack->push(Request::create($pathinfo));
+        $extension = new HttpFoundationExtension($stack);
+
+        $this->assertEquals($expected, $extension->generateRelativePath($path));
+    }
+
+    public function getGenerateRelativePathData()
+    {
+        return array(
+            array('../foo.png', '/foo.png', '/foo/bar.html'),
+            array('../baz/foo.png', '/baz/foo.png', '/foo/bar.html'),
+            array('baz/foo.png', 'baz/foo.png', '/foo/bar.html'),
+
+            array('http://example.com/baz', 'http://example.com/baz', '/'),
+            array('https://example.com/baz', 'https://example.com/baz', '/'),
+            array('//example.com/baz', '//example.com/baz', '/'),
+        );
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -42,5 +42,9 @@ class ExtensionPass implements CompilerPassInterface
         if ($container->has('fragment.handler')) {
             $container->getDefinition('twig.extension.httpkernel')->addTag('twig.extension');
         }
+
+        if ($container->has('request_stack')) {
+            $container->getDefinition('twig.extension.httpfoundation')->addTag('twig.extension');
+        }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -103,6 +103,9 @@
             <argument type="service" id="fragment.handler" />
         </service>
 
+        <service id="twig.extension.httpfoundation" class="Symfony\Bridge\Twig\Extension\HttpFoundationExtension" public="false">
+            <argument type="service" id="request_stack" />
+        </service>
 
         <service id="twig.extension.form" class="%twig.extension.form.class%" public="false">
             <argument type="service" id="twig.form.renderer" />

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -576,6 +576,26 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider getRelativeUriForPathData()
+     */
+    public function testGetRelativeUriForPath($expected, $pathinfo, $path)
+    {
+        $this->assertEquals($expected, Request::create($pathinfo)->getRelativeUriForPath($path));
+    }
+
+    public function getRelativeUriForPathData()
+    {
+        return array(
+            array('me.png', '/foo', '/me.png'),
+            array('../me.png', '/foo/bar', '/me.png'),
+            array('me.png', '/foo/bar', '/foo/me.png'),
+            array('../baz/me.png', '/foo/bar/b', '/foo/baz/me.png'),
+            array('../../fooz/baz/me.png', '/foo/bar/b', '/fooz/baz/me.png'),
+            array('baz/me.png', '/foo/bar/b', 'baz/me.png'),
+        );
+    }
+
+    /**
      * @covers Symfony\Component\HttpFoundation\Request::getUserInfo
      */
     public function testGetUserInfo()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#4805 |

While working on the new asset component, I realized that the "absolute URL" feature was misplaced and would benefit from being exposed as a Twig function (composition is always a good thing). Then, I wondered if having a Twig function to generate a relative path (like done by the Routing component would also make sense). And here is the corresponding PR.

``` jinja
{# generate an absolute URL for the given absolute path #}
{{ absolute_url('/me.png') }}

{# generate a relative path for the given absolute path (based on the current Request) #}
{{ relative_path('/foo/me.png') }}

{# compose as you see fit #}
{{ absolute_url(asset('me.png')) }}
```

As you can see, we require an absolute path for both functions (and we even add the leading slash if it is omitted), not sure if we want to do otherwise.

ping @tobion
