### PR TITLE
[Form] Added DayOfWeek type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -80,6 +80,9 @@
         <service id="form.type.datetime" class="Symfony\Component\Form\Extension\Core\Type\DateTimeType">
             <tag name="form.type" alias="datetime" />
         </service>
+        <service id="form.type.dayofweek" class="Symfony\Component\Form\Extension\Core\Type\DayOfWeekType">
+            <tag name="form.type" alias="dayofweek" />
+        </service>
         <service id="form.type.email" class="Symfony\Component\Form\Extension\Core\Type\EmailType">
             <tag name="form.type" alias="email" />
         </service>

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -32,6 +32,7 @@ class CoreExtension extends AbstractExtension
             new Type\CountryType(),
             new Type\DateType(),
             new Type\DateTimeType(),
+            new Type\DayOfWeekType(),
             new Type\EmailType(),
             new Type\HiddenType(),
             new Type\IntegerType(),

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DayOfWeekTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DayOfWeekTransformer.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * Transforms a day of week between an iso-8601 integer and a localized string.
+ *
+ * @author Sebastien Lavoie <seb@wemakecustom.com>
+ */
+class DayOfWeekTransformer implements DataTransformerInterface
+{
+    /**
+     * @var string
+     */
+    private $pattern;
+
+    /**
+     * @var DateTimeToLocalizedStringTransformer
+     */
+    private $transformer;
+
+    /**
+     * Constructor.
+     *
+     * @param string $pattern A pattern to pass to \IntlDateFormatter
+     */
+    public function __construct($pattern = 'eeee')
+    {
+        if (!preg_match('/^e{1,5}$/i', $pattern)) {
+            throw new UnexpectedTypeException($pattern, '/^e{1,5}$/i');
+        }
+
+        $this->pattern = $pattern;
+        $this->transformer = new DateTimeToLocalizedStringTransformer(
+            null,
+            null,
+            \IntlDateFormatter::NONE,
+            \IntlDateFormatter::NONE,
+            \IntlDateFormatter::GREGORIAN,
+            $pattern
+        );
+    }
+
+    /**
+     * Transforms a normalized date into a localized date string/array.
+     *
+     * @param int     $int iso-8601 Day of week in integer (1 = monday, 7 = sunday)
+     *
+     * @return string Localized string, depending on pattern.
+     *
+     * @throws TransformationFailedException If the given value is not an integer
+     *                                       and a valid day of the week.
+     */
+    public function transform($value)
+    {
+        if (!is_numeric($value)) {
+            throw new TransformationFailedException('Expected an integer.');
+        }
+
+        $value = intval($value);
+
+        if (!in_array($value, range(1, 7))) {
+            throw new TransformationFailedException('Expected a day of week [1-7].');
+        }
+
+        // cannot use IntlDateFormatter::parse or DateTime::createFromFormat
+        // https://github.com/symfony/symfony/pull/13471#issuecomment-72063748
+        $datetime = new \DateTime('sunday');
+        $datetime->modify('+'.$value.' day');
+
+        return $this->transformer->transform($datetime);
+    }
+
+    /**
+     * Transforms a localized date string/array into a normalized date.
+     *
+     * @param string|int     $value Localized string, depending on pattern.
+     *
+     * @return int     Day of week in integer (1 = monday, 7 = sunday)
+     *
+     * @throws TransformationFailedException if the given value is not a string
+     *                                       or if the date could not be parsed.
+     */
+    public function reverseTransform($value)
+    {
+        if ($this->pattern === 'e' || $this->pattern === 'ee') {
+            if (!in_array($value, range(1, 7))) {
+                throw new TransformationFailedException('Expected a day of week [1-7].');
+            }
+            $value = ''.$value; // DateTimeToLocalizedStringTransformer expects a string
+        } elseif (!is_string($value)) {
+            throw new TransformationFailedException('Expected a string.');
+        }
+
+        $datetime = $this->transformer->reverseTransform($value);
+
+        if (null === $datetime) {
+            throw new TransformationFailedException('Unable to reverseTransform \''.$value.'\'.');
+        }
+
+        return $datetime->format('N');
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/DayOfWeekType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DayOfWeekType.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
+use Symfony\Component\Form\Extension\Core\DataTransformer\DayOfWeekTransformer;
+
+/**
+ * Choice between all days of the week
+ * Values are <1-7>, 1 = monday, 7 = sunday, ISO-8601
+ * Labels are the localized names (Monday-Sunday)
+ * The first day of the week is governed by the Locale
+ *
+ * @author Sebastien Lavoie <seb@wemakecustom.com>
+ */
+class DayOfWeekType extends AbstractType
+{
+    /**
+     * IntlCalendar::DOW_* constants are not compatible with ISO-8601, redo mapping
+     * @var int[]
+     */
+    private static $intlCalendarMapping = array(
+        \IntlCalendar::DOW_MONDAY    => 1,
+        \IntlCalendar::DOW_TUESDAY   => 2,
+        \IntlCalendar::DOW_WEDNESDAY => 3,
+        \IntlCalendar::DOW_THURSDAY  => 4,
+        \IntlCalendar::DOW_FRIDAY    => 5,
+        \IntlCalendar::DOW_SATURDAY  => 6,
+        \IntlCalendar::DOW_SUNDAY    => 7,
+    );
+
+    const PATTERN_DOW = 'e';
+    const PATTERN_SHORT = 'eee';
+    const PATTERN_FULL = 'eeee';
+    const PATTERN_LETTER = 'eeeee';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $choiceList = function (Options $options) {
+            $calendar = \IntlCalendar::createInstance();
+            $days = DayOfWeekType::getOrderedDaysOfWeek($calendar->getFirstDayOfWeek());
+            $transformer = new DayOfWeekTransformer($options['label_format']);
+            $labels = array_map(array($transformer, 'transform'), $days);
+
+            return new SimpleChoiceList(array_combine($days, $labels));
+        };
+
+        $resolver->setDefaults(array(
+            'label_format' => self::PATTERN_FULL,
+            'choice_list' => $choiceList,
+        ));
+
+        $resolver->setAllowedValues(array(
+            // http://userguide.icu-project.org/formatparse/datetime
+            'label_format' => array('e', 'ee', 'eee', 'eeee', 'eeeee', 'eeeeee', 'E', 'EE', 'EEE', 'EEEE', 'EEEEE', 'EEEEEE'),
+        ));
+    }
+
+    /**
+     * Goes through all intlCalendarMapping once, starting at $firstDayOfWeek
+     *
+     * @internal Closure binding only available in 5.4+
+     * @param int $firstDayOfWeek IntlCalendar::DOW_* constant
+     * @return int[] array of iso-8601 integers
+     */
+    public static function getOrderedDaysOfWeek($firstDayOfWeek)
+    {
+        $days = array();
+
+        // goes through all items once, starting at $firstDayOfWeek
+        for ($index = $firstDayOfWeek - 1; $index < ($firstDayOfWeek + 6); $index++) {
+            $dayOfWeek = ($index % 7) + 1;
+            $iso = self::$intlCalendarMapping[$dayOfWeek];
+            $days[] = $iso;
+        }
+
+        return $days;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'choice';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'dayofweek';
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/DayOfWeekType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DayOfWeekType.php
@@ -52,12 +52,19 @@ class DayOfWeekType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $choiceList = function (Options $options) {
-            $calendar = \IntlCalendar::createInstance();
-            $days = DayOfWeekType::getOrderedDaysOfWeek($calendar->getFirstDayOfWeek());
-            $transformer = new DayOfWeekTransformer($options['label_format']);
-            $labels = array_map(array($transformer, 'transform'), $days);
+            static $cache = array();
+            $cache_key = \Locale::getDefault().'|'.$options['label_format'];
 
-            return new SimpleChoiceList(array_combine($days, $labels));
+            if (!isset($cache[$cache_key])) {
+                $calendar = \IntlCalendar::createInstance();
+                $days = DayOfWeekType::getOrderedDaysOfWeek($calendar->getFirstDayOfWeek());
+                $transformer = new DayOfWeekTransformer($options['label_format']);
+                $labels = array_map(array($transformer, 'transform'), $days);
+
+                return $cache[$cache_key] = new SimpleChoiceList(array_combine($days, $labels));
+            }
+
+            return $cache[$cache_key];
         };
 
         $resolver->setDefaults(array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DayOfWeekTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DayOfWeekTransformerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
+
+use Symfony\Component\Form\Extension\Core\DataTransformer\DayOfWeekTransformer;
+
+class DayOfWeekTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DayOfWeekTransformer
+     */
+    private $transformer;
+
+    /**
+     * @var string
+     */
+    private $oldLocale;
+
+    protected function setUp()
+    {
+        $this->transformer = new DayOfWeekTransformer();
+        $this->oldLocale = \Locale::getDefault();
+    }
+
+    protected function tearDown()
+    {
+        $this->transformer = null;
+        \Locale::setDefault($this->oldLocale);
+    }
+
+    /**
+     * @dataProvider getValidData
+     */
+    public function testTransforms($locale, $pattern, $in, $out)
+    {
+        \Locale::setDefault($locale);
+        $transformer = new DayOfWeekTransformer($pattern);
+
+        $this->assertEquals($out, $transformer->transform($in));
+    }
+
+    /**
+     * @dataProvider getValidData
+     */
+    public function testReverseTransforms($locale, $pattern, $in, $out)
+    {
+        \Locale::setDefault($locale);
+        $transformer = new DayOfWeekTransformer($pattern);
+
+        $this->assertEquals($in, $transformer->reverseTransform($out));
+    }
+
+    public function getValidData()
+    {
+        return array(
+            array('fr_FR', 'eeee', 7, 'dimanche'),
+            array('en_US', 'eeee', 7, 'Sunday'),
+
+            array('fr_FR', 'e', 1, 1), // locale dependent
+            array('en_US', 'e', 1, 2),
+
+            array('en_US', 'eee', 6, 'Sat'),
+            array('en_US', 'eee', '6', 'Sat'), // string int is ok
+        );
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testInvalidPattern()
+    {
+        new DayOfWeekTransformer('w');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     * @dataProvider getInvalidTransforms
+     */
+    public function testInvalidTransforms($in)
+    {
+        $this->transformer->transform($in);
+    }
+
+    public function getInvalidTransforms()
+    {
+        return array(
+            array(''),
+            array('Monday'),
+            array(0),
+            array(8),
+            array(null),
+            array(new \stdClass()),
+            array(array()),
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     * @dataProvider getInvalidReverseTransforms
+     */
+    public function testInvalidReverseTransforms($in)
+    {
+        $this->transformer->reverseTransform($in);
+    }
+
+    public function getInvalidReverseTransforms()
+    {
+        return array(
+            array(1),
+            array(''),
+            array(null),
+            array(new \stdClass()),
+            array(array()),
+        );
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DayOfWeekTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DayOfWeekTypeTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+use Symfony\Component\Form\Test\TypeTestCase as TestCase;
+use Symfony\Component\Intl\Util\IntlTestHelper;
+use Symfony\Component\Form\FormView;
+
+class DayOfWeekTypeTest extends TestCase
+{
+    private $oldLocale;
+
+    protected function setUp()
+    {
+        IntlTestHelper::requireIntl($this);
+        $this->oldLocale = \Locale::getDefault();
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        \Locale::setDefault($this->oldLocale);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getLocaleDow
+     */
+    public function testLocaleDow($locale, $firstdow)
+    {
+        \Locale::setDefault($locale);
+
+        $form = $this->createForm();
+        $this->assertSame($firstdow, $form->createView()->vars['choices'][0]->label);
+    }
+
+    public function getLocaleDow()
+    {
+        return array(
+            array('en_US', 'Sunday'),
+            array('fr_FR', 'lundi'),
+        );
+    }
+
+    /**
+     * @dataProvider getValidValue
+     */
+    public function testValidValue($value)
+    {
+        $form = $this->createForm();
+        $form->submit($value);
+        $this->assertEquals($value, $form->getData());
+    }
+
+    public function getValidValue()
+    {
+        return array(
+            array('1'),
+            array('7'),
+            array(7),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidValue
+     */
+    public function testInvalidValue($value)
+    {
+        $form = $this->createForm();
+        $form->submit($value);
+        $this->assertNull($form->getData());
+    }
+
+    public function getInvalidValue()
+    {
+        return array(
+            array(0),
+            array(8),
+        );
+    }
+
+    /**
+     * @dataProvider getLabelFormat
+     */
+    public function testLabelFormat($labelFormat, $data, $label)
+    {
+        \Locale::setDefault('en_US');
+        $form = $this->createForm(array('label_format' => $labelFormat));
+        $form->submit($data);
+        $selected = $this->getSelectedChoice($form->createView());
+
+        $this->assertSame($label, $selected->label);
+    }
+
+    public function getLabelFormat()
+    {
+        return array(
+            array('e', 1, '2'),
+            array('eeee', 1, 'Monday'),
+            array('EEEEE', 1, 'M'),
+        );
+    }
+
+    private function createForm(array $options = array(), $data = null)
+    {
+        return $this->factory->create('dayofweek', $data, $options);
+    }
+
+    private function getSelectedChoice(FormView $view)
+    {
+        $is_selected = $view->vars['is_selected'];
+        $data = $view->vars['data'];
+
+        foreach ($view->vars['choices'] as $choice) {
+            if ($is_selected($choice->data, $data)) {
+                return $choice;
+            }
+        }
+
+        return;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes, but errors with intl extension |
| Fixed tickets | - |
| License | MIT |
| Doc PR | not written yet |
- [ ] Gather comments on how to address this.
- [x] Switch to DataTransformer.
- [x] Write tests.
- [ ] Handle label translation in buildView instead of configureOptions.
- [ ] Write documentation.
- [x] Normalize and validate options in the OptionResolver.

This PR is a proof of concept and I would like to gather some comments before finishing the work.

As of now, it uses `IntlDateFormatter` to figure out which is the first day of the week and the generated choices look like this:

``` php
<?php
// fr_FR
array(
    7 => 'dimanche',
    1 => 'lundi',
    2 => 'mardi',
    3 => 'mercredi',
    4 => 'jeudi',
    5 => 'vendredi',
    6 => 'samedi',
);

// en_US
array(
    1 => 'Monday',
    2 => 'Tuesday',
    3 => 'Wednesday',
    4 => 'Thursday',
    5 => 'Friday',
    6 => 'Saturday',
    7 => 'Sunday',
);
?>
```

The options are:
- `label_format`: format passed to `IntlDateFormatter::format`. Default `eeee` (full day name)

The locale is voluntarily not an option to match the behaviour of the other date types and transformers.

It also features a `DayOfWeekTransformer` that converts between the localized label and the ISO-8601 integer.

---

So, anyone interested ?
