### PR TITLE
added missing deprecation notice when using the form_enctype function

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/FormEnctypeNode.php
+++ b/src/Symfony/Bridge/Twig/Node/FormEnctypeNode.php
@@ -22,7 +22,6 @@ class FormEnctypeNode extends SearchAndRenderBlockNode
     {
         parent::compile($compiler);
 
-        // Uncomment this as soon as the deprecation note should be shown
-        // $compiler->write('trigger_error(\'The helper form_enctype(form) is deprecated since version 2.3 and will be removed in 3.0. Use form_start(form) instead.\', E_USER_DEPRECATED)');
+        $compiler->write('trigger_error(\'The helper form_enctype(form) is deprecated since version 2.3 and will be removed in 3.0. Use form_start(form) instead.\', E_USER_DEPRECATED)');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
