### PR TITLE
[Console] “console help” ignores --raw option

### DIFF
--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -83,7 +83,7 @@ EOF
         $helper = new DescriptorHelper();
         $helper->describe($output, $this->command, array(
             'format' => $input->getOption('format'),
-            'raw' => $input->getOption('raw'),
+            'raw_text' => $input->getOption('raw'),
         ));
 
         $this->command = null;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

The option for DescriptorHelper::describe() is `raw_text`, not `raw`.
