### PR TITLE
[EventDispatcher] update changelog entry wording

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -4,9 +4,9 @@ CHANGELOG
 3.0.0
 -----
 
-  * The methods Event::setDispatcher(), Event::getDispatcher(), Event::setName()
-    and Event::setName() have been removed.
-    The event dispatcher and name is passed to the listener call.
+  * The methods `Event::setDispatcher()`, `Event::getDispatcher()`, `Event::setName()`
+    and `Event::getName()` have been removed.
+    The event dispatcher and the event name are passed to the listener call.
 
 2.5.0
 -----


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets |  |
| License | MIT |

Updates the wording and adds missing `Event::getName()` method (the
`Event::setName()` method was actually listed twice instead).
