### PR TITLE
[2.3][Form] Fix issue with checkboxType where data was never set to false

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxDataListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxDataListener.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Fix an issue where value was never set
+ * to false in specific cases.
+ *
+ * Class FixCheckboxDataListener
+ *
+ * @author Sylvain Rascar <rascar.sylvain@gmail.com>
+ *
+ * @package Symfony\Component\Form\Extension\Core\EventListener
+ */
+class FixCheckboxDataListener implements EventSubscriberInterface
+{
+    /**
+     * @param FormEvent $event
+     */
+    public function preSubmit(FormEvent $event)
+    {
+        $data = $event->getData();
+
+        if ($data === '0') {
+            $event->setData(null);
+        }
+    }
+
+    /**
+     * Alias of {@link preSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link preSubmit()} instead.
+     *
+     * @param FormEvent $event
+     */
+    public function preBind(FormEvent $event)
+    {
+        $this->preSubmit($event);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(FormEvents::PRE_SUBMIT => 'preSubmit');
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\EventListener\FixCheckboxDataListener;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
@@ -33,6 +34,10 @@ class CheckboxType extends AbstractType
         // doing so also calls setDataLocked(true).
         $builder->setData(isset($options['data']) ? $options['data'] : false);
         $builder->addViewTransformer(new BooleanToStringTransformer($options['value']));
+        // When coming from an api for example, form data need to be set to 0 or false
+        // which will end up setting true in the field when object in persisted
+        // since the value is not null
+        $builder->addEventSubscriber(new FixCheckboxDataListener());
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixCheckboxDataListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixCheckboxDataListenerTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
+
+use Symfony\Component\Form\Extension\Core\EventListener\FixCheckboxDataListener;
+use Symfony\Component\Form\FormEvent;
+
+class FixCheckboxDataListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider valuesProvider
+     */
+    public function testFixCheckbox($data, $expexted)
+    {
+        $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
+        $event = new FormEvent($form, $data);
+
+        $listener = new FixCheckboxDataListener();
+        $listener->preSubmit($event);
+
+        $this->assertEquals($expexted, $event->getData());
+    }
+
+    public function valuesProvider()
+    {
+        return array(
+            array('0', null),
+            array('', ''),
+            array('1', true),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This fix an the following issue:
FriendsOfSymfony/FOSRestBundle#296

_Send data with a JSON boolean in the request using FOSRestBundle_

```
{"subject":{"id":2,"enabled":false}}

// Controller.php

$form->submit($request);
$form->get('enabled')->getData(); // true
```
