### PR TITLE
[Form] fixed the CSRF extension to allow using only the new interfaces

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -128,6 +128,10 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
 
         // BC clause for the "csrf_provider" option
         $csrfTokenManager = function (Options $options) {
+            if ($options['csrf_provider'] instanceof CsrfTokenManagerInterface) {
+                return $options['csrf_provider'];
+            }
+
             return $options['csrf_provider'] instanceof CsrfTokenManagerAdapter
                 ? $options['csrf_provider']->getTokenManager()
                 : new CsrfProviderAdapter($options['csrf_provider']);
@@ -139,7 +143,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             'csrf_message' => 'The CSRF token is invalid. Please try to resubmit the form.',
             'csrf_token_manager' => $csrfTokenManager,
             'csrf_token_id' => $csrfTokenId,
-            'csrf_provider' => new CsrfTokenManagerAdapter($this->defaultTokenManager),
+            'csrf_provider' => $this->defaultTokenManager,
             'intention' => null,
         ));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The CSRF extension did not allow to only use the new interfaces, which leads to deprecation notices you cannot get rid of in 2.7.
