### PR TITLE
[Process] Make test AbstractProcessTest::testStartAfterATimeout useful again

### DIFF
--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -724,7 +724,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testStartAfterATimeout()
     {
-        $process = $this->getProcess('php -r "$n = 1000; while ($n--) {echo \'\'; usleep(1000); }"');
+        $process = $this->getProcess(sprintf('php -r %s', escapeshellarg('$n = 1000; while ($n--) {echo \'\'; usleep(1000); }')));
         $process->setTimeout(0.1);
         try {
             $process->run();

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -728,8 +728,8 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $process->setTimeout(0.1);
         try {
             $process->run();
-            $this->fail('An exception should have been raised.');
-        } catch (\Exception $e) {
+            $this->fail('A RuntimeException should have been raised.');
+        } catch (RuntimeException $e) {
         }
         $process->start();
         usleep(10000);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The test AbstractProcessTest::testStartAfterATimeout() is pretty useless, due to two reasons:
1. Any exception is caught
   This means even the exception thrown with
   <code>$this->fail('A RuntimeException should have been raised.');</code>
   is caught, making the test pretty useless.
2. Invalid PHP code gets executed
   The command that is executed in the tests actually is:
   <code># php -r "$n = 1000; while ($n--) {echo ''; usleep(1000); }"</code>
   .
   This does not wait ~1s, but produces the following error:
   <code>PHP Parse error:  syntax error, unexpected '=' in Command line code on line 1</code>
