### PR TITLE
[EventDispatcher] Wrong EventDispatcher instance injected in listeners

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -216,7 +216,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
             $this->dispatcher->removeListener($eventName, $listener);
             $info = $this->getListenerInfo($listener, $eventName);
             $name = isset($info['class']) ? $info['class'] : $info['type'];
-            $this->dispatcher->addListener($eventName, new WrappedListener($listener, $name, $this->stopwatch));
+            $this->dispatcher->addListener($eventName, new WrappedListener($listener, $name, $this->stopwatch, $this));
         }
     }
 

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -25,12 +25,14 @@ class WrappedListener
     private $called;
     private $stoppedPropagation;
     private $stopwatch;
+    private $dispatcher;
 
-    public function __construct($listener, $name, Stopwatch $stopwatch)
+    public function __construct($listener, $name, Stopwatch $stopwatch, EventDispatcherInterface $dispatcher = null)
     {
         $this->listener = $listener;
         $this->name = $name;
         $this->stopwatch = $stopwatch;
+        $this->dispatcher = $dispatcher;
         $this->called = false;
         $this->stoppedPropagation = false;
     }
@@ -56,7 +58,7 @@ class WrappedListener
 
         $e = $this->stopwatch->start($this->name, 'event_listener');
 
-        call_user_func($this->listener, $event, $eventName, $dispatcher);
+        call_user_func($this->listener, $event, $eventName, $this->dispatcher ?: $dispatcher);
 
         if ($e->isStarted()) {
             $e->stop();

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -86,6 +86,20 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $tdispatcher->getNotCalledListeners());
     }
 
+    public function testGetCalledListenersNested()
+    {
+        $tdispatcher = null;
+        $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $dispatcher->addListener('foo', function (Event $event, $eventName, $dispatcher) use (&$tdispatcher) {
+            $tdispatcher = $dispatcher;
+            $dispatcher->dispatch('bar');
+        });
+        $dispatcher->addListener('bar', function (Event $event) {});
+        $dispatcher->dispatch('foo');
+        $this->assertSame($dispatcher, $tdispatcher);
+        $this->assertCount(2, $dispatcher->getCalledListeners());
+    }
+
     public function testLogger()
     {
         $logger = $this->getMock('Psr\Log\LoggerInterface');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Actually, when using the `TraceableEventDispatcher` the listeners gets injected as third parameter the original `EventDispatcher` instead of the decorated dispatcher, this causes that the method `getCalledListeners` returns a wrong result if we dispatch another event inside a listener.

Code to reproduce:

``` php
<?php

require_once __DIR__.'/vendor/autoload.php';

use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
use Symfony\Component\EventDispatcher\EventDispatcher;
use Symfony\Component\Stopwatch\Stopwatch;

$dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());

$dispatcher->addListener('bar', function ($event, $eventName, $dispatcher) {});

$dispatcher->addListener('foo', function ($event, $eventName, $dispatcher) {
    $dispatcher->dispatch('bar');
});

$dispatcher->dispatch('foo');

$calledListeners = $dispatcher->getCalledListeners();

print_r($calledListeners);
```

Expected result:

```
Array
(
    [bar.closure] => Array
        (
            [event] => bar
            [type] => Closure
            [pretty] => closure
        )
    [foo.closure] => Array
        (
            [event] => foo
            [type] => Closure
            [pretty] => closure
        )
)
```

Actual result:

```
Array
(
    [foo.closure] => Array
        (
            [event] => foo
            [type] => Closure
            [pretty] => closure
        )
)

```
