### PR TITLE
[Form] [2.3] test to demonstrate that `submit` and `handleRequest` behave differently

### DIFF
--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -909,6 +909,23 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame($form, $form->handleRequest('REQUEST'));
     }
 
+    public function testSimilarBehaviorOfSubmitAndHandleRequestWhenPassingRequest()
+    {
+        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $factory = \Symfony\Component\Form\Forms::createFormFactoryBuilder()->getFormFactory();
+        $formBuilder = new \Symfony\Component\Form\FormBuilder(null, null, $dispatcher, $factory);
+        $request = \Symfony\Component\HttpFoundation\Request::create('', 'POST', array());
+
+        $form1 = $formBuilder->setRequestHandler(new \Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler())->getForm();
+        $form2 = $formBuilder->setRequestHandler(new \Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler())->getForm();
+
+        $form1->submit($request);
+        $form2->handleRequest($request);
+
+        $this->assertTrue($form1->isSubmitted());
+        $this->assertTrue($form2->isSubmitted());
+    }
+
     public function testFormInheritsParentData()
     {
         $child = $this->getBuilder('child')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| License | MIT |

The upgrade guide for 3.0 mentions replacing `$form->submit($request)` with `$form->handleRequest($request)`. While doing that I noticed that both methods behave differently, making one of my tests fail. So I made up this test to demonstrate that.
Using `'PUT'` instead of `'POST'` in this test is also problematic.
Is it a bug/glitch or am I doing something wrong?
