### PR TITLE
[3.0] Travis Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
         - php: 5.5.9
         - php: 5.5
         - php: 5.6
+        - php: 5.5.9
           env: components=low
         - php: 5.6
           env: components=high


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Previously we were not actually running the framework tests on php 5.6, but only the component tests. I assume we want the same setup we've got on the 2.7 branch.
