### PR TITLE
[Serializer] Remove deprecated JSON error methods

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -51,23 +51,6 @@ class JsonDecode implements DecoderInterface
     }
 
     /**
-     * Returns the last decoding error (if any).
-     *
-     * @return int
-     *
-     * @deprecated since version 2.5, to be removed in 3.0.
-     *             The {@self decode()} method throws an exception if error found.
-     *
-     * @see http://php.net/manual/en/function.json-last-error.php json_last_error
-     */
-    public function getLastError()
-    {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the decode() method instead to get the last JSON decoding error.', E_USER_DEPRECATED);
-
-        return $this->lastError;
-    }
-
-    /**
      * Decodes data.
      *
      * @param string $data    The encoded JSON string to decode

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -29,23 +29,6 @@ class JsonEncode implements EncoderInterface
     }
 
     /**
-     * Returns the last encoding error (if any).
-     *
-     * @return int
-     *
-     * @deprecated since version 2.5, to be removed in 3.0.
-     *             The {@self encode()} throws an exception if error found.
-     *
-     * @see http://php.net/manual/en/function.json-last-error.php json_last_error
-     */
-    public function getLastError()
-    {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the encode() method instead to get the last JSON encoding error.', E_USER_DEPRECATED);
-
-        return $this->lastError;
-    }
-
-    /**
      * Encodes PHP data to a JSON string.
      *
      * {@inheritdoc}

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -37,34 +37,6 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
     }
 
     /**
-     * Returns the last encoding error (if any).
-     *
-     * @return int
-     *
-     * @deprecated since version 2.5, to be removed in 3.0. JsonEncode throws exception if an error is found.
-     */
-    public function getLastEncodingError()
-    {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the Symfony\Component\Serializer\Encoder\JsonEncode::encode() method instead to get the last JSON encoding error.', E_USER_DEPRECATED);
-
-        return $this->encodingImpl->getLastError();
-    }
-
-    /**
-     * Returns the last decoding error (if any).
-     *
-     * @return int
-     *
-     * @deprecated since version 2.5, to be removed in 3.0. JsonDecode throws exception if an error is found.
-     */
-    public function getLastDecodingError()
-    {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the Symfony\Component\Serializer\Encoder\JsonDecode::decode() method instead to get the last JSON decoding error.', E_USER_DEPRECATED);
-
-        return $this->decodingImpl->getLastError();
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function encode($data, $format, array $context = array())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | n/a |

Remove deprecated methods of the Serializer component.
