### PR TITLE
[Console] ConsoleOuput::isDecorated is detected from STDOUT and STDERR

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -47,10 +47,21 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
         if (!$this->hasStdoutSupport()) {
             $outputStream = 'php://output';
         }
+        $autodetection = null === $decorated;
 
         parent::__construct(fopen($outputStream, 'w'), $verbosity, $decorated, $formatter);
 
+        // remember autodetected value for stdout and reset
+        $stdoutIsDecorated = $this->isDecorated();
+        if ($autodetection) {
+            $this->getFormatter()->setDecorated(null);
+        }
+
         $this->stderr = new StreamOutput(fopen('php://stderr', 'w'), $verbosity, $decorated, $this->getFormatter());
+
+        if ($this->stderr->isDecorated() !== $stdoutIsDecorated) {
+            $this->setDecorated(false);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
@@ -13,6 +13,16 @@ namespace Symfony\Component\Console\Tests\Output;
 
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
+class ConsoleOutputWithMixedDecoratedSupport extends ConsoleOutput
+{
+    protected function hasColorSupport()
+    {
+        // emulate posix_isatty(STDOUT) !== posix_isatty(STDERR)
+        return !parent::hasColorSupport();
+    }
+}
 
 class ConsoleOutputTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,5 +31,32 @@ class ConsoleOutputTest extends \PHPUnit_Framework_TestCase
         $output = new ConsoleOutput(Output::VERBOSITY_QUIET, true);
         $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity(), '__construct() takes the verbosity as its first argument');
         $this->assertSame($output->getFormatter(), $output->getErrorOutput()->getFormatter(), '__construct() takes a formatter or null as the third argument');
+    }
+
+    public function testIsDecorated()
+    {
+        $output = new ConsoleOutput(Output::VERBOSITY_QUIET, true);
+
+        $this->assertTrue($output->isDecorated());
+        $this->assertTrue($output->getErrorOutput()->isDecorated());
+
+        $output = new ConsoleOutput(Output::VERBOSITY_QUIET, false);
+
+        $this->assertFalse($output->isDecorated());
+        $this->assertFalse($output->getErrorOutput()->isDecorated());
+    }
+
+    public function testMixedDecoratedSupportDetection()
+    {
+        $formatter = new OutputFormatter();
+        $output = new ConsoleOutputWithMixedDecoratedSupport(Output::VERBOSITY_QUIET, null, $formatter);
+
+        $this->assertFalse($formatter->isDecorated());
+        $this->assertFalse($output->isDecorated());
+        $this->assertFalse($output->getErrorOutput()->isDecorated());
+
+        $output = new ConsoleOutputWithMixedDecoratedSupport(Output::VERBOSITY_QUIET);
+        $this->assertFalse($output->isDecorated());
+        $this->assertFalse($output->getErrorOutput()->isDecorated());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

In a Symfony command, the `OutputInterface` has wrong result for `isDecorated` in this very simple scenario:

``` sh
 $ app/console vendor:command > output
```

Here `output` is a regular file, so `$output->isDecorated()` should return `false`, but it returns `true`. This happen because, the the automatic detection is done on `stdout` first, and then overridden by a second detection on `stderr` (which is tty in the example above).

I've added a test which (hopefully) make clear the scenario.
