### PR TITLE
[Var-Dumper] Fixed encoding issue

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -204,7 +204,13 @@ class Data
     public static function utf8Encode($s)
     {
         if (function_exists('mb_convert_encoding')) {
-            return mb_convert_encoding($s, 'UTF-8', 'CP1252');
+            $availableEncodings = mb_detect_order();
+            if (!in_array('Windows-1252', $availableEncodings)) {
+                array_unshift($availableEncodings, 'Windows-1252');
+            }
+            $encoding = mb_detect_encoding($s, $availableEncodings);
+
+            return mb_convert_encoding($s, 'UTF-8', $encoding);
         }
 
         $s .= $s;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Not ready yet. I need to change implementation first because this one is not working well enough

When I started using symfony/var-dumper in non-Symfony app i ran across the following encoding issue:

Applications files are in windows-1251 encoding,
Everything in browser output is OK except the var-dumper output which is broken: 
![before](https://cloud.githubusercontent.com/assets/2826480/5792305/fb57849e-9f22-11e4-8022-6f0792c4cd38.png)

After this fix, as soon as somewhere in bootstrap `mb_detect_order` is set as needed, we get the correct output:
![after](https://cloud.githubusercontent.com/assets/2826480/5792302/dba3c860-9f22-11e4-9609-06cf051c943e.png)

`Windows-1252` is explicitly added to the array of available encodings only for BC.

Please correct me I'm wrong
