### PR TITLE
[Validator] re-added support for 2.4 API version in tests

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -113,6 +113,7 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
                     $translator
                 );
                 break;
+            case Validation::API_VERSION_2_4:
             case Validation::API_VERSION_2_5_BC:
                 $context = new LegacyExecutionContext(
                     $validator,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Alternative to #13414
