### PR TITLE
[Config] minor: adding chainability to addLoader() in LoaderResolver

### DIFF
--- a/src/Symfony/Component/Config/Loader/LoaderResolver.php
+++ b/src/Symfony/Component/Config/Loader/LoaderResolver.php
@@ -55,12 +55,15 @@ class LoaderResolver implements LoaderResolverInterface
     /**
      * Adds a loader.
      *
-     * @param LoaderInterface $loader A LoaderInterface instance
+     * @param  LoaderInterface $loader A LoaderInterface instance
+     * @return LoaderResolver
      */
     public function addLoader(LoaderInterface $loader)
     {
         $this->loaders[] = $loader;
         $loader->setResolver($this);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Allows for more readable code through chaining when adding resolvers to a `LoaderResolver`. Since this method previously did not return anything, its return type can be changed without BC breaks.
Allows for more readable code through chaining when adding resolvers to a `LoaderResolver`. Since this method previously did not return anything, its return type can be changed without BC breaks.
