### PR TITLE
[Validator] - Added Timezone Constraint Validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+* This file is part of the Symfony package.
+*
+* (c) Fabien Potencier <fabien@symfony.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Mickaël Andrieu <andrieu.travail@gmail.com>
+ *
+ */
+class Timezone extends Constraint
+{
+    public $message = '"{{ value }}" is not a valid timezone.';
+}

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @author Mickaël Andrieu <andrieu.travail@gmail.com>
+ *
+ */
+class TimezoneValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof Timezone) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Timezone');
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (!in_array($value, \DateTimeZone::listIdentifiers(), true)) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -306,6 +306,10 @@
                 <source>The host could not be resolved.</source>
                 <target>The host could not be resolved.</target>
             </trans-unit>
+            <trans-unit id="80">
+                <source>"{{ value }}" is not a valid timezone.</source>
+                <target>"{{ value }}" is not a valid timezone.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -306,6 +306,10 @@
                 <source>The host could not be resolved.</source>
                 <target>Le nom de domaine n'a pas pu être résolu.</target>
             </trans-unit>
+            <trans-unit id="80">
+                <source>"{{ value }}" is not a valid timezone.</source>
+                <target>"{{ value }}" n'est pas un fuseau horaire valide.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Timezone;
+use Symfony\Component\Validator\Constraints\TimezoneValidator;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @author Mickaël Andrieu <andrieu.travail@gmail.com>
+ */
+class TimezoneValidatorTest extends AbstractConstraintValidatorTest
+{
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new TimezoneValidator();
+    }
+
+    public function testEuropeParisIsValid()
+    {
+        $this->validator->validate('Europe/Paris', new Timezone());
+
+        $this->assertNoViolation();
+    }
+
+    public function testAmericaIndianaIndianapolisIsValid()
+    {
+        $this->validator->validate('America/Indiana/Indianapolis', new Timezone());
+
+        $this->assertNoViolation();
+    }
+
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new Timezone());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->validator->validate('', new Timezone());
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getInvalidValues
+     */
+    public function testInvalidValues($value, $valueAsString)
+    {
+        $constraint = new Timezone(array(
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $valueAsString)
+            ->assertRaised();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
+    public function testExpectsStringCompatibleType()
+    {
+        $this->validator->validate(new \stdClass(), new Timezone());
+    }
+
+    public function getInvalidValues()
+    {
+        return array(
+            array('foobar', '"foobar"'),
+            array(0, '0'),
+            array(false, 'false'),
+            array(1234, '1234'),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | yes (symfony/symfony-docs#3907) |

comments: was previously, https://github.com/symfony/symfony/pull/11010. Re-created because I've deleted my old fork.

ping @webmozart  
