### PR TITLE
[Form] [Collection] Pass prototype_name value to the view

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -25,7 +25,7 @@
 
 {% block collection_widget -%}
     {% if prototype is defined %}
-        {%- set attr = attr|merge({'data-prototype': form_row(prototype) }) -%}
+        {%- set attr = attr|merge({'data-prototype': form_row(prototype), 'data-prototype-name': form.vars.prototype_name }) -%}
     {% endif %}
     {{- block('form_widget') -}}
 {%- endblock collection_widget %}

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -56,6 +56,7 @@ class CollectionType extends AbstractType
 
         if ($form->getConfig()->hasAttribute('prototype')) {
             $view->vars['prototype'] = $form->getConfig()->getAttribute('prototype')->createView($view);
+            $view->vars['prototype_name'] = $options['prototype_name'];
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This commit allows to handle the collection field option `prototype_name` from the view. Associated JS can now count on it to get the placeholder for prototype replace string on adding element.
