### PR TITLE
[Console] ArgvInput and empty tokens

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -309,9 +309,11 @@ class ArgvInput extends Input
     public function getParameterOption($values, $default = false)
     {
         $values = (array) $values;
-
         $tokens = $this->tokens;
-        while ($token = array_shift($tokens)) {
+
+        while (0 < count($tokens)) {
+            $token = array_shift($tokens);
+
             foreach ($values as $value) {
                 if ($token === $value || 0 === strpos($token, $value.'=')) {
                     if (false !== $pos = strpos($token, '=')) {

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -304,6 +304,7 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
             array(array('app/console', 'foo:bar', '-e', 'dev'), array('-e', '--env'), 'dev'),
             array(array('app/console', 'foo:bar', '--env=dev'), array('-e', '--env'), 'dev'),
             array(array('app/console', 'foo:bar', '--env=dev', '--en=1'), array('--en'), '1'),
+            array(array('app/console', 'foo:bar', '--env=dev', '', '--en=1'), array('--en'), '1'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

If an empty token is provided (from automated tools, or on purpose when running a command), the argument getter was not checking the other tokens, as '' == false in php, which is the stop condition of the while loop in this method.

This method should now rely on the count of tokens rather than on the value of the return of `array_shift`

If the fix is removed on the ArgvInput, the test `testGetParameterOptionEqualSign` should fail, as it shows why this fix is needed (last line of its provider `provideGetParameterOptionValues`)

This is relevant on 2.4+, but as 2.4 has stopped expecting bug fixes since july 2014, I based this PR on 2.5+. So this should be merged in 2.5, 2.6, 2.7 and possibly on master. This should also be cherry-pickable on 2.3 (as it is the current LTS)
