### PR TITLE
[DX][Translator] Return domain when no fallback was found

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -128,7 +128,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             return $this->fallbackCatalogue->get($id, $domain);
         }
 
-        return $id;
+        return $domain . ':' . $id;
     }
 
     /**


### PR DESCRIPTION
The backup translation that is shown when an application makes use of separate translation files for `backend`, `frontend`, `messages`, `validators` could be better. It is not entirely clear for our translators where a missing translation is located. We make use of the Yaml format at the moment.

Currently when a translation key from `backend` is missing, and there is no fallback, the key is like:

``` yml
     page.msg_header
```

I would like to propose that the the catalog gets prepended to the message, so translators can locate the proper file more easy:

``` yml
     backend:page.msg_header
```
