### PR TITLE
[HttpKernel] Add entry point to more easily create/configure the DI extension

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -72,13 +72,13 @@ abstract class Bundle extends ContainerAware implements BundleInterface
     public function getContainerExtension()
     {
         if (null === $this->extension) {
-            $class = $this->getContainerExtensionClass();
-            if (class_exists($class)) {
-                $extension = new $class();
+            $extension = $this->createContainerExtension();
 
+            if (null !== $extension) {
                 // check naming convention
                 $basename = preg_replace('/Bundle$/', '', $this->getName());
                 $expectedAlias = Container::underscore($basename);
+
                 if ($expectedAlias != $extension->getAlias()) {
                     throw new \LogicException(sprintf(
                         'Users will expect the alias of the default extension of a bundle to be the underscored version of the bundle name ("%s"). You can override "Bundle::getContainerExtension()" if you want to use "%s" or another alias.',
@@ -207,5 +207,17 @@ abstract class Bundle extends ContainerAware implements BundleInterface
         $basename = preg_replace('/Bundle$/', '', $this->getName());
 
         return $this->getNamespace().'\\DependencyInjection\\'.$basename.'Extension';
+    }
+
+    /**
+     * Creates the bundle's container extension.
+     *
+     * @return ExtensionInterface|null
+     */
+    protected function createContainerExtension()
+    {
+        if (class_exists($class = $this->getContainerExtensionClass())) {
+            return new $class();
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -17,6 +17,16 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Command\F
 
 class BundleTest extends \PHPUnit_Framework_TestCase
 {
+    public function testGetContainerExtension()
+    {
+        $bundle = new ExtensionPresentBundle();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\DependencyInjection\ExtensionPresentExtension',
+            $bundle->getContainerExtension()
+        );
+    }
+
     public function testRegisterCommands()
     {
         $cmd = new FooCommand();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Hey!

I would like to pass some dependencies to the DI extension through the bundle. In the current implementation, I need to duplicate the whole `getContainerExtension` in order to keep the extension alias check. This PR proposes to introduce an entry point for more easily do it.

What do you think?
