### PR TITLE
[Security] [Translator] Add translation to 'Bad credentials' message

### DIFF
--- a/src/Symfony/Component/Security/Resources/translations/security.ar.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.ar.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>الحساب مغلق.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>إسم المستخدم او كلمة المرور غير صحيحة.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.az.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.az.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Hesab kilitlənib.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Səhv istifadəçi adı və parol.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.bg.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.bg.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Акаунта е заключен.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Невалидно потребителско име или парола.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.ca.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.ca.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>El compte està bloquejat.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Nom d'usuari o Contrasenya incorrectes.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.cs.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.cs.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Účet je zablokovaný.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Neplatné přihlašovací údaje.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.da.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.da.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Brugerkonto er låst.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Forkert brugernavn eller adgangskode.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.de.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.de.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Der Account ist gesperrt.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Benutzername oder Passwort ungültig.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.el.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.el.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Ο λογαριασμός είναι κλειδωμένος.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Λάθος όνομα χρήστη ή τον κωδικό πρόσβασης.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.en.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.en.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Account is locked.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Bad credentials.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.es.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.es.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>La cuenta está bloqueada.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Nombre de usuario o Contraseña inválido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.fa.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.fa.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>حساب کاربری قفل شده است.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>نام کاربری یا کلمه عبور غیر مجاز.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.fr.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.fr.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Le compte est bloqué.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Nom d'utilisateur ou mot de passe incorrect.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.gl.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.gl.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>A conta está bloqueada.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Nome de usuario ou contrasinal incorrecto.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.he.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.he.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Account is locked.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Bad credentials.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.hr.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.hr.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Račun je zaključan.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Krivo korisničko ime ili lozinka.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.hu.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.hu.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Zárolt fiók.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Helytelen felhasználónév vagy jelszó.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.id.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.id.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Akun terkunci.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Nama Pengguna atau Password salah.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.it.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.it.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>L'account è bloccato.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Username o password non validi.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.ja.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.ja.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>アカウントはロックされています。</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>ユーザ名またはパスワードが間違っています.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.lb.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.lb.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>De Konto ass gespaart.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Bad credentials.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.lt.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.lt.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Paskyra yra užblokuota.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Neteisingas naudotojo vardas arba slaptažodis.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.nl.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.nl.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Account is geblokkeerd.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Gebruikersnaam of wachtwoord ongeldig.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.no.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.no.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Brukerkonto er sperret.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Feil brukernavn eller passord.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.pl.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.pl.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Konto jest zablokowane.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Nieprawidłowa nazwa użytkownika lub hasło.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.pt_BR.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.pt_BR.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>A conta está travada.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Usuário ou senha inválida.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.pt_PT.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.pt_PT.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>A conta esta trancada.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Utilizador e/ou password inválidos.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.ro.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.ro.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Contul este blocat.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Nume de utilizator sau parolă greșită.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.ru.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.ru.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Учетная запись заблокирована.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Неправильное имя пользователя или пароль.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.sk.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.sk.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Účet je zablokovaný.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Chybné uživateľské meno alebo heslo.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.sl.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.sl.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Račun je zaklenjen.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Napačno uporabniško ime ali geslo.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.sr_Cyrl.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Налог је закључан.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Погрешно корисничко име или лозинка.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.sr_Latn.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.sr_Latn.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Nalog je zaključan.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Nevalidno korisničko ime ili lozinka.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.sv.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.sv.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Kontot är låst.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Ogiltigt användarnamn eller lösenord.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.th.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.th.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>บัญชีถูกล็อกแล้ว</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.tr.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.tr.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Hesap kilitlenmiş.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Geçersiz kullanıcı adı ya da parola.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.ua.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.ua.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Обліковий запис заблоковано.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Невірне ім'я користувача або пароль.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.vi.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.vi.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>Tài khoản bị khóa.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>Tên người dùng hoặc mật khẩu không chính xác.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.zh_CN.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.zh_CN.xlf
@@ -66,6 +66,10 @@
                 <source>Account is locked.</source>
                 <target>帐号已被锁定。</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials</source>
+                <target>用户名或密码不正确.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |

For 2.6 source message should be updated (add dot to the end, see #11215)
