### PR TITLE
[TwigBridge] exit when Twig environment is not set in the DebugCommand

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -83,6 +83,13 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $twig = $this->getTwigEnvironment();
+
+        if (null === $twig) {
+            $output->writeln('<error>The Twig environment needs to be set.</error>');
+
+            return 1;
+        }
+
         $types = array('functions', 'filters', 'tests', 'globals');
 
         if ($input->getOption('format') === 'json') {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `DebugCommand` from the TwigBridge requires the `Twig_Environment`
to be set. Thus, if the `setTwigEnvironment()` were not called, the
command execution would have been aborted with a PHP error.
