### PR TITLE
Make that AddExpressionLanguageProviderPass works with aliases 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -28,7 +28,7 @@ class AddExpressionLanguageProvidersPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         // routing
-        if ($container->hasDefinition('router')) {
+        if ($container->has('router')) {
             $definition = $container->findDefinition('router');
             foreach ($container->findTaggedServiceIds('routing.expression_language_provider') as $id => $attributes) {
                 $definition->addMethodCall('addExpressionLanguageProvider', array(new Reference($id)));
@@ -36,7 +36,7 @@ class AddExpressionLanguageProvidersPass implements CompilerPassInterface
         }
 
         // security
-        if ($container->hasDefinition('security.access.expression_voter')) {
+        if ($container->has('security.access.expression_voter')) {
             $definition = $container->findDefinition('security.access.expression_voter');
             foreach ($container->findTaggedServiceIds('security.expression_language_provider') as $id => $attributes) {
                 $definition->addMethodCall('addExpressionLanguageProvider', array(new Reference($id)));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
@@ -37,6 +37,26 @@ class AddExpressionLanguageProvidersPassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new Reference('some_routing_provider'), $calls[0][1][0]);
     }
 
+    public function testProcessForRouterAlias()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
+
+        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition->addTag('routing.expression_language_provider');
+        $container->setDefinition('some_routing_provider', $definition);
+
+        $container->register('my_router', '\stdClass');
+        $container->setAlias('router', 'my_router');
+        $container->compile();
+
+        $router = $container->getDefinition('my_router');
+        $calls = $router->getMethodCalls();
+        $this->assertCount(1, $calls);
+        $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
+        $this->assertEquals(new Reference('some_routing_provider'), $calls[0][1][0]);
+    }
+
     public function testProcessForSecurity()
     {
         $container = new ContainerBuilder();
@@ -50,6 +70,26 @@ class AddExpressionLanguageProvidersPassTest extends \PHPUnit_Framework_TestCase
         $container->compile();
 
         $router = $container->getDefinition('security.access.expression_voter');
+        $calls = $router->getMethodCalls();
+        $this->assertCount(1, $calls);
+        $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
+        $this->assertEquals(new Reference('some_security_provider'), $calls[0][1][0]);
+    }
+
+    public function testProcessForSecurityAlias()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
+
+        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition->addTag('security.expression_language_provider');
+        $container->setDefinition('some_security_provider', $definition);
+
+        $container->register('my_security.access.expression_voter', '\stdClass');
+        $container->setAlias('security.access.expression_voter', 'my_security.access.expression_voter');
+        $container->compile();
+
+        $router = $container->getDefinition('my_security.access.expression_voter');
         $calls = $router->getMethodCalls();
         $this->assertCount(1, $calls);
         $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12847 |
| License | MIT |
| Doc PR |  |

Replaces #12982 by @maarekj (includes his commit).
