### PR TITLE
[TwigBridge] exit when Twig environment is not set in the LintCommand

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -87,6 +87,13 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $twig = $this->getTwigEnvironment();
+
+        if (null === $twig) {
+            $output->writeln('<error>The Twig environment needs to be set.</error>');
+
+            return 1;
+        }
+
         $filename = $input->getArgument('filename');
 
         if (!$filename) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `LintCommand` from the TwigBridge requires the `Twig_Environment`
to be set. Thus, if the `setTwigEnvironment()` were not called, the
command execution would have been aborted with a PHP error.
