### PR TITLE
[HttpFoundation] Removed host validation from Request::getHost()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1249,7 +1249,7 @@ class Request
      *
      * @return string
      *
-     * @throws \UnexpectedValueException when the host name is invalid
+     * @throws \UnexpectedValueException when the host name is untrusted
      *
      * @api
      */
@@ -1268,13 +1268,6 @@ class Request
         // trim and remove port number from host
         // host is lowercase as per RFC 952/2181
         $host = strtolower(preg_replace('/:\d+$/', '', trim($host)));
-
-        // as the host can come from the user (HTTP_HOST and depending on the configuration, SERVER_NAME too can come from the user)
-        // check that it does not contain forbidden characters (see RFC 952 and RFC 2181)
-        // use preg_replace() instead of preg_match() to prevent DoS attacks with long host names
-        if ($host && '' !== preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $host)) {
-            throw new \UnexpectedValueException(sprintf('Invalid Host "%s"', $host));
-        }
 
         if (count(self::$trustedHostPatterns) > 0) {
             // to avoid host header injection attacks, you should provide a list of trusted host patterns

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -783,16 +783,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
-     */
-    public function testGetHostWithFakeHttpHostValue()
-    {
-        $request = new Request();
-        $request->initialize(array(), array(), array(), array(), array(), array('HTTP_HOST' => 'www.host.com?query=string'));
-        $request->getHost();
-    }
-
-    /**
      * @covers Symfony\Component\HttpFoundation\Request::setMethod
      * @covers Symfony\Component\HttpFoundation\Request::getMethod
      */
@@ -1707,38 +1697,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->headers->set('host', $host);
         $this->assertEquals($host, $request->getHost());
         $this->assertLessThan(1, microtime(true) - $start);
-    }
-
-    /**
-     * @dataProvider getHostValidities
-     */
-    public function testHostValidity($host, $isValid, $expectedHost = null, $expectedPort = null)
-    {
-        $request = Request::create('/');
-        $request->headers->set('host', $host);
-
-        if ($isValid) {
-            $this->assertSame($expectedHost ?: $host, $request->getHost());
-            if ($expectedPort) {
-                $this->assertSame($expectedPort, $request->getPort());
-            }
-        } else {
-            $this->setExpectedException('UnexpectedValueException', 'Invalid Host');
-            $request->getHost();
-        }
-    }
-
-    public function getHostValidities()
-    {
-        return array(
-            array('.a', false),
-            array('a..', false),
-            array('a.', true),
-            array("\xE9", false),
-            array('[::1]', true),
-            array('[::1]:80', true, '[::1]', 80),
-            array(str_repeat('.', 101), false),
-        );
     }
 
     public function getLongHostNames()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | n/a |

As discussed in #13522, remove host validation from `Request` because:
- this is not the responsability of this class
- the current validation doesn't work in some cases and fixing it is not obvious (prefer using `filter_var()` in conjunction with `parse_url()` as explained in https://github.com/symfony/symfony/pull/13522#issuecomment-71554732).

cc @phansys
