### PR TITLE
[Form] fixed form tests when using 2.7 deps

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
 use Symfony\Component\Form\Extension\Validator\Constraints\FormValidator;
 use Symfony\Component\Form\SubmitButtonBuilder;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest;
@@ -224,14 +225,12 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($form, new Form());
 
-        $is2Dot4Api = Validation::API_VERSION_2_4 === $this->getApiVersion();
-
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
             ->setParameter('{{ foo }}', 'bar')
             ->setInvalidValue('foo')
             ->setCode(Form::NOT_SYNCHRONIZED_ERROR)
-            ->setCause($is2Dot4Api ? null : $form->getTransformationFailure())
+            ->setCause($this->context instanceof ExecutionContextInterface ? $form->getTransformationFailure() : null)
             ->assertRaised();
     }
 
@@ -261,14 +260,12 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($form, new Form());
 
-        $is2Dot4Api = Validation::API_VERSION_2_4 === $this->getApiVersion();
-
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
             ->setParameter('{{ foo }}', 'bar')
             ->setInvalidValue('foo')
             ->setCode(Form::NOT_SYNCHRONIZED_ERROR)
-            ->setCause($is2Dot4Api ? null : $form->getTransformationFailure())
+            ->setCause($this->context instanceof ExecutionContextInterface ? $form->getTransformationFailure() : null)
             ->assertRaised();
     }
 
@@ -298,13 +295,11 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($form, new Form());
 
-        $is2Dot4Api = Validation::API_VERSION_2_4 === $this->getApiVersion();
-
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
             ->setInvalidValue('foo')
             ->setCode(Form::NOT_SYNCHRONIZED_ERROR)
-            ->setCause($is2Dot4Api ? null : $form->getTransformationFailure())
+            ->setCause($this->context instanceof ExecutionContextInterface ? $form->getTransformationFailure() : null)
             ->assertRaised();
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR allows tests to pass for the Form subtree-split when using any version of the Validator component. The build was broken because the 2.4 API works in the same way as the 2.5 one in Symfony 2.7, so the cause is set. Testing the implementation of the context allows to know whether to expect the cause more reliably.
