### PR TITLE
Twig decoupling from Templating

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/old_assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/old_assets.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="templating.asset.path_package.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\PathPackage</parameter>
+        <parameter key="templating.asset.url_package.class">Symfony\Component\Templating\Asset\UrlPackage</parameter>
+        <parameter key="templating.asset.package_factory.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\PackageFactory</parameter>
+    </parameters>
+
+    <services>
+        <service id="templating.asset.path_package" class="%templating.asset.path_package.class%" abstract="true">
+            <argument type="service" id="request" />
+            <argument /> <!-- version -->
+            <argument /> <!-- version format -->
+        </service>
+
+        <service id="templating.asset.url_package" class="%templating.asset.url_package.class%" abstract="true">
+            <argument /> <!-- base urls -->
+            <argument /> <!-- version -->
+            <argument /> <!-- version format -->
+        </service>
+
+        <service id="templating.asset.request_aware_package" class="Symfony\Component\Templating\Asset\PackageInterface" abstract="true">
+            <factory service="templating.asset.package_factory" method="getPackage" />
+            <argument type="service" id="request" strict="false" />
+            <argument /> <!-- HTTP id -->
+            <argument /> <!-- SSL id -->
+        </service>
+
+        <service id="templating.asset.package_factory" class="%templating.asset.package_factory.class%">
+            <argument type="service" id="service_container" />
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
@@ -14,6 +14,7 @@
         <parameter key="templating.loader.cache.class">Symfony\Component\Templating\Loader\CacheLoader</parameter>
         <parameter key="templating.loader.chain.class">Symfony\Component\Templating\Loader\ChainLoader</parameter>
         <parameter key="templating.finder.class">Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinder</parameter>
+        <parameter key="templating.helper.assets.class">Symfony\Component\Templating\Helper\CoreAssetsHelper</parameter>
     </parameters>
 
     <services>
@@ -58,5 +59,15 @@
         </service>
 
         <service id="templating.loader" alias="templating.loader.filesystem" />
+
+        <!--
+            This should be in templating_php.xml but unfortunately, Twig depends on this helper.
+            As the Twig extension depending on this service is deprecated, this will be removed in 3.0.
+        -->
+        <service id="templating.helper.assets" class="%templating.helper.assets.class%">
+            <tag name="templating.helper" alias="assets" />
+            <argument /> <!-- default package -->
+            <argument type="collection" /> <!-- named packages -->
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -7,7 +7,6 @@
     <parameters>
         <parameter key="templating.engine.php.class">Symfony\Bundle\FrameworkBundle\Templating\PhpEngine</parameter>
         <parameter key="templating.helper.slots.class">Symfony\Component\Templating\Helper\SlotsHelper</parameter>
-        <parameter key="templating.helper.assets.class">Symfony\Component\Templating\Helper\CoreAssetsHelper</parameter>
         <parameter key="templating.helper.actions.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper</parameter>
         <parameter key="templating.helper.router.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\RouterHelper</parameter>
         <parameter key="templating.helper.request.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\RequestHelper</parameter>
@@ -19,9 +18,6 @@
         <parameter key="templating.form.engine.class">Symfony\Component\Form\Extension\Templating\TemplatingRendererEngine</parameter>
         <parameter key="templating.form.renderer.class">Symfony\Component\Form\FormRenderer</parameter>
         <parameter key="templating.globals.class">Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables</parameter>
-        <parameter key="templating.asset.path_package.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\PathPackage</parameter>
-        <parameter key="templating.asset.url_package.class">Symfony\Component\Templating\Asset\UrlPackage</parameter>
-        <parameter key="templating.asset.package_factory.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\PackageFactory</parameter>
     </parameters>
 
     <services>
@@ -35,35 +31,6 @@
 
         <service id="templating.helper.slots" class="%templating.helper.slots.class%">
             <tag name="templating.helper" alias="slots" />
-        </service>
-
-        <service id="templating.helper.assets" class="%templating.helper.assets.class%">
-            <tag name="templating.helper" alias="assets" />
-            <argument /> <!-- default package -->
-            <argument type="collection" /> <!-- named packages -->
-        </service>
-
-        <service id="templating.asset.path_package" class="%templating.asset.path_package.class%" abstract="true">
-            <argument type="service" id="request" />
-            <argument /> <!-- version -->
-            <argument /> <!-- version format -->
-        </service>
-
-        <service id="templating.asset.url_package" class="%templating.asset.url_package.class%" abstract="true">
-            <argument /> <!-- base urls -->
-            <argument /> <!-- version -->
-            <argument /> <!-- version format -->
-        </service>
-
-        <service id="templating.asset.request_aware_package" class="Symfony\Component\Templating\Asset\PackageInterface" abstract="true">
-            <factory service="templating.asset.package_factory" method="getPackage" />
-            <argument type="service" id="request" strict="false" />
-            <argument /> <!-- HTTP id -->
-            <argument /> <!-- SSL id -->
-        </service>
-
-        <service id="templating.asset.package_factory" class="%templating.asset.package_factory.class%">
-            <argument type="service" id="service_container" />
         </service>
 
         <service id="templating.helper.request" class="%templating.helper.request.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\SecurityContext;
 
 /**
- * GlobalVariables is the entry point for Symfony global variables in Twig templates.
+ * GlobalVariables is the entry point for Symfony global variables in PHP templates.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Bundle/TwigBundle/AppVariable.php
+++ b/src/Symfony/Bundle/TwigBundle/AppVariable.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+/**
+ * Exposes some Symfony parameters and services as an "app" global variable.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AppVariable
+{
+    private $security;
+    private $tokenStorage;
+    private $requestStack;
+    private $environment;
+    private $debug;
+
+    /**
+     * @deprecated since version 2.7, to be removed in 3.0.
+     */
+    public function setSecurity(SecurityContextInterface $security)
+    {
+        $this->security = $security;
+    }
+
+    public function setTokenStorage(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function setRequestStack(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function setEnvironment($environment)
+    {
+        $this->environment = $environment;
+    }
+
+    public function setDebug($debug)
+    {
+        $this->debug = (bool) $debug;
+    }
+
+    /**
+     * Returns the security context service.
+     *
+     * @deprecated since version 2.6, to be removed in 3.0.
+     *
+     * @return SecurityContext|null The security context
+     */
+    public function getSecurity()
+    {
+        trigger_error('The "app.security" variable is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+
+        if (null === $this->security) {
+            throw new \RuntimeException('The "app.security" variable is not available.');
+        }
+
+        return $this->security;
+    }
+
+    /**
+     * Returns the current user.
+     *
+     * @return mixed
+     *
+     * @see TokenInterface::getUser()
+     */
+    public function getUser()
+    {
+        if (null === $this->tokenStorage) {
+            throw new \RuntimeException('The "app.user" variable is not available.');
+        }
+
+        if (!$token = $this->tokenStorage->getToken()) {
+            return;
+        }
+
+        $user = $token->getUser();
+        if (is_object($user)) {
+            return $user;
+        }
+    }
+
+    /**
+     * Returns the current request.
+     *
+     * @return Request|null The HTTP request object
+     */
+    public function getRequest()
+    {
+        if (null === $this->requestStack) {
+            throw new \RuntimeException('The "app.request" variable is not available.');
+        }
+
+        return $this->requestStack->getCurrentRequest();
+    }
+
+    /**
+     * Returns the current session.
+     *
+     * @return Session|null The session
+     */
+    public function getSession()
+    {
+        if (null === $this->requestStack) {
+            throw new \RuntimeException('The "app.session" variable is not available.');
+        }
+
+        if ($request = $this->getRequest()) {
+            return $request->getSession();
+        }
+    }
+
+    /**
+     * Returns the current app environment.
+     *
+     * @return string The current environment string (e.g 'dev')
+     */
+    public function getEnvironment()
+    {
+        if (null === $this->environment) {
+            throw new \RuntimeException('The "app.environment" variable is not available.');
+        }
+
+        return $this->environment;
+    }
+
+    /**
+     * Returns the current app debug mode.
+     *
+     * @return bool The current debug mode
+     */
+    public function getDebug()
+    {
+        if (null === $this->debug) {
+            throw new \RuntimeException('The "app.debug" variable is not available.');
+        }
+
+        return $this->debug;
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -46,5 +46,24 @@ class ExtensionPass implements CompilerPassInterface
         if ($container->has('request_stack')) {
             $container->getDefinition('twig.extension.httpfoundation')->addTag('twig.extension');
         }
+
+        if ($container->hasParameter('templating.helper.code.file_link_format')) {
+            $container->getDefinition('twig.extension.code')->replaceArgument(0, $container->getParameter('templating.helper.code.file_link_format'));
+        }
+
+        if ($container->has('templating')) {
+            $container->getDefinition('twig.cache_warmer')->addTag('kernel.cache_warmer');
+
+            if ($container->getParameter('kernel.debug')) {
+                $container->setDefinition('templating.engine.twig', $container->findDefinition('debug.templating.engine.twig'));
+                $container->setAlias('debug.templating.engine.twig', 'templating.engine.twig');
+            }
+        } else {
+            $loader = $container->getDefinition('twig.loader.native_filesystem');
+            $loader->addTag('twig.loader');
+            $loader->setMethodCalls($container->getDefinition('twig.loader.filesystem')->getMethodCalls());
+
+            $container->setDefinition('twig.loader.filesystem', $loader);
+        }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -103,9 +103,6 @@ class TwigExtension extends Extension
 
         if ($container->getParameter('kernel.debug')) {
             $loader->load('debug.xml');
-
-            $container->setDefinition('templating.engine.twig', $container->findDefinition('debug.templating.engine.twig'));
-            $container->setAlias('debug.templating.engine.twig', 'templating.engine.twig');
         }
 
         if (isset($config['autoescape_service']) && isset($config['autoescape_service_method'])) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -47,9 +47,12 @@
         </service>
 
         <service id="twig.cache_warmer" class="%twig.cache_warmer.class%" public="false">
-            <tag name="kernel.cache_warmer" />
             <argument type="service" id="service_container" />
             <argument type="service" id="templating.finder" />
+        </service>
+
+        <service id="twig.loader.native_filesystem" class="Twig_Loader_Filesystem" public="false">
+            <argument type="collection" />
         </service>
 
         <service id="twig.loader.filesystem" class="%twig.loader.filesystem.class%" public="false">
@@ -84,7 +87,7 @@
 
         <service id="twig.extension.code" class="%twig.extension.code.class%" public="false">
             <tag name="twig.extension" />
-            <argument>%templating.helper.code.file_link_format%</argument>
+            <argument /> <!-- %templating.helper.code.file_link_format% -->
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -34,8 +34,16 @@
             <argument>%twig.options%</argument>
             <call method="addGlobal">
                 <argument>app</argument>
-                <argument type="service" id="templating.globals" />
+                <argument type="service" id="twig.app_variable" />
             </call>
+        </service>
+
+        <service id="twig.app_variable" class="Symfony\Bundle\TwigBundle\AppVariable" public="false">
+            <call method="setEnvironment"><argument>%kernel.environment%</argument></call>
+            <call method="setDebug"><argument>%kernel.debug%</argument></call>
+            <call method="setSecurity"><argument type="service" id="security.context" on-invalid="ignore" /></call>
+            <call method="setTokenStorage"><argument type="service" id="security.token_storage" on-invalid="ignore" /></call>
+            <call method="setRequestStack"><argument type="service" id="request_stack" on-invalid="ignore" /></call>
         </service>
 
         <service id="twig.cache_warmer" class="%twig.cache_warmer.class%" public="false">

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -99,7 +99,7 @@ class TwigExtensionTest extends TestCase
         // Globals
         $calls = $container->getDefinition('twig')->getMethodCalls();
         $this->assertEquals('app', $calls[0][1][0], '->load() registers services as Twig globals');
-        $this->assertEquals(new Reference('templating.globals'), $calls[0][1][1]);
+        $this->assertEquals(new Reference('twig.app_variable'), $calls[0][1][1]);
         $this->assertEquals('foo', $calls[1][1][0], '->load() registers services as Twig globals');
         $this->assertEquals(new Reference('bar'), $calls[1][1][1], '->load() registers services as Twig globals');
         $this->assertEquals('baz', $calls[2][1][0], '->load() registers variables as Twig globals');

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Tests;
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+
+class NoTemplatingEntryTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $kernel = new NoTemplatingEntryKernel('dev', true);
+        $kernel->boot();
+
+        $container = $kernel->getContainer();
+        $content = $container->get('twig')->render('index.html.twig');
+        $this->assertContains('{ a: b }', $content);
+    }
+
+    protected function setUp()
+    {
+        $this->deleteTempDir();
+    }
+
+    protected function tearDown()
+    {
+        $this->deleteTempDir();
+    }
+
+    protected function deleteTempDir()
+    {
+        if (!file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel')) {
+            return;
+        }
+
+        $fs = new Filesystem();
+        $fs->remove($dir);
+    }
+}
+
+class NoTemplatingEntryKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return array(new FrameworkBundle(), new TwigBundle());
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function ($container) {
+            $container->loadFromExtension('framework', array(
+                'secret' => '$ecret',
+            ));
+        });
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel/cache/'.$this->environment;
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel/logs';
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/Resources/views/index.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/Resources/views/index.html.twig
@@ -1,0 +1,1 @@
+{{ {a: 'b'}|yaml_encode }}

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/twig-bridge": "~2.6|~3.0.0",
+        "symfony/twig-bridge": "~2.7|~3.0.0",
         "symfony/http-foundation": "~2.5|~3.0.0",
         "symfony/http-kernel": "~2.3.24|~2.5.9|~2.6,>=2.6.2|~3.0.0"
     },

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/config": "~2.2|~3.0.0",
         "symfony/routing": "~2.1|~3.0.0",
         "symfony/templating": "~2.1|~3.0.0",
-        "symfony/framework-bundle": "~2.1|~3.0.0"
+        "symfony/framework-bundle": "~2.7|~3.0.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\TwigBundle\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #11748, #11876 |
| License | MIT |
| Doc PR | n/a |

The goal of this PR is to make Twig independent of the Symfony Templating system. With this PR, you can now use the Twig bundle without activating `framework.templating`. Also, even when registering the templating system in FrameworkBundle, the `php` engine is only registered when specified explicitly in `engines`.

First, the global variables has been decoupled from FrameworkBundle.

Then, the Twig bundle now tries to only rely on native Twig extensions and loaders and use the Templating sub-system only if `framework.templating` is enabled.
