### PR TITLE
Fix form icon position in web profiler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -278,12 +278,12 @@ class FrameworkExtension extends Extension
             return;
         }
 
+        $loader->load('profiling.xml');
+        $loader->load('collectors.xml');
+
         if (true === $this->formConfigEnabled) {
             $loader->load('form_debug.xml');
         }
-
-        $loader->load('profiling.xml');
-        $loader->load('collectors.xml');
 
         $container->setParameter('profiler_listener.only_exceptions', $config['only_exceptions']);
         $container->setParameter('profiler_listener.only_master_requests', $config['only_master_requests']);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Form icon in web profiler toolbar moved to the left edge
![pe64g11](https://cloud.githubusercontent.com/assets/213810/6077805/4523c5ba-adfb-11e4-9e8c-61c4940cd7c1.png)

This fix changes icon position to its default value.
