### PR TITLE
[FrameworkBundle] FormDataCollector should be loaded only if form config is enabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -13,8 +13,6 @@
         <parameter key="data_collector.time.class">Symfony\Component\HttpKernel\DataCollector\TimeDataCollector</parameter>
         <parameter key="data_collector.memory.class">Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector</parameter>
         <parameter key="data_collector.router.class">Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector</parameter>
-        <parameter key="data_collector.form.class">Symfony\Component\Form\Extension\DataCollector\FormDataCollector</parameter>
-        <parameter key="data_collector.form.extractor.class">Symfony\Component\Form\Extension\DataCollector\FormDataExtractor</parameter>
     </parameters>
 
     <services>
@@ -57,13 +55,5 @@
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
             <tag name="data_collector" template="@WebProfiler/Collector/router.html.twig" id="router" priority="255" />
         </service>
-
-        <service id="data_collector.form.extractor" class="%data_collector.form.extractor.class%" />
-
-        <service id="data_collector.form" class="%data_collector.form.class%">
-            <tag name="data_collector" template="@WebProfiler/Collector/form.html.twig" id="form" priority="255" />
-            <argument type="service" id="data_collector.form.extractor" />
-        </service>
-
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
@@ -7,6 +7,8 @@
     <parameters>
         <parameter key="form.resolved_type_factory.data_collector_proxy.class">Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeFactoryDataCollectorProxy</parameter>
         <parameter key="form.type_extension.form.data_collector.class">Symfony\Component\Form\Extension\DataCollector\Type\DataCollectorTypeExtension</parameter>
+        <parameter key="data_collector.form.class">Symfony\Component\Form\Extension\DataCollector\FormDataCollector</parameter>
+        <parameter key="data_collector.form.extractor.class">Symfony\Component\Form\Extension\DataCollector\FormDataExtractor</parameter>
     </parameters>
 
     <services>
@@ -21,6 +23,14 @@
         <service id="form.type_extension.form.data_collector" class="%form.type_extension.form.data_collector.class%">
             <tag name="form.type_extension" alias="form" />
             <argument type="service" id="data_collector.form" />
+        </service>
+
+        <!-- DataCollector -->
+        <service id="data_collector.form.extractor" class="%data_collector.form.extractor.class%" />
+
+        <service id="data_collector.form" class="%data_collector.form.class%">
+            <tag name="data_collector" template="@WebProfiler/Collector/form.html.twig" id="form" priority="255" />
+            <argument type="service" id="data_collector.form.extractor" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11407 |
| License | MIT |
| Doc PR | - |
