### PR TITLE
[HttpKernel] deprecated ContainerAwareHttpKernel

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -25,6 +25,8 @@ use Symfony\Component\DependencyInjection\Scope;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since version 2.7, to be removed in 3.0.
  */
 class ContainerAwareHttpKernel extends HttpKernel
 {
@@ -55,8 +57,6 @@ class ContainerAwareHttpKernel extends HttpKernel
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
-        $request->headers->set('X-Php-Ob-Level', ob_get_level());
-
         $this->container->enterScope('request');
         $this->container->set('request', $request, 'request');
 

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -62,6 +62,8 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
+        $request->headers->set('X-Php-Ob-Level', ob_get_level());
+
         try {
             return $this->handleRaw($request, $type);
         } catch (\Exception $e) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

In Symfony 3.0, the `request` scope will be removed as the `request` is not a service anymore. So, the `ContainerAwareHttpKernel` should be deprecated now as it won't be needed anymore in 3.0. I've moved the only line of code that is still relevant in `HttpKernel` directly.

Note that I did not trigger a deprecation notice as the class is still used in Symfony 2.7.
