### PR TITLE
[HttpKernel] Fixed Kernel::getContainerClass, to prevent invalid PHP class name

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -242,7 +242,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @throws \RuntimeException if a custom resource is hidden by a resource in a derived bundle
      */
@@ -308,7 +308,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     public function getName()
     {
         if (null === $this->name) {
-            $this->name = preg_replace('/(^[0-9]*|[^a-zA-Z0-9_]+)/', '', basename($this->rootDir)) ?: 'app';
+            $this->name = preg_replace('/[^a-zA-Z0-9_]+/', '', basename($this->rootDir));
         }
 
         return $this->name;
@@ -502,7 +502,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     protected function getContainerClass()
     {
-        return $this->name.ucfirst($this->environment).($this->debug ? 'Debug' : '').'ProjectContainer';
+        return preg_replace('/(^[0-9]*|[^a-zA-Z0-9_]+)/', '', $this->name.ucfirst($this->environment)).($this->debug ? 'Debug' : '').'ProjectContainer';
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -308,7 +308,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     public function getName()
     {
         if (null === $this->name) {
-            $this->name = preg_replace('/[^a-zA-Z0-9_]+/', '', basename($this->rootDir));
+            $this->name = preg_replace('/(^[0-9]*|[^a-zA-Z0-9_]+)/', '', basename($this->rootDir)) ?: 'app';
         }
 
         return $this->name;

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -386,6 +386,31 @@ EOF;
         $this->assertEquals('Fixtures', $kernel->getName());
     }
 
+    public function getGetNameWithWeirdDirectoryTests()
+    {
+        return array(
+            array('app', 12345),
+            array('Application', '12345Application'),
+            array('Application12345', 'Application12345'),
+            array('Application12345', '12345Application12345'),
+        );
+    }
+
+    /** @dataProvider getGetNameWithWeirdDirectoryTests */
+    public function testGetNameWithWeirdDirectory($expected, $rootDir)
+    {
+        $kernel = new KernelForTest('test', true);
+        $p = new \ReflectionProperty($kernel, 'rootDir');
+        $p->setAccessible(true);
+        $p->setValue($kernel, $rootDir);
+
+        $p = new \ReflectionProperty($kernel, 'name');
+        $p->setAccessible(true);
+        $p->setValue($kernel, null);
+
+        $this->assertEquals($expected, $kernel->getName());
+    }
+
     public function testOverrideGetName()
     {
         $kernel = new KernelForOverrideName('test', true);

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -389,26 +389,30 @@ EOF;
     public function getGetNameWithWeirdDirectoryTests()
     {
         return array(
-            array('app', 12345),
-            array('Application', '12345Application'),
-            array('Application12345', 'Application12345'),
-            array('Application12345', '12345Application12345'),
+            array('appDevProjectContainer', 'dev', 'app'),
+            array('appFoobarProjectContainer', 'foo bar', 'app'),
+            array('appProjectContainer', '..**..', 'app'),
+            array('ProjectContainer', '..**..', '12345'),
+            array('DevProjectContainer', 'dev', 12345),
+            array('ApplicationDevProjectContainer', 'dev', '12345Application'),
+            array('Application12345DevProjectContainer', 'dev', 'Application12345'),
+            array('Application12345DevProjectContainer', 'dev', '12345Application12345'),
         );
     }
 
     /** @dataProvider getGetNameWithWeirdDirectoryTests */
-    public function testGetNameWithWeirdDirectory($expected, $rootDir)
+    public function testGetContainerClass($expected, $environment, $rootDir)
     {
-        $kernel = new KernelForTest('test', true);
-        $p = new \ReflectionProperty($kernel, 'rootDir');
-        $p->setAccessible(true);
-        $p->setValue($kernel, $rootDir);
+        $kernel = new KernelForTest($environment, false);
 
         $p = new \ReflectionProperty($kernel, 'name');
         $p->setAccessible(true);
-        $p->setValue($kernel, null);
+        $p->setValue($kernel, $rootDir);
 
-        $this->assertEquals($expected, $kernel->getName());
+        $m = new \ReflectionMethod($kernel, 'getContainerClass');
+        $m->setAccessible(true);
+
+        $this->assertEquals($expected, $m->invoke($kernel));
     }
 
     public function testOverrideGetName()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

If the folder which contains the kernel begin with a number, symfony will crash because symfony will create a container class starting with a number.

~~I'm not sure if I should fix the `getName` method, or only the `getContainerClass()`.
More over, if the `environment` contains some invalid characters, it should be fixed too.~~

Actually, I sanitaze only the `getContainerClass` method. I did not squashed my commit if I need to revert ;)
