### PR TITLE
[Validator][Translation][ES] Spanish translation for checkDNS option

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -302,6 +302,10 @@
                 <source>An empty file is not allowed.</source>
                 <target>No está permitido un archivo vacío.</target>
             </trans-unit>
+            <trans-unit id="79">
+                <source>The host could not be resolved.</source>
+                <target>No se puede resolver el host.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Spanish translation for the `checkDNS` option introduced in #12956.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Doc PR | none |
