### PR TITLE
[Twig] autoescape_service option stops container from being dumped

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -136,6 +137,9 @@ class TwigExtensionTest extends TestCase
 
         $options = $container->getParameter('twig.options');
         $this->assertEquals(array(new Reference('my_project.some_bundle.template_escaping_guesser'), 'guess'), $options['autoescape']);
+
+        $dumper = new PhpDumper($container);
+        $this->assertNotNull($dumper->dump());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

If the `twig.autoescape_service` option is set from then the container cannot be dumped.

I haven't been able to nail down why this is the case, but I have added to the test to show this happening. In a symfony project this means this error is shown when trying to run the console:

```
[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
You cannot dump a container with parameters that contain references to other services (reference to service "my_project.some_bundle.template_escaping_guesser" found in "/twig.options/autoescape/0").
```
