### PR TITLE
fix missing comma in YamlDumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -85,7 +85,7 @@ class YamlDumper extends Dumper
                 foreach ($attributes as $key => $value) {
                     $att[] = sprintf('%s: %s', $this->dumper->dump($key), $this->dumper->dump($value));
                 }
-                $att = $att ? ', '.implode(' ', $att) : '';
+                $att = $att ? ', '.implode(', ', $att) : '';
 
                 $tagsCode .= sprintf("            - { name: %s%s }\n", $this->dumper->dump($name), $att);
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -11,7 +11,7 @@ $container = new ContainerBuilder();
 $container->
     register('foo', 'FooClass')->
     addTag('foo', array('foo' => 'foo'))->
-    addTag('foo', array('bar' => 'bar'))->
+    addTag('foo', array('bar' => 'bar', 'baz' => 'baz'))->
     setFactoryClass('FooClass')->
     setFactoryMethod('getInstance')->
     setArguments(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))->

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -8,7 +8,7 @@
   <services>
     <service id="foo" class="FooClass" factory-method="getInstance" factory-class="FooClass">
       <tag name="foo" foo="foo"/>
-      <tag name="foo" bar="bar"/>
+      <tag name="foo" bar="bar" baz="baz"/>
       <argument>foo</argument>
       <argument type="service" id="foo.baz"/>
       <argument type="collection">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -8,7 +8,7 @@ services:
         class: FooClass
         tags:
             - { name: foo, foo: foo }
-            - { name: foo, bar: bar }
+            - { name: foo, bar: bar, baz: baz }
         factory_class: FooClass
         factory_method: getInstance
         arguments: [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%' }, true, '@service_container']


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The YamlDumper were missing commas between tag attributes.
See https://github.com/rosstuck/TuckConverterBundle/issues/6
