### PR TITLE
[DependencyInjection] resolve parameters in inlined factories on compile

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1312,16 +1312,20 @@ EOF;
                 }
 
                 if (is_array($factory)) {
+                    $factoryMethod = substr($this->dumpValue($factory[1]), 1, -1);
+
                     if (is_string($factory[0])) {
-                        return sprintf('\\%s::%s(%s)', $factory[0], $factory[1], implode(', ', $arguments));
+                        $factoryClass = substr(str_replace('\\\\', '\\', $this->dumpValue($factory[0])), 1, -1);
+
+                        return sprintf('\\%s::%s(%s)', $factoryClass, $factoryMethod, implode(', ', $arguments));
                     }
 
                     if ($factory[0] instanceof Definition) {
-                        return sprintf("call_user_func(array(%s, '%s')%s)", $this->dumpValue($factory[0]), $factory[1], count($arguments) > 0 ? ', '.implode(', ', $arguments) : '');
+                        return sprintf("call_user_func(array(%s, '%s')%s)", $this->dumpValue($factory[0]), $factoryMethod, count($arguments) > 0 ? ', '.implode(', ', $arguments) : '');
                     }
 
                     if ($factory[0] instanceof Reference) {
-                        return sprintf('%s->%s(%s)', $this->dumpValue($factory[0]), $factory[1], implode(', ', $arguments));
+                        return sprintf('%s->%s(%s)', $this->dumpValue($factory[0]), $factoryMethod, implode(', ', $arguments));
                     }
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -208,4 +208,12 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
     }
+
+    public function testResolvesParametersOnCompilationInFactories()
+    {
+        $container = include self::$fixturesPath.'/containers/container21.php';
+        $container->compile();
+        $dumper = new PhpDumper($container);
+        $this->assertEquals(str_replace('%path%', str_replace('\\', '\\\\', self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR), file_get_contents(self::$fixturesPath.'/php/services21.php')), $dumper->dump(), '->dump() dumps services');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container21.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container21.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once __DIR__.'/../includes/classes.php';
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+$container = new ContainerBuilder();
+
+$container->setParameter('factory.service', 'foo_factory');
+$container->setParameter('factory.class', 'FooFactory');
+$container->setParameter('factory.method', 'createFoo');
+
+$container
+    ->register('foo', 'Foo')
+    ->setFactory(array('%factory.class%', '%factory.method%'))
+    ->setPublic(false)
+;
+$container
+    ->register('bar', 'Bar')
+    ->setFactory(array(new Definition('%factory.class%'), '%factory.method%'))
+    ->setPublic(false)
+;
+$container
+    ->register('foobar', 'Foobar')
+    ->addMethodCall('setFoo', array(new Reference('foo')))
+    ->addMethodCall('setBar', array(new Reference('bar')))
+;
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services21.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services21.php
@@ -1,0 +1,127 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * ProjectServiceContainer
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ */
+class ProjectServiceContainer extends Container
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->parameters = $this->getDefaultParameters();
+
+        $this->services =
+        $this->scopedServices =
+        $this->scopeStacks = array();
+
+        $this->set('service_container', $this);
+
+        $this->scopes = array();
+        $this->scopeChildren = array();
+        $this->methodMap = array(
+            'foobar' => 'getFoobarService',
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped frozen container.');
+    }
+
+    /**
+     * Gets the 'foobar' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Foobar A Foobar instance.
+     */
+    protected function getFoobarService()
+    {
+        $this->services['foobar'] = $instance = new \Foobar();
+
+        $instance->setFoo(\FooFactory::createFoo());
+        $instance->setBar(call_user_func(array(new \FooFactory(), 'createFoo')));
+
+        return $instance;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameter($name)
+    {
+        $name = strtolower($name);
+
+        if (!(isset($this->parameters[$name]) || array_key_exists($name, $this->parameters))) {
+            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
+        }
+
+        return $this->parameters[$name];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasParameter($name)
+    {
+        $name = strtolower($name);
+
+        return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParameter($name, $value)
+    {
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameterBag()
+    {
+        if (null === $this->parameterBag) {
+            $this->parameterBag = new FrozenParameterBag($this->parameters);
+        }
+
+        return $this->parameterBag;
+    }
+
+    /**
+     * Gets the default parameters.
+     *
+     * @return array An array of the default parameters
+     */
+    protected function getDefaultParameters()
+    {
+        return array(
+            'factory.service' => 'foo_factory',
+            'factory.class' => 'FooFactory',
+            'factory.method' => 'createFoo',
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Before this commit, parameters in service configuration would not have
been resolved if the new factory syntax (introduced with Symfony 2.6)
were used.
