### PR TITLE
[Form] moved a deprecation notice

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Form\Extension\HttpFoundation\EventListener;
 
-trigger_error('The '.__NAMESPACE__.'\BindRequestListener class is deprecated since version 2.3 and will be removed in 3.0. Pass the Request instance to the \Symfony\Component\Form\Form::handleRequest() method instead.', E_USER_DEPRECATED);
-
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -43,6 +41,8 @@ class BindRequestListener implements EventSubscriberInterface
         if (!$request instanceof Request) {
             return;
         }
+
+        trigger_error('The '.__CLASS__.' class is deprecated since version 2.3 and will be removed in 3.0. Pass the Request instance to the \Symfony\Component\Form\Form::handleRequest() method instead.', E_USER_DEPRECATED);
 
         // Uncomment this as soon as the deprecation note should be shown
         // trigger_error('Passing a Request instance to Form::submit() is deprecated since version 2.3 and will be disabled in 3.0. Call Form::process($request) instead.', E_USER_DEPRECATED);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This deprecation notice on BindListener was wrongly put at the top of the class. This listener is always registered to provide BC, but the deprecation notice should only be generated when taking the path that is deprecated.
