### PR TITLE
[Serializer] Normalizers can serialize collections and scalars

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -73,6 +73,15 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->serializer->denormalize(json_encode($data), 'stdClass', 'json'));
     }
 
+    public function testCustomNormalizerCanNormalizeCollectionsAndScalar()
+    {
+        $this->serializer = new Serializer(array(new TestNormalizer()), array());
+        $this->assertNull($this->serializer->normalize(array('a', 'b')));
+        $this->assertNull($this->serializer->normalize(new \ArrayObject(array('c', 'd'))));
+        $this->assertNull($this->serializer->normalize(array()));
+        $this->assertNull($this->serializer->normalize('test'));
+    }
+
     public function testSerialize()
     {
         $this->serializer = new Serializer(array(new GetSetMethodNormalizer()), array('json' => new JsonEncoder()));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | n/a |

Currently, the logic for serializing `array` and scalars is hardcoded in the serializer. This is not possible to have a custom serializer normalizing collections. This a big limitation, for instance it's not possible to create an normalizer creating [Hydra collections](http://www.hydra-cg.com/spec/latest/core/#h-collections) for a PHP array.

This PR fix that.
