### PR TITLE
[DX] Attempt to improve logging messages with  parameters

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -146,7 +146,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
             $allListeners = $this->getListeners();
         } catch (\Exception $e) {
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('An exception was thrown while getting the uncalled listeners (%s)', $e->getMessage()), array('exception' => $e));
+                $this->logger->info('An exception was thrown while getting the uncalled listeners', array('exception' => $e));
             }
 
             // unable to retrieve the uncalled listeners

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -146,7 +146,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
             $allListeners = $this->getListeners();
         } catch (\Exception $e) {
             if (null !== $this->logger) {
-                $this->logger->info('An exception was thrown while getting the uncalled listeners', array('exception' => $e));
+                $this->logger->info('An exception was thrown while getting the uncalled listeners.', array('exception' => $e));
             }
 
             // unable to retrieve the uncalled listeners

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -51,7 +51,7 @@ class ControllerResolver implements ControllerResolverInterface
     {
         if (!$controller = $request->attributes->get('_controller')) {
             if (null !== $this->logger) {
-                $this->logger->warning('Unable to look for the controller as the "_controller" parameter is missing');
+                $this->logger->warning('Unable to look for the controller as the "_controller" parameter is missing.');
             }
 
             return false;

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -140,7 +140,7 @@ class RouterListener implements EventSubscriberInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s"', $parameters['_route']), $parameters);
+                $this->logger->info(sprintf('Matched route "%s".', $parameters['_route']), $parameters);
             }
 
             $request->attributes->add($parameters);

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -117,7 +117,7 @@ class Profiler
         }
 
         if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {
-            $this->logger->warning('Unable to store the profiler information.');
+            $this->logger->warning('Unable to store the profiler information.', array('used_storage' => get_class($this->storage)));
         }
 
         return $ret;

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -117,7 +117,7 @@ class Profiler
         }
 
         if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {
-            $this->logger->warning('Unable to store the profiler information.', array('used_storage' => get_class($this->storage)));
+            $this->logger->warning('Unable to store the profiler information.', array('configured_storage' => get_class($this->storage)));
         }
 
         return $ret;

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -20,7 +20,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
     public function testGetControllerWithoutControllerParameter()
     {
         $logger = $this->getMock('Psr\Log\LoggerInterface');
-        $logger->expects($this->once())->method('warning')->with('Unable to look for the controller as the "_controller" parameter is missing');
+        $logger->expects($this->once())->method('warning')->with('Unable to look for the controller as the "_controller" parameter is missing.');
         $resolver = $this->createControllerResolver($logger);
 
         $request = Request::create('/');

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -64,7 +64,7 @@ class AclVoter implements VoterInterface
 
             if (null === $object) {
                 if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable ? 'grant access' : 'abstain'));
+                    $this->logger->debug(sprintf('Object identity unavailable. Voting to %s.', $this->allowIfObjectIdentityUnavailable ? 'grant access' : 'abstain'));
                 }
 
                 return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
@@ -79,7 +79,7 @@ class AclVoter implements VoterInterface
                 $oid = $object;
             } elseif (null === $oid = $this->objectIdentityRetrievalStrategy->getObjectIdentity($object)) {
                 if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable ? 'grant access' : 'abstain'));
+                    $this->logger->debug(sprintf('Object identity unavailable. Voting to %s.', $this->allowIfObjectIdentityUnavailable ? 'grant access' : 'abstain'));
                 }
 
                 return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
@@ -96,13 +96,13 @@ class AclVoter implements VoterInterface
 
                 if (null === $field && $acl->isGranted($masks, $sids, false)) {
                     if (null !== $this->logger) {
-                        $this->logger->debug('ACL found, permission granted. Voting to grant access');
+                        $this->logger->debug('ACL found, permission granted. Voting to grant access.');
                     }
 
                     return self::ACCESS_GRANTED;
                 } elseif (null !== $field && $acl->isFieldGranted($field, $masks, $sids, false)) {
                     if (null !== $this->logger) {
-                        $this->logger->debug('ACL found, permission granted. Voting to grant access');
+                        $this->logger->debug('ACL found, permission granted. Voting to grant access.');
                     }
 
                     return self::ACCESS_GRANTED;

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -92,7 +92,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
 
         if ($this->options['failure_forward']) {
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Forwarding to %s', $this->options['failure_path']));
+                $this->logger->debug('Authentication failure, forward triggered', array('failure_path' => $this->options['failure_path']));
             }
 
             $subRequest = $this->httpUtils->createRequest($request, $this->options['failure_path']);
@@ -102,7 +102,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Redirecting to %s', $this->options['failure_path']));
+            $this->logger->debug('Authentication failure, redirect triggered', array('failure_path' => $this->options['failure_path']));
         }
 
         $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -92,7 +92,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
 
         if ($this->options['failure_forward']) {
             if (null !== $this->logger) {
-                $this->logger->debug('Authentication failure, forward triggered', array('failure_path' => $this->options['failure_path']));
+                $this->logger->debug('Authentication failure, forward triggered.', array('failure_path' => $this->options['failure_path']));
             }
 
             $subRequest = $this->httpUtils->createRequest($request, $this->options['failure_path']);
@@ -102,7 +102,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('Authentication failure, redirect triggered', array('failure_path' => $this->options['failure_path']));
+            $this->logger->debug('Authentication failure, redirect triggered.', array('failure_path' => $this->options['failure_path']));
         }
 
         $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);

--- a/src/Symfony/Component/Security/Http/Authentication/SimpleAuthenticationHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimpleAuthenticationHandler.php
@@ -57,7 +57,7 @@ class SimpleAuthenticationHandler implements AuthenticationFailureHandlerInterfa
     {
         if ($this->simpleAuthenticator instanceof AuthenticationSuccessHandlerInterface) {
             if ($this->logger) {
-                $this->logger->debug('Selected an authentication success handler', array('handler' => get_class($this->simpleAuthenticator)));
+                $this->logger->debug('Selected an authentication success handler.', array('handler' => get_class($this->simpleAuthenticator)));
             }
 
             $response = $this->simpleAuthenticator->onAuthenticationSuccess($request, $token);
@@ -71,7 +71,7 @@ class SimpleAuthenticationHandler implements AuthenticationFailureHandlerInterfa
         }
 
         if ($this->logger) {
-            $this->logger->debug('Fallback to the default authentication success handler');
+            $this->logger->debug('Fallback to the default authentication success handler.');
         }
 
         return $this->successHandler->onAuthenticationSuccess($request, $token);
@@ -84,7 +84,7 @@ class SimpleAuthenticationHandler implements AuthenticationFailureHandlerInterfa
     {
         if ($this->simpleAuthenticator instanceof AuthenticationFailureHandlerInterface) {
             if ($this->logger) {
-                $this->logger->debug('Selected an authentication failure handler', array('handler' => get_class($this->simpleAuthenticator)));
+                $this->logger->debug('Selected an authentication failure handler.', array('handler' => get_class($this->simpleAuthenticator)));
             }
 
             $response = $this->simpleAuthenticator->onAuthenticationFailure($request, $exception);
@@ -98,7 +98,7 @@ class SimpleAuthenticationHandler implements AuthenticationFailureHandlerInterfa
         }
 
         if ($this->logger) {
-            $this->logger->debug('Fallback to the default authentication failure handler');
+            $this->logger->debug('Fallback to the default authentication failure handler.');
         }
 
         return $this->failureHandler->onAuthenticationFailure($request, $exception);

--- a/src/Symfony/Component/Security/Http/Authentication/SimpleAuthenticationHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimpleAuthenticationHandler.php
@@ -57,7 +57,7 @@ class SimpleAuthenticationHandler implements AuthenticationFailureHandlerInterfa
     {
         if ($this->simpleAuthenticator instanceof AuthenticationSuccessHandlerInterface) {
             if ($this->logger) {
-                $this->logger->debug(sprintf('Using the %s object as authentication success handler', get_class($this->simpleAuthenticator)));
+                $this->logger->debug('Selected an authentication success handler', array('handler' => get_class($this->simpleAuthenticator)));
             }
 
             $response = $this->simpleAuthenticator->onAuthenticationSuccess($request, $token);
@@ -84,7 +84,7 @@ class SimpleAuthenticationHandler implements AuthenticationFailureHandlerInterfa
     {
         if ($this->simpleAuthenticator instanceof AuthenticationFailureHandlerInterface) {
             if ($this->logger) {
-                $this->logger->debug(sprintf('Using the %s object as authentication failure handler', get_class($this->simpleAuthenticator)));
+                $this->logger->debug('Selected an authentication failure handler', array('handler' => get_class($this->simpleAuthenticator)));
             }
 
             $response = $this->simpleAuthenticator->onAuthenticationFailure($request, $exception);

--- a/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
@@ -54,7 +54,7 @@ class DigestAuthenticationEntryPoint implements AuthenticationEntryPointInterfac
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('WWW-Authenticate header sent to user agent: "%s"', $authenticateHeader));
+            $this->logger->debug('WWW-Authenticate header sent', array('header' => $authenticateHeader));
         }
 
         $response = new Response();

--- a/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
@@ -54,7 +54,7 @@ class DigestAuthenticationEntryPoint implements AuthenticationEntryPointInterfac
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('WWW-Authenticate header sent', array('header' => $authenticateHeader));
+            $this->logger->debug('WWW-Authenticate header sent.', array('header' => $authenticateHeader));
         }
 
         $response = new Response();

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -193,7 +193,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     private function onFailure(Request $request, AuthenticationException $failed)
     {
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Authentication request failed: %s', $failed->getMessage()));
+            $this->logger->info('Authentication request failed', array('exception' => $failed));
         }
 
         $token = $this->tokenStorage->getToken();

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -193,7 +193,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     private function onFailure(Request $request, AuthenticationException $failed)
     {
         if (null !== $this->logger) {
-            $this->logger->info('Authentication request failed', array('exception' => $failed));
+            $this->logger->info('Authentication request failed.', array('exception' => $failed));
         }
 
         $token = $this->tokenStorage->getToken();
@@ -213,7 +213,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     private function onSuccess(Request $request, TokenInterface $token)
     {
         if (null !== $this->logger) {
-            $this->logger->info('User has been authenticated successfully', array('username' => $token->getUsername()));
+            $this->logger->info('User has been authenticated successfully.', array('username' => $token->getUsername()));
         }
 
         $this->tokenStorage->setToken($token);

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -213,7 +213,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     private function onSuccess(Request $request, TokenInterface $token)
     {
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('User "%s" has been authenticated successfully', $token->getUsername()));
+            $this->logger->info('User has been authenticated successfully', array('username' => $token->getUsername()));
         }
 
         $this->tokenStorage->setToken($token);

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -56,16 +56,16 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
     {
         $request = $event->getRequest();
 
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Checking secure context token: %s', $this->tokenStorage->getToken()));
-        }
-
         try {
             list($user, $credentials) = $this->getPreAuthenticatedData($request);
         } catch (BadCredentialsException $exception) {
             $this->clearToken($exception);
 
             return;
+        }
+
+        if (null !== $this->logger) {
+            $this->logger->debug('Checking current security token', array('token' => (string) $this->tokenStorage->getToken()));
         }
 
         if (null !== $token = $this->tokenStorage->getToken()) {
@@ -75,14 +75,14 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Trying to pre-authenticate user "%s"', $user));
+            $this->logger->debug('Trying to pre-authenticate user', array('username' => (string) $user));
         }
 
         try {
             $token = $this->authenticationManager->authenticate(new PreAuthenticatedToken($user, $credentials, $this->providerKey));
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Authentication success: %s', $token));
+                $this->logger->info('Pre-authentication successful', array('token' => (string) $token));
             }
             $this->tokenStorage->setToken($token);
 
@@ -107,7 +107,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->info("Cleared security token due to an exception", array('exception' => $exception));
+                $this->logger->info('Cleared security token due to an exception', array('exception' => $exception));
             }
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -65,7 +65,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('Checking current security token', array('token' => (string) $this->tokenStorage->getToken()));
+            $this->logger->debug('Checking current security token.', array('token' => (string) $this->tokenStorage->getToken()));
         }
 
         if (null !== $token = $this->tokenStorage->getToken()) {
@@ -75,14 +75,14 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('Trying to pre-authenticate user', array('username' => (string) $user));
+            $this->logger->debug('Trying to pre-authenticate user.', array('username' => (string) $user));
         }
 
         try {
             $token = $this->authenticationManager->authenticate(new PreAuthenticatedToken($user, $credentials, $this->providerKey));
 
             if (null !== $this->logger) {
-                $this->logger->info('Pre-authentication successful', array('token' => (string) $token));
+                $this->logger->info('Pre-authentication successful.', array('token' => (string) $token));
             }
             $this->tokenStorage->setToken($token);
 
@@ -107,7 +107,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->info('Cleared security token due to an exception', array('exception' => $exception));
+                $this->logger->info('Cleared security token due to an exception.', array('exception' => $exception));
             }
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -107,7 +107,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf("Cleared security context due to exception: %s", $exception->getMessage()));
+                $this->logger->info("Cleared security token due to an exception", array('exception' => $exception));
             }
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -63,7 +63,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
             }
         } catch (AuthenticationException $failed) {
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Anonymous authentication failed: %s', $failed->getMessage()));
+                $this->logger->info('Anonymous authentication failed', array('exception' => $failed));
             }
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -59,11 +59,11 @@ class AnonymousAuthenticationListener implements ListenerInterface
             $this->tokenStorage->setToken($token);
 
             if (null !== $this->logger) {
-                $this->logger->info('Populated TokenStorage with an anonymous Token');
+                $this->logger->info('Populated the TokenStorage with an anonymous Token.');
             }
         } catch (AuthenticationException $failed) {
             if (null !== $this->logger) {
-                $this->logger->info('Anonymous authentication failed', array('exception' => $failed));
+                $this->logger->info('Anonymous authentication failed.', array('exception' => $failed));
             }
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -67,7 +67,7 @@ class BasicAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Basic Authentication Authorization header found for user "%s"', $username));
+            $this->logger->info(sprintf('Basic authentication Authorization header found for user "%s"', $username));
         }
 
         try {
@@ -80,7 +80,7 @@ class BasicAuthenticationListener implements ListenerInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Authentication request failed for user "%s": %s', $username, $failed->getMessage()));
+                $this->logger->info(sprintf('Basic authentication failed for user "%s"', $username), array('exception' => $failed));
             }
 
             if ($this->ignoreFailure) {

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -67,7 +67,7 @@ class BasicAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info('Basic authentication Authorization header found for user', array('username' => $username));
+            $this->logger->info('Basic authentication Authorization header found for user.', array('username' => $username));
         }
 
         try {
@@ -80,7 +80,7 @@ class BasicAuthenticationListener implements ListenerInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->info('Basic authentication failed for user', array('username' => $username, 'exception' => $failed));
+                $this->logger->info('Basic authentication failed for user.', array('username' => $username, 'exception' => $failed));
             }
 
             if ($this->ignoreFailure) {

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -67,7 +67,7 @@ class BasicAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Basic authentication Authorization header found for user "%s"', $username));
+            $this->logger->info('Basic authentication Authorization header found for user', array('username' => $username));
         }
 
         try {
@@ -80,7 +80,7 @@ class BasicAuthenticationListener implements ListenerInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Basic authentication failed for user "%s"', $username), array('exception' => $failed));
+                $this->logger->info('Basic authentication failed for user', array('username' => $username, 'exception' => $failed));
             }
 
             if ($this->ignoreFailure) {

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -48,7 +48,7 @@ class ChannelListener implements ListenerInterface
 
         if ('https' === $channel && !$request->isSecure()) {
             if (null !== $this->logger) {
-                $this->logger->info('Redirecting to HTTPS');
+                $this->logger->info('Redirecting to HTTPS.');
             }
 
             $response = $this->authenticationEntryPoint->start($request);
@@ -60,7 +60,7 @@ class ChannelListener implements ListenerInterface
 
         if ('http' === $channel && $request->isSecure()) {
             if (null !== $this->logger) {
-                $this->logger->info('Redirecting to HTTP');
+                $this->logger->info('Redirecting to HTTP.');
             }
 
             $response = $this->authenticationEntryPoint->start($request);

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -44,7 +44,7 @@ class ChannelListener implements ListenerInterface
     {
         $request = $event->getRequest();
 
-        list($attributes, $channel) = $this->map->getPatterns($request);
+        list(, $channel) = $this->map->getPatterns($request);
 
         if ('https' === $channel && !$request->isSecure()) {
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -84,14 +84,14 @@ class ContextListener implements ListenerInterface
         $token = unserialize($token);
 
         if (null !== $this->logger) {
-            $this->logger->debug('Read existing security token from the session', array('key' => $this->sessionKey));
+            $this->logger->debug('Read existing security token from the session.', array('key' => $this->sessionKey));
         }
 
         if ($token instanceof TokenInterface) {
             $token = $this->refreshUser($token);
         } elseif (null !== $token) {
             if (null !== $this->logger) {
-                $this->logger->warning('Expected a security token from the session, got something else', array('key' => $this->sessionKey, 'received' => $token));
+                $this->logger->warning('Expected a security token from the session, got something else.', array('key' => $this->sessionKey, 'received' => $token));
             }
 
             $token = null;
@@ -130,7 +130,7 @@ class ContextListener implements ListenerInterface
             $session->set($this->sessionKey, serialize($token));
 
             if (null !== $this->logger) {
-                $this->logger->debug('Stored the security token in the session', array('key' => $this->sessionKey));
+                $this->logger->debug('Stored the security token in the session.', array('key' => $this->sessionKey));
             }
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -157,7 +157,7 @@ class ContextListener implements ListenerInterface
                 $token->setUser($refreshedUser);
 
                 if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Username "%s" was reloaded from user provider.', $refreshedUser->getUsername()), array('provider' => get_class($provider)));
+                    $this->logger->debug('User was reloaded from a user provider.', array('username' => $refreshedUser->getUsername(), 'provider' => get_class($provider)));
                 }
 
                 return $token;
@@ -165,7 +165,7 @@ class ContextListener implements ListenerInterface
                 // let's try the next user provider
             } catch (UsernameNotFoundException $notFound) {
                 if (null !== $this->logger) {
-                    $this->logger->warning(sprintf('Username "%s" could not be found.', $notFound->getUsername()));
+                    $this->logger->warning('Username could not be found in the selected user provider.', array('username' => $notFound->getUsername(), 'provider' => get_class($provider)));
                 }
 
                 return;

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -74,7 +74,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Digest Authorization header received from user agent: %s', $header));
+            $this->logger->debug('Digest Authorization header received from user agent', array('header' => $header));
         }
 
         try {
@@ -89,7 +89,7 @@ class DigestAuthenticationListener implements ListenerInterface
             $user = $this->provider->loadUserByUsername($digestAuth->getUsername());
 
             if (null === $user) {
-                throw new AuthenticationServiceException('AuthenticationDao returned null, which is an interface contract violation');
+                throw new AuthenticationServiceException('Digest User provider returned null, which is an interface contract violation');
             }
 
             $serverDigestMd5 = $digestAuth->calculateServerDigest($user->getPassword(), $request->getMethod());
@@ -101,7 +101,7 @@ class DigestAuthenticationListener implements ListenerInterface
 
         if ($serverDigestMd5 !== $digestAuth->getResponse()) {
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf("Expected response: '%s' but received: '%s'; is AuthenticationDao returning clear text passwords?", $serverDigestMd5, $digestAuth->getResponse()));
+                $this->logger->debug(sprintf("Expected response: '%s' but received: '%s'; is the header returning a clear text passwords?", $serverDigestMd5, $digestAuth->getResponse()));
             }
 
             $this->fail($event, $request, new BadCredentialsException('Incorrect response'));
@@ -116,7 +116,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Authentication success for user "%s" with response "%s"', $digestAuth->getUsername(), $digestAuth->getResponse()));
+            $this->logger->info(sprintf('Digest authentication success for user "%s" with response "%s"', $digestAuth->getUsername(), $digestAuth->getResponse()));
         }
 
         $this->tokenStorage->setToken(new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey));
@@ -130,7 +130,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info($authException);
+            $this->logger->info('Digest authentication failed', array('exception' => $authException));
         }
 
         $event->setResponse($this->authenticationEntryPoint->start($request, $authException));

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -101,7 +101,7 @@ class DigestAuthenticationListener implements ListenerInterface
 
         if ($serverDigestMd5 !== $digestAuth->getResponse()) {
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf("Expected response: '%s' but received: '%s'; is the header returning a clear text passwords?", $serverDigestMd5, $digestAuth->getResponse()));
+                $this->logger->debug("Unexpected response from the DigestAuth received; is the header returning a clear text passwords?", array('expected' => $serverDigestMd5, 'received' => $digestAuth->getResponse()));
             }
 
             $this->fail($event, $request, new BadCredentialsException('Incorrect response'));
@@ -116,7 +116,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Digest authentication success for user "%s" with response "%s"', $digestAuth->getUsername(), $digestAuth->getResponse()));
+            $this->logger->info('Digest authentication successful', array('username' => $digestAuth->getUsername(), 'received' => $digestAuth->getResponse()));
         }
 
         $this->tokenStorage->setToken(new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey));

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -74,7 +74,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('Digest Authorization header received from user agent', array('header' => $header));
+            $this->logger->debug('Digest Authorization header received from user agent.', array('header' => $header));
         }
 
         try {
@@ -116,7 +116,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info('Digest authentication successful', array('username' => $digestAuth->getUsername(), 'received' => $digestAuth->getResponse()));
+            $this->logger->info('Digest authentication successful.', array('username' => $digestAuth->getUsername(), 'received' => $digestAuth->getResponse()));
         }
 
         $this->tokenStorage->setToken(new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey));
@@ -130,7 +130,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info('Digest authentication failed', array('exception' => $authException));
+            $this->logger->info('Digest authentication failed.', array('exception' => $authException));
         }
 
         $event->setResponse($this->authenticationEntryPoint->start($request, $authException));

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -102,7 +102,7 @@ class ExceptionListener
     private function handleAuthenticationException(GetResponseForExceptionEvent $event, AuthenticationException $exception)
     {
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Authentication exception occurred; redirecting to authentication entry point (%s)', $exception->getMessage()));
+            $this->logger->info('An AuthenticationException was thrown; redirecting to authentication entry point', array('exception' => $exception));
         }
 
         try {
@@ -119,7 +119,7 @@ class ExceptionListener
         $token = $this->tokenStorage->getToken();
         if (!$this->authenticationTrustResolver->isFullFledged($token)) {
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Access is denied (user is not fully authenticated) by "%s" at line %s; redirecting to authentication entry point', $exception->getFile(), $exception->getLine()));
+                $this->logger->debug('Access denied, the user is not fully authenticated; redirecting to authentication entry point', array('exception' => $exception));
             }
 
             try {
@@ -135,7 +135,7 @@ class ExceptionListener
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Access is denied (and user is neither anonymous, nor remember-me) by "%s" at line %s', $exception->getFile(), $exception->getLine()));
+            $this->logger->debug('Access denied, the user is neither anonymous, nor remember-me', array('exception' => $exception));
         }
 
         try {
@@ -153,7 +153,7 @@ class ExceptionListener
             }
         } catch (\Exception $e) {
             if (null !== $this->logger) {
-                $this->logger->error(sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage()));
+                $this->logger->error('An exception was thrown when handling an AccessDeniedException', array('exception' => $e));
             }
 
             $event->setException(new \RuntimeException('Exception thrown when handling an exception.', 0, $e));
@@ -163,7 +163,7 @@ class ExceptionListener
     private function handleLogoutException(GetResponseForExceptionEvent $event, LogoutException $exception)
     {
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Logout exception occurred; wrapping with AccessDeniedHttpException (%s)', $exception->getMessage()));
+            $this->logger->info('A LogoutException was thrown', array('exception' => $exception));
         }
     }
 
@@ -190,6 +190,10 @@ class ExceptionListener
         if ($authException instanceof AccountStatusException) {
             // remove the security token to prevent infinite redirect loops
             $this->tokenStorage->setToken(null);
+
+            if (null !== $this->logger) {
+                $this->logger->info('The security token was removed due to an AccountStatusException', array('exception' => $authException));
+            }
         }
 
         return $this->authenticationEntryPoint->start($request, $authException);

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -102,7 +102,7 @@ class ExceptionListener
     private function handleAuthenticationException(GetResponseForExceptionEvent $event, AuthenticationException $exception)
     {
         if (null !== $this->logger) {
-            $this->logger->info('An AuthenticationException was thrown; redirecting to authentication entry point', array('exception' => $exception));
+            $this->logger->info('An AuthenticationException was thrown; redirecting to authentication entry point.', array('exception' => $exception));
         }
 
         try {
@@ -119,7 +119,7 @@ class ExceptionListener
         $token = $this->tokenStorage->getToken();
         if (!$this->authenticationTrustResolver->isFullFledged($token)) {
             if (null !== $this->logger) {
-                $this->logger->debug('Access denied, the user is not fully authenticated; redirecting to authentication entry point', array('exception' => $exception));
+                $this->logger->debug('Access denied, the user is not fully authenticated; redirecting to authentication entry point.', array('exception' => $exception));
             }
 
             try {
@@ -135,7 +135,7 @@ class ExceptionListener
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('Access denied, the user is neither anonymous, nor remember-me', array('exception' => $exception));
+            $this->logger->debug('Access denied, the user is neither anonymous, nor remember-me.', array('exception' => $exception));
         }
 
         try {
@@ -153,7 +153,7 @@ class ExceptionListener
             }
         } catch (\Exception $e) {
             if (null !== $this->logger) {
-                $this->logger->error('An exception was thrown when handling an AccessDeniedException', array('exception' => $e));
+                $this->logger->error('An exception was thrown when handling an AccessDeniedException.', array('exception' => $e));
             }
 
             $event->setException(new \RuntimeException('Exception thrown when handling an exception.', 0, $e));
@@ -163,7 +163,7 @@ class ExceptionListener
     private function handleLogoutException(GetResponseForExceptionEvent $event, LogoutException $exception)
     {
         if (null !== $this->logger) {
-            $this->logger->info('A LogoutException was thrown', array('exception' => $exception));
+            $this->logger->info('A LogoutException was thrown.', array('exception' => $exception));
         }
     }
 
@@ -182,7 +182,7 @@ class ExceptionListener
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('Calling Authentication entry point');
+            $this->logger->debug('Calling Authentication entry point.');
         }
 
         $this->setTargetPath($request);
@@ -192,7 +192,7 @@ class ExceptionListener
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->info('The security token was removed due to an AccountStatusException', array('exception' => $authException));
+                $this->logger->info('The security token was removed due to an AccountStatusException.', array('exception' => $authException));
             }
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -81,14 +81,14 @@ class RememberMeListener implements ListenerInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->debug('Populated the token storage with a remember-me token');
+                $this->logger->debug('Populated the token storage with a remember-me token.');
             }
         } catch (AuthenticationException $failed) {
             if (null !== $this->logger) {
                 $this->logger->warning(
                     'The token storage was not populated with remember-me token as the'
                    .' AuthenticationManager rejected the AuthenticationToken returned'
-                   .' by the RememberMeServices', array('exception' => $failed)
+                   .' by the RememberMeServices.', array('exception' => $failed)
                 );
             }
 

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -81,14 +81,14 @@ class RememberMeListener implements ListenerInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->debug('Token storage populated with remember-me token.');
+                $this->logger->debug('Token storage populated with remember-me token');
             }
         } catch (AuthenticationException $failed) {
             if (null !== $this->logger) {
                 $this->logger->warning(
                     'Token storage not populated with remember-me token as the'
                    .' AuthenticationManager rejected the AuthenticationToken returned'
-                   .' by the RememberMeServices: '.$failed->getMessage()
+                   .' by the RememberMeServices', array('exception' => $failed)
                 );
             }
 

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -81,12 +81,12 @@ class RememberMeListener implements ListenerInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->debug('Token storage populated with remember-me token');
+                $this->logger->debug('Populated the token storage with a remember-me token');
             }
         } catch (AuthenticationException $failed) {
             if (null !== $this->logger) {
                 $this->logger->warning(
-                    'Token storage not populated with remember-me token as the'
+                    'The token storage was not populated with remember-me token as the'
                    .' AuthenticationManager rejected the AuthenticationToken returned'
                    .' by the RememberMeServices', array('exception' => $failed)
                 );

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -73,7 +73,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
         $request = $event->getRequest();
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Attempting simple pre-authorization %s', $this->providerKey));
+            $this->logger->info(sprintf('Attempting SimplePreAuthentication %s', $this->providerKey));
         }
 
         if (null !== $this->tokenStorage->getToken() && !$this->tokenStorage->getToken() instanceof AnonymousToken) {
@@ -99,7 +99,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Authentication request failed: %s', $e->getMessage()));
+                $this->logger->info('SimplePreAuthentication request failed', array('exception' => $e));
             }
 
             if ($this->simpleAuthenticator instanceof AuthenticationFailureHandlerInterface) {

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -73,7 +73,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
         $request = $event->getRequest();
 
         if (null !== $this->logger) {
-            $this->logger->info('Attempting SimplePreAuthentication', array('key' => $this->providerKey, 'authenticator' => get_class($this->simpleAuthenticator)));
+            $this->logger->info('Attempting SimplePreAuthentication.', array('key' => $this->providerKey, 'authenticator' => get_class($this->simpleAuthenticator)));
         }
 
         if (null !== $this->tokenStorage->getToken() && !$this->tokenStorage->getToken() instanceof AnonymousToken) {
@@ -99,7 +99,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->info('SimplePreAuthentication request failed', array('exception' => $e, 'authenticator' => get_class($this->simpleAuthenticator)));
+                $this->logger->info('SimplePreAuthentication request failed.', array('exception' => $e, 'authenticator' => get_class($this->simpleAuthenticator)));
             }
 
             if ($this->simpleAuthenticator instanceof AuthenticationFailureHandlerInterface) {

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -73,7 +73,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
         $request = $event->getRequest();
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Attempting SimplePreAuthentication %s', $this->providerKey));
+            $this->logger->info('Attempting SimplePreAuthentication', array('key' => $this->providerKey, 'authenticator' => get_class($this->simpleAuthenticator)));
         }
 
         if (null !== $this->tokenStorage->getToken() && !$this->tokenStorage->getToken() instanceof AnonymousToken) {
@@ -99,7 +99,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->info('SimplePreAuthentication request failed', array('exception' => $e));
+                $this->logger->info('SimplePreAuthentication request failed', array('exception' => $e, 'authenticator' => get_class($this->simpleAuthenticator)));
             }
 
             if ($this->simpleAuthenticator instanceof AuthenticationFailureHandlerInterface) {

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -127,7 +127,7 @@ class SwitchUserListener implements ListenerInterface
         $username = $request->get($this->usernameParameter);
 
         if (null !== $this->logger) {
-            $this->logger->info('Attempting to switch to user', array('username' => $username));
+            $this->logger->info('Attempting to switch to user.', array('username' => $username));
         }
 
         $user = $this->provider->loadUserByUsername($username);

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -127,7 +127,7 @@ class SwitchUserListener implements ListenerInterface
         $username = $request->get($this->usernameParameter);
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Attempt to switch to user "%s"', $username));
+            $this->logger->info('Attempting to switch to user', array('username' => $username));
         }
 
         $user = $this->provider->loadUserByUsername($username);

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -282,7 +282,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
     protected function cancelCookie(Request $request)
     {
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Clearing remember-me cookie "%s"', $this->options['name']));
+            $this->logger->debug('Clearing remember-me cookie', array('name' => $this->options['name']));
         }
 
         $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie($this->options['name'], null, 1, $this->options['path'], $this->options['domain']));
@@ -304,7 +304,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
         $parameter = $request->get($this->options['remember_me_parameter'], null, true);
 
         if (null === $parameter && null !== $this->logger) {
-            $this->logger->debug(sprintf('Did not send remember-me cookie (remember-me parameter "%s" was not sent).', $this->options['remember_me_parameter']));
+            $this->logger->debug('Did not send remember-me cookie.', array('parameter' => $this->options['remember_me_parameter']));
         }
 
         return $parameter === 'true' || $parameter === 'on' || $parameter === '1' || $parameter === 'yes';

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -137,7 +137,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             }
         } catch (AuthenticationException $invalid) {
             if (null !== $this->logger) {
-                $this->logger->debug('Remember-Me authentication failed', array('exception' => $invalid));
+                $this->logger->debug('Remember-Me authentication failed.', array('exception' => $invalid));
             }
         }
 
@@ -282,7 +282,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
     protected function cancelCookie(Request $request)
     {
         if (null !== $this->logger) {
-            $this->logger->debug('Clearing remember-me cookie', array('name' => $this->options['name']));
+            $this->logger->debug('Clearing remember-me cookie.', array('name' => $this->options['name']));
         }
 
         $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie($this->options['name'], null, 1, $this->options['path'], $this->options['domain']));

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -137,7 +137,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             }
         } catch (AuthenticationException $invalid) {
             if (null !== $this->logger) {
-                $this->logger->debug('Remember-Me authentication failed: '.$invalid->getMessage());
+                $this->logger->debug('Remember-Me authentication failed', array('exception' => $invalid));
             }
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -105,7 +105,10 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
 
     public function testRedirectIsLogged()
     {
-        $this->logger->expects($this->once())->method('debug')->with('Redirecting to /login');
+        $this->logger
+            ->expects($this->once())
+            ->method('debug')
+            ->with('Authentication failure, redirect triggered', array('failure_path' => '/login'));
 
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, array(), $this->logger);
         $handler->onAuthenticationFailure($this->request, $this->exception);
@@ -119,7 +122,10 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
             ->method('createRequest')->with($this->request, '/login')
             ->will($this->returnValue($this->getRequest()));
 
-        $this->logger->expects($this->once())->method('debug')->with('Forwarding to /login');
+        $this->logger
+            ->expects($this->once())
+            ->method('debug')
+            ->with('Authentication failure, forward triggered', array('failure_path' => '/login'));
 
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
         $handler->onAuthenticationFailure($this->request, $this->exception);

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -108,7 +108,7 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
         $this->logger
             ->expects($this->once())
             ->method('debug')
-            ->with('Authentication failure, redirect triggered', array('failure_path' => '/login'));
+            ->with('Authentication failure, redirect triggered.', array('failure_path' => '/login'));
 
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, array(), $this->logger);
         $handler->onAuthenticationFailure($this->request, $this->exception);
@@ -125,7 +125,7 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
         $this->logger
             ->expects($this->once())
             ->method('debug')
-            ->with('Authentication failure, forward triggered', array('failure_path' => '/login'));
+            ->with('Authentication failure, forward triggered.', array('failure_path' => '/login'));
 
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
         $handler->onAuthenticationFailure($this->request, $this->exception);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -77,7 +77,7 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $logger = $this->getMock('Psr\Log\LoggerInterface');
         $logger->expects($this->once())
             ->method('info')
-            ->with('Populated TokenStorage with an anonymous Token')
+            ->with('Populated the TokenStorage with an anonymous Token.')
         ;
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');

--- a/src/Symfony/Component/Templating/Loader/CacheLoader.php
+++ b/src/Symfony/Component/Templating/Loader/CacheLoader.php
@@ -57,10 +57,10 @@ class CacheLoader extends Loader
 
         if (is_file($path)) {
             if (null !== $this->logger) {
-                $this->logger->debug('Fetching template from cache', array('name' => $template->get('name')));
+                $this->logger->debug('Fetching template from cache.', array('name' => $template->get('name')));
             } elseif (null !== $this->debugger) {
                 // just for BC, to be removed in 3.0
-                $this->debugger->log(sprintf('Fetching template "%s" from cache', $template->get('name')));
+                $this->debugger->log(sprintf('Fetching template "%s" from cache.', $template->get('name')));
             }
 
             return new FileStorage($path);
@@ -79,10 +79,10 @@ class CacheLoader extends Loader
         file_put_contents($path, $content);
 
         if (null !== $this->logger) {
-            $this->logger->debug('Storing template in cache', array('name' => $template->get('name')));
+            $this->logger->debug('Storing template in cache.', array('name' => $template->get('name')));
         } elseif (null !== $this->debugger) {
             // just for BC, to be removed in 3.0
-            $this->debugger->log(sprintf('Storing template "%s" in cache', $template->get('name')));
+            $this->debugger->log(sprintf('Storing template "%s" in cache.', $template->get('name')));
         }
 
         return new FileStorage($path);

--- a/src/Symfony/Component/Templating/Loader/CacheLoader.php
+++ b/src/Symfony/Component/Templating/Loader/CacheLoader.php
@@ -57,7 +57,7 @@ class CacheLoader extends Loader
 
         if (is_file($path)) {
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Fetching template "%s" from cache', $template->get('name')));
+                $this->logger->debug('Fetching template from cache', array('name' => $template->get('name')));
             } elseif (null !== $this->debugger) {
                 // just for BC, to be removed in 3.0
                 $this->debugger->log(sprintf('Fetching template "%s" from cache', $template->get('name')));
@@ -79,7 +79,7 @@ class CacheLoader extends Loader
         file_put_contents($path, $content);
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Storing template "%s" in cache', $template->get('name')));
+            $this->logger->debug('Storing template in cache', array('name' => $template->get('name')));
         } elseif (null !== $this->debugger) {
             // just for BC, to be removed in 3.0
             $this->debugger->log(sprintf('Storing template "%s" in cache', $template->get('name')));

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -64,10 +64,10 @@ class FilesystemLoader extends Loader
         foreach ($this->templatePathPatterns as $templatePathPattern) {
             if (is_file($file = strtr($templatePathPattern, $replacements)) && is_readable($file)) {
                 if (null !== $this->logger) {
-                    $this->logger->debug('Loaded template file', array('file' => $file));
+                    $this->logger->debug('Loaded template file.', array('file' => $file));
                 } elseif (null !== $this->debugger) {
                     // just for BC, to be removed in 3.0
-                    $this->debugger->log(sprintf('Loaded template file "%s"', $file));
+                    $this->debugger->log(sprintf('Loaded template file "%s".', $file));
                 }
 
                 return new FileStorage($file);
@@ -81,10 +81,10 @@ class FilesystemLoader extends Loader
         // only log failures if no template could be loaded at all
         foreach ($fileFailures as $file) {
             if (null !== $this->logger) {
-                $this->logger->debug('Failed loading template file', array('file' => $file));
+                $this->logger->debug('Failed loading template file.', array('file' => $file));
             } elseif (null !== $this->debugger) {
                 // just for BC, to be removed in 3.0
-                $this->debugger->log(sprintf('Failed loading template file "%s"', $file));
+                $this->debugger->log(sprintf('Failed loading template file "%s".', $file));
             }
         }
 

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -60,11 +60,11 @@ class FilesystemLoader extends Loader
             $replacements['%'.$key.'%'] = $value;
         }
 
-        $logs = array();
+        $fileFailures = array();
         foreach ($this->templatePathPatterns as $templatePathPattern) {
             if (is_file($file = strtr($templatePathPattern, $replacements)) && is_readable($file)) {
                 if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Loaded template file "%s"', $file));
+                    $this->logger->debug('Loaded template file', array('file' => $file));
                 } elseif (null !== $this->debugger) {
                     // just for BC, to be removed in 3.0
                     $this->debugger->log(sprintf('Loaded template file "%s"', $file));
@@ -74,15 +74,17 @@ class FilesystemLoader extends Loader
             }
 
             if (null !== $this->logger || null !== $this->debugger) {
-                $logs[] = sprintf('Failed loading template file "%s"', $file);
+                $fileFailures[] = $file;
             }
         }
 
-        foreach ($logs as $log) {
+        // only log failures if no template could be loaded at all
+        foreach ($fileFailures as $file) {
             if (null !== $this->logger) {
-                $this->logger->debug($log);
+                $this->logger->debug('Failed loading template file', array('file' => $file));
             } elseif (null !== $this->debugger) {
-                $this->debugger->log($log);
+                // just for BC, to be removed in 3.0
+                $this->debugger->log(sprintf('Failed loading template file "%s"', $file));
             }
         }
 

--- a/src/Symfony/Component/Templating/Tests/Loader/CacheLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/CacheLoaderTest.php
@@ -38,7 +38,7 @@ class CacheLoaderTest extends \PHPUnit_Framework_TestCase
         $logger
             ->expects($this->once())
             ->method('debug')
-            ->with('Storing template in cache', array('name' => 'index'));
+            ->with('Storing template in cache.', array('name' => 'index'));
         $loader->setLogger($logger);
         $loader->load(new TemplateReference('index'));
 
@@ -46,7 +46,7 @@ class CacheLoaderTest extends \PHPUnit_Framework_TestCase
         $logger
             ->expects($this->once())
             ->method('debug')
-            ->with('Fetching template from cache', array('name' => 'index'));
+            ->with('Fetching template from cache.', array('name' => 'index'));
         $loader->setLogger($logger);
         $loader->load(new TemplateReference('index'));
     }

--- a/src/Symfony/Component/Templating/Tests/Loader/CacheLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/CacheLoaderTest.php
@@ -35,12 +35,18 @@ class CacheLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($loader->load(new TemplateReference('foo', 'php')), '->load() returns false if the embed loader is not able to load the template');
 
         $logger = $this->getMock('Psr\Log\LoggerInterface');
-        $logger->expects($this->once())->method('debug')->with('Storing template "index" in cache');
+        $logger
+            ->expects($this->once())
+            ->method('debug')
+            ->with('Storing template in cache', array('name' => 'index'));
         $loader->setLogger($logger);
         $loader->load(new TemplateReference('index'));
 
         $logger = $this->getMock('Psr\Log\LoggerInterface');
-        $logger->expects($this->once())->method('debug')->with('Fetching template "index" from cache');
+        $logger
+            ->expects($this->once())
+            ->method('debug')
+            ->with('Fetching template from cache', array('name' => 'index'));
         $loader->setLogger($logger);
         $loader->load(new TemplateReference('index'));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/12594#issuecomment-68589400 |
| License | MIT |
| Doc PR | n/a |

This PR is a follow-up of #12594 `[DX] [HttpKernel] Use "context" argument when logging route in RouterListener`.

I have attempted to improve the log messages, as well as updating the usage context. I wasn't sure if the log messages should end with a `.` or not, if so I can update all messages to confirm a standard. 
