### PR TITLE
[Form] Make sure Form always submit when Form expected method and Request method match.

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -108,11 +108,6 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             }
         }
 
-        // Don't auto-submit the form unless at least one field is present.
-        if ('' === $name && count(array_intersect_key($data, $form->all())) <= 0) {
-            return;
-        }
-
         $form->submit($data, 'PATCH' !== $method);
     }
 }

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -121,11 +121,6 @@ class NativeRequestHandler implements RequestHandlerInterface
             }
         }
 
-        // Don't auto-submit the form unless at least one field is present.
-        if ('' === $name && count(array_intersect_key($data, $form->all())) <= 0) {
-            return;
-        }
-
         $form->submit($data, 'PATCH' !== $method);
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -176,7 +176,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function testDoNotSubmitFormWithEmptyNameIfNoFieldInRequest($method)
+    public function testShouldSubmitFormWithEmptyNameIfNoFieldInRequest($method)
     {
         $form = $this->getMockForm('', $method);
         $form->expects($this->any())
@@ -190,7 +190,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
             'paramx' => 'submitted value',
         ));
 
-        $form->expects($this->never())
+        $form->expects($this->once())
             ->method('submit');
 
         $this->requestHandler->handleRequest($form, $this->request);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Unnamed form submission must happen independently of form being submitted or not, as long as request method and form expected method patches.
