### PR TITLE
Fix usage of app.security

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Exposes some Symfony parameters and services as an "app" global variable.
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  */
 class AppVariable
 {
-    private $security;
+    private $container;
     private $tokenStorage;
     private $requestStack;
     private $environment;
@@ -34,9 +34,9 @@ class AppVariable
     /**
      * @deprecated since version 2.7, to be removed in 3.0.
      */
-    public function setSecurity(SecurityContextInterface $security)
+    public function setContainer(ContainerInterface $container)
     {
-        $this->security = $security;
+        $this->container = $container;
     }
 
     public function setTokenStorage(TokenStorageInterface $tokenStorage)
@@ -70,11 +70,11 @@ class AppVariable
     {
         trigger_error('The "app.security" variable is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
 
-        if (null === $this->security) {
+        if (null === $this->container) {
             throw new \RuntimeException('The "app.security" variable is not available.');
         }
 
-        return $this->security;
+        return $this->container->get('security');
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\TwigBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -62,10 +61,6 @@ class ExtensionPass implements CompilerPassInterface
 
         if ($container->hasParameter('templating.helper.code.file_link_format')) {
             $container->getDefinition('twig.extension.code')->replaceArgument(0, $container->getParameter('templating.helper.code.file_link_format'));
-        }
-
-        if (!$container->has('security.token_storage')) {
-            $container->getDefinition('twig.app_variable')->addMethodCall('setSecurity', array(new Reference('security.context', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)));
         }
 
         if ($container->has('templating')) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -41,7 +41,7 @@
         <service id="twig.app_variable" class="Symfony\Bridge\Twig\AppVariable" public="false">
             <call method="setEnvironment"><argument>%kernel.environment%</argument></call>
             <call method="setDebug"><argument>%kernel.debug%</argument></call>
-            <call method="setSecurity"><argument type="service" id="security.context" on-invalid="ignore" /></call>
+            <call method="setContainer"><argument type="service" id="service_container" /></call>
             <call method="setTokenStorage"><argument type="service" id="security.token_storage" on-invalid="ignore" /></call>
             <call method="setRequestStack"><argument type="service" id="request_stack" on-invalid="ignore" /></call>
         </service>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -41,6 +41,7 @@
         <service id="twig.app_variable" class="Symfony\Bridge\Twig\AppVariable" public="false">
             <call method="setEnvironment"><argument>%kernel.environment%</argument></call>
             <call method="setDebug"><argument>%kernel.debug%</argument></call>
+            <call method="setSecurity"><argument type="service" id="security.context" on-invalid="ignore" /></call>
             <call method="setTokenStorage"><argument type="service" id="security.token_storage" on-invalid="ignore" /></call>
             <call method="setRequestStack"><argument type="service" id="request_stack" on-invalid="ignore" /></call>
         </service>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Reverts the previous attempt to remove notices when using the `app.security` variable in Twig because it did not work (it prevents using `app.security` altogether).

So, instead, we inject the container and only get the security service (and thus triggering the deprecation notice) when the user is using `app.security`.
