### PR TITLE
[FrameworkBundle] Made ServerParams a service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -154,7 +154,13 @@
         </service>
 
         <!-- HttpFoundationRequestHandler -->
-        <service id="form.type_extension.form.request_handler" class="%form.type_extension.form.request_handler.class%" public="false" />
+        <service id="form.type_extension.form.request_handler" class="%form.type_extension.form.request_handler.class%" public="false">
+            <argument type="service" id="form.server_params" />
+        </service>
+
+        <service id="form.server_params" class="Symfony\Component\Form\Util\ServerParams" public="false">
+            <argument type="service" id="request_stack" />
+        </service>
 
         <!-- FormTypeValidatorExtension -->
         <service id="form.type_extension.form.validator" class="Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |

Since 2.5 we can inject the request stack in ServerParams (see #10912).
Now when a request is handled by HttpFoundationRequestHandler, the content length will be fetched via the current request and not the super global anymore.
