### PR TITLE
[2.7] [HttpFoundation] [Request] Added check for valid host size limit

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1271,9 +1271,15 @@ class Request
 
         // as the host can come from the user (HTTP_HOST and depending on the configuration, SERVER_NAME too can come from the user)
         // check that it does not contain forbidden characters (see RFC 952 and RFC 2181)
+        // IDNs must be sent as Punycode (see RFC 5890)
+        // and if it honors size limits (63 octets for label, 255 octets for name - see RFC 1035 - 2.3.4)
         // use preg_replace() instead of preg_match() to prevent DoS attacks with long host names
-        if ($host && '' !== preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $host)) {
-            throw new \UnexpectedValueException(sprintf('Invalid Host "%s"', $host));
+        if ($host) {
+            if ('' !== preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $host) ||
+                0 !== preg_match('/(?:^\[)?[a-zA-Z0-9-:\.\]_]{256,}|[a-zA-Z0-9-:\]_]{64,}\.?/', $host)
+            ) {
+                throw new \UnexpectedValueException(sprintf('Invalid Host "%s"', $host));
+            }
         }
 
         if (count(self::$trustedHostPatterns) > 0) {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1275,8 +1275,8 @@ class Request
         // and if it honors size limits (63 octets for label, 255 octets for name - see RFC 1035 - 2.3.4)
         // use preg_replace() instead of preg_match() to prevent DoS attacks with long host names
         if ($host) {
-            if ('' !== preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $host) ||
-                0 !== preg_match('/(?:^\[)?[a-zA-Z0-9-:\.\]_]{256,}|[a-zA-Z0-9-:\]_]{64,}\.?/', $host)
+            if ('' !== preg_replace('/(?:^\[)?[a-z0-9-:\]_]+\.?/', '', $host) ||
+                0 !== preg_match('/(?:^\[)?[a-z0-9-:\.\]_]{256,257}|[a-z0-9-:\]_]{64,65}\.?/', $host)
             ) {
                 throw new \UnexpectedValueException(sprintf('Invalid Host "%s"', $host));
             }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1271,12 +1271,14 @@ class Request
 
         // as the host can come from the user (HTTP_HOST and depending on the configuration, SERVER_NAME too can come from the user)
         // check that it does not contain forbidden characters (see RFC 952 and RFC 2181)
-        // IDNs must be sent as Punycode (see RFC 5890)
         // and if it honors size limits (63 octets for label, 255 octets for name - see RFC 1035 - 2.3.4)
-        // use preg_replace() instead of preg_match() to prevent DoS attacks with long host names
+        // IDNs must be sent as Punycode (see RFC 5890)
         if ($host) {
-            if ('' !== preg_replace('/(?:^\[)?[a-z0-9-:\]_]+\.?/', '', $host) ||
-                0 !== preg_match('/(?:^\[)?[a-z0-9-:\.\]_]{256,257}|[a-z0-9-:\]_]{64,65}\.?/', $host)
+            // trimmed $host in order to prevent DoS attacks with long host names
+            $trimmedHost = substr($host, 0, 256);
+            // use preg_replace() instead of preg_match() when possible
+            if ('' !== preg_replace('/(?:^\[)?[a-z0-9-:\]_]+\.?/', '', $trimmedHost) ||
+                0 !== preg_match('/(?:^\[)?[a-z0-9-:\.\]_]{256,257}|[a-z0-9-:\]_]{64,65}\.?/', $trimmedHost)
             ) {
                 throw new \UnexpectedValueException(sprintf('Invalid Host "%s"', $host));
             }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1738,14 +1738,20 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('[::1]', true),
             array('[::1]:80', true, '[::1]', 80),
             array(str_repeat('.', 101), false),
+            array('a.'.str_repeat('a', 253), false),
+            array('a.'.str_repeat('a', 64), false),
+            array(str_repeat('a', 63).'.'.str_repeat('b', 63).'.'.str_repeat('c', 63), true),
+            array('a'.str_repeat('a', 63).'.'.str_repeat('b', 63).'.'.str_repeat('c', 63).'.'.str_repeat('d', 63), false),
+            array('áäéë.íïóö.úüçñ', false),
+            array('xn--1cagpi.xn--edaemm.xn--7cauzi', true), // Punycode representation of "áäéë.íïóö.úüçñ"
         );
     }
 
     public function getLongHostNames()
     {
         return array(
-            array('a'.str_repeat('.a', 40000)),
-            array(str_repeat(':', 101)),
+            array('a.'.str_repeat('a', 61).'.'.str_repeat('b', 63).'.'.str_repeat('c', 63).'.'.str_repeat('d', 63)),
+            array(str_repeat(':', 63)),
         );
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1719,7 +1719,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $request = Request::create('/');
         $request->headers->set('host', $host);
-        $callsPerSecond = 1000;
+        $callsPerSecond = 500;
 
         for ($i = 0; $i < $callsPerSecond; $i++) {
             try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | kinda |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12349 |
| License | MIT |
| Doc PR | none |

Added check for valid host size limit according to RFC 1035 - 2.3.4 (ticket #12349):
http://www.ietf.org/rfc/rfc1035.txt
- 63 bytes limit for each domain label
- 255 bytes limit for whole domain name

TODO:
- [x] ~~Replace preg_match() by preg_replace().~~ (after a timing benchmark I found `preg_match()` faster than `preg_replace()`, but I also have made some little improvements in regexs).
