### PR TITLE
[HttpFoundation] overwrite default encodingOptions in child class

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -47,6 +47,7 @@ class JsonResponse extends Response
         $this->setData($data);
     }
     
+    
     protected function setDefaultEncodingOptions()
     {
         // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -48,14 +48,12 @@ class JsonResponse extends Response
         $this->setData($data);
     }
     
-    /**
-     *  Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
-     */ 
     protected function setDefaultEncodingOptions()
     {
+        // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
         $this->encodingOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
     }
-
+    
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -44,13 +44,15 @@ class JsonResponse extends Response
         }
 
         $this->setDefaultEncodingOptions();
+        
         $this->setData($data);
     }
     
-    
+    /**
+     *  Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
+     */ 
     protected function setDefaultEncodingOptions()
     {
-        // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
         $this->encodingOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
     }
 

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -44,16 +44,15 @@ class JsonResponse extends Response
         }
 
         $this->setDefaultEncodingOptions();
-        
         $this->setData($data);
     }
-    
+
     protected function setDefaultEncodingOptions()
     {
         // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
         $this->encodingOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -43,10 +43,14 @@ class JsonResponse extends Response
             $data = new \ArrayObject();
         }
 
+        $this->setDefaultEncodingOptions();
+        $this->setData($data);
+    }
+    
+    protected function setDefaultEncodingOptions()
+    {
         // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
         $this->encodingOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
-
-        $this->setData($data);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR |  |

This will allow to change the default encoding options without calling `\json_decode` and `\json_encode`.
