### PR TITLE
[Translation] add fix to ignore empty translation

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -514,6 +514,9 @@ UPGRADE FROM 2.x to 3.0
 
  * The `Translator::setFallbackLocale()` method has been removed in favor of
    `Translator::setFallbackLocales()`.
+   
+ * The `MessageCatalogue::get()` method has been changed to also dismiss empty
+   translations and return the fallback or original string instead. 
 
 ### Twig Bridge
 

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -120,7 +120,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function get($id, $domain = 'messages')
     {
-        if (isset($this->messages[$domain][$id])) {
+        if (isset($this->messages[$domain][$id]) && !empty($this->messages[$domain][$id])) {
             return $this->messages[$domain][$id];
         }
 

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -120,7 +120,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function get($id, $domain = 'messages')
     {
-        if (isset($this->messages[$domain][$id]) && !empty($this->messages[$domain][$id])) {
+        if (isset($this->messages[$domain][$id]) && '' !== $this->messages[$domain][$id]) {
             return $this->messages[$domain][$id];
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [unsure] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | #13483 |
| License | MIT |
| Doc PR | [] |

The expected behaviour is to treat empty translations like PHP gettext do, and show the fallback or original message instead.
