### PR TITLE
[FrameworkBundle] Keep "pre" meaning for var_dump quick-and-dirty debug

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/structure.css
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/structure.css
@@ -62,7 +62,7 @@ img {
     width: 970px;
     margin: 0 auto;
 }
-pre {
+#content pre {
     white-space: normal;
     font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This is a minor fix to have a quick-and-dirty var_dump nicely work with the exception output from Symfony.
In short, the default "pre" whitespace CSS rules should be kept outside of block "#content", so that var_dump output is not diplayed in a single huge line.
