### PR TITLE
Test lowest deps with latest 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
         - php: 5.4
         - php: 5.5
         - php: 5.6
-        - php: 5.3.3
+        - php: 5.3
           env: components=low
         - php: 5.6
           env: components=high


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Once merged back into 2.6 and as demonstrated in #13555 / https://travis-ci.org/symfony/symfony/builds/48954841, this works around the segfault that happens there all the time since 8892cf0 (reverting the patch introduced on src/Symfony/Bridge/Twig/NodeVisitor/Scope.php also works around the segfault, but choosing this path would make no sense).
