### PR TITLE
[HttpKernel][2.7] Add request uri to Logger context

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -140,7 +140,10 @@ class RouterListener implements EventSubscriberInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s"', $parameters['_route']), $parameters);
+                $this->logger->info(sprintf('Matched route "%s"', $parameters['_route']), array(
+                    'route_parameters' => $parameters,
+                    'request_uri' => $request->getUri(),
+                ));
             }
 
             $request->attributes->add($parameters);


### PR DESCRIPTION
... so host info does not get lost in the logging. The current situation does not allow the user, that receives a `Monolog` email for instance, to determine at which host an error occurred.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | - |
