### PR TITLE
[OptionsResolver] added test for allowed values and types that default to null

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -504,7 +504,19 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
      */
     public function testResolveFailsIfInvalidType()
     {
-        $this->resolver->setDefault('foo', 42);
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'string');
+
+        $this->resolver->resolve(array('foo' => 42));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value null is expected to be of type "string", but is of type "NULL".
+     */
+    public function testResolveFailsIfInvalidTypeIsNull()
+    {
+        $this->resolver->setDefault('foo', null);
         $this->resolver->setAllowedTypes('foo', 'string');
 
         $this->resolver->resolve();
@@ -675,7 +687,19 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
      */
     public function testResolveFailsIfInvalidValue()
     {
-        $this->resolver->setDefault('foo', 42);
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedValues('foo', 'bar');
+
+        $this->resolver->resolve(array('foo' => 42));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value null is invalid. Accepted values are: "bar".
+     */
+    public function testResolveFailsIfInvalidValueIsNull()
+    {
+        $this->resolver->setDefault('foo', null);
         $this->resolver->setAllowedValues('foo', 'bar');
 
         $this->resolver->resolve();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Added test to keep logic as experienced in #12809
