### PR TITLE
[HttpKernel][2.6] Add request uri to Logger context

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -128,7 +128,8 @@ class RouterListener implements EventSubscriberInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
+                $logContext = $parameters + array('request-uri' => $request->getUri());
+                $this->logger->info(sprintf('Matched route "%s"', $parameters['_route']), $logContext);
             }
 
             $request->attributes->add($parameters);
@@ -148,16 +149,6 @@ class RouterListener implements EventSubscriberInterface
 
             throw new MethodNotAllowedHttpException($e->getAllowedMethods(), $message, $e);
         }
-    }
-
-    private function parametersToString(array $parameters)
-    {
-        $pieces = array();
-        foreach ($parameters as $key => $val) {
-            $pieces[] = sprintf('"%s": "%s"', $key, (is_string($val) ? $val : json_encode($val)));
-        }
-
-        return implode(', ', $pieces);
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
... so host info does not get lost in the logging. The current situation does not allow the user, that receives a `Monolog` email for instance, to determine at which host an error occurred.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | - |
