### PR TITLE
[Security] Don't destroy the session on buggy php releases.

### DIFF
--- a/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
@@ -47,7 +47,10 @@ class SessionAuthenticationStrategy implements SessionAuthenticationStrategyInte
                 return;
 
             case self::MIGRATE:
-                $request->getSession()->migrate(true);
+                // Destroying the old session is broken in php 5.4.0 - 5.4.10
+                // See php bug #63379
+                $destroy = PHP_VERSION_ID < 50400 || PHP_VERSION_ID >= 50411;
+                $request->getSession()->migrate($destroy);
 
                 return;
 

--- a/src/Symfony/Component/Security/Tests/Http/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Session/SessionAuthenticationStrategyTest.php
@@ -40,7 +40,7 @@ class SessionAuthenticationStrategyTest extends \PHPUnit_Framework_TestCase
     public function testSessionIsMigrated()
     {
         if (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50411) {
-            $this->markTestSkipped('We must not destroy the old session on php 5.4.0 - 5.4.10.');
+            $this->markTestSkipped('We cannot destroy the old session on PHP 5.4.0 - 5.4.10.');
         }
 
         $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
@@ -53,7 +53,7 @@ class SessionAuthenticationStrategyTest extends \PHPUnit_Framework_TestCase
     public function testSessionIsMigratedWithPhp54Workaround()
     {
         if (PHP_VERSION_ID < 50400 || PHP_VERSION_ID >= 50411) {
-            $this->markTestSkipped('This php version is not affected.');
+            $this->markTestSkipped('This PHP version is not affected.');
         }
 
         $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');

--- a/src/Symfony/Component/Security/Tests/Http/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Session/SessionAuthenticationStrategyTest.php
@@ -39,8 +39,25 @@ class SessionAuthenticationStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testSessionIsMigrated()
     {
+        if (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50411) {
+            $this->markTestSkipped('We must not destroy the old session on php 5.4.0 - 5.4.10.');
+        }
+
         $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
         $session->expects($this->once())->method('migrate')->with($this->equalTo(true));
+
+        $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE);
+        $strategy->onAuthentication($this->getRequest($session), $this->getToken());
+    }
+
+    public function testSessionIsMigratedWithPhp54Workaround()
+    {
+        if (PHP_VERSION_ID < 50400 || PHP_VERSION_ID >= 50411) {
+            $this->markTestSkipped('This php version is not affected.');
+        }
+
+        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session->expects($this->once())->method('migrate')->with($this->equalTo(false));
 
         $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE);
         $strategy->onAuthentication($this->getRequest($session), $this->getToken());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13269, #13283 |
| License | MIT |
| Doc PR | none |

See #13269 for the discussion. This workaround avoids destroying the old session after login on the migrate strategy when running under a php version that we know to be broken.

Corresponding php bug: https://bugs.php.net/bug.php?id=63379
