### PR TITLE
[Form][DoctrineBridge] Optimize EntityType by only loading choices for values restricted by values

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -218,8 +218,10 @@ class EntityChoiceList extends ObjectChoiceList
         if (!$this->loaded) {
             // Optimize performance in case we have an entity loader and
             // a single-field identifier
-            if ($this->idAsValue && $this->entityLoader) {
-                $unorderedEntities = $this->entityLoader->getEntitiesByIds($this->idField, $values);
+            if ($this->idAsValue) {
+                $unorderedEntities = $this->entityLoader
+                    ? $this->entityLoader->getEntitiesByIds($this->idField, $values)
+                    : $this->em->getRepository($this->class)->findBy(array($this->idField => $values));
                 $entitiesByValue = array();
                 $entities = array();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Optimize EntityType by only loading choices for values in the same way that EntityLoader customization does (if you provide a query_builder).
