### PR TITLE
[TwigBridge] Fix bootstrap rendering when user explicitly use form_label

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -156,19 +156,22 @@
 {%- endblock radio_label %}
 
 {% block checkbox_radio_label %}
-    {% if required %}
-        {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
+    {# Do no display the label if widget is not defined in order to prevent double label rendering #}
+    {% if widget is defined %}
+        {% if required %}
+            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
+        {% endif %}
+        {% if parent_label_class is defined %}
+            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
+        {% endif %}
+        {% if label is empty %}
+            {% set label = name|humanize %}
+        {% endif %}
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+                {{ widget|raw }}
+                {{ label|trans({}, translation_domain) }}
+        </label>
     {% endif %}
-    {% if parent_label_class is defined %}
-        {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
-    {% endif %}
-    {% if label is empty %}
-        {% set label = name|humanize %}
-    {% endif %}
-    <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-        {{ widget|raw }}
-        {{ label|trans({}, translation_domain) }}
-    </label>
 {% endblock checkbox_radio_label %}
 
 {# Rows #}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | #13417 |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I implemented what @javiereguiluz said in this [comment](https://github.com/symfony/symfony/issues/13417#issuecomment-71162558)
