### PR TITLE
[2.7] [Form] Replaced calls to array_search() by in_array()

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -144,7 +144,7 @@ class FormExtension extends \Twig_Extension
     public function isSelectedChoice(ChoiceView $choice, $selectedValue)
     {
         if (is_array($selectedValue)) {
-            return false !== array_search($choice->value, $selectedValue, true);
+            return in_array($choice->value, $selectedValue, true);
         }
 
         return $choice->value === $selectedValue;

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -389,7 +389,7 @@ class ChoiceList implements ChoiceListInterface
      */
     protected function isPreferred($choice, array $preferredChoices)
     {
-        return false !== array_search($choice, $preferredChoices, true);
+        return in_array($choice, $preferredChoices, true);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -110,7 +110,7 @@ class ChoiceType extends AbstractType
         // avoid making the type check inside the closure.
         if ($options['multiple']) {
             $view->vars['is_selected'] = function ($choice, array $values) {
-                return false !== array_search($choice, $values, true);
+                return in_array($choice, $values, true);
             };
         } else {
             $view->vars['is_selected'] = function ($choice, $value) {


### PR DESCRIPTION
[2.7] [Form] Replaced calls to `array_search()` by `in_array()` where is no need to get the index.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

It's a semantic improvement mostly, for readability (no performance impact).
