### PR TITLE
[Routing] merge instead of replace class and method scheme/method annotations

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -145,8 +145,8 @@ abstract class AnnotationClassLoader implements LoaderInterface
         }
         $requirements = array_replace($globals['requirements'], $annot->getRequirements());
         $options = array_replace($globals['options'], $annot->getOptions());
-        $schemes = array_replace($globals['schemes'], $annot->getSchemes());
-        $methods = array_replace($globals['methods'], $annot->getMethods());
+        $schemes = array_merge($globals['schemes'], $annot->getSchemes());
+        $methods = array_merge($globals['methods'], $annot->getMethods());
 
         $host = $annot->getHost();
         if (null === $host) {

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -73,22 +73,27 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         return array(
             array(
                 'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('name' => 'route1'),
+                array('name' => 'route1', 'path' => '/path'),
                 array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
             ),
             array(
                 'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('name' => 'route1', 'defaults' => array('arg2' => 'foo')),
+                array('defaults' => array('arg2' => 'foo'), 'requirements' => array('arg3' => '\w+')),
                 array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
             ),
             array(
                 'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('name' => 'route1', 'defaults' => array('arg2' => 'foobar')),
+                array('options' => array('foo' => 'bar')),
                 array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
             ),
             array(
                 'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('name' => 'route1', 'defaults' => array('arg2' => 'foo'), 'condition' => 'context.getMethod() == "GET"'),
+                array('schemes' => array('https'), 'methods' => array('GET')),
+                array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
+            ),
+            array(
+                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
+                array('condition' => 'context.getMethod() == "GET"'),
                 array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
             ),
         );
@@ -97,9 +102,9 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     /**
      * @dataProvider getLoadTests
      */
-    public function testLoad($className, $routeDatas = array(), $methodArgs = array())
+    public function testLoad($className, $routeData = array(), $methodArgs = array())
     {
-        $routeDatas = array_replace(array(
+        $routeData = array_replace(array(
             'name' => 'route',
             'path' => '/',
             'requirements' => array(),
@@ -107,52 +112,76 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
             'defaults' => array(),
             'schemes' => array(),
             'methods' => array(),
-            'condition' => null,
-        ), $routeDatas);
+            'condition' => '',
+        ), $routeData);
 
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue(array($this->getAnnotatedRoute($routeDatas))))
+            ->will($this->returnValue(array($this->getAnnotatedRoute($routeData))))
         ;
-        $routeCollection = $this->loader->load($className);
-        $route = $routeCollection->get($routeDatas['name']);
 
-        $this->assertSame($routeDatas['path'], $route->getPath(), '->load preserves path annotation');
-        $this->assertSame($routeDatas['requirements'], $route->getRequirements(), '->load preserves requirements annotation');
-        $this->assertCount(0, array_intersect($route->getOptions(), $routeDatas['options']), '->load preserves options annotation');
-        $this->assertSame(array_replace($methodArgs, $routeDatas['defaults']), $route->getDefaults(), '->load preserves defaults annotation');
-        $this->assertEquals($routeDatas['condition'], $route->getCondition(), '->load preserves condition annotation');
+        $routeCollection = $this->loader->load($className);
+        $route = $routeCollection->get($routeData['name']);
+
+        $this->assertSame($routeData['path'], $route->getPath(), '->load preserves path annotation');
+        $this->assertCount(
+            count($routeData['requirements']),
+            array_intersect_assoc($routeData['requirements'], $route->getRequirements()),
+            '->load preserves requirements annotation'
+        );
+        $this->assertCount(
+            count($routeData['options']),
+            array_intersect_assoc($routeData['options'], $route->getOptions()),
+            '->load preserves options annotation'
+        );
+        $defaults = array_replace($methodArgs, $routeData['defaults']);
+        $this->assertCount(
+            count($defaults),
+            array_intersect_assoc($defaults, $route->getDefaults()),
+            '->load preserves defaults annotation and merges them with default arguments in method signature'
+        );
+        $this->assertEquals($routeData['schemes'], $route->getSchemes(), '->load preserves schemes annotation');
+        $this->assertEquals($routeData['methods'], $route->getMethods(), '->load preserves methods annotation');
+        $this->assertSame($routeData['condition'], $route->getCondition(), '->load preserves condition annotation');
     }
 
     public function testClassRouteLoad()
     {
-        $classRouteDatas = array('path' => '/classRoutePrefix');
+        $classRouteData = array(
+            'path' => '/prefix',
+            'schemes' => array('https'),
+            'methods' => array('GET')
+        );
 
-        $routeDatas = array(
+        $methodRouteData = array(
             'name' => 'route1',
-            'path' => '/',
+            'path' => '/path',
+            'schemes' => array('http'),
+            'methods' => array('POST', 'PUT')
         );
 
         $this->reader
             ->expects($this->once())
             ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteDatas)))
+            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
         ;
-
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue(array($this->getAnnotatedRoute($routeDatas))))
+            ->will($this->returnValue(array($this->getAnnotatedRoute($methodRouteData))))
         ;
-        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass');
-        $route = $routeCollection->get($routeDatas['name']);
 
-        $this->assertSame($classRouteDatas['path'].$routeDatas['path'], $route->getPath(), '->load preserves class route path annotation');
+        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass');
+        $route = $routeCollection->get($methodRouteData['name']);
+
+        $this->assertSame($classRouteData['path'].$methodRouteData['path'], $route->getPath(), '->load concatenates class and method route path');
+        $this->assertEquals(array_merge($classRouteData['schemes'], $methodRouteData['schemes']), $route->getSchemes(), '->load merges class and method route schemes');
+        $this->assertEquals(array_merge($classRouteData['methods'], $methodRouteData['methods']), $route->getMethods(), '->load merges class and method route methods');
     }
 
-    private function getAnnotatedRoute($datas)
+    private function getAnnotatedRoute($data)
     {
-        return new Route($datas);
+        return new Route($data);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | slightly (but since it only widens the scheme/method requirements, it should not really affect anyone) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7132 |
| License | MIT |
| Doc PR |  |

Using replace for schemes/methods makes no sense, since it's not associative. So it can produce unexpected outcomes as demonstrated in the referenced ticket.

I chose 2.7 as  target branch because it's a bug fix but also a minor change in behavior. I also added more and better tests.
