### PR TITLE
[TwigBundle] fixed Twig options (removed the parameter as it cannot contain service references)

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -110,7 +110,7 @@ class TwigExtension extends Extension
         }
         unset($config['autoescape_service'], $config['autoescape_service_method']);
 
-        $container->setParameter('twig.options', $config);
+        $container->getDefinition('twig')->replaceArgument(1, $config);
 
         $this->addClassesToCompile(array(
             'Twig_Environment',

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -31,7 +31,7 @@
     <services>
         <service id="twig" class="%twig.class%">
             <argument type="service" id="twig.loader" />
-            <argument>%twig.options%</argument>
+            <argument /> <!-- Twig options -->
             <call method="addGlobal">
                 <argument>app</argument>
                 <argument type="service" id="twig.app_variable" />

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -73,10 +73,10 @@ class TwigExtensionTest extends TestCase
         $this->assertContains('form_div_layout.html.twig', $container->getParameter('twig.form.resources'), '->load() includes default template for form resources');
 
         // Twig options
-        $options = $container->getParameter('twig.options');
-        $this->assertEquals(__DIR__.'/twig', $options['cache'], '->load() sets default value for cache option');
-        $this->assertEquals('UTF-8', $options['charset'], '->load() sets default value for charset option');
-        $this->assertFalse($options['debug'], '->load() sets default value for debug option');
+        $options = $container->getDefinition('twig')->getArgument(1);
+        $this->assertEquals('%kernel.cache_dir%/twig', $options['cache'], '->load() sets default value for cache option');
+        $this->assertEquals('%kernel.charset%', $options['charset'], '->load() sets default value for charset option');
+        $this->assertEquals('%kernel.debug%', $options['debug'], '->load() sets default value for debug option');
     }
 
     /**
@@ -114,7 +114,7 @@ class TwigExtensionTest extends TestCase
         }
 
         // Twig options
-        $options = $container->getParameter('twig.options');
+        $options = $container->getDefinition('twig')->getArgument(1);
         $this->assertTrue($options['auto_reload'], '->load() sets the auto_reload option');
         $this->assertTrue($options['autoescape'], '->load() sets the autoescape option');
         $this->assertEquals('stdClass', $options['base_template_class'], '->load() sets the base_template_class option');
@@ -134,7 +134,7 @@ class TwigExtensionTest extends TestCase
         $this->loadFromFile($container, 'customTemplateEscapingGuesser', $format);
         $this->compileContainer($container);
 
-        $options = $container->getParameter('twig.options');
+        $options = $container->getDefinition('twig')->getArgument(1);
         $this->assertEquals(array(new Reference('my_project.some_bundle.template_escaping_guesser'), 'guess'), $options['autoescape']);
     }
 
@@ -148,7 +148,7 @@ class TwigExtensionTest extends TestCase
         $this->loadFromFile($container, 'empty', $format);
         $this->compileContainer($container);
 
-        $options = $container->getParameter('twig.options');
+        $options = $container->getDefinition('twig')->getArgument(1);
         $this->assertEquals('filename', $options['autoescape']);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #13467 |
| License | MIT |
| Doc PR | n/a |

The new `autoescape_service` option is used to set the `autoescape` Twig option, which can be a callable. The Twig options are stored in a parameter (`twig.options`), but as parameters cannot have references, that does not work well.

So, this PR removed the parameter as it is not needed.
