### PR TITLE
[security] Fetching current stored context when not explicitly specified

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
@@ -12,8 +12,9 @@
     <services>
         <service id="templating.helper.logout_url" class="%templating.helper.logout_url.class%">
             <tag name="templating.helper" alias="logout_url" />
-            <argument type="service" id="service_container" />
+            <argument type="service" id="request_stack" />
             <argument type="service" id="router" />
+            <argument type="service" id="security.token_storage" />
         </service>
 
         <service id="templating.helper.security" class="%templating.helper.security.class%">

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -14,7 +14,9 @@ namespace Symfony\Bundle\SecurityBundle\Templating\Helper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderAdapter;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
@@ -25,20 +27,33 @@ use Symfony\Component\Templating\Helper\Helper;
  */
 class LogoutUrlHelper extends Helper
 {
-    private $container;
+    private $requestStack;
     private $listeners = array();
     private $router;
+    private $tokenStorage;
 
     /**
      * Constructor.
      *
-     * @param ContainerInterface    $container A ContainerInterface instance
-     * @param UrlGeneratorInterface $router    A Router instance
+     * @param ContainerInterface|RequestStack $requestStack A ContainerInterface instance or RequestStack
+     * @param UrlGeneratorInterface           $router       The router service
+     * @param TokenStorageInterface|null      $tokenStorage The token storage service
+     *
+     * @deprecated Passing a ContainerInterface as a first argument is deprecated since 2.7 and will be removed in 3.0.
      */
-    public function __construct(ContainerInterface $container, UrlGeneratorInterface $router)
+    public function __construct($requestStack, UrlGeneratorInterface $router, TokenStorageInterface $tokenStorage = null)
     {
-        $this->container = $container;
+        if ($requestStack instanceof ContainerInterface) {
+            $this->requestStack = $requestStack->get('request_stack');
+            trigger_error('The '.__CLASS__.' constructor will require a RequestStack instead of a containerInterface instance in 3.0.', E_USER_DEPRECATED);
+        } elseif ($requestStack instanceof RequestStack) {
+            $this->requestStack = $requestStack;
+        } else {
+            throw new \InvalidArgumentException(sprintf('%s takes either a RequestStack or a ContainerInterface object as its first argument.', __METHOD__));
+        }
+
         $this->router = $router;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -64,11 +79,11 @@ class LogoutUrlHelper extends Helper
     /**
      * Generates the absolute logout path for the firewall.
      *
-     * @param string $key The firewall key
+     * @param string|null $key The firewall key or null to use the current firewall key
      *
      * @return string The logout path
      */
-    public function getLogoutPath($key)
+    public function getLogoutPath($key = null)
     {
         return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_PATH);
     }
@@ -76,11 +91,11 @@ class LogoutUrlHelper extends Helper
     /**
      * Generates the absolute logout URL for the firewall.
      *
-     * @param string $key The firewall key
+     * @param string|null $key The firewall key or null to use the current firewall key
      *
      * @return string The logout URL
      */
-    public function getLogoutUrl($key)
+    public function getLogoutUrl($key = null)
     {
         return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_URL);
     }
@@ -88,15 +103,27 @@ class LogoutUrlHelper extends Helper
     /**
      * Generates the logout URL for the firewall.
      *
-     * @param string      $key           The firewall key
+     * @param string|null $key           The firewall key or null to use the current firewall key
      * @param bool|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The logout URL
      *
-     * @throws \InvalidArgumentException if no LogoutListener is registered for the key
+     * @throws \InvalidArgumentException if no LogoutListener is registered for the key or the key could not be found automatically.
      */
     private function generateLogoutUrl($key, $referenceType)
     {
+        // Fetch the current provider key from token, if possible
+        if (null === $key && null !== $this->tokenStorage) {
+            $token = $this->tokenStorage->getToken();
+            if (null !== $token && method_exists($token, 'getProviderKey')) {
+                $key = $token->getProviderKey();
+            }
+        }
+
+        if (null === $key) {
+            throw new \InvalidArgumentException('Unable to find the current firewall LogoutListener, please provide the provider key manually.');
+        }
+
         if (!array_key_exists($key, $this->listeners)) {
             throw new \InvalidArgumentException(sprintf('No LogoutListener found for firewall key "%s".', $key));
         }
@@ -106,7 +133,7 @@ class LogoutUrlHelper extends Helper
         $parameters = null !== $csrfTokenManager ? array($csrfParameter => (string) $csrfTokenManager->getToken($csrfTokenId)) : array();
 
         if ('/' === $logoutPath[0]) {
-            $request = $this->container->get('request_stack')->getCurrentRequest();
+            $request = $this->requestStack->getCurrentRequest();
 
             $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($logoutPath) : $request->getBasePath().$logoutPath;
 

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -45,7 +45,7 @@ class LogoutUrlHelper extends Helper
     {
         if ($requestStack instanceof ContainerInterface) {
             $this->requestStack = $requestStack->get('request_stack');
-            trigger_error('The '.__CLASS__.' constructor will require a RequestStack instead of a containerInterface instance in 3.0.', E_USER_DEPRECATED);
+            trigger_error('The '.__CLASS__.' constructor will require a RequestStack instead of a ContainerInterface instance in 3.0.', E_USER_DEPRECATED);
         } elseif ($requestStack instanceof RequestStack) {
             $this->requestStack = $requestStack;
         } else {

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -83,7 +83,7 @@ class LogoutUrlHelper extends Helper
      *
      * @return string The logout path
      */
-    public function getLogoutPath($key = null)
+    public function getLogoutPath($key)
     {
         return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_PATH);
     }
@@ -95,7 +95,7 @@ class LogoutUrlHelper extends Helper
      *
      * @return string The logout URL
      */
-    public function getLogoutUrl($key = null)
+    public function getLogoutUrl($key)
     {
         return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_URL);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/after_login.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/after_login.html.twig
@@ -3,4 +3,14 @@
 {% block body %}
     Hello {{ app.user.username }}!<br /><br />
     You're browsing to path "{{ app.request.pathInfo }}".
+
+    <a href="{{ logout_path('default') }}">Log out</a>.
+    <a href="{{ logout_url('default') }}">Log out</a>.
+
+    <a href="{{ logout_path('second_area') }}">Log out</a>.
+    <a href="{{ logout_url('second_area') }}">Log out</a>.
+
+    <a href="{{ logout_path() }}">Log out</a>.
+    <a href="{{ logout_url() }}">Log out</a>.
+
 {% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -39,6 +39,40 @@ class FormLoginTest extends WebTestCase
     /**
      * @dataProvider getConfigs
      */
+    public function testFormLogout($config)
+    {
+        $client = $this->createClient(array('test_case' => 'StandardFormLogin', 'root_config' => $config));
+        $client->insulate();
+
+        $form = $client->request('GET', '/login')->selectButton('login')->form();
+        $form['_username'] = 'johannes';
+        $form['_password'] = 'test';
+        $client->submit($form);
+
+        $this->assertRedirect($client->getResponse(), '/profile');
+
+        $crawler = $client->followRedirect();
+        $text = $crawler->text();
+
+        $this->assertContains('Hello johannes!', $text);
+        $this->assertContains('You\'re browsing to path "/profile".', $text);
+
+        $logoutLinks = $crawler->selectLink('Log out')->links();
+        $this->assertCount(6, $logoutLinks);
+        $this->assertSame($logoutLinks[0]->getUri(), $logoutLinks[1]->getUri());
+        $this->assertSame($logoutLinks[2]->getUri(), $logoutLinks[3]->getUri());
+        $this->assertSame($logoutLinks[4]->getUri(), $logoutLinks[5]->getUri());
+
+        $this->assertNotSame($logoutLinks[0]->getUri(), $logoutLinks[2]->getUri());
+        $this->assertNotSame($logoutLinks[1]->getUri(), $logoutLinks[3]->getUri());
+
+        $this->assertSame($logoutLinks[0]->getUri(), $logoutLinks[4]->getUri());
+        $this->assertSame($logoutLinks[1]->getUri(), $logoutLinks[5]->getUri());
+    }
+
+    /**
+     * @dataProvider getConfigs
+     */
     public function testFormLoginWithCustomTargetPath($config)
     {
         $client = $this->createClient(array('test_case' => 'StandardFormLogin', 'root_config' => $config));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/config.yml
@@ -23,7 +23,16 @@ security:
             form_login:
                 check_path: /login_check
                 default_target_path: /profile
+            logout: ~
             anonymous: ~
+
+        # This firewall is here just to check its the logout functionality
+        second_area:
+            http_basic: ~
+            anonymous: ~
+            logout:
+                target: /second/target
+                path: /second/logout
 
     access_control:
         - { path: ^/unprotected_resource$, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/src/Symfony/Bundle/SecurityBundle/Twig/Extension/LogoutUrlExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/Twig/Extension/LogoutUrlExtension.php
@@ -41,11 +41,11 @@ class LogoutUrlExtension extends \Twig_Extension
     /**
      * Generates the relative logout URL for the firewall.
      *
-     * @param string $key The firewall key
+     * @param string|null $key The firewall key or null to use the current firewall key
      *
      * @return string The relative logout URL
      */
-    public function getLogoutPath($key)
+    public function getLogoutPath($key = null)
     {
         return $this->helper->getLogoutPath($key);
     }
@@ -53,11 +53,11 @@ class LogoutUrlExtension extends \Twig_Extension
     /**
      * Generates the absolute logout URL for the firewall.
      *
-     * @param string $key The firewall key
+     * @param string|null $key The firewall key or null to use the current firewall key
      *
      * @return string The absolute logout URL
      */
-    public function getLogoutUrl($key)
+    public function getLogoutUrl($key = null)
     {
         return $this->helper->getLogoutUrl($key);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12160 |
| License | MIT |
| Doc PR | N/A |

This patch will use the current stored context found in a token (provided, there is one), if none has been specified.

According to a quick scan of the code, this will be the only place where `getProviderKey()` is used outside a specific class (the authentication providers will check token type before calling `getProviderKey()`, but maybe it's be a good idea to implement a "providerKeyTokenInterface" or something. It's a nicer solution imho than the current `method_exists()`
