### PR TITLE
[TwigBundle] make date formats and number formats configurable

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.7.0
 -----
 
+ * made it possible to configure the default formats for both the `date` and the `number_format` filter
  * added support for the new Asset component (from Twig bridge)
  * deprecated the assets extension (use the one from the Twig bridge instead)
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ class Configuration implements ConfigurationInterface
         $this->addFormThemesSection($rootNode);
         $this->addGlobalsSection($rootNode);
         $this->addTwigOptions($rootNode);
+        $this->addTwigFormatOptions($rootNode);
 
         return $treeBuilder;
     }
@@ -203,6 +204,35 @@ class Configuration implements ConfigurationInterface
                         })
                     ->end()
                     ->prototype('variable')->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addTwigFormatOptions(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('date')
+                    ->info('The default format options used by the date filter')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('format')->defaultValue('F j, Y H:i')->end()
+                        ->scalarNode('interval_format')->defaultValue('%d days')->end()
+                        ->scalarNode('timezone')
+                            ->info('The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used')
+                            ->defaultNull()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('number_format')
+                    ->info('The default format options for the number_format filter')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->integerNode('decimals')->defaultValue(0)->end()
+                        ->scalarNode('decimal_point')->defaultValue('.')->end()
+                        ->scalarNode('thousands_separator')->defaultValue(',')->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfigurator.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfigurator.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\DependencyInjection\Configurator;
+
+/**
+ * Twig environment configurator.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class EnvironmentConfigurator
+{
+    private $dateFormat;
+    private $intervalFormat;
+    private $timezone;
+    private $decimals;
+    private $decimalPoint;
+    private $thousandsSeparator;
+
+    public function __construct($dateFormat, $intervalFormat, $timezone, $decimals, $decimalPoint, $thousandsSeparator)
+    {
+        $this->dateFormat = $dateFormat;
+        $this->intervalFormat = $intervalFormat;
+        $this->timezone = $timezone;
+        $this->decimals = $decimals;
+        $this->decimalPoint = $decimalPoint;
+        $this->thousandsSeparator = $thousandsSeparator;
+    }
+
+    public function configure(\Twig_Environment $environment)
+    {
+        $environment->getExtension('core')->setDateFormat($this->dateFormat, $this->intervalFormat);
+
+        if (null !== $this->timezone) {
+            $environment->getExtension('core')->setTimezone($this->timezone);
+        }
+
+        $environment->getExtension('core')->setNumberFormat($this->decimals, $this->decimalPoint, $this->thousandsSeparator);
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -57,6 +57,14 @@ class TwigExtension extends Extension
 
         $container->setParameter('twig.form.resources', $config['form_themes']);
 
+        $envConfiguratorDefinition = $container->getDefinition('twig.configurator.environment');
+        $envConfiguratorDefinition->replaceArgument(0, $config['date']['format']);
+        $envConfiguratorDefinition->replaceArgument(1, $config['date']['interval_format']);
+        $envConfiguratorDefinition->replaceArgument(2, $config['date']['timezone']);
+        $envConfiguratorDefinition->replaceArgument(3, $config['number_format']['decimals']);
+        $envConfiguratorDefinition->replaceArgument(4, $config['number_format']['decimal_point']);
+        $envConfiguratorDefinition->replaceArgument(5, $config['number_format']['thousands_separator']);
+
         $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.filesystem');
 
         // register user-configured paths

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -35,6 +35,7 @@
                 <argument>app</argument>
                 <argument type="service" id="twig.app_variable" />
             </call>
+            <configurator service="twig.configurator.environment" method="configure" />
         </service>
 
         <service id="twig.app_variable" class="Symfony\Bridge\Twig\AppVariable" public="false">
@@ -162,6 +163,15 @@
         <service id="twig.controller.preview_error" class="%twig.controller.preview_error.class%">
             <argument type="service" id="http_kernel" />
             <argument>%twig.exception_listener.controller%</argument>
+        </service>
+
+        <service id="twig.configurator.environment" class="Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfigurator" public="false">
+            <argument /> <!-- date format, set in TwigExtension -->
+            <argument /> <!-- interval format, set in TwigExtension -->
+            <argument /> <!-- timezone, set in TwigExtension -->
+            <argument /> <!-- decimals, set in TwigExtension -->
+            <argument /> <!-- decimal point, set in TwigExtension -->
+            <argument /> <!-- thousands separator, set in TwigExtension -->
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13552 |
| License | MIT |
| Doc PR | TODO |

This adds new Twig configuration options that make it possible to
configure the format of both numbers and dates as well as timezones
without the need to write custom code.

For example, using the new configuration options can look like this:

``` yaml
twig:
    date:
        format: d.m.Y, H:i:s
        interval_format: %%d days
        timezone: Europe/Berlin
    number_format:
        decimals: 2
        decimal_point: ,
        thousands_separator: .
```
