### PR TITLE
[Console][Table] Add support for colspan/rowspan + multiple header lines

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -305,11 +305,13 @@ class Table
             $width += strlen($cell) - mb_strwidth($cell, $encoding);
         }
 
-        $width += Helper::strlen($cell) - Helper::strlenWithoutDecoration($this->output->getFormatter(), $cell);
-
-        $content = sprintf($this->style->getCellRowContentFormat(), $cell);
-
-        $this->output->write(sprintf($cellFormat, str_pad($content, $width, $this->style->getPaddingChar(), $this->style->getPadType())));
+        if ($cell instanceof TableSeparator) {
+            $this->output->write(sprintf($this->style->getBorderFormat(), str_repeat($this->style->getHorizontalBorderChar(), $width)));
+        } else {
+            $width += Helper::strlen($cell) - Helper::strlenWithoutDecoration($this->output->getFormatter(), $cell);
+            $content = sprintf($this->style->getCellRowContentFormat(), $cell);
+            $this->output->write(sprintf($cellFormat, str_pad($content, $width, $this->style->getPaddingChar(), $this->style->getPadType())));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/TableCell.php
+++ b/src/Symfony/Component/Console/Helper/TableCell.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+/**
+ * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
+ */
+class TableCell
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @var array
+     */
+    private $options = array(
+        'rowspan' => 1,
+        'colspan' => 1,
+    );
+
+    /**
+     * @param string $value
+     * @param array  $options
+     */
+    public function __construct($value, array $options = array())
+    {
+        $this->value = $value;
+
+        // check option names
+        if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
+            throw new \InvalidArgumentException(sprintf('The TableCell does not support the following options: \'%s\'.', implode('\', \'', $diff)));
+        }
+
+        $this->options = array_merge($this->options, $options);
+    }
+
+    /**
+     * Returns the cell value.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Gets number of colspan.
+     *
+     * @return int
+     */
+    public function getColspan()
+    {
+        return (int) $this->options['colspan'];
+    }
+
+    /**
+     * Gets number of rowspan.
+     *
+     * @return int
+     */
+    public function getRowspan()
+    {
+        return (int) $this->options['rowspan'];
+    }
+}

--- a/src/Symfony/Component/Console/Helper/TableCell.php
+++ b/src/Symfony/Component/Console/Helper/TableCell.php
@@ -33,7 +33,7 @@ class TableCell
      * @param string $value
      * @param array  $options
      */
-    public function __construct($value, array $options = array())
+    public function __construct($value = '', array $options = array())
     {
         $this->value = $value;
 

--- a/src/Symfony/Component/Console/Helper/TableSeparator.php
+++ b/src/Symfony/Component/Console/Helper/TableSeparator.php
@@ -16,6 +16,14 @@ namespace Symfony\Component\Console\Helper;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class TableSeparator
+class TableSeparator extends TableCell
 {
+    /**
+     * @param string $value
+     * @param array  $options
+     */
+    public function __construct(array $options = array())
+    {
+        parent::__construct('', $options);
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tests\Helper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableStyle;
 use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Output\StreamOutput;
 
 class TableTest extends \PHPUnit_Framework_TestCase
@@ -249,6 +250,145 @@ TABLE
 | <strong>99921-58-10-700</strong> | <f>Divine Com</f>    | Dante Alighieri |
 | 9971-5-0210-0                    | A Tale of Two Cities | Charles Dickens |
 +----------------------------------+----------------------+-----------------+
+
+TABLE
+            ),
+            'Cell with colspan' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
+                    new TableSeparator(),
+                    array(new TableCell('Divine Comedy(Dante Alighieri)', array('colspan' => 3))),
+                    new TableSeparator(),
+                    array(
+                        new TableCell('Arduino: A Quick-Start Guide', array('colspan' => 2)),
+                        'Mark Schmidt',
+                    ),
+                    new TableSeparator(),
+                    array(
+                        '9971-5-0210-0',
+                        new TableCell("A Tale of \nTwo Cities", array('colspan' => 2)),
+                    ),
+                ),
+                'default',
+<<<TABLE
++----------------+---------------+-----------------+
+| ISBN           | Title         | Author          |
++----------------+---------------+-----------------+
+| 99921-58-10-7  | Divine Comedy | Dante Alighieri |
++----------------+---------------+-----------------+
+| Divine Comedy(Dante Alighieri)                   |
++----------------+---------------+-----------------+
+| Arduino: A Quick-Start Guide   | Mark Schmidt    |
++----------------+---------------+-----------------+
+| 9971-5-0210-0  | A Tale of                       |
+|                | Two Cities                      |
++----------------+---------------+-----------------+
+
+TABLE
+            ),
+            'Cell with rowspan' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array(
+                        new TableCell('9971-5-0210-0', array('rowspan' => 3)),
+                        'Divine Comedy',
+                        'Dante Alighieri',
+                    ),
+                    array('A Tale of Two Cities', 'Charles Dickens'),
+                    array("The Lord of \nthe Rings", "J. R. \nR. Tolkien"),
+                    new TableSeparator(),
+                    array('80-902734-1-6', new TableCell("And Then \nThere \nWere None", array('rowspan' => 3)), 'Agatha Christie'),
+                    array('80-902734-1-7', 'Test'),
+                ),
+                'default',
+<<<TABLE
++---------------+----------------------+-----------------+
+| ISBN          | Title                | Author          |
++---------------+----------------------+-----------------+
+| 9971-5-0210-0 | Divine Comedy        | Dante Alighieri |
+|               | A Tale of Two Cities | Charles Dickens |
+|               | The Lord of          | J. R.           |
+|               | the Rings            | R. Tolkien      |
++---------------+----------------------+-----------------+
+| 80-902734-1-6 | And Then             | Agatha Christie |
+| 80-902734-1-7 | There                | Test            |
+|               | Were None            |                 |
++---------------+----------------------+-----------------+
+
+TABLE
+            ),
+            'Cell with rowspan and colspan' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array(
+                        new TableCell('9971-5-0210-0', array('rowspan' => 2, 'colspan' => 2)),
+                        'Dante Alighieri',
+                    ),
+                    array('Charles Dickens'),
+                    new TableSeparator(),
+                    array(
+                        'Dante Alighieri',
+                        new TableCell('9971-5-0210-0', array('rowspan' => 3, 'colspan' => 2)),
+                    ),
+                    array('J. R. R. Tolkien'),
+                    array('J. R. R'),
+                ),
+                'default',
+<<<TABLE
++------------------+--------+-----------------+
+| ISBN             | Title  | Author          |
++------------------+--------+-----------------+
+| 9971-5-0210-0             | Dante Alighieri |
+|                           | Charles Dickens |
++------------------+--------+-----------------+
+| Dante Alighieri  | 9971-5-0210-0            |
+| J. R. R. Tolkien |                          |
+| J. R. R          |                          |
++------------------+--------+-----------------+
+
+TABLE
+            ),
+            'Cell with rowspan and colspan contains new line break' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array(
+                        new TableCell("9971\n-5-\n021\n0-0", array('rowspan' => 2, 'colspan' => 2)),
+                        'Dante Alighieri',
+                    ),
+                    array('Charles Dickens'),
+                    new TableSeparator(),
+                    array(
+                        'Dante Alighieri',
+                        new TableCell("9971\n-5-\n021\n0-0", array('rowspan' => 2, 'colspan' => 2)),
+                    ),
+                    array('Charles Dickens'),
+                    new TableSeparator(),
+                    array(
+                        new TableCell("9971\n-5-\n021\n0-0", array('rowspan' => 2, 'colspan' => 2)),
+                        new TableCell("Dante \nAlighieri", array('rowspan' => 2, 'colspan' => 1)),
+                    ),
+                ),
+                'default',
+<<<TABLE
++-----------------+-------+-----------------+
+| ISBN            | Title | Author          |
++-----------------+-------+-----------------+
+| 9971                    | Dante Alighieri |
+| -5-                     | Charles Dickens |
+| 021                     |                 |
+| 0-0                     |                 |
++-----------------+-------+-----------------+
+| Dante Alighieri | 9971                    |
+| Charles Dickens | -5-                     |
+|                 | 021                     |
+|                 | 0-0                     |
++-----------------+-------+-----------------+
+| 9971                    | Dante           |
+| -5-                     | Alighieri       |
+| 021                     |                 |
+| 0-0                     |                 |
++-----------------+-------+-----------------+
 
 TABLE
             ),

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -423,6 +423,28 @@ TABLE
 
 TABLE
             ),
+            'Cell with rowspan and colspan with separator inside a rowspan' => array(
+                array('ISBN', 'Author'),
+                array(
+                    array(
+                        new TableCell("9971-5-0210-0", array('rowspan' => 3, 'colspan' => 1)),
+                        'Dante Alighieri',
+                    ),
+                    array(new TableSeparator()),
+                    array('Charles Dickens'),
+                ),
+                'default',
+<<<TABLE
++---------------+-----------------+
+| ISBN          | Author          |
++---------------+-----------------+
+| 9971-5-0210-0 | Dante Alighieri |
+|               |-----------------|
+|               | Charles Dickens |
++---------------+-----------------+
+
+TABLE
+            ),
             'Multiple header lines' => array(
                 array(
                     array(new TableCell('Main title', array('colspan' => 3))),

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -423,6 +423,22 @@ TABLE
 
 TABLE
             ),
+            'Multiple header lines' => array(
+                array(
+                    array(new TableCell('Main title', array('colspan' => 3))),
+                    array('ISBN', 'Title', 'Author'),
+                ),
+                array(),
+                'default',
+<<<TABLE
++------+-------+--------+
+| Main title            |
++------+-------+--------+
+| ISBN | Title | Author |
++------+-------+--------+
+
+TABLE
+            ),
         );
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -392,6 +392,37 @@ TABLE
 
 TABLE
             ),
+            'Cell with rowspan and colspan without using TableSeparator' => array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array(
+                        new TableCell("9971\n-5-\n021\n0-0", array('rowspan' => 2, 'colspan' => 2)),
+                        'Dante Alighieri',
+                    ),
+                    array('Charles Dickens'),
+                    array(
+                        'Dante Alighieri',
+                        new TableCell("9971\n-5-\n021\n0-0", array('rowspan' => 2, 'colspan' => 2)),
+                    ),
+                    array('Charles Dickens'),
+                ),
+                'default',
+<<<TABLE
++-----------------+-------+-----------------+
+| ISBN            | Title | Author          |
++-----------------+-------+-----------------+
+| 9971                    | Dante Alighieri |
+| -5-                     | Charles Dickens |
+| 021                     |                 |
+| 0-0                     |                 |
+| Dante Alighieri | 9971                    |
+| Charles Dickens | -5-                     |
+|                 | 021                     |
+|                 | 0-0                     |
++-----------------+-------+-----------------+
+
+TABLE
+            ),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #13368, #13369 |
| Tests pass? | yes |
| License | MIT |

This PR introduce a new feature described in #13368 and #13369,
I created a new class `TableCell` which can allow us to specify colspan/rowspan for each cell.

``` php
$table->addRow([new TableCell("data", array('rowspan' => 1, 'colspan' => 2)), 'data']);
```
- [x] #13368 Add support for colspan/rowspan
- [x] #13369 Add support for multiple header lines
- [ ] add doc
