### PR TITLE
[Console] Fixed output bug, if escaped string in a formatted string.

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -144,17 +144,15 @@ class OutputFormatter implements OutputFormatterInterface
     {
         $offset = 0;
         $output = '';
-        $unescapedMatches = array();
         $tagRegex = '[a-z][a-z0-9_=;-]*';
         preg_match_all("#<(($tagRegex) | /($tagRegex)?)>#isx", $message, $matches, PREG_OFFSET_CAPTURE);
-        foreach ($matches[0] as $match) {
-            if (0 == $match[1] || (0 < $match[1] && '\\' != $message[$match[1] - 1])) {
-                $unescapedMatches[] = $match;
-            }
-        }
-        foreach ($unescapedMatches as $i => $match) {
+        foreach ($matches[0] as $i => $match) {
             $pos = $match[1];
             $text = $match[0];
+
+            if (0 != $pos && '\\' == $message[$pos - 1]) {
+                continue;
+            }
 
             // add the text up to the next tag
             $output .= $this->applyCurrentStyle(substr($message, $offset, $pos - $offset));

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -144,9 +144,15 @@ class OutputFormatter implements OutputFormatterInterface
     {
         $offset = 0;
         $output = '';
+        $unescapedMatches = array();
         $tagRegex = '[a-z][a-z0-9_=;-]*';
         preg_match_all("#<(($tagRegex) | /($tagRegex)?)>#isx", $message, $matches, PREG_OFFSET_CAPTURE);
-        foreach ($matches[0] as $i => $match) {
+        foreach ($matches[0] as $match) {
+            if (0 == $match[1] || (0 < $match[1] && '\\' != $message[$match[1] - 1])) {
+                $unescapedMatches[] = $match;
+            }
+        }
+        foreach ($unescapedMatches as $i => $match) {
             $pos = $match[1];
             $text = $match[0];
 
@@ -164,9 +170,6 @@ class OutputFormatter implements OutputFormatterInterface
             if (!$open && !$tag) {
                 // </>
                 $this->styleStack->pop();
-            } elseif ($pos && '\\' == $message[$pos - 1]) {
-                // escaped tag
-                $output .= $this->applyCurrentStyle($text);
             } elseif (false === $style = $this->createStyleFromString(strtolower($tag))) {
                 $output .= $this->applyCurrentStyle($text);
             } elseif ($open) {

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -101,6 +101,11 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
             "(\033[32mz>=2.0,<a2.3\033[39m)",
             $formatter->format('(<info>'.$formatter->escape('z>=2.0,<a2.3').'</info>)')
         );
+
+        $this->assertEquals(
+            "\033[32m<error>some error</error>\033[39m",
+            $formatter->format('<info>'.$formatter->escape('<error>some error</error>').'</info>')
+        );
     }
 
     public function testDeepNestedStyles()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

If there is a escaped tag in a formatted string, the output wasn't correct. 

I have add a test for this problem and integrated a solution for this.
