### PR TITLE
[ExpressionLanguage] Parser dynamic name validator

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -74,7 +74,7 @@ class ExpressionLanguage
      * Parses an expression.
      *
      * @param Expression|string $expression The expression to parse
-     * @param array             $names      An array of valid names
+     * @param array|callable    $names      An array of valid names or a callable to validate a name
      *
      * @return ParsedExpression A ParsedExpression instance
      */

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -49,6 +49,30 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($node, $parser->parse($lexer->tokenize($expression), $names));
     }
 
+    /**
+     * @expectedException        \Symfony\Component\ExpressionLanguage\SyntaxError
+     * @expectedExceptionMessage Variable "foo" is not valid around position 1.
+     */
+    public function testParseWithCallableInvalidName()
+    {
+        $callable = function ($name) {
+            return $name === 'bar';
+        };
+        $lexer = new Lexer();
+        $parser = new Parser(array());
+        $parser->parse($lexer->tokenize('foo'), $callable);
+    }
+
+    public function testParseWithCallableValidName()
+    {
+        $callable = function ($name) {
+            return $name === 'bar';
+        };
+        $lexer = new Lexer();
+        $parser = new Parser(array());
+        $parser->parse($lexer->tokenize('bar'), $callable);
+    }
+
     public function getParseData()
     {
         $arguments = new Node\ArgumentsNode();


### PR DESCRIPTION
Added the ability to pass a callable to the `Parser` to validate
names dynamically instead of passing a list of predefined names.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
