### PR TITLE
Deprecate the global variables in Twig in favor of Twig functions

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
@@ -36,6 +36,8 @@ class HttpFoundationExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFunction('absolute_url', array($this, 'generateAbsoluteUrl')),
             new \Twig_SimpleFunction('relative_path', array($this, 'generateRelativePath')),
+            new \Twig_SimpleFunction('request', array($this, 'getRequest')),
+            new \Twig_SimpleFunction('session', array($this, 'getSession')),
         );
     }
 
@@ -95,6 +97,28 @@ class HttpFoundationExtension extends \Twig_Extension
         }
 
         return $request->getRelativeUriForPath($path);
+    }
+
+    /**
+     * Returns the current request.
+     *
+     * @return Request|null The HTTP request object
+     */
+    public function getRequest()
+    {
+        return $this->requestStack->getCurrentRequest();
+    }
+
+    /**
+     * Returns the current session.
+     *
+     * @return Session|null The session
+     */
+    public function getSession()
+    {
+        if ($request = $this->getRequest()) {
+            return $request->getSession();
+        }
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Extension/KernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/KernelExtension.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class KernelExtension extends \Twig_Extension
+{
+    private $environment;
+    private $debug;
+
+    public function __construct($environment, $debug)
+    {
+        $this->environment = $environment;
+        $this->debug = $debug;
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('is_debug', array($this, 'isDebug')),
+            new \Twig_SimpleFunction('env', array($this, 'getEnvironment')),
+        );
+    }
+
+    /**
+     * Returns the current app environment.
+     *
+     * @return string The current environment string (e.g 'dev')
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    /**
+     * Returns the current debug flag.
+     *
+     * @return bool Whether debug is enabled or not
+     */
+    public function isDebug()
+    {
+        return $this->debug;
+    }
+
+    public function getName()
+    {
+        return 'kernel';
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
@@ -71,4 +71,24 @@ class HttpFoundationExtensionTest extends \PHPUnit_Framework_TestCase
             array('//example.com/baz', '//example.com/baz', '/'),
         );
     }
+
+    public function testGetRequest()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = Request::create('/'));
+        $extension = new HttpFoundationExtension($stack);
+
+        $this->assertSame($request, $extension->getRequest());
+    }
+
+    public function testGetSession()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = Request::create('/'));
+        $extension = new HttpFoundationExtension($stack);
+
+        $request->setSession($this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
+
+        $this->assertSame($request->getSession(), $extension->getSession());
+    }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/KernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/KernelExtensionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use Symfony\Bridge\Twig\Extension\KernelExtension;
+
+class KernelExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $extension = new KernelExtension('foo', true);
+        $this->assertTrue($extension->isDebug());
+        $this->assertEquals('foo', $extension->getEnvironment());
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use Symfony\Bridge\Twig\Extension\SecurityExtension;
+
+class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsGranted()
+    {
+        $checker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $checker->expects($this->once())->method('isGranted')->will($this->returnValue(true));
+        $storage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+
+        $extension = new SecurityExtension($checker, $storage);
+        $this->assertTrue($extension->isGranted('ROLE_ADMIN'));
+    }
+
+    public function testGetUserWithoutToken()
+    {
+        $checker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $storage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $storage->expects($this->once())->method('getToken')->will($this->returnValue(null));
+
+        $extension = new SecurityExtension($checker, $storage);
+        $this->assertNull($extension->getUser());
+    }
+
+    public function testGetUserWithNullUser()
+    {
+        $checker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token->expects($this->once())->method('getUser')->will($this->returnValue(null));
+
+        $storage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $storage->expects($this->once())->method('getToken')->will($this->returnValue($token));
+
+        $extension = new SecurityExtension($checker, $storage);
+        $this->assertNull($extension->getUser());
+    }
+
+    public function testGetUserWithUser()
+    {
+        $checker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+
+        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token->expects($this->once())->method('getUser')->will($this->returnValue($user));
+
+        $storage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $storage->expects($this->once())->method('getToken')->will($this->returnValue($token));
+
+        $extension = new SecurityExtension($checker, $storage);
+        $this->assertSame($user, $extension->getUser());
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
@@ -17,7 +17,8 @@
 
         <service id="twig.extension.security" class="%twig.extension.security.class%" public="false">
             <tag name="twig.extension" />
-            <argument type="service" id="security.authorization_checker" on-invalid="ignore" />
+            <argument type="service" id="security.authorization_checker" />
+            <argument type="service" id="security.token_storage" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/AppVariable.php
+++ b/src/Symfony/Bundle/TwigBundle/AppVariable.php
@@ -22,6 +22,8 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  * Exposes some Symfony parameters and services as an "app" global variable.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.7, to be removed in 3.0. Use request(), user(), env(), session(), is_debug() instead.
  */
 class AppVariable
 {
@@ -86,6 +88,8 @@ class AppVariable
      */
     public function getUser()
     {
+        trigger_error('The "app.user" variable is deprecated since version 2.7 and will be removed in 3.0. Use the user() function instead.', E_USER_DEPRECATED);
+
         if (null === $this->tokenStorage) {
             throw new \RuntimeException('The "app.user" variable is not available.');
         }
@@ -107,6 +111,8 @@ class AppVariable
      */
     public function getRequest()
     {
+        trigger_error('The "app.request" variable is deprecated since version 2.7 and will be removed in 3.0. Use the request() function instead.', E_USER_DEPRECATED);
+
         if (null === $this->requestStack) {
             throw new \RuntimeException('The "app.request" variable is not available.');
         }
@@ -121,6 +127,8 @@ class AppVariable
      */
     public function getSession()
     {
+        trigger_error('The "app.session" variable is deprecated since version 2.7 and will be removed in 3.0. Use the session() function instead.', E_USER_DEPRECATED);
+
         if (null === $this->requestStack) {
             throw new \RuntimeException('The "app.session" variable is not available.');
         }
@@ -137,6 +145,8 @@ class AppVariable
      */
     public function getEnvironment()
     {
+        trigger_error('The "app.environment" variable is deprecated since version 2.7 and will be removed in 3.0. Use the env() function instead.', E_USER_DEPRECATED);
+
         if (null === $this->environment) {
             throw new \RuntimeException('The "app.environment" variable is not available.');
         }
@@ -151,6 +161,8 @@ class AppVariable
      */
     public function getDebug()
     {
+        trigger_error('The "app.debug" variable is deprecated since version 2.7 and will be removed in 3.0. Use the is_debug() function instead.', E_USER_DEPRECATED);
+
         if (null === $this->debug) {
             throw new \RuntimeException('The "app.debug" variable is not available.');
         }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -122,6 +122,12 @@
             <argument type="service" id="twig.form.renderer" />
         </service>
 
+        <service id="twig.extension.kernel" class="Symfony\Bridge\Twig\Extension\KernelExtension" public="false">
+            <tag name="twig.extension" />
+            <argument>%kernel.environment%</argument>
+            <argument>%kernel.debug%</argument>
+        </service>
+
         <service id="twig.form.engine" class="%twig.form.engine.class%" public="false">
             <argument>%twig.form.resources%</argument>
         </service>

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -25,8 +25,11 @@ class NoTemplatingEntryTest extends \PHPUnit_Framework_TestCase
         $kernel->boot();
 
         $container = $kernel->getContainer();
+
         $content = $container->get('twig')->render('index.html.twig');
         $this->assertContains('{ a: b }', $content);
+        $this->assertContains('Debug: 1', $content);
+        $this->assertContains('Env: dev', $content);
     }
 
     protected function setUp()

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/Resources/views/index.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/Resources/views/index.html.twig
@@ -1,1 +1,3 @@
 {{ {a: 'b'}|yaml_encode }}
+Debug: {{ is_debug() }}
+Env: {{ env() }}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I propose to deprecate the `app` global variable and replace it with Twig functions:
- `app.request` -> `request()`
- `app.session` -> `session()`
- `app.user` -> `user()`
- `app.environment` -> `env()`
- `app.debug` -> `is_debug()`
