### PR TITLE
Update composer.json to autoload dump() global method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,10 @@
             "src/Symfony/Component/HttpFoundation/Resources/stubs",
             "src/Symfony/Component/Intl/Resources/stubs"
         ],
-        "files": [ "src/Symfony/Component/Intl/Resources/stubs/functions.php" ]
+        "files": [
+            "src/Symfony/Component/Intl/Resources/stubs/functions.php",
+            "src/Symfony/Component/VarDumper/Resources/functions/dump.php"
+        ]
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I am not sure if this is a bugfix or not but in the Symfony VarDump Component's composer.json it has an autoload call to [require the dump.php file](https://github.com/symfony/var-dumper/blob/09357c94ab8f68bcf1a92440f5588de36119f697/composer.json#L21)

Since symfony's root package doesn't have that autoload-file, you cannot use the dump() global function as described in [the component documentation](http://symfony.com/doc/current/components/var_dumper/introduction.html#the-dump-function)
