### PR TITLE
[2.7] [FrameworkBundle] remove usage of deprecated Definition::setFactoryClass(), Definition::setFactoryService() and Definition::setFactoryMethod() methods.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -216,23 +216,24 @@ class JsonDescriptor extends Descriptor
             'synthetic' => $definition->isSynthetic(),
             'lazy' => $definition->isLazy(),
         );
+
         if (method_exists($definition, 'isSynchronized')) {
-            $data['synchronized'] = $definition->isSynchronized();
+            $data['synchronized'] = $definition->isSynchronized(false);
         }
 
         $data['abstract'] = $definition->isAbstract();
         $data['file'] = $definition->getFile();
 
-        if ($definition->getFactoryClass()) {
-            $data['factory_class'] = $definition->getFactoryClass();
+        if ($definition->getFactoryClass(false)) {
+            $data['factory_class'] = $definition->getFactoryClass(false);
         }
 
-        if ($definition->getFactoryService()) {
-            $data['factory_service'] = $definition->getFactoryService();
+        if ($definition->getFactoryService(false)) {
+            $data['factory_service'] = $definition->getFactoryService(false);
         }
 
-        if ($definition->getFactoryMethod()) {
-            $data['factory_method'] = $definition->getFactoryMethod();
+        if ($definition->getFactoryMethod(false)) {
+            $data['factory_method'] = $definition->getFactoryMethod(false);
         }
 
         if ($factory = $definition->getFactory()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -186,7 +186,7 @@ class MarkdownDescriptor extends Descriptor
         ;
 
         if (method_exists($definition, 'isSynchronized')) {
-            $output .= "\n".'- Synchronized: '.($definition->isSynchronized() ? 'yes' : 'no');
+            $output .= "\n".'- Synchronized: '.($definition->isSynchronized(false) ? 'yes' : 'no');
         }
 
         $output .= "\n".'- Abstract: '.($definition->isAbstract() ? 'yes' : 'no');
@@ -195,16 +195,16 @@ class MarkdownDescriptor extends Descriptor
             $output .= "\n".'- File: `'.$definition->getFile().'`';
         }
 
-        if ($definition->getFactoryClass()) {
-            $output .= "\n".'- Factory Class: `'.$definition->getFactoryClass().'`';
+        if ($definition->getFactoryClass(false)) {
+            $output .= "\n".'- Factory Class: `'.$definition->getFactoryClass(false).'`';
         }
 
-        if ($definition->getFactoryService()) {
-            $output .= "\n".'- Factory Service: `'.$definition->getFactoryService().'`';
+        if ($definition->getFactoryService(false)) {
+            $output .= "\n".'- Factory Service: `'.$definition->getFactoryService(false).'`';
         }
 
-        if ($definition->getFactoryMethod()) {
-            $output .= "\n".'- Factory Method: `'.$definition->getFactoryMethod().'`';
+        if ($definition->getFactoryMethod(false)) {
+            $output .= "\n".'- Factory Method: `'.$definition->getFactoryMethod(false).'`';
         }
 
         if ($factory = $definition->getFactory()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -266,7 +266,7 @@ class TextDescriptor extends Descriptor
         $description[] = sprintf('<comment>Synthetic</comment>        %s', $definition->isSynthetic() ? 'yes' : 'no');
         $description[] = sprintf('<comment>Lazy</comment>             %s', $definition->isLazy() ? 'yes' : 'no');
         if (method_exists($definition, 'isSynchronized')) {
-            $description[] = sprintf('<comment>Synchronized</comment>     %s', $definition->isSynchronized() ? 'yes' : 'no');
+            $description[] = sprintf('<comment>Synchronized</comment>     %s', $definition->isSynchronized(false) ? 'yes' : 'no');
         }
         $description[] = sprintf('<comment>Abstract</comment>         %s', $definition->isAbstract() ? 'yes' : 'no');
 
@@ -274,16 +274,16 @@ class TextDescriptor extends Descriptor
             $description[] = sprintf('<comment>Required File</comment>    %s', $definition->getFile() ? $definition->getFile() : '-');
         }
 
-        if ($definition->getFactoryClass()) {
-            $description[] = sprintf('<comment>Factory Class</comment>    %s', $definition->getFactoryClass());
+        if ($definition->getFactoryClass(false)) {
+            $description[] = sprintf('<comment>Factory Class</comment>    %s', $definition->getFactoryClass(false));
         }
 
-        if ($definition->getFactoryService()) {
-            $description[] = sprintf('<comment>Factory Service</comment>  %s', $definition->getFactoryService());
+        if ($definition->getFactoryService(false)) {
+            $description[] = sprintf('<comment>Factory Service</comment>  %s', $definition->getFactoryService(false));
         }
 
-        if ($definition->getFactoryMethod()) {
-            $description[] = sprintf('<comment>Factory Method</comment>   %s', $definition->getFactoryMethod());
+        if ($definition->getFactoryMethod(false)) {
+            $description[] = sprintf('<comment>Factory Method</comment>   %s', $definition->getFactoryMethod(false));
         }
 
         if ($factory = $definition->getFactory()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -66,6 +66,21 @@ abstract class AbstractDescriptorTest extends \PHPUnit_Framework_TestCase
         return $this->getContainerBuilderDescriptionTestData(ObjectsProvider::getContainerBuilders());
     }
 
+    /** @dataProvider provideLegacySynchronizedServiceDefinitionTestData */
+    public function testLegacyDescribeSynchronizedServiceDefinition(Definition $definition, $expectedDescription)
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $this->assertDescription($expectedDescription, $definition);
+    }
+
+    public function provideLegacySynchronizedServiceDefinitionTestData()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        return $this->getDescriptionTestData(ObjectsProvider::getLegacyContainerDefinitions());
+    }
+
     /** @dataProvider getDescribeContainerDefinitionTestData */
     public function testDescribeContainerDefinition(Definition $definition, $expectedDescription)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -97,10 +97,40 @@ class ObjectsProvider
                 ->setPublic(true)
                 ->setSynthetic(false)
                 ->setLazy(true)
-                ->setSynchronized(true)
                 ->setAbstract(true)
                 ->setFactory(array('Full\\Qualified\\FactoryClass', 'get')),
             'definition_2' => $definition2
+                ->setPublic(false)
+                ->setSynthetic(true)
+                ->setFile('/path/to/file')
+                ->setLazy(false)
+                ->setAbstract(false)
+                ->addTag('tag1', array('attr1' => 'val1', 'attr2' => 'val2'))
+                ->addTag('tag1', array('attr3' => 'val3'))
+                ->addTag('tag2')
+                ->setFactory(array(new Reference('factory.service'), 'get')),
+        );
+    }
+
+    /**
+     * @deprecated since version 2.7, to be removed in 3.0
+     * @internal
+     */
+    public static function getLegacyContainerDefinitions()
+    {
+        $definition1 = new Definition('Full\\Qualified\\Class1');
+        $definition2 = new Definition('Full\\Qualified\\Class2');
+
+        return array(
+            'legacy_synchronized_service_definition_1' => $definition1
+                ->setPublic(true)
+                ->setSynthetic(false)
+                ->setLazy(true)
+                ->setSynchronized(true)
+                ->setAbstract(true)
+                ->setFactoryClass('Full\\Qualified\\FactoryClass', 'get')
+                ->setFactoryMethod('get'),
+            'legacy_synchronized_service_definition_2' => $definition2
                 ->setPublic(false)
                 ->setSynthetic(true)
                 ->setFile('/path/to/file')
@@ -110,7 +140,8 @@ class ObjectsProvider
                 ->addTag('tag1', array('attr1' => 'val1', 'attr2' => 'val2'))
                 ->addTag('tag1', array('attr3' => 'val3'))
                 ->addTag('tag2')
-                ->setFactory(array(new Reference('factory.service'), 'get')),
+                ->setFactoryService('factory.service')
+                ->setFactoryMethod('get'),
         );
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
@@ -6,7 +6,7 @@
             "public": true,
             "synthetic": false,
             "lazy": true,
-            "synchronized": true,
+            "synchronized": false,
             "abstract": true,
             "file": null,
             "factory_class": "Full\\Qualified\\FactoryClass",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
@@ -12,7 +12,7 @@ definition_1
 - Public: yes
 - Synthetic: no
 - Lazy: yes
-- Synchronized: yes
+- Synchronized: no
 - Abstract: yes
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
@@ -2,7 +2,7 @@
 <container>
   <alias id="alias_1" service="service_1" public="true"/>
   <alias id="alias_2" service="service_2" public="false"/>
-  <definition id="definition_1" class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file="">
+  <definition id="definition_1" class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="false" abstract="true" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
   </definition>
   <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
@@ -6,7 +6,7 @@
             "public": true,
             "synthetic": false,
             "lazy": true,
-            "synchronized": true,
+            "synchronized": false,
             "abstract": true,
             "file": null,
             "factory_class": "Full\\Qualified\\FactoryClass",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
@@ -12,7 +12,7 @@ definition_1
 - Public: yes
 - Synthetic: no
 - Lazy: yes
-- Synchronized: yes
+- Synchronized: no
 - Abstract: yes
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
@@ -2,7 +2,7 @@
 <container>
   <alias id="alias_1" service="service_1" public="true"/>
   <alias id="alias_2" service="service_2" public="false"/>
-  <definition id="definition_1" class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file="">
+  <definition id="definition_1" class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="false" abstract="true" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
   </definition>
   <definition id="definition_2" class="Full\Qualified\Class2" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.json
@@ -4,7 +4,7 @@
     "public": true,
     "synthetic": false,
     "lazy": true,
-    "synchronized": true,
+    "synchronized": false,
     "abstract": true,
     "file": null,
     "factory_class": "Full\\Qualified\\FactoryClass",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definition class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file="">
+<definition class="Full\Qualified\Class1" scope="container" public="true" synthetic="false" lazy="true" synchronized="false" abstract="true" file="">
   <factory class="Full\Qualified\FactoryClass" method="get"/>
 </definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_1.json
@@ -1,0 +1,15 @@
+{
+  "class": "Full\\Qualified\\Class1",
+  "scope": "container",
+  "public": true,
+  "synthetic": false,
+  "lazy": true,
+  "synchronized": true,
+  "abstract": true,
+  "file": null,
+  "factory_class": "Full\\Qualified\\FactoryClass",
+  "factory_method": "get",
+  "tags": [
+
+  ]
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_1.md
@@ -3,7 +3,7 @@
 - Public: yes
 - Synthetic: no
 - Lazy: yes
-- Synchronized: no
+- Synchronized: yes
 - Abstract: yes
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_1.txt
@@ -5,7 +5,7 @@
 <comment>Public</comment>           yes
 <comment>Synthetic</comment>        no
 <comment>Lazy</comment>             yes
-<comment>Synchronized</comment>     no
+<comment>Synchronized</comment>     yes
 <comment>Abstract</comment>         yes
 <comment>Factory Class</comment>    Full\Qualified\FactoryClass
 <comment>Factory Method</comment>   get

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_1.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Full\Qualified\Class1" factory-class="Full\Qualified\FactoryClass" factory-method="get" scope="container" public="true" synthetic="false" lazy="true" synchronized="true" abstract="true" file=""/>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.json
@@ -1,0 +1,33 @@
+{
+  "class": "Full\\Qualified\\Class2",
+  "scope": "container",
+  "public": false,
+  "synthetic": true,
+  "lazy": false,
+  "synchronized": false,
+  "abstract": false,
+  "file": "\/path\/to\/file",
+  "factory_service": "factory.service",
+  "factory_method": "get",
+  "tags": [
+    {
+      "name": "tag1",
+      "parameters": {
+        "attr1": "val1",
+        "attr2": "val2"
+      }
+    },
+    {
+      "name": "tag1",
+      "parameters": {
+        "attr3": "val3"
+      }
+    },
+    {
+      "name": "tag2",
+      "parameters": [
+
+      ]
+    }
+  ]
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.md
@@ -1,0 +1,16 @@
+- Class: `Full\Qualified\Class2`
+- Scope: `container`
+- Public: no
+- Synthetic: yes
+- Lazy: no
+- Synchronized: no
+- Abstract: no
+- File: `/path/to/file`
+- Factory Service: `factory.service`
+- Factory Method: `get`
+- Tag: `tag1`
+    - Attr1: val1
+    - Attr2: val2
+- Tag: `tag1`
+    - Attr3: val3
+- Tag: `tag2`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.txt
@@ -1,0 +1,15 @@
+<comment>Service Id</comment>       -
+<comment>Class</comment>            Full\Qualified\Class2
+<comment>Tags</comment>
+    - tag1                           (<info>attr1</info>: val1, <info>attr2</info>: val2)
+    - tag1                           (<info>attr3</info>: val3)
+    - tag2                           ()
+<comment>Scope</comment>            container
+<comment>Public</comment>           no
+<comment>Synthetic</comment>        yes
+<comment>Lazy</comment>             no
+<comment>Synchronized</comment>     no
+<comment>Abstract</comment>         no
+<comment>Required File</comment>    /path/to/file
+<comment>Factory Service</comment>  factory.service
+<comment>Factory Method</comment>   get

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Full\Qualified\Class2" factory-service="factory.service" factory-method="get" scope="container" public="false" synthetic="true" lazy="false" synchronized="false" abstract="false" file="/path/to/file">
+  <tags>
+    <tag name="tag1">
+      <parameter name="attr1">val1</parameter>
+      <parameter name="attr2">val2</parameter>
+    </tag>
+    <tag name="tag1">
+      <parameter name="attr3">val3</parameter>
+    </tag>
+    <tag name="tag2"/>
+  </tags>
+</definition>

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -98,7 +98,7 @@ class Definition
      */
     public function setFactoryClass($factoryClass)
     {
-        trigger_error('The '.__METHOD__.' is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
 
         $this->factoryClass = $factoryClass;
 
@@ -116,7 +116,7 @@ class Definition
     public function getFactoryClass($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            trigger_error('The '.__METHOD__.' is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+            trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
         }
 
         return $this->factoryClass;
@@ -134,7 +134,7 @@ class Definition
      */
     public function setFactoryMethod($factoryMethod)
     {
-        trigger_error('The '.__METHOD__.' is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
 
         $this->factoryMethod = $factoryMethod;
 
@@ -187,7 +187,7 @@ class Definition
     public function getFactoryMethod($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            trigger_error('The '.__METHOD__.' is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+            trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
         }
 
         return $this->factoryMethod;
@@ -205,7 +205,7 @@ class Definition
      */
     public function setFactoryService($factoryService)
     {
-        trigger_error('The '.__METHOD__.' is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
 
         $this->factoryService = $factoryService;
 
@@ -223,7 +223,7 @@ class Definition
     public function getFactoryService($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            trigger_error('The '.__METHOD__.' is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+            trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
         }
 
         return $this->factoryService;
@@ -667,7 +667,7 @@ class Definition
     public function setSynchronized($boolean, $triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            trigger_error('The '.__METHOD__.' method is deprecated in version 2.7 and will be removed in version 3.0.', E_USER_DEPRECATED);
+            trigger_error('The '.__METHOD__.' method is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
         }
 
         $this->synchronized = (bool) $boolean;
@@ -687,7 +687,7 @@ class Definition
     public function isSynchronized($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            trigger_error('The '.__METHOD__.' method is deprecated in version 2.7 and will be removed in version 3.0.', E_USER_DEPRECATED);
+            trigger_error('The '.__METHOD__.' method is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
         }
 
         return $this->synchronized;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -53,8 +53,10 @@ class CheckDefinitionValidityPassTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      */
-    public function testProcessDetectsBothFactorySyntaxesUsed()
+    public function testLegacyProcessDetectsBothFactorySyntaxesUsed()
     {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
         $container = new ContainerBuilder();
         $container->register('a')->setFactory(array('a', 'b'))->setFactoryClass('a');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionDecoratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionDecoratorTest.php
@@ -44,11 +44,35 @@ class DefinitionDecoratorTest extends \PHPUnit_Framework_TestCase
         return array(
             array('class', 'class'),
             array('factory', 'factory'),
+            array('configurator', 'configurator'),
+            array('file', 'file'),
+        );
+    }
+
+    /**
+     * @dataProvider provideLegacyPropertyTests
+     */
+    public function testLegacySetProperty($property, $changeKey)
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $def = new DefinitionDecorator('foo');
+
+        $getter = 'get'.ucfirst($property);
+        $setter = 'set'.ucfirst($property);
+
+        $this->assertNull($def->$getter());
+        $this->assertSame($def, $def->$setter('foo'));
+        $this->assertEquals('foo', $def->$getter());
+        $this->assertEquals(array($changeKey => true), $def->getChanges());
+    }
+
+    public function provideLegacyPropertyTests()
+    {
+        return array(
             array('factoryClass', 'factory_class'),
             array('factoryMethod', 'factory_method'),
             array('factoryService', 'factory_service'),
-            array('configurator', 'configurator'),
-            array('file', 'file'),
         );
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
@@ -23,6 +23,13 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
         self::$fixturesPath = __DIR__.'/../Fixtures/';
     }
 
+    public function testLegacyDump()
+    {
+        $container = include self::$fixturesPath.'/containers/legacy-container9.php';
+        $dumper = new GraphvizDumper($container);
+        $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/legacy-services9.dot')), $dumper->dump(), '->dump() dumps services');
+    }
+
     public function testDump()
     {
         $dumper = new GraphvizDumper($container = new ContainerBuilder());

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -47,10 +47,31 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/xml/services8.xml', $dumper->dump(), '->dump() dumps parameters');
     }
 
+    public function testLegacyAddService()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $container = include self::$fixturesPath.'/containers/legacy-container9.php';
+        $dumper = new XmlDumper($container);
+
+        $this->assertEquals(str_replace('%path%', self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR, file_get_contents(self::$fixturesPath.'/xml/legacy-services9.xml')), $dumper->dump(), '->dump() dumps services');
+
+        $dumper = new XmlDumper($container = new ContainerBuilder());
+        $container->register('foo', 'FooClass')->addArgument(new \stdClass());
+        try {
+            $dumper->dump();
+            $this->fail('->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\RuntimeException', $e, '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+            $this->assertEquals('Unable to dump a service container if a parameter is an object or a resource.', $e->getMessage(), '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+        }
+    }
+
     public function testAddService()
     {
         $container = include self::$fixturesPath.'/containers/container9.php';
         $dumper = new XmlDumper($container);
+
         $this->assertEquals(str_replace('%path%', self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR, file_get_contents(self::$fixturesPath.'/xml/services9.xml')), $dumper->dump(), '->dump() dumps services');
 
         $dumper = new XmlDumper($container = new ContainerBuilder());

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -40,6 +40,26 @@ class YamlDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services8.yml', $dumper->dump(), '->dump() dumps parameters');
     }
 
+    public function testLegacyAddService()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $container = include self::$fixturesPath.'/containers/legacy-container9.php';
+        $dumper = new YamlDumper($container);
+
+        $this->assertEquals(str_replace('%path%', self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR, file_get_contents(self::$fixturesPath.'/yaml/legacy-services9.yml')), $dumper->dump(), '->dump() dumps services');
+
+        $dumper = new YamlDumper($container = new ContainerBuilder());
+        $container->register('foo', 'FooClass')->addArgument(new \stdClass());
+        try {
+            $dumper->dump();
+            $this->fail('->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\RuntimeException', $e, '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+            $this->assertEquals('Unable to dump a service container if a parameter is an object or a resource.', $e->getMessage(), '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+        }
+    }
+
     public function testAddService()
     {
         $container = include self::$fixturesPath.'/containers/container9.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -9,33 +9,31 @@ use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 $container = new ContainerBuilder();
-$container->
-    register('foo', 'Bar\FooClass')->
-    addTag('foo', array('foo' => 'foo'))->
-    addTag('foo', array('bar' => 'bar', 'baz' => 'baz'))->
-    setFactoryClass('Bar\\FooClass')->
-    setFactoryMethod('getInstance')->
-    setArguments(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))->
-    setProperties(array('foo' => 'bar', 'moo' => new Reference('foo.baz'), 'qux' => array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%')))->
-    addMethodCall('setBar', array(new Reference('bar')))->
-    addMethodCall('initialize')->
-    setConfigurator('sc_configure')
+$container
+    ->register('foo', 'Bar\FooClass')
+    ->addTag('foo', array('foo' => 'foo'))
+    ->addTag('foo', array('bar' => 'bar', 'baz' => 'baz'))
+    ->setFactory(array('Bar\\FooClass', 'getInstance'))
+    ->setArguments(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))
+    ->setProperties(array('foo' => 'bar', 'moo' => new Reference('foo.baz'), 'qux' => array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%')))
+    ->addMethodCall('setBar', array(new Reference('bar')))
+    ->addMethodCall('initialize')
+    ->setConfigurator('sc_configure')
 ;
-$container->
-    register('bar', 'Bar\FooClass')->
-    setArguments(array('foo', new Reference('foo.baz'), new Parameter('foo_bar')))->
-    setScope('container')->
-    setConfigurator(array(new Reference('foo.baz'), 'configure'))
+$container
+    ->register('foo.baz', '%baz_class%')
+    ->setFactory(array('%baz_class%', 'getInstance'))
+    ->setConfigurator(array('%baz_class%', 'configureStatic1'))
 ;
-$container->
-    register('foo.baz', '%baz_class%')->
-    setFactoryClass('%baz_class%')->
-    setFactoryMethod('getInstance')->
-    setConfigurator(array('%baz_class%', 'configureStatic1'))
+$container
+    ->register('bar', 'Bar\FooClass')
+    ->setArguments(array('foo', new Reference('foo.baz'), new Parameter('foo_bar')))
+    ->setScope('container')
+    ->setConfigurator(array(new Reference('foo.baz'), 'configure'))
 ;
-$container->
-    register('foo_bar', '%foo_class%')->
-    setScope('prototype')
+$container
+    ->register('foo_bar', '%foo_class%')
+    ->setScope('prototype')
 ;
 $container->getParameterBag()->clear();
 $container->getParameterBag()->add(array(
@@ -45,21 +43,15 @@ $container->getParameterBag()->add(array(
 ));
 $container->setAlias('alias_for_foo', 'foo');
 $container->setAlias('alias_for_alias', 'alias_for_foo');
-$container->
-    register('method_call1', 'Bar\FooClass')->
-    setFile(realpath(__DIR__.'/../includes/foo.php'))->
-    addMethodCall('setBar', array(new Reference('foo')))->
-    addMethodCall('setBar', array(new Reference('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE)))->
-    addMethodCall('setBar', array(new Reference('foo3', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))->
-    addMethodCall('setBar', array(new Reference('foobaz', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))->
-    addMethodCall('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))
+$container
+    ->register('method_call1', 'Bar\FooClass')
+    ->setFile(realpath(__DIR__.'/../includes/foo.php'))
+    ->addMethodCall('setBar', array(new Reference('foo')))
+    ->addMethodCall('setBar', array(new Reference('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE)))
+    ->addMethodCall('setBar', array(new Reference('foo3', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
+    ->addMethodCall('setBar', array(new Reference('foobaz', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
+    ->addMethodCall('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))
 ;
-$container->
-    register('factory_service', 'Bar')->
-    setFactoryService('foo.baz')->
-    setFactoryMethod('getInstance')
-;
-
 $container
     ->register('foo_with_inline', 'Foo')
     ->addMethodCall('setBar', array(new Reference('inlined')))
@@ -103,6 +95,10 @@ $container
     ->setProperty('foo', 'bar')
     ->setScope('container')
     ->setPublic(false)
+;
+$container
+    ->register('factory_service', 'Bar')
+    ->setFactory(array(new Reference('foo.baz'), 'getInstance'))
 ;
 $container
     ->register('new_factory_service', 'FooBarBaz')

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/legacy-container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/legacy-container9.php
@@ -1,0 +1,39 @@
+<?php
+
+require_once __DIR__.'/../includes/classes.php';
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+$container = new ContainerBuilder();
+$container->
+    register('foo', 'Bar\FooClass')->
+    addTag('foo', array('foo' => 'foo'))->
+    addTag('foo', array('bar' => 'bar'))->
+    setFactoryClass('Bar\\FooClass')->
+    setFactoryMethod('getInstance')->
+    setArguments(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))->
+    setProperties(array('foo' => 'bar', 'moo' => new Reference('foo.baz'), 'qux' => array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%')))->
+    addMethodCall('setBar', array(new Reference('bar')))->
+    addMethodCall('initialize')->
+    setConfigurator('sc_configure')
+;
+$container->
+    register('foo.baz', '%baz_class%')->
+    setFactoryClass('%baz_class%')->
+    setFactoryMethod('getInstance')->
+    setConfigurator(array('%baz_class%', 'configureStatic1'))
+;
+$container->
+    register('factory_service', 'Bar')->
+    setFactoryService('foo.baz')->
+    setFactoryMethod('getInstance')
+;
+$container->getParameterBag()->clear();
+$container->getParameterBag()->add(array(
+    'baz_class' => 'BazClass',
+    'foo' => 'bar',
+));
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/legacy-services9.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/legacy-services9.dot
@@ -1,0 +1,15 @@
+digraph sc {
+  ratio="compress"
+  node [fontsize="11" fontname="Arial" shape="record"];
+  edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
+
+  node_foo [label="foo\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_foo_baz [label="foo.baz\nBazClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_factory_service [label="factory_service\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];
+  node_bar [label="bar\n\n", shape=record, fillcolor="#ff9999", style="filled"];
+  node_foo -> node_foo_baz [label="" style="filled"];
+  node_foo -> node_service_container [label="" style="filled"];
+  node_foo -> node_foo_baz [label="" style="dashed"];
+  node_foo -> node_bar [label="setBar()" style="dashed"];
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
@@ -4,11 +4,10 @@ digraph sc {
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
   node_foo [label="foo (alias_for_foo)\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
-  node_bar [label="bar\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo_baz [label="foo.baz\nBazClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_bar [label="bar\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo_bar [label="foo_bar\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="dotted"];
   node_method_call1 [label="method_call1\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
-  node_factory_service [label="factory_service\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo_with_inline [label="foo_with_inline\nFoo\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_inlined [label="inlined\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_baz [label="baz\nBaz\n", shape=record, fillcolor="#eeeeee", style="filled"];
@@ -19,6 +18,7 @@ digraph sc {
   node_decorator_service [label="decorator_service\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_decorator_service_with_name [label="decorator_service_with_name\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_new_factory [label="new_factory\nFactoryClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_factory_service [label="factory_service\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_new_factory_service [label="new_factory_service\nFooBarBaz\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_service_from_static_method [label="service_from_static_method\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy-services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy-services6.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="constructor" class="FooClass" factory-method="getInstance" />
+    <service id="factory_service" factory-method="getInstance" factory-service="baz_factory" />
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy-services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy-services9.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <parameters>
+    <parameter key="baz_class">BazClass</parameter>
+    <parameter key="foo">bar</parameter>
+  </parameters>
+  <services>
+    <service id="foo" class="Bar\FooClass" factory-method="getInstance" factory-class="Bar\FooClass">
+      <tag name="foo" foo="foo"/>
+      <tag name="foo" bar="bar"/>
+      <argument>foo</argument>
+      <argument type="service" id="foo.baz"/>
+      <argument type="collection">
+        <argument key="%foo%">foo is %foo%</argument>
+        <argument key="foobar">%foo%</argument>
+      </argument>
+      <argument>true</argument>
+      <argument type="service" id="service_container"/>
+      <property name="foo">bar</property>
+      <property name="moo" type="service" id="foo.baz"/>
+      <property name="qux" type="collection">
+        <property key="%foo%">foo is %foo%</property>
+        <property key="foobar">%foo%</property>
+      </property>
+      <call method="setBar">
+        <argument type="service" id="bar"/>
+      </call>
+      <call method="initialize"/>
+      <configurator function="sc_configure"/>
+    </service>
+    <service id="foo.baz" class="%baz_class%" factory-method="getInstance" factory-class="%baz_class%">
+      <configurator class="%baz_class%" method="configureStatic1"/>
+    </service>
+    <service id="factory_service" class="Bar" factory-method="getInstance" factory-service="foo.baz"/>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -9,7 +9,6 @@
     <service id="scope.container" class="FooClass" scope="container" />
     <service id="scope.custom" class="FooClass" scope="custom" />
     <service id="scope.prototype" class="FooClass" scope="prototype" />
-    <service id="constructor" class="FooClass" factory-method="getInstance" />
     <service id="file" class="FooClass">
       <file>%path%/foo.php</file>
     </service>
@@ -48,7 +47,6 @@
     </service>
     <service id="alias_for_foo" alias="foo" />
     <service id="another_alias_for_foo" alias="foo" public="false" />
-    <service id="factory_service" factory-method="getInstance" factory-service="baz_factory" />
     <service id="request" class="Request" synthetic="true" synchronized="true" lazy="true"/>
     <service id="decorator_service" decorates="decorated" />
     <service id="decorator_service_with_name" decorates="decorated" decoration-inner-name="decorated.pif-pouf"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -6,7 +6,7 @@
     <parameter key="foo">bar</parameter>
   </parameters>
   <services>
-    <service id="foo" class="Bar\FooClass" factory-method="getInstance" factory-class="Bar\FooClass">
+    <service id="foo" class="Bar\FooClass">
       <tag name="foo" foo="foo"/>
       <tag name="foo" bar="bar" baz="baz"/>
       <argument>foo</argument>
@@ -27,16 +27,18 @@
         <argument type="service" id="bar"/>
       </call>
       <call method="initialize"/>
+      <factory class="Bar\FooClass" method="getInstance"/>
       <configurator function="sc_configure"/>
+    </service>
+    <service id="foo.baz" class="%baz_class%">
+      <factory class="%baz_class%" method="getInstance"/>
+      <configurator class="%baz_class%" method="configureStatic1"/>
     </service>
     <service id="bar" class="Bar\FooClass">
       <argument>foo</argument>
       <argument type="service" id="foo.baz"/>
       <argument>%foo_bar%</argument>
       <configurator service="foo.baz" method="configure"/>
-    </service>
-    <service id="foo.baz" class="%baz_class%" factory-method="getInstance" factory-class="%baz_class%">
-      <configurator class="%baz_class%" method="configureStatic1"/>
     </service>
     <service id="foo_bar" class="%foo_class%" scope="prototype"/>
     <service id="method_call1" class="Bar\FooClass">
@@ -57,7 +59,6 @@
         <argument type="expression">service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")</argument>
       </call>
     </service>
-    <service id="factory_service" class="Bar" factory-method="getInstance" factory-service="foo.baz"/>
     <service id="foo_with_inline" class="Foo">
       <call method="setBar">
         <argument type="service" id="inlined"/>
@@ -88,6 +89,9 @@
     <service id="decorator_service_with_name" class="stdClass" decorates="decorated" decoration-inner-name="decorated.pif-pouf"/>
     <service id="new_factory" class="FactoryClass" public="false">
       <property name="foo">bar</property>
+    </service>
+    <service id="factory_service" class="Bar">
+      <factory service="foo.baz" method="getInstance"/>
     </service>
     <service id="new_factory_service" class="FooBarBaz">
       <property name="foo">bar</property>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy-services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy-services6.yml
@@ -1,0 +1,3 @@
+services:
+    constructor: { class: FooClass, factory_method: getInstance }
+    factory_service: { class: BazClass, factory_method: getInstance, factory_service: baz_factory }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy-services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy-services9.yml
@@ -1,0 +1,28 @@
+parameters:
+    baz_class: BazClass
+    foo: bar
+
+services:
+    foo:
+        class: Bar\FooClass
+        tags:
+            - { name: foo, foo: foo }
+            - { name: foo, bar: bar }
+        factory_class: Bar\FooClass
+        factory_method: getInstance
+        arguments: [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%' }, true, '@service_container']
+        properties: { foo: bar, moo: '@foo.baz', qux: { '%foo%': 'foo is %foo%', foobar: '%foo%' } }
+        calls:
+            - [setBar, ['@bar']]
+            - [initialize, {  }]
+
+        configurator: sc_configure
+    foo.baz:
+        class: %baz_class%
+        factory_class: %baz_class%
+        factory_method: getInstance
+        configurator: ['%baz_class%', configureStatic1]
+    factory_service:
+        class: Bar
+        factory_method: getInstance
+        factory_service: foo.baz

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -4,7 +4,6 @@ services:
     scope.container: { class: FooClass, scope: container }
     scope.custom: { class: FooClass, scope: custom }
     scope.prototype: { class: FooClass, scope: prototype }
-    constructor: { class: FooClass, factory_method: getInstance }
     file: { class: FooClass, file: %path%/foo.php }
     arguments: { class: FooClass, arguments: [foo, @foo, [true, false]] }
     configurator1: { class: FooClass, configurator: sc_configure }
@@ -24,7 +23,6 @@ services:
     another_alias_for_foo:
         alias: foo
         public: false
-    factory_service: { class: BazClass, factory_method: getInstance, factory_service: baz_factory }
     request:
         class: Request
         synthetic: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -9,24 +9,22 @@ services:
         tags:
             - { name: foo, foo: foo }
             - { name: foo, bar: bar, baz: baz }
-        factory_class: Bar\FooClass
-        factory_method: getInstance
         arguments: [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%' }, true, '@service_container']
         properties: { foo: bar, moo: '@foo.baz', qux: { '%foo%': 'foo is %foo%', foobar: '%foo%' } }
         calls:
             - [setBar, ['@bar']]
             - [initialize, {  }]
 
+        factory: [Bar\FooClass, getInstance]
         configurator: sc_configure
+    foo.baz:
+        class: %baz_class%
+        factory: ['%baz_class%', getInstance]
+        configurator: ['%baz_class%', configureStatic1]
     bar:
         class: Bar\FooClass
         arguments: [foo, '@foo.baz', '%foo_bar%']
         configurator: ['@foo.baz', configure]
-    foo.baz:
-        class: %baz_class%
-        factory_class: %baz_class%
-        factory_method: getInstance
-        configurator: ['%baz_class%', configureStatic1]
     foo_bar:
         class: %foo_class%
         scope: prototype
@@ -40,10 +38,6 @@ services:
             - [setBar, ['@?foobaz']]
             - [setBar, ['@=service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")']]
 
-    factory_service:
-        class: Bar
-        factory_method: getInstance
-        factory_service: foo.baz
     foo_with_inline:
         class: Foo
         calls:
@@ -86,6 +80,9 @@ services:
         class: FactoryClass
         public: false
         properties: { foo: bar }
+    factory_service:
+        class: Bar
+        factory: ['@foo.baz', getInstance]
     new_factory_service:
         class: FooBarBaz
         properties: { foo: bar }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -191,6 +191,21 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('BazClass', $inner->getClass(), '->load() uses the same configuration as for the anonymous ones');
     }
 
+    public function testLegacyLoadServices()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('legacy-services6.xml');
+        $services = $container->getDefinitions();
+        $this->assertEquals('FooClass', $services['constructor']->getClass());
+        $this->assertEquals('getInstance', $services['constructor']->getFactoryMethod());
+        $this->assertNull($services['factory_service']->getClass());
+        $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
+        $this->assertEquals('getInstance', $services['factory_service']->getFactoryMethod());
+    }
+
     public function testLoadServices()
     {
         $container = new ContainerBuilder();
@@ -203,7 +218,6 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('container', $services['scope.container']->getScope());
         $this->assertEquals('custom', $services['scope.custom']->getScope());
         $this->assertEquals('prototype', $services['scope.prototype']->getScope());
-        $this->assertEquals('getInstance', $services['constructor']->getFactoryMethod(), '->load() parses the factory-method attribute');
         $this->assertEquals('%path%/foo.php', $services['file']->getFile(), '->load() parses the file tag');
         $this->assertEquals(array('foo', new Reference('foo'), array(true, false)), $services['arguments']->getArguments(), '->load() parses the argument tags');
         $this->assertEquals('sc_configure', $services['configurator1']->getConfigurator(), '->load() parses the configurator tag');
@@ -211,9 +225,6 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('BazClass', 'configureStatic'), $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array(array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
-        $this->assertNull($services['factory_service']->getClass());
-        $this->assertEquals('getInstance', $services['factory_service']->getFactoryMethod());
-        $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');
         $this->assertEquals(array(new Reference('baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false), 'getClass'), $services['new_factory2']->getFactory(), '->load() parses the factory tag');
         $this->assertEquals(array('BazClass', 'getInstance'), $services['new_factory3']->getFactory(), '->load() parses the factory tag');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -120,6 +120,19 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services4_bad_import.yml');
     }
 
+    public function testLegacyLoadServices()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('legacy-services6.yml');
+        $services = $container->getDefinitions();
+        $this->assertEquals('FooClass', $services['constructor']->getClass());
+        $this->assertEquals('getInstance', $services['constructor']->getFactoryMethod());
+        $this->assertEquals('BazClass', $services['factory_service']->getClass());
+        $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
+        $this->assertEquals('getInstance', $services['factory_service']->getFactoryMethod());
+    }
+
     public function testLoadServices()
     {
         $container = new ContainerBuilder();
@@ -132,7 +145,6 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('container', $services['scope.container']->getScope());
         $this->assertEquals('custom', $services['scope.custom']->getScope());
         $this->assertEquals('prototype', $services['scope.prototype']->getScope());
-        $this->assertEquals('getInstance', $services['constructor']->getFactoryMethod(), '->load() parses the factory_method attribute');
         $this->assertEquals('%path%/foo.php', $services['file']->getFile(), '->load() parses the file tag');
         $this->assertEquals(array('foo', new Reference('foo'), array(true, false)), $services['arguments']->getArguments(), '->load() parses the argument tags');
         $this->assertEquals('sc_configure', $services['configurator1']->getConfigurator(), '->load() parses the configurator tag');
@@ -140,7 +152,6 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('BazClass', 'configureStatic'), $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array(array('setBar', array()), array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
-        $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');
         $this->assertEquals(array(new Reference('baz'), 'getClass'), $services['new_factory2']->getFactory(), '->load() parses the factory tag');
         $this->assertEquals(array('BazClass', 'getInstance'), $services['new_factory3']->getFactory(), '->load() parses the factory tag');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
