### PR TITLE
use valid event name in EventDispatcherDebugCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -33,7 +33,7 @@ class EventDispatcherDebugCommand extends ContainerAwareCommand
         $this
             ->setName('debug:event-dispatcher')
             ->setDefinition(array(
-                new InputArgument('event', InputArgument::OPTIONAL, 'An event name (foo)'),
+                new InputArgument('event', InputArgument::OPTIONAL, 'An event name (kernel.request)'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'To output description in other formats', 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw description'),
             ))


### PR DESCRIPTION
"foo" does not provide a result
