### PR TITLE
[Process] Fix input reset in WindowsPipes

### DIFF
--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -230,7 +230,7 @@ class WindowsPipes extends AbstractPipes
             if (false === $data || (true === $close && feof($r['input']) && '' === $data)) {
                 // no more data to read on input resource
                 // use an empty buffer in the next reads
-                unset($this->input);
+                $this->input = null;
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Unsetting the input property causes an E_NOTICE error when the
property is checked on line 249 (and is likely unintentional anyway).
