### PR TITLE
[Security] removed usage of the deprecated SecurityContextInterface

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Extension;
 
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * SecurityExtension exposes security context features.
@@ -21,16 +22,21 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  */
 class SecurityExtension extends \Twig_Extension
 {
-    private $context;
+    private $securityChecker;
 
-    public function __construct(SecurityContextInterface $context = null)
+    /**
+     * @param SecurityContextInterface|AuthorizationCheckerInterface
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     */
+    public function __construct($securityChecker = null)
     {
-        $this->context = $context;
+        $this->securityChecker = $securityChecker;
     }
 
     public function isGranted($role, $object = null, $field = null)
     {
-        if (null === $this->context) {
+        if (null === $this->securityChecker) {
             return false;
         }
 
@@ -38,7 +44,7 @@ class SecurityExtension extends \Twig_Extension
             $object = new FieldVote($object, $field);
         }
 
-        return $this->context->isGranted($role, $object);
+        return $this->securityChecker->isGranted($role, $object);
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Twig\Extension;
 
 use Symfony\Component\Security\Acl\Voter\FieldVote;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
@@ -24,12 +23,7 @@ class SecurityExtension extends \Twig_Extension
 {
     private $securityChecker;
 
-    /**
-     * @param SecurityContextInterface|AuthorizationCheckerInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($securityChecker = null)
+    public function __construct(AuthorizationCheckerInterface $securityChecker = null)
     {
         $this->securityChecker = $securityChecker;
     }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/security-csrf": "~2.4|~3.0.0",
+        "symfony/security-csrf": "~2.6|~3.0.0",
         "twig/twig": "~1.13,>=1.13.1"
     },
     "require-dev": {
@@ -29,7 +29,7 @@
         "symfony/templating": "~2.1|~3.0.0",
         "symfony/translation": "~2.2|~3.0.0",
         "symfony/yaml": "~2.0,>=2.0.5|~3.0.0",
-        "symfony/security": "~2.4|~3.0.0",
+        "symfony/security": "~2.6|~3.0.0",
         "symfony/stopwatch": "~2.2|~3.0.0",
         "symfony/console": "~2.4|~3.0.0",
         "symfony/var-dumper": "~2.6|~3.0.0",

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -11,7 +11,7 @@
 
         <service id="form.type_extension.csrf" class="Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension">
             <tag name="form.type_extension" alias="form" />
-            <argument type="service" id="form.csrf_provider" />
+            <argument type="service" id="security.csrf.token_manager" />
             <argument>%form.type_extension.csrf.enabled%</argument>
             <argument>%form.type_extension.csrf.field_name%</argument>
             <argument type="service" id="translator.default" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -115,7 +115,7 @@
 
         <service id="templating.form.renderer" class="%templating.form.renderer.class%" public="false">
             <argument type="service" id="templating.form.engine" />
-            <argument type="service" id="form.csrf_provider" on-invalid="null" />
+            <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
         </service>
 
         <service id="templating.globals" class="%templating.globals.class%">

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -52,7 +52,7 @@
     <services>
         <service id="security.authentication.listener.anonymous" class="%security.authentication.listener.anonymous.class%" public="false">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument /> <!-- Key -->
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="security.authentication.manager" />
@@ -82,7 +82,7 @@
 
         <service id="security.context_listener" class="%security.context_listener.class%" public="false">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="collection"></argument>
             <argument /> <!-- Provider Key -->
             <argument type="service" id="logger" on-invalid="null" />
@@ -90,7 +90,7 @@
         </service>
 
         <service id="security.logout_listener" class="%security.logout_listener.class%" public="false" abstract="true">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.http_utils" />
             <argument type="service" id="security.logout.success_handler" />
             <argument /> <!-- Options -->
@@ -109,7 +109,7 @@
 
         <service id="security.authentication.listener.abstract" abstract="true" public="false">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="security.authentication.session_strategy" />
             <argument type="service" id="security.http_utils" />
@@ -167,7 +167,7 @@
 
         <service id="security.authentication.listener.simple_preauth" class="%security.authentication.listener.simple_preauth.class%" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- Authenticator -->
@@ -177,7 +177,7 @@
 
         <service id="security.authentication.listener.x509" class="%security.authentication.listener.x509.class%" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- x509 user -->
@@ -188,7 +188,7 @@
 
         <service id="security.authentication.listener.remote_user" class="Symfony\Component\Security\Http\Firewall\RemoteUserAuthenticationListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- REMOTE_USER server env var -->
@@ -198,7 +198,7 @@
 
         <service id="security.authentication.listener.basic" class="%security.authentication.listener.basic.class%" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- Entry Point -->
@@ -207,7 +207,7 @@
 
         <service id="security.authentication.listener.digest" class="%security.authentication.listener.digest.class%" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument /> <!-- User Provider -->
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- Entry Point -->
@@ -235,7 +235,7 @@
 
         <service id="security.exception_listener" class="%security.exception_listener.class%" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.trust_resolver" />
             <argument type="service" id="security.http_utils" />
             <argument />
@@ -247,7 +247,7 @@
 
         <service id="security.authentication.switchuser_listener" class="%security.authentication.switchuser_listener.class%" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument /> <!-- User Provider -->
             <argument type="service" id="security.user_checker" />
             <argument /> <!--  Provider Key -->
@@ -260,7 +260,7 @@
 
         <service id="security.access_listener" class="%security.access_listener.class%" public="false">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.access.decision_manager" />
             <argument type="service" id="security.access_map" />
             <argument type="service" id="security.authentication.manager" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
@@ -19,7 +19,7 @@
     <services>
         <service id="security.authentication.listener.rememberme" class="%security.authentication.listener.rememberme.class%" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.rememberme" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="logger" on-invalid="null" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
@@ -18,7 +18,7 @@
 
         <service id="templating.helper.security" class="%templating.helper.security.class%">
             <tag name="templating.helper" alias="security" />
-            <argument type="service" id="security.context" on-invalid="ignore" />
+            <argument type="service" id="security.authorization_checker" on-invalid="ignore" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
@@ -17,7 +17,7 @@
 
         <service id="twig.extension.security" class="%twig.extension.security.class%" public="false">
             <tag name="twig.extension" />
-            <argument type="service" id="security.context" on-invalid="ignore" />
+            <argument type="service" id="security.authorization_checker" on-invalid="ignore" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/SecurityHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/SecurityHelper.php
@@ -14,29 +14,30 @@ namespace Symfony\Bundle\SecurityBundle\Templating\Helper;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
- * SecurityHelper provides read-only access to the security context.
+ * SecurityHelper provides read-only access to the security checker.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class SecurityHelper extends Helper
 {
-    private $context;
+    private $securityChecker;
 
     /**
-     * Constructor.
+     * @param SecurityContextInterface|AuthorizationCheckerInterface
      *
-     * @param SecurityContextInterface $context A SecurityContext instance
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
      */
-    public function __construct(SecurityContextInterface $context = null)
+    public function __construct($securityChecker = null)
     {
-        $this->context = $context;
+        $this->securityChecker = $securityChecker;
     }
 
     public function isGranted($role, $object = null, $field = null)
     {
-        if (null === $this->context) {
+        if (null === $this->securityChecker) {
             return false;
         }
 
@@ -44,7 +45,7 @@ class SecurityHelper extends Helper
             $object = new FieldVote($object, $field);
         }
 
-        return $this->context->isGranted($role, $object);
+        return $this->securityChecker->isGranted($role, $object);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/SecurityHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/SecurityHelper.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\SecurityBundle\Templating\Helper;
 
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Templating\Helper\Helper;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
@@ -25,12 +24,7 @@ class SecurityHelper extends Helper
 {
     private $securityChecker;
 
-    /**
-     * @param SecurityContextInterface|AuthorizationCheckerInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($securityChecker = null)
+    public function __construct(AuthorizationCheckerInterface $securityChecker = null)
     {
         $this->securityChecker = $securityChecker;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -25,9 +25,9 @@ class SecurityDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($collector->getUser());
     }
 
-    /** @dataProvider provideTokenStorage */
-    public function testCollectWhenAuthenticationTokenIsNull($tokenStorage)
+    public function testCollectWhenAuthenticationTokenIsNull()
     {
+        $tokenStorage = new TokenStorage();
         $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy());
         $collector->collect($this->getRequest(), $this->getResponse());
 
@@ -40,12 +40,21 @@ class SecurityDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($collector->getUser());
     }
 
-    public function provideTokenStorage()
+    public function testLegacyCollectWhenAuthenticationTokenIsNull()
     {
-        return array(
-            array(new TokenStorage()),
-            array($this->getMock('Symfony\Component\Security\Core\SecurityContextInterface')),
-        );
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy());
+        $collector->collect($this->getRequest(), $this->getResponse());
+
+        $this->assertTrue($collector->isEnabled());
+        $this->assertFalse($collector->isAuthenticated());
+        $this->assertNull($collector->getTokenClass());
+        $this->assertTrue($collector->supportsRoleHierarchy());
+        $this->assertCount(0, $collector->getRoles());
+        $this->assertCount(0, $collector->getInheritedRoles());
+        $this->assertEmpty($collector->getUser());
     }
 
     /** @dataProvider provideRoles */

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LocalizedController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LocalizedController.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller;
 
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\DependencyInjection\ContainerAware;
@@ -21,15 +21,15 @@ class LocalizedController extends ContainerAware
     public function loginAction(Request $request)
     {
         // get the login error if there is one
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(Security::AUTHENTICATION_ERROR);
         } else {
-            $error = $request->getSession()->get(SecurityContext::AUTHENTICATION_ERROR);
+            $error = $request->getSession()->get(Security::AUTHENTICATION_ERROR);
         }
 
         return $this->container->get('templating')->renderResponse('FormLoginBundle:Localized:login.html.twig', array(
             // last username entered by the user
-            'last_username' => $request->getSession()->get(SecurityContext::LAST_USERNAME),
+            'last_username' => $request->getSession()->get(Security::LAST_USERNAME),
             'error' => $error,
         ));
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\DependencyInjection\ContainerAware;
 
 class LoginController extends ContainerAware
@@ -22,15 +22,15 @@ class LoginController extends ContainerAware
     public function loginAction(Request $request)
     {
         // get the login error if there is one
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(Security::AUTHENTICATION_ERROR);
         } else {
-            $error = $request->getSession()->get(SecurityContext::AUTHENTICATION_ERROR);
+            $error = $request->getSession()->get(Security::AUTHENTICATION_ERROR);
         }
 
         return $this->container->get('templating')->renderResponse('FormLoginBundle:Login:login.html.twig', array(
             // last username entered by the user
-            'last_username' => $request->getSession()->get(SecurityContext::LAST_USERNAME),
+            'last_username' => $request->getSession()->get(Security::LAST_USERNAME),
             'error' => $error,
         ));
     }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/security": "~2.6|~3.0.0",
+        "symfony/security": "~2.7|~3.0.0",
         "symfony/http-kernel": "~2.2|~3.0.0"
     },
     "require-dev": {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -114,7 +114,7 @@
 
         <service id="twig.form.renderer" class="%twig.form.renderer.class%" public="false">
             <argument type="service" id="twig.form.engine" />
-            <argument type="service" id="form.csrf_provider" on-invalid="null" />
+            <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
         </service>
 
         <service id="twig.translation.extractor" class="%twig.translation.extractor.class%">

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfTokenManagerAdapter.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfTokenManagerAdapter.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Form\Extension\Csrf\CsrfProvider;
 
-trigger_error('The '.__NAMESPACE__.'\CsrfTokenManagerAdapter is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', E_USER_DEPRECATED);
-
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
@@ -36,8 +34,12 @@ class CsrfTokenManagerAdapter implements CsrfProviderInterface
         $this->tokenManager = $tokenManager;
     }
 
-    public function getTokenManager()
+    public function getTokenManager($triggerDeprecationError = true)
     {
+        if ($triggerDeprecationError) {
+            trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', E_USER_DEPRECATED);
+        }
+
         return $this->tokenManager;
     }
 
@@ -46,6 +48,8 @@ class CsrfTokenManagerAdapter implements CsrfProviderInterface
      */
     public function generateCsrfToken($intention)
     {
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', E_USER_DEPRECATED);
+
         return $this->tokenManager->getToken($intention)->getValue();
     }
 
@@ -54,6 +58,8 @@ class CsrfTokenManagerAdapter implements CsrfProviderInterface
      */
     public function isCsrfTokenValid($intention, $token)
     {
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', E_USER_DEPRECATED);
+
         return $this->tokenManager->isTokenValid(new CsrfToken($intention, $token));
     }
 }

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -133,7 +133,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             }
 
             return $options['csrf_provider'] instanceof CsrfTokenManagerAdapter
-                ? $options['csrf_provider']->getTokenManager()
+                ? $options['csrf_provider']->getTokenManager(false)
                 : new CsrfProviderAdapter($options['csrf_provider']);
         };
 

--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core;
 
+trigger_error('The '.__NAMESPACE__.'\SecurityContext class is deprecated since version 2.6 and will be removed in 3.0. Use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage or Symfony\Component\Security\Core\Authorization\AuthorizationChecker instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -76,8 +78,6 @@ class SecurityContext implements SecurityContextInterface
      */
     public function getToken()
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage::getToken() method instead.', E_USER_DEPRECATED);
-
         return $this->tokenStorage->getToken();
     }
 
@@ -88,8 +88,6 @@ class SecurityContext implements SecurityContextInterface
      */
     public function setToken(TokenInterface $token = null)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage::setToken() method instead.', E_USER_DEPRECATED);
-
         return $this->tokenStorage->setToken($token);
     }
 
@@ -100,8 +98,6 @@ class SecurityContext implements SecurityContextInterface
      */
     public function isGranted($attributes, $object = null)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface::isGranted() method instead.', E_USER_DEPRECATED);
-
         return $this->authorizationChecker->isGranted($attributes, $object);
     }
 }

--- a/src/Symfony/Component/Security/Core/SecurityContextInterface.php
+++ b/src/Symfony/Component/Security/Core/SecurityContextInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core;
 
+trigger_error('The '.__NAMESPACE__.'\SecurityContextInterface interface is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 

--- a/src/Symfony/Component/Security/Core/Tests/LegacySecurityContextTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/LegacySecurityContextTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 use Symfony\Component\Security\Core\SecurityContext;
 
-class SecurityContextTest extends \PHPUnit_Framework_TestCase
+class LegacySecurityContextTest extends \PHPUnit_Framework_TestCase
 {
     private $tokenStorage;
     private $authorizationChecker;
@@ -23,6 +23,8 @@ class SecurityContextTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
         $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         $this->authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         $this->securityContext = new SecurityContext($this->tokenStorage, $this->authorizationChecker);

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Tests\Validator\Constraints;
 
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
 use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest;
@@ -28,9 +28,9 @@ abstract class UserPasswordValidatorTest extends AbstractConstraintValidatorTest
     const SALT = '^S4lt$';
 
     /**
-     * @var SecurityContextInterface
+     * @var TokenStorageInterface
      */
-    protected $securityContext;
+    protected $tokenStorage;
 
     /**
      * @var PasswordEncoderInterface
@@ -44,13 +44,13 @@ abstract class UserPasswordValidatorTest extends AbstractConstraintValidatorTest
 
     protected function createValidator()
     {
-        return new UserPasswordValidator($this->securityContext, $this->encoderFactory);
+        return new UserPasswordValidator($this->tokenStorage, $this->encoderFactory);
     }
 
     protected function setUp()
     {
         $user = $this->createUser();
-        $this->securityContext = $this->createSecurityContext($user);
+        $this->tokenStorage = $this->createTokenStorage($user);
         $this->encoder = $this->createPasswordEncoder();
         $this->encoderFactory = $this->createEncoderFactory($this->encoder);
 
@@ -97,7 +97,7 @@ abstract class UserPasswordValidatorTest extends AbstractConstraintValidatorTest
     {
         $user = $this->getMock('Foo\Bar\User');
 
-        $this->securityContext = $this->createSecurityContext($user);
+        $this->tokenStorage = $this->createTokenStorage($user);
         $this->validator = $this->createValidator();
         $this->validator->initialize($this->context);
 
@@ -141,11 +141,11 @@ abstract class UserPasswordValidatorTest extends AbstractConstraintValidatorTest
         return $mock;
     }
 
-    protected function createSecurityContext($user = null)
+    protected function createTokenStorage($user = null)
     {
         $token = $this->createAuthenticationToken($user);
 
-        $mock = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $mock = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         $mock
             ->expects($this->any())
             ->method('getToken')

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Core\Validator\Constraints;
 
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Validator\Constraint;
@@ -25,12 +24,7 @@ class UserPasswordValidator extends ConstraintValidator
     private $tokenStorage;
     private $encoderFactory;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, EncoderFactoryInterface $encoderFactory)
+    public function __construct(TokenStorageInterface $tokenStorage, EncoderFactoryInterface $encoderFactory)
     {
         $this->tokenStorage = $tokenStorage;
         $this->encoderFactory = $encoderFactory;

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Core\Validator\Constraints;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
@@ -21,12 +22,17 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class UserPasswordValidator extends ConstraintValidator
 {
-    private $securityContext;
+    private $tokenStorage;
     private $encoderFactory;
 
-    public function __construct(SecurityContextInterface $securityContext, EncoderFactoryInterface $encoderFactory)
+    /**
+     * @param SecurityContextInterface|TokenStorageInterface
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     */
+    public function __construct($tokenStorage, EncoderFactoryInterface $encoderFactory)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->encoderFactory = $encoderFactory;
     }
 
@@ -39,7 +45,7 @@ class UserPasswordValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\UserPassword');
         }
 
-        $user = $this->securityContext->getToken()->getUser();
+        $user = $this->tokenStorage->getToken()->getUser();
 
         if (!$user instanceof UserInterface) {
             throw new ConstraintDefinitionException('The User object must implement the UserInterface interface.');

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -16,7 +16,6 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -67,23 +66,21 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     /**
      * Constructor.
      *
-     * @param SecurityContextInterface|TokenStorageInterface $tokenStorage          A SecurityContext or a TokenStorageInterface instance
-     * @param AuthenticationManagerInterface                 $authenticationManager An AuthenticationManagerInterface instance
-     * @param SessionAuthenticationStrategyInterface         $sessionStrategy
-     * @param HttpUtils                                      $httpUtils             An HttpUtilsInterface instance
-     * @param string                                         $providerKey
-     * @param AuthenticationSuccessHandlerInterface          $successHandler
-     * @param AuthenticationFailureHandlerInterface          $failureHandler
-     * @param array                                          $options               An array of options for the processing of a
-     *                                                                              successful, or failed authentication attempt
-     * @param LoggerInterface                                $logger                A LoggerInterface instance
-     * @param EventDispatcherInterface                       $dispatcher            An EventDispatcherInterface instance
+     * @param TokenStorageInterface                  $tokenStorage          A TokenStorageInterface instance
+     * @param AuthenticationManagerInterface         $authenticationManager An AuthenticationManagerInterface instance
+     * @param SessionAuthenticationStrategyInterface $sessionStrategy
+     * @param HttpUtils                              $httpUtils             An HttpUtilsInterface instance
+     * @param string                                 $providerKey
+     * @param AuthenticationSuccessHandlerInterface  $successHandler
+     * @param AuthenticationFailureHandlerInterface  $failureHandler
+     * @param array                                  $options               An array of options for the processing of a
+     *                                                                      successful, or failed authentication attempt
+     * @param LoggerInterface                        $logger                A LoggerInterface instance
+     * @param EventDispatcherInterface               $dispatcher            An EventDispatcherInterface instance
      *
      * @throws \InvalidArgumentException
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
      */
-    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -39,12 +38,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
     private $providerKey;
     private $dispatcher;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->tokenStorage = $tokenStorage;
         $this->authenticationManager = $authenticationManager;

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
@@ -32,12 +31,7 @@ class AccessListener implements ListenerInterface
     private $map;
     private $authManager;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, AccessDecisionManagerInterface $accessDecisionManager, AccessMapInterface $map, AuthenticationManagerInterface $authManager)
+    public function __construct(TokenStorageInterface $tokenStorage, AccessDecisionManagerInterface $accessDecisionManager, AccessMapInterface $map, AuthenticationManagerInterface $authManager)
     {
         $this->tokenStorage = $tokenStorage;
         $this->accessDecisionManager = $accessDecisionManager;

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Psr\Log\LoggerInterface;
@@ -26,14 +27,19 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
  */
 class AnonymousAuthenticationListener implements ListenerInterface
 {
-    private $context;
+    private $tokenStorage;
     private $key;
     private $authenticationManager;
     private $logger;
 
-    public function __construct(SecurityContextInterface $context, $key, LoggerInterface $logger = null, AuthenticationManagerInterface $authenticationManager = null)
+    /**
+     * @param SecurityContextInterface|TokenStorageInterface
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     */
+    public function __construct($tokenStorage, $key, LoggerInterface $logger = null, AuthenticationManagerInterface $authenticationManager = null)
     {
-        $this->context = $context;
+        $this->tokenStorage = $tokenStorage;
         $this->key = $key;
         $this->authenticationManager = $authenticationManager;
         $this->logger = $logger;
@@ -46,7 +52,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
      */
     public function handle(GetResponseEvent $event)
     {
-        if (null !== $this->context->getToken()) {
+        if (null !== $this->tokenStorage->getToken()) {
             return;
         }
 
@@ -56,10 +62,10 @@ class AnonymousAuthenticationListener implements ListenerInterface
                 $token = $this->authenticationManager->authenticate($token);
             }
 
-            $this->context->setToken($token);
+            $this->tokenStorage->setToken($token);
 
             if (null !== $this->logger) {
-                $this->logger->info('Populated SecurityContext with an anonymous Token');
+                $this->logger->info('Populated TokenStorage with an anonymous Token');
             }
         } catch (AuthenticationException $failed) {
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
@@ -32,12 +31,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
     private $authenticationManager;
     private $logger;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, $key, LoggerInterface $logger = null, AuthenticationManagerInterface $authenticationManager = null)
+    public function __construct(TokenStorageInterface $tokenStorage, $key, LoggerInterface $logger = null, AuthenticationManagerInterface $authenticationManager = null)
     {
         $this->tokenStorage = $tokenStorage;
         $this->key = $key;

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
@@ -34,12 +33,7 @@ class BasicAuthenticationListener implements ListenerInterface
     private $logger;
     private $ignoreFailure;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, AuthenticationEntryPointInterface $authenticationEntryPoint, LoggerInterface $logger = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, AuthenticationEntryPointInterface $authenticationEntryPoint, LoggerInterface $logger = null)
     {
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -20,7 +20,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -40,12 +39,7 @@ class ContextListener implements ListenerInterface
     private $dispatcher;
     private $registered;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, array $userProviders, $contextKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(TokenStorageInterface $tokenStorage, array $userProviders, $contextKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         if (empty($contextKey)) {
             throw new \InvalidArgumentException('$contextKey must not be empty.');

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint;
 use Psr\Log\LoggerInterface;
@@ -38,12 +37,7 @@ class DigestAuthenticationListener implements ListenerInterface
     private $authenticationEntryPoint;
     private $logger;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, UserProviderInterface $provider, $providerKey, DigestAuthenticationEntryPoint $authenticationEntryPoint, LoggerInterface $logger = null)
+    public function __construct(TokenStorageInterface $tokenStorage, UserProviderInterface $provider, $providerKey, DigestAuthenticationEntryPoint $authenticationEntryPoint, LoggerInterface $logger = null)
     {
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
@@ -31,19 +32,24 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  */
 class DigestAuthenticationListener implements ListenerInterface
 {
-    private $securityContext;
+    private $tokenStorage;
     private $provider;
     private $providerKey;
     private $authenticationEntryPoint;
     private $logger;
 
-    public function __construct(SecurityContextInterface $securityContext, UserProviderInterface $provider, $providerKey, DigestAuthenticationEntryPoint $authenticationEntryPoint, LoggerInterface $logger = null)
+    /**
+     * @param SecurityContextInterface|TokenStorageInterface
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     */
+    public function __construct($tokenStorage, UserProviderInterface $provider, $providerKey, DigestAuthenticationEntryPoint $authenticationEntryPoint, LoggerInterface $logger = null)
     {
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');
         }
 
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->provider = $provider;
         $this->providerKey = $providerKey;
         $this->authenticationEntryPoint = $authenticationEntryPoint;
@@ -67,7 +73,7 @@ class DigestAuthenticationListener implements ListenerInterface
 
         $digestAuth = new DigestData($header);
 
-        if (null !== $token = $this->securityContext->getToken()) {
+        if (null !== $token = $this->tokenStorage->getToken()) {
             if ($token instanceof UsernamePasswordToken && $token->isAuthenticated() && $token->getUsername() === $digestAuth->getUsername()) {
                 return;
             }
@@ -119,14 +125,14 @@ class DigestAuthenticationListener implements ListenerInterface
             $this->logger->info(sprintf('Authentication success for user "%s" with response "%s"', $digestAuth->getUsername(), $digestAuth->getResponse()));
         }
 
-        $this->securityContext->setToken(new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey));
+        $this->tokenStorage->setToken(new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey));
     }
 
     private function fail(GetResponseEvent $event, Request $request, AuthenticationException $authException)
     {
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
         if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey()) {
-            $this->securityContext->setToken(null);
+            $this->tokenStorage->setToken(null);
         }
 
         if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
@@ -49,12 +48,7 @@ class ExceptionListener
     private $logger;
     private $httpUtils;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, AuthenticationTrustResolverInterface $trustResolver, HttpUtils $httpUtils, $providerKey, AuthenticationEntryPointInterface $authenticationEntryPoint = null, $errorPage = null, AccessDeniedHandlerInterface $accessDeniedHandler = null, LoggerInterface $logger = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationTrustResolverInterface $trustResolver, HttpUtils $httpUtils, $providerKey, AuthenticationEntryPointInterface $authenticationEntryPoint = null, $errorPage = null, AccessDeniedHandlerInterface $accessDeniedHandler = null, LoggerInterface $logger = null)
     {
         $this->tokenStorage = $tokenStorage;
         $this->accessDeniedHandler = $accessDeniedHandler;

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -43,15 +42,13 @@ class LogoutListener implements ListenerInterface
     /**
      * Constructor.
      *
-     * @param SecurityContextInterface|TokenStorageInterface $tokenStorage
-     * @param HttpUtils                                      $httpUtils        An HttpUtilsInterface instance
-     * @param LogoutSuccessHandlerInterface                  $successHandler   A LogoutSuccessHandlerInterface instance
-     * @param array                                          $options          An array of options to process a logout attempt
-     * @param CsrfTokenManagerInterface                      $csrfTokenManager A CsrfTokenManagerInterface instance
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     * @param TokenStorageInterface         $tokenStorage
+     * @param HttpUtils                     $httpUtils        An HttpUtilsInterface instance
+     * @param LogoutSuccessHandlerInterface $successHandler   A LogoutSuccessHandlerInterface instance
+     * @param array                         $options          An array of options to process a logout attempt
+     * @param CsrfTokenManagerInterface     $csrfTokenManager A CsrfTokenManagerInterface instance
      */
-    public function __construct($tokenStorage, HttpUtils $httpUtils, LogoutSuccessHandlerInterface $successHandler, array $options = array(), $csrfTokenManager = null)
+    public function __construct(TokenStorageInterface $tokenStorage, HttpUtils $httpUtils, LogoutSuccessHandlerInterface $successHandler, array $options = array(), $csrfTokenManager = null)
     {
         if ($csrfTokenManager instanceof CsrfProviderInterface) {
             $csrfTokenManager = new CsrfProviderAdapter($csrfTokenManager);

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -39,16 +38,14 @@ class RememberMeListener implements ListenerInterface
     /**
      * Constructor.
      *
-     * @param SecurityContextInterface|TokenStorageInterface $tokenStorage
-     * @param RememberMeServicesInterface                    $rememberMeServices
-     * @param AuthenticationManagerInterface                 $authenticationManager
-     * @param LoggerInterface                                $logger
-     * @param EventDispatcherInterface                       $dispatcher
-     * @param bool                                           $catchExceptions
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     * @param TokenStorageInterface          $tokenStorage
+     * @param RememberMeServicesInterface    $rememberMeServices
+     * @param AuthenticationManagerInterface $authenticationManager
+     * @param LoggerInterface                $logger
+     * @param EventDispatcherInterface       $dispatcher
+     * @param bool                           $catchExceptions
      */
-    public function __construct($tokenStorage, RememberMeServicesInterface $rememberMeServices, AuthenticationManagerInterface $authenticationManager, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $catchExceptions = true)
+    public function __construct(TokenStorageInterface $tokenStorage, RememberMeServicesInterface $rememberMeServices, AuthenticationManagerInterface $authenticationManager, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $catchExceptions = true)
     {
         $this->tokenStorage = $tokenStorage;
         $this->rememberMeServices = $rememberMeServices;

--- a/src/Symfony/Component/Security/Http/Firewall/RemoteUserAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RemoteUserAuthenticationListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
@@ -28,9 +29,14 @@ class RemoteUserAuthenticationListener extends AbstractPreAuthenticatedListener
 {
     private $userKey;
 
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'REMOTE_USER', LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    /**
+     * @param SecurityContextInterface|TokenStorageInterface
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     */
+    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'REMOTE_USER', LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
-        parent::__construct($securityContext, $authenticationManager, $providerKey, $logger, $dispatcher);
+        parent::__construct($tokenStorage, $authenticationManager, $providerKey, $logger, $dispatcher);
 
         $this->userKey = $userKey;
     }

--- a/src/Symfony/Component/Security/Http/Firewall/RemoteUserAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RemoteUserAuthenticationListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Psr\Log\LoggerInterface;
@@ -29,12 +28,7 @@ class RemoteUserAuthenticationListener extends AbstractPreAuthenticatedListener
 {
     private $userKey;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'REMOTE_USER', LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'REMOTE_USER', LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         parent::__construct($tokenStorage, $authenticationManager, $providerKey, $logger, $dispatcher);
 

--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -25,7 +25,6 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 use Psr\Log\LoggerInterface;
@@ -41,26 +40,24 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
     /**
      * Constructor.
      *
-     * @param SecurityContextInterface|TokenStorageInterface  $tokenStorage          A SecurityContext or TokenStorageInterface instance
-     * @param AuthenticationManagerInterface                  $authenticationManager An AuthenticationManagerInterface instance
-     * @param SessionAuthenticationStrategyInterface          $sessionStrategy
-     * @param HttpUtils                                       $httpUtils             An HttpUtilsInterface instance
-     * @param string                                          $providerKey
-     * @param AuthenticationSuccessHandlerInterface           $successHandler
-     * @param AuthenticationFailureHandlerInterface           $failureHandler
-     * @param array                                           $options               An array of options for the processing of a
-     *                                                                               successful, or failed authentication attempt
-     * @param LoggerInterface                                 $logger                A LoggerInterface instance
-     * @param EventDispatcherInterface                        $dispatcher            An EventDispatcherInterface instance
-     * @param CsrfTokenManagerInterface                       $csrfTokenManager      A CsrfTokenManagerInterface instance
-     * @param SimpleFormAuthenticatorInterface                $simpleAuthenticator   A SimpleFormAuthenticatorInterface instance
+     * @param TokenStorageInterface                  $tokenStorage          A TokenStorageInterface instance
+     * @param AuthenticationManagerInterface         $authenticationManager An AuthenticationManagerInterface instance
+     * @param SessionAuthenticationStrategyInterface $sessionStrategy
+     * @param HttpUtils                              $httpUtils             An HttpUtilsInterface instance
+     * @param string                                 $providerKey
+     * @param AuthenticationSuccessHandlerInterface  $successHandler
+     * @param AuthenticationFailureHandlerInterface  $failureHandler
+     * @param array                                  $options               An array of options for the processing of a
+     *                                                                      successful, or failed authentication attempt
+     * @param LoggerInterface                        $logger                A LoggerInterface instance
+     * @param EventDispatcherInterface               $dispatcher            An EventDispatcherInterface instance
+     * @param CsrfTokenManagerInterface              $csrfTokenManager      A CsrfTokenManagerInterface instance
+     * @param SimpleFormAuthenticatorInterface       $simpleAuthenticator   A SimpleFormAuthenticatorInterface instance
      *
      * @throws \InvalidArgumentException In case no simple authenticator is provided
      * @throws InvalidArgumentException  In case an invalid CSRF token manager is passed
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
      */
-    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $csrfTokenManager = null, SimpleFormAuthenticatorInterface $simpleAuthenticator = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $csrfTokenManager = null, SimpleFormAuthenticatorInterface $simpleAuthenticator = null)
     {
         if (!$simpleAuthenticator) {
             throw new \InvalidArgumentException('Missing simple authenticator');

--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -23,6 +23,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\HttpUtils;
@@ -40,24 +41,26 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
     /**
      * Constructor.
      *
-     * @param SecurityContextInterface               $securityContext       A SecurityContext instance
-     * @param AuthenticationManagerInterface         $authenticationManager An AuthenticationManagerInterface instance
-     * @param SessionAuthenticationStrategyInterface $sessionStrategy
-     * @param HttpUtils                              $httpUtils             An HttpUtilsInterface instance
-     * @param string                                 $providerKey
-     * @param AuthenticationSuccessHandlerInterface  $successHandler
-     * @param AuthenticationFailureHandlerInterface  $failureHandler
-     * @param array                                  $options               An array of options for the processing of a
-     *                                                                      successful, or failed authentication attempt
-     * @param LoggerInterface                        $logger                A LoggerInterface instance
-     * @param EventDispatcherInterface               $dispatcher            An EventDispatcherInterface instance
-     * @param CsrfTokenManagerInterface              $csrfTokenManager      A CsrfTokenManagerInterface instance
-     * @param SimpleFormAuthenticatorInterface       $simpleAuthenticator   A SimpleFormAuthenticatorInterface instance
+     * @param SecurityContextInterface|TokenStorageInterface  $tokenStorage          A SecurityContext or TokenStorageInterface instance
+     * @param AuthenticationManagerInterface                  $authenticationManager An AuthenticationManagerInterface instance
+     * @param SessionAuthenticationStrategyInterface          $sessionStrategy
+     * @param HttpUtils                                       $httpUtils             An HttpUtilsInterface instance
+     * @param string                                          $providerKey
+     * @param AuthenticationSuccessHandlerInterface           $successHandler
+     * @param AuthenticationFailureHandlerInterface           $failureHandler
+     * @param array                                           $options               An array of options for the processing of a
+     *                                                                               successful, or failed authentication attempt
+     * @param LoggerInterface                                 $logger                A LoggerInterface instance
+     * @param EventDispatcherInterface                        $dispatcher            An EventDispatcherInterface instance
+     * @param CsrfTokenManagerInterface                       $csrfTokenManager      A CsrfTokenManagerInterface instance
+     * @param SimpleFormAuthenticatorInterface                $simpleAuthenticator   A SimpleFormAuthenticatorInterface instance
      *
      * @throws \InvalidArgumentException In case no simple authenticator is provided
      * @throws InvalidArgumentException  In case an invalid CSRF token manager is passed
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $csrfTokenManager = null, SimpleFormAuthenticatorInterface $simpleAuthenticator = null)
+    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $csrfTokenManager = null, SimpleFormAuthenticatorInterface $simpleAuthenticator = null)
     {
         if (!$simpleAuthenticator) {
             throw new \InvalidArgumentException('Missing simple authenticator');
@@ -79,7 +82,8 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
             'intention' => 'authenticate',
             'post_only' => true,
         ), $options);
-        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, $options, $logger, $dispatcher);
+
+        parent::__construct($tokenStorage, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, $options, $logger, $dispatcher);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -43,16 +42,14 @@ class SimplePreAuthenticationListener implements ListenerInterface
     /**
      * Constructor.
      *
-     * @param SecurityContextInterface|TokenStorageInterface $tokenStorage          A SecurityContext or TokenStorageInterface instance
-     * @param AuthenticationManagerInterface                 $authenticationManager An AuthenticationManagerInterface instance
-     * @param string                                         $providerKey
-     * @param SimplePreAuthenticatorInterface                $simpleAuthenticator   A SimplePreAuthenticatorInterface instance
-     * @param LoggerInterface                                $logger                A LoggerInterface instance
-     * @param EventDispatcherInterface                       $dispatcher            An EventDispatcherInterface instance
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     * @param TokenStorageInterface           $tokenStorage          A TokenStorageInterface instance
+     * @param AuthenticationManagerInterface  $authenticationManager An AuthenticationManagerInterface instance
+     * @param string                          $providerKey
+     * @param SimplePreAuthenticatorInterface $simpleAuthenticator   A SimplePreAuthenticatorInterface instance
+     * @param LoggerInterface                 $logger                A LoggerInterface instance
+     * @param EventDispatcherInterface        $dispatcher            An EventDispatcherInterface instance
      */
-    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, SimplePreAuthenticatorInterface $simpleAuthenticator, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, SimplePreAuthenticatorInterface $simpleAuthenticator, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
@@ -32,7 +33,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class SimplePreAuthenticationListener implements ListenerInterface
 {
-    private $securityContext;
+    private $tokenStorage;
     private $authenticationManager;
     private $providerKey;
     private $simpleAuthenticator;
@@ -42,20 +43,22 @@ class SimplePreAuthenticationListener implements ListenerInterface
     /**
      * Constructor.
      *
-     * @param SecurityContextInterface         $securityContext       A SecurityContext instance
-     * @param AuthenticationManagerInterface   $authenticationManager An AuthenticationManagerInterface instance
-     * @param string                           $providerKey
-     * @param SimplePreAuthenticatorInterface  $simpleAuthenticator   A SimplePreAuthenticatorInterface instance
-     * @param LoggerInterface                  $logger                A LoggerInterface instance
-     * @param EventDispatcherInterface         $dispatcher            An EventDispatcherInterface instance
+     * @param SecurityContextInterface|TokenStorageInterface $tokenStorage          A SecurityContext or TokenStorageInterface instance
+     * @param AuthenticationManagerInterface                 $authenticationManager An AuthenticationManagerInterface instance
+     * @param string                                         $providerKey
+     * @param SimplePreAuthenticatorInterface                $simpleAuthenticator   A SimplePreAuthenticatorInterface instance
+     * @param LoggerInterface                                $logger                A LoggerInterface instance
+     * @param EventDispatcherInterface                       $dispatcher            An EventDispatcherInterface instance
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, SimplePreAuthenticatorInterface $simpleAuthenticator, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, SimplePreAuthenticatorInterface $simpleAuthenticator, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');
         }
 
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->providerKey = $providerKey;
         $this->simpleAuthenticator = $simpleAuthenticator;
@@ -76,7 +79,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
             $this->logger->info(sprintf('Attempting simple pre-authorization %s', $this->providerKey));
         }
 
-        if (null !== $this->securityContext->getToken() && !$this->securityContext->getToken() instanceof AnonymousToken) {
+        if (null !== $this->tokenStorage->getToken() && !$this->tokenStorage->getToken() instanceof AnonymousToken) {
             return;
         }
 
@@ -89,14 +92,14 @@ class SimplePreAuthenticationListener implements ListenerInterface
             }
 
             $token = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($token);
+            $this->tokenStorage->setToken($token);
 
             if (null !== $this->dispatcher) {
                 $loginEvent = new InteractiveLoginEvent($request, $token);
                 $this->dispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN, $loginEvent);
             }
         } catch (AuthenticationException $e) {
-            $this->securityContext->setToken(null);
+            $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {
                 $this->logger->info(sprintf('Authentication request failed: %s', $e->getMessage()));

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
@@ -48,12 +47,7 @@ class SwitchUserListener implements ListenerInterface
     private $logger;
     private $dispatcher;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, UserProviderInterface $provider, UserCheckerInterface $userChecker, $providerKey, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, $usernameParameter = '_switch_user', $role = 'ROLE_ALLOWED_TO_SWITCH', EventDispatcherInterface $dispatcher = null)
+    public function __construct(TokenStorageInterface $tokenStorage, UserProviderInterface $provider, UserCheckerInterface $userChecker, $providerKey, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, $usernameParameter = '_switch_user', $role = 'ROLE_ALLOWED_TO_SWITCH', EventDispatcherInterface $dispatcher = null)
     {
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Role\SwitchUserRole;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
@@ -37,7 +38,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class SwitchUserListener implements ListenerInterface
 {
-    private $securityContext;
+    private $tokenStorage;
     private $provider;
     private $userChecker;
     private $providerKey;
@@ -48,15 +49,17 @@ class SwitchUserListener implements ListenerInterface
     private $dispatcher;
 
     /**
-     * Constructor.
+     * @param SecurityContextInterface|TokenStorageInterface
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
      */
-    public function __construct(SecurityContextInterface $securityContext, UserProviderInterface $provider, UserCheckerInterface $userChecker, $providerKey, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, $usernameParameter = '_switch_user', $role = 'ROLE_ALLOWED_TO_SWITCH', EventDispatcherInterface $dispatcher = null)
+    public function __construct($tokenStorage, UserProviderInterface $provider, UserCheckerInterface $userChecker, $providerKey, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, $usernameParameter = '_switch_user', $role = 'ROLE_ALLOWED_TO_SWITCH', EventDispatcherInterface $dispatcher = null)
     {
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');
         }
 
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->provider = $provider;
         $this->userChecker = $userChecker;
         $this->providerKey = $providerKey;
@@ -83,10 +86,10 @@ class SwitchUserListener implements ListenerInterface
         }
 
         if ('_exit' === $request->get($this->usernameParameter)) {
-            $this->securityContext->setToken($this->attemptExitUser($request));
+            $this->tokenStorage->setToken($this->attemptExitUser($request));
         } else {
             try {
-                $this->securityContext->setToken($this->attemptSwitchUser($request));
+                $this->tokenStorage->setToken($this->attemptSwitchUser($request));
             } catch (AuthenticationException $e) {
                 throw new \LogicException(sprintf('Switch User failed: "%s"', $e->getMessage()));
             }
@@ -112,7 +115,7 @@ class SwitchUserListener implements ListenerInterface
      */
     private function attemptSwitchUser(Request $request)
     {
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
         $originalToken = $this->getOriginalToken($token);
 
         if (false !== $originalToken) {
@@ -137,7 +140,7 @@ class SwitchUserListener implements ListenerInterface
         $this->userChecker->checkPostAuth($user);
 
         $roles = $user->getRoles();
-        $roles[] = new SwitchUserRole('ROLE_PREVIOUS_ADMIN', $this->securityContext->getToken());
+        $roles[] = new SwitchUserRole('ROLE_PREVIOUS_ADMIN', $this->tokenStorage->getToken());
 
         $token = new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey, $roles);
 
@@ -160,7 +163,7 @@ class SwitchUserListener implements ListenerInterface
      */
     private function attemptExitUser(Request $request)
     {
-        if (false === $original = $this->getOriginalToken($this->securityContext->getToken())) {
+        if (false === $original = $this->getOriginalToken($this->tokenStorage->getToken())) {
             throw new AuthenticationCredentialsNotFoundException('Could not find original Token object.');
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -27,7 +27,6 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -40,12 +39,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
 {
     private $csrfTokenManager;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $csrfTokenManager = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $csrfTokenManager = null)
     {
         if ($csrfTokenManager instanceof CsrfProviderInterface) {
             $csrfTokenManager = new CsrfProviderAdapter($csrfTokenManager);

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerI
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
@@ -40,9 +41,11 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
     private $csrfTokenManager;
 
     /**
-     * {@inheritdoc}
+     * @param SecurityContextInterface|TokenStorageInterface
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $csrfTokenManager = null)
+    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, $csrfTokenManager = null)
     {
         if ($csrfTokenManager instanceof CsrfProviderInterface) {
             $csrfTokenManager = new CsrfProviderAdapter($csrfTokenManager);
@@ -50,7 +53,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
             throw new InvalidArgumentException('The CSRF token manager should be an instance of CsrfProviderInterface or CsrfTokenManagerInterface.');
         }
 
-        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, array_merge(array(
+        parent::__construct($tokenStorage, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, array_merge(array(
             'username_parameter' => '_username',
             'password_parameter' => '_password',
             'csrf_parameter' => '_csrf_token',

--- a/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Psr\Log\LoggerInterface;
@@ -29,12 +28,7 @@ class X509AuthenticationListener extends AbstractPreAuthenticatedListener
     private $userKey;
     private $credentialKey;
 
-    /**
-     * @param SecurityContextInterface|TokenStorageInterface
-     *
-     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
-     */
-    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'SSL_CLIENT_S_DN_Email', $credentialKey = 'SSL_CLIENT_S_DN', LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'SSL_CLIENT_S_DN_Email', $credentialKey = 'SSL_CLIENT_S_DN', LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         parent::__construct($tokenStorage, $authenticationManager, $providerKey, $logger, $dispatcher);
 

--- a/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
@@ -28,9 +29,14 @@ class X509AuthenticationListener extends AbstractPreAuthenticatedListener
     private $userKey;
     private $credentialKey;
 
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'SSL_CLIENT_S_DN_Email', $credentialKey = 'SSL_CLIENT_S_DN', LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    /**
+     * @param SecurityContextInterface|TokenStorageInterface
+     *
+     * Passing a SecurityContextInterface as a first argument was deprecated in 2.7 and will be removed in 3.0
+     */
+    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'SSL_CLIENT_S_DN_Email', $credentialKey = 'SSL_CLIENT_S_DN', LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
-        parent::__construct($securityContext, $authenticationManager, $providerKey, $logger, $dispatcher);
+        parent::__construct($tokenStorage, $authenticationManager, $providerKey, $logger, $dispatcher);
 
         $this->userKey = $userKey;
         $this->credentialKey = $credentialKey;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
@@ -26,13 +26,13 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue(null))
         ;
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->with($this->equalTo($token))
@@ -47,7 +47,7 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener', array(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey',
         ));
@@ -72,13 +72,13 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
 
         $request = new Request(array(), array(), array(), array(), array(), array());
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue(null))
         ;
-        $context
+        $tokenStorage
             ->expects($this->never())
             ->method('setToken')
         ;
@@ -93,7 +93,7 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener', array(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey',
         ));
@@ -120,13 +120,13 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
 
         $request = new Request(array(), array(), array(), array(), array(), array());
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($token))
         ;
-        $context
+        $tokenStorage
             ->expects($this->never())
             ->method('setToken')
         ;
@@ -141,7 +141,7 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener', array(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey',
         ));
@@ -168,8 +168,8 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
 
         $token = new PreAuthenticatedToken('TheUser', 'TheCredentials', 'TheProviderKey', array('ROLE_FOO'));
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($token))
@@ -182,7 +182,7 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener', array(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey',
         ));
@@ -209,13 +209,13 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
 
         $token = new PreAuthenticatedToken('AnotherUser', 'TheCredentials', 'TheProviderKey', array('ROLE_FOO'));
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($token))
         ;
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->with($this->equalTo(null))
@@ -231,7 +231,7 @@ class AbstractPreAuthenticatedListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener', array(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey',
         ));

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -37,8 +37,8 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true))
         ;
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($token))
@@ -53,7 +53,7 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new AccessListener(
-            $context,
+            $tokenStorage,
             $accessDecisionManager,
             $accessMap,
             $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')
@@ -103,13 +103,13 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($authenticatedToken))
         ;
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($notAuthenticatedToken))
         ;
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->with($this->equalTo($authenticatedToken))
@@ -124,7 +124,7 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new AccessListener(
-            $context,
+            $tokenStorage,
             $accessDecisionManager,
             $accessMap,
             $authManager
@@ -158,15 +158,15 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
             ->method('isAuthenticated')
         ;
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($token))
         ;
 
         $listener = new AccessListener(
-            $context,
+            $tokenStorage,
             $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface'),
             $accessMap,
             $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')
@@ -185,17 +185,17 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
      */
-    public function testHandleWhenTheSecurityContextHasNoToken()
+    public function testHandleWhenTheSecurityTokenStorageHasNoToken()
     {
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue(null))
         ;
 
         $listener = new AccessListener(
-            $context,
+            $tokenStorage,
             $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface'),
             $this->getMock('Symfony\Component\Security\Http\AccessMapInterface'),
             $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -16,15 +16,15 @@ use Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener;
 
 class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testHandleWithContextHavingAToken()
+    public function testHandleWithTokenStorageHavingAToken()
     {
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')))
         ;
-        $context
+        $tokenStorage
             ->expects($this->never())
             ->method('setToken')
         ;
@@ -35,14 +35,14 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->method('authenticate')
         ;
 
-        $listener = new AnonymousAuthenticationListener($context, 'TheKey', null, $authenticationManager);
+        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheKey', null, $authenticationManager);
         $listener->handle($this->getMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false));
     }
 
-    public function testHandleWithContextHavingNoToken()
+    public function testHandleWithTokenStorageHavingNoToken()
     {
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue(null))
@@ -61,28 +61,28 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($anonymousToken))
         ;
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->with($anonymousToken)
         ;
 
-        $listener = new AnonymousAuthenticationListener($context, 'TheKey', null, $authenticationManager);
+        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheKey', null, $authenticationManager);
         $listener->handle($this->getMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false));
     }
 
     public function testHandledEventIsLogged()
     {
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         $logger = $this->getMock('Psr\Log\LoggerInterface');
         $logger->expects($this->once())
             ->method('info')
-            ->with('Populated SecurityContext with an anonymous Token')
+            ->with('Populated TokenStorage with an anonymous Token')
         ;
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new AnonymousAuthenticationListener($context, 'TheKey', $logger, $authenticationManager);
+        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheKey', $logger, $authenticationManager);
         $listener->handle($this->getMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false));
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
@@ -29,13 +29,13 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue(null))
         ;
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->with($this->equalTo($token))
@@ -50,7 +50,7 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new BasicAuthenticationListener(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey',
             $this->getMock('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')
@@ -75,13 +75,13 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue(null))
         ;
-        $context
+        $tokenStorage
             ->expects($this->never())
             ->method('setToken')
         ;
@@ -97,7 +97,7 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new BasicAuthenticationListener(
-            $context,
+            $tokenStorage,
             new AuthenticationProviderManager(array($this->getMock('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface'))),
             'TheProviderKey',
             $authenticationEntryPoint
@@ -122,14 +122,14 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->never())
             ->method('getToken')
         ;
 
         $listener = new BasicAuthenticationListener(
-            $context,
+            $tokenStorage,
             $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface'),
             'TheProviderKey',
             $this->getMock('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')
@@ -151,8 +151,8 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $token = new UsernamePasswordToken('TheUsername', 'ThePassword', 'TheProviderKey', array('ROLE_FOO'));
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($token))
@@ -165,7 +165,7 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new BasicAuthenticationListener(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey',
             $this->getMock('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')
@@ -188,7 +188,7 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
     public function testItRequiresProviderKey()
     {
         new BasicAuthenticationListener(
-            $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface'),
+            $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'),
             $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface'),
             '',
             $this->getMock('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')
@@ -204,13 +204,13 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $token = new PreAuthenticatedToken('TheUser', 'TheCredentials', 'TheProviderKey', array('ROLE_FOO'));
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
             ->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($token))
         ;
-        $context
+        $tokenStorage
             ->expects($this->never())
             ->method('setToken')
         ;
@@ -226,7 +226,7 @@ class BasicAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new BasicAuthenticationListener(
-            $context,
+            $tokenStorage,
             new AuthenticationProviderManager(array($this->getMock('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface'))),
             'TheProviderKey',
             $authenticationEntryPoint

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
@@ -123,10 +123,10 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
     {
         $event = $this->createEvent($exception);
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $context->expects($this->once())->method('getToken')->will($this->returnValue($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')));
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage->expects($this->once())->method('getToken')->will($this->returnValue($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')));
 
-        $listener = $this->createExceptionListener($context, $this->createTrustResolver(false), null, $this->createEntryPoint());
+        $listener = $this->createExceptionListener($tokenStorage, $this->createTrustResolver(false), null, $this->createEntryPoint());
         $listener->onKernelException($event);
 
         $this->assertEquals('OK', $event->getResponse()->getContent());
@@ -169,10 +169,10 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
         return new GetResponseForExceptionEvent($kernel, Request::create('/'), HttpKernelInterface::MASTER_REQUEST, $exception);
     }
 
-    private function createExceptionListener(SecurityContextInterface $context = null, AuthenticationTrustResolverInterface $trustResolver = null, HttpUtils $httpUtils = null, AuthenticationEntryPointInterface $authenticationEntryPoint = null, $errorPage = null, AccessDeniedHandlerInterface $accessDeniedHandler = null)
+    private function createExceptionListener(TokenStorageInterface $tokenStorage = null, AuthenticationTrustResolverInterface $trustResolver = null, HttpUtils $httpUtils = null, AuthenticationEntryPointInterface $authenticationEntryPoint = null, $errorPage = null, AccessDeniedHandlerInterface $accessDeniedHandler = null)
     {
         return new ExceptionListener(
-            $context ? $context : $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface'),
+            $tokenStorage ? $tokenStorage : $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'),
             $trustResolver ? $trustResolver : $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface'),
             $httpUtils ? $httpUtils : $this->getMock('Symfony\Component\Security\Http\HttpUtils'),
             'key',

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -19,7 +19,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
 {
     public function testHandleUnmatchedPath()
     {
-        list($listener, $context, $httpUtils, $options) = $this->getListener();
+        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener();
 
         list($event, $request) = $this->getGetResponseEvent();
 
@@ -39,7 +39,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
         $successHandler = $this->getSuccessHandler();
         $tokenManager = $this->getTokenManager();
 
-        list($listener, $context, $httpUtils, $options) = $this->getListener($successHandler, $tokenManager);
+        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($successHandler, $tokenManager);
 
         list($event, $request) = $this->getGetResponseEvent();
 
@@ -59,7 +59,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
             ->with($request)
             ->will($this->returnValue($response = new Response()));
 
-        $context->expects($this->once())
+        $tokenStorage->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue($token = $this->getToken()));
 
@@ -68,7 +68,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
             ->method('logout')
             ->with($request, $response, $token);
 
-        $context->expects($this->once())
+        $tokenStorage->expects($this->once())
             ->method('setToken')
             ->with(null);
 
@@ -85,7 +85,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
     {
         $successHandler = $this->getSuccessHandler();
 
-        list($listener, $context, $httpUtils, $options) = $this->getListener($successHandler);
+        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($successHandler);
 
         list($event, $request) = $this->getGetResponseEvent();
 
@@ -99,7 +99,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
             ->with($request)
             ->will($this->returnValue($response = new Response()));
 
-        $context->expects($this->once())
+        $tokenStorage->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue($token = $this->getToken()));
 
@@ -108,7 +108,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
             ->method('logout')
             ->with($request, $response, $token);
 
-        $context->expects($this->once())
+        $tokenStorage->expects($this->once())
             ->method('setToken')
             ->with(null);
 
@@ -128,7 +128,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
     {
         $successHandler = $this->getSuccessHandler();
 
-        list($listener, $context, $httpUtils, $options) = $this->getListener($successHandler);
+        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($successHandler);
 
         list($event, $request) = $this->getGetResponseEvent();
 
@@ -152,7 +152,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
     {
         $tokenManager = $this->getTokenManager();
 
-        list($listener, $context, $httpUtils, $options) = $this->getListener(null, $tokenManager);
+        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener(null, $tokenManager);
 
         list($event, $request) = $this->getGetResponseEvent();
 
@@ -175,11 +175,9 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
         return $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
     }
 
-    private function getContext()
+    private function getTokenStorage()
     {
-        return $this->getMockBuilder('Symfony\Component\Security\Core\SecurityContext')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
     }
 
     private function getGetResponseEvent()
@@ -210,7 +208,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
     private function getListener($successHandler = null, $tokenManager = null)
     {
         $listener = new LogoutListener(
-            $context = $this->getContext(),
+            $tokenStorage = $this->getTokenStorage(),
             $httpUtils = $this->getHttpUtils(),
             $successHandler ?: $this->getSuccessHandler(),
             $options = array(
@@ -222,7 +220,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
             $tokenManager
         );
 
-        return array($listener, $context, $httpUtils, $options);
+        return array($listener, $tokenStorage, $httpUtils, $options);
     }
 
     private function getSuccessHandler()

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -18,17 +18,17 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testOnCoreSecurityDoesNotTryToPopulateNonEmptySecurityContext()
+    public function testOnCoreSecurityDoesNotTryToPopulateNonEmptyTokenStorage()
     {
-        list($listener, $context, , , ,) = $this->getListener();
+        list($listener, $tokenStorage, , , ,) = $this->getListener();
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')))
         ;
 
-        $context
+        $tokenStorage
             ->expects($this->never())
             ->method('setToken')
         ;
@@ -38,9 +38,9 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOnCoreSecurityDoesNothingWhenNoCookieIsSet()
     {
-        list($listener, $context, $service, ,) = $this->getListener();
+        list($listener, $tokenStorage, $service, ,) = $this->getListener();
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue(null))
@@ -64,9 +64,9 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOnCoreSecurityIgnoresAuthenticationExceptionThrownByAuthenticationManagerImplementation()
     {
-        list($listener, $context, $service, $manager,) = $this->getListener();
+        list($listener, $tokenStorage, $service, $manager,) = $this->getListener();
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue(null))
@@ -106,9 +106,9 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnCoreSecurityIgnoresAuthenticationOptionallyRethrowsExceptionThrownAuthenticationManagerImplementation()
     {
-        list($listener, $context, $service, $manager,) = $this->getListener(false, false);
+        list($listener, $tokenStorage, $service, $manager,) = $this->getListener(false, false);
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue(null))
@@ -144,9 +144,9 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOnCoreSecurity()
     {
-        list($listener, $context, $service, $manager,) = $this->getListener();
+        list($listener, $tokenStorage, $service, $manager,) = $this->getListener();
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue(null))
@@ -159,7 +159,7 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($token))
         ;
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->with($this->equalTo($token))
@@ -183,9 +183,9 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOnCoreSecurityInteractiveLoginEventIsDispatchedIfDispatcherIsPresent()
     {
-        list($listener, $context, $service, $manager, , $dispatcher) = $this->getListener(true);
+        list($listener, $tokenStorage, $service, $manager, , $dispatcher) = $this->getListener(true);
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue(null))
@@ -198,7 +198,7 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($token))
         ;
 
-        $context
+        $tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->with($this->equalTo($token))
@@ -243,7 +243,7 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
     protected function getListener($withDispatcher = false, $catchExceptions = true)
     {
         $listener = new RememberMeListener(
-            $context = $this->getContext(),
+            $tokenStorage = $this->getTokenStorage(),
             $service = $this->getService(),
             $manager = $this->getManager(),
             $logger = $this->getLogger(),
@@ -251,7 +251,7 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
             $catchExceptions
         );
 
-        return array($listener, $context, $service, $manager, $logger, $dispatcher);
+        return array($listener, $tokenStorage, $service, $manager, $logger, $dispatcher);
     }
 
     protected function getLogger()
@@ -269,9 +269,9 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
         return $this->getMock('Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface');
     }
 
-    protected function getContext()
+    protected function getTokenStorage()
     {
-        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
     }
 
     protected function getDispatcher()

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RemoteUserAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RemoteUserAuthenticationListenerTest.php
@@ -24,12 +24,12 @@ class RemoteUserAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $request = new Request(array(), array(), array(), array(), array(), $serverVars);
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
         $listener = new RemoteUserAuthenticationListener(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey'
         );
@@ -48,12 +48,12 @@ class RemoteUserAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request(array(), array(), array(), array(), array(), array());
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
         $listener = new RemoteUserAuthenticationListener(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey'
         );
@@ -71,12 +71,12 @@ class RemoteUserAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $request = new Request(array(), array(), array(), array(), array(), array(
             'TheUserKey' => 'TheUser',
         ));
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
         $listener = new RemoteUserAuthenticationListener(
-            $context,
+            $tokenStorage,
             $authenticationManager,
             'TheProviderKey',
             'TheUserKey'

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -24,12 +24,12 @@ class SimplePreAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
     private $event;
     private $logger;
     private $request;
-    private $securityContext;
+    private $tokenStorage;
     private $token;
 
     public function testHandle()
     {
-        $this->securityContext
+        $this->tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->with($this->equalTo($this->token))
@@ -58,7 +58,7 @@ class SimplePreAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(SecurityEvents::INTERACTIVE_LOGIN), $this->equalTo($loginEvent))
         ;
 
-        $listener = new SimplePreAuthenticationListener($this->securityContext, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
+        $listener = new SimplePreAuthenticationListener($this->tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
 
         $listener->handle($this->event);
     }
@@ -74,7 +74,7 @@ class SimplePreAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->throwException($exception))
         ;
 
-        $this->securityContext->expects($this->once())
+        $this->tokenStorage->expects($this->once())
             ->method('setToken')
             ->with($this->equalTo(null))
         ;
@@ -87,7 +87,7 @@ class SimplePreAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->token))
         ;
 
-        $listener = new SimplePreAuthenticationListener($this->securityContext, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
+        $listener = new SimplePreAuthenticationListener($this->tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
 
         $listener->handle($this->event);
     }
@@ -111,12 +111,7 @@ class SimplePreAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $this->logger = $this->getMock('Psr\Log\LoggerInterface');
-
-        $this->securityContext = $this->getMockBuilder('Symfony\Component\Security\Core\SecurityContext')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
+        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         $this->token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
     }
 
@@ -127,7 +122,7 @@ class SimplePreAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $this->event = null;
         $this->logger = null;
         $this->request = null;
-        $this->securityContext = null;
+        $this->tokenStorage = null;
         $this->token = null;
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 
 class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
 {
-    private $securityContext;
+    private $tokenStorage;
 
     private $userProvider;
 
@@ -29,7 +29,7 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->securityContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         $this->userProvider = $this->getMock('Symfony\Component\Security\Core\User\UserProviderInterface');
         $this->userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
         $this->accessDecisionManager = $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface');
@@ -45,7 +45,7 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testProviderKeyIsRequired()
     {
-        new SwitchUserListener($this->securityContext, $this->userProvider, $this->userChecker, '', $this->accessDecisionManager);
+        new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, '', $this->accessDecisionManager);
     }
 
     public function testEventIsIgnoredIfUsernameIsNotPassedWithTheRequest()
@@ -53,9 +53,9 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
         $this->request->expects($this->any())->method('get')->with('_switch_user')->will($this->returnValue(null));
 
         $this->event->expects($this->never())->method('setResponse');
-        $this->securityContext->expects($this->never())->method('setToken');
+        $this->tokenStorage->expects($this->never())->method('setToken');
 
-        $listener = new SwitchUserListener($this->securityContext, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
     }
 
@@ -66,10 +66,10 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
     {
         $token = $this->getToken(array($this->getMock('Symfony\Component\Security\Core\Role\RoleInterface')));
 
-        $this->securityContext->expects($this->any())->method('getToken')->will($this->returnValue($token));
+        $this->tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
         $this->request->expects($this->any())->method('get')->with('_switch_user')->will($this->returnValue('_exit'));
 
-        $listener = new SwitchUserListener($this->securityContext, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
     }
 
@@ -81,7 +81,7 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $role->expects($this->any())->method('getSource')->will($this->returnValue($originalToken));
 
-        $this->securityContext->expects($this->any())
+        $this->tokenStorage->expects($this->any())
             ->method('getToken')
             ->will($this->returnValue($this->getToken(array($role))));
 
@@ -91,12 +91,12 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
         $this->request->query->expects($this->any())->method('all')->will($this->returnValue(array()));
         $this->request->server->expects($this->once())->method('set')->with('QUERY_STRING', '');
 
-        $this->securityContext->expects($this->once())
+        $this->tokenStorage->expects($this->once())
             ->method('setToken')->with($originalToken);
         $this->event->expects($this->once())
             ->method('setResponse')->with($this->isInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse'));
 
-        $listener = new SwitchUserListener($this->securityContext, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
     }
 
@@ -107,14 +107,14 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
     {
         $token = $this->getToken(array($this->getMock('Symfony\Component\Security\Core\Role\RoleInterface')));
 
-        $this->securityContext->expects($this->any())->method('getToken')->will($this->returnValue($token));
+        $this->tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
         $this->request->expects($this->any())->method('get')->with('_switch_user')->will($this->returnValue('kuba'));
 
         $this->accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'))
             ->will($this->returnValue(false));
 
-        $listener = new SwitchUserListener($this->securityContext, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
     }
 
@@ -124,7 +124,7 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $user->expects($this->any())->method('getRoles')->will($this->returnValue(array()));
 
-        $this->securityContext->expects($this->any())->method('getToken')->will($this->returnValue($token));
+        $this->tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
         $this->request->expects($this->any())->method('get')->with('_switch_user')->will($this->returnValue('kuba'));
         $this->request->query->expects($this->once())->method('remove', '_switch_user');
         $this->request->query->expects($this->any())->method('all')->will($this->returnValue(array()));
@@ -141,10 +141,10 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($user));
         $this->userChecker->expects($this->once())
             ->method('checkPostAuth')->with($user);
-        $this->securityContext->expects($this->once())
+        $this->tokenStorage->expects($this->once())
             ->method('setToken')->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken'));
 
-        $listener = new SwitchUserListener($this->securityContext, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
     }
 
@@ -154,7 +154,7 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $user->expects($this->any())->method('getRoles')->will($this->returnValue(array()));
 
-        $this->securityContext->expects($this->any())->method('getToken')->will($this->returnValue($token));
+        $this->tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
         $this->request->expects($this->any())->method('get')->with('_switch_user')->will($this->returnValue('kuba'));
         $this->request->query->expects($this->once())->method('remove', '_switch_user');
         $this->request->query->expects($this->any())->method('all')->will($this->returnValue(array('page' => 3, 'section' => 2)));
@@ -170,10 +170,10 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($user));
         $this->userChecker->expects($this->once())
             ->method('checkPostAuth')->with($user);
-        $this->securityContext->expects($this->once())
+        $this->tokenStorage->expects($this->once())
             ->method('setToken')->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken'));
 
-        $listener = new SwitchUserListener($this->securityContext, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/X509AuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/X509AuthenticationListenerTest.php
@@ -31,11 +31,11 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $request = new Request(array(), array(), array(), array(), array(), $serverVars);
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new X509AuthenticationListener($context, $authenticationManager, 'TheProviderKey');
+        $listener = new X509AuthenticationListener($tokenStorage, $authenticationManager, 'TheProviderKey');
 
         $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
         $method->setAccessible(true);
@@ -60,11 +60,11 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $credentials = 'CN=Sample certificate DN/emailAddress='.$emailAddress;
         $request = new Request(array(), array(), array(), array(), array(), array('SSL_CLIENT_S_DN' => $credentials));
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new X509AuthenticationListener($context, $authenticationManager, 'TheProviderKey');
+        $listener = new X509AuthenticationListener($tokenStorage, $authenticationManager, 'TheProviderKey');
 
         $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
         $method->setAccessible(true);
@@ -88,11 +88,11 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request(array(), array(), array(), array(), array(), array());
 
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new X509AuthenticationListener($context, $authenticationManager, 'TheProviderKey');
+        $listener = new X509AuthenticationListener($tokenStorage, $authenticationManager, 'TheProviderKey');
 
         $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
         $method->setAccessible(true);
@@ -108,11 +108,11 @@ class X509AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             'TheUserKey' => 'TheUser',
             'TheCredentialsKey' => 'TheCredentials',
         ));
-        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new X509AuthenticationListener($context, $authenticationManager, 'TheProviderKey', 'TheUserKey', 'TheCredentialsKey');
+        $listener = new X509AuthenticationListener($tokenStorage, $authenticationManager, 'TheProviderKey', 'TheUserKey', 'TheCredentialsKey');
 
         $method = new \ReflectionMethod($listener, 'getPreAuthenticatedData');
         $method->setAccessible(true);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR removed internal usage of SecurityContextInterface in favor of the new alternatives, it also fixes removes as many deprecation notices as possible for the Security component.
