### PR TITLE
[Form] Fixed edge case where empty data may not be a string and throws TransformationFailedException

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -617,6 +617,17 @@ class Form implements \IteratorAggregate, FormInterface
                         $emptyData = $emptyData($this, $viewData);
                     }
 
+                    // Treat false as NULL to support binding false to checkboxes.
+                    // Don't convert NULL to a string here in order to determine later
+                    // whether an empty value has been submitted or whether no value has
+                    // been submitted at all. This is important for processing checkboxes
+                    // and radio buttons with empty values.
+                    if (false === $emptyData) {
+                        $emptyData = null;
+                    } elseif (is_scalar($emptyData)) {
+                        $emptyData = (string) $emptyData;
+                    }
+
                     $viewData = $emptyData;
                 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I just can't recreate this error, by any means.
I somehow have a form with an integer type which happens to submit "null" as `viewData` (somehow) and it reuses `empty_data` option. Now my field was configured like:

``` php
$builder->add('page', 'integer', array(
    'empty_data' => 1,
));
```

And since the assignment of `viewData` is the `empty_data`, one of the normalizers (while calling `viewToNorm()`) throws a `TransformationFailedException` with the following message: `Expected a string.`
