### PR TITLE
Enhance deprecation summary at end of tests

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -20,13 +20,19 @@ class DeprecationErrorHandler
         if (self::$isRegistered) {
             return;
         }
-        $deprecations = array(0);
-        $oldErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context) use (&$deprecations) {
+        $deprecations = array(
+            'remainingCount' => 0,
+            'legacyCount' => 0,
+            'otherCount' => 0,
+            'remaining' => array(),
+            'legacy' => array(),
+            'other' => array(),
+        );
+        $deprecationHandler = function ($type, $msg, $file, $line, $context) use (&$deprecations) {
             if (E_USER_DEPRECATED !== $type) {
                 return PHPUnit_Util_ErrorHandler::handleError($type, $msg, $file, $line, $context);
             }
 
-            ++$deprecations[0];
             $trace = debug_backtrace(PHP_VERSION_ID >= 50400 ? DEBUG_BACKTRACE_IGNORE_ARGS : false);
 
             $i = count($trace);
@@ -35,13 +41,24 @@ class DeprecationErrorHandler
             }
 
             if (isset($trace[$i]['class'])) {
-                if (isset($deprecations[$trace[$i]['class']][$trace[$i]['function']][$msg])) {
-                    ++$deprecations[$trace[$i]['class']][$trace[$i]['function']][$msg];
+                $class = $trace[$i]['class'];
+                $method = $trace[$i]['function'];
+
+                $type = 0 === strpos($method, 'testLegacy') || 0 === strpos($method, 'provideLegacy') || strpos($class, '\Legacy') ? 'legacy' : 'remaining';
+
+                if ('legacy' === $type && 0 === (error_reporting() & E_USER_DEPRECATED)) {
+                    @++$deprecations[$type]['Silenced']['count'];
                 } else {
-                    $deprecations[$trace[$i]['class']][$trace[$i]['function']][$msg] = 1;
+                    @++$deprecations[$type][$msg]['count'];
+                    @++$deprecations[$type][$msg][$class.'::'.$method];
                 }
+            } else {
+                $type = 'other';
+                @++$deprecations[$type][$msg]['count'];
             }
-        });
+            ++$deprecations[$type.'Count'];
+        };
+        $oldErrorHandler = set_error_handler($deprecationHandler);
 
         if (null !== $oldErrorHandler) {
             restore_error_handler();
@@ -51,31 +68,52 @@ class DeprecationErrorHandler
             }
         } else {
             self::$isRegistered = true;
-            register_shutdown_function(function () use (&$deprecations) {
-                if ($deprecations[0]) {
-                    if (function_exists('posix_isatty') && @posix_isatty(STDOUT)) {
-                        echo "\n\x1B[43;30mDeprecation notices ($deprecations[0]):\x1B[0m\n";
-                    } else {
-                        echo "\nDeprecation notices ($deprecations[0]):\n";
-                    }
+            register_shutdown_function(function () use (&$deprecations, $deprecationHandler) {
 
-                    foreach ($deprecations as $class => $notices) {
-                        if (0 !== $class) {
-                            echo "\n{$class}\n";
-                            foreach ($notices as $method => $notices) {
-                                echo "  ->{$method}()\n";
-                                foreach ($notices as $msg => $freq) {
-                                    echo "      {$msg}: $freq\n";
+                $colorize = new \SebastianBergmann\Environment\Console();
+
+                if ($colorize->hasColorSupport()) {
+                    $colorize = function ($str, $red) {
+                        $color = $red ? '41;37' : '43;30';
+
+                        return "\x1B[{$color}m{$str}\x1B[0m";
+                    };
+                } else {
+                    $colorize = function ($str) {return $str;};
+                }
+
+                $currErrorHandler = set_error_handler('var_dump');
+                restore_error_handler();
+
+                if ($currErrorHandler !== $deprecationHandler) {
+                    echo "\n", $colorize('THE ERROR HANDLER HAS CHANGED!', true), "\n";
+                }
+
+                $cmp = function ($a, $b) {
+                    return $b['count'] - $a['count'];
+                };
+
+                foreach (array('remaining', 'legacy', 'other') as $type) {
+                    if ($deprecations[$type]) {
+                        echo "\n", $colorize(sprintf('%s deprecation notices (%d)', ucfirst($type), $deprecations[$type.'Count']), 'legacy' !== $type), "\n";
+
+                        uasort($deprecations[$type], $cmp);
+
+                        foreach ($deprecations[$type] as $msg => $notices) {
+                            echo "\n", $msg, ': ', $notices['count'], "x\n";
+
+                            arsort($notices);
+
+                            foreach ($notices as $method => $count) {
+                                if ('count' !== $method) {
+                                    echo '    ', $count, 'x in ', preg_replace('/(.*)\\\\(.*?::.*?)$/', '$2 from $1', $method), "\n";
                                 }
                             }
                         }
                     }
-                } else {
-                    if (function_exists('posix_isatty') && @posix_isatty(STDOUT)) {
-                        echo "\n\x1B[42;30mNo deprecation notice\x1B[0m\n";
-                    } else {
-                        echo "\nNo deprecation notice\n";
-                    }
+                }
+                if (!empty($notices)) {
+                    echo "\n";
                 }
             });
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Splits deprecations triggered by legacy tests and non-legacy ones.
