### PR TITLE
[Security] Don't throw a warning if the voter is called on a scalar value

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
@@ -58,7 +58,7 @@ abstract class AbstractVoter implements VoterInterface
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$object || !$this->supportsClass(get_class($object))) {
+        if (!$object || !is_object($object) || !$this->supportsClass(get_class($object))) {
             return self::ACCESS_ABSTAIN;
         }
 

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Voter/AbstractVoterTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Voter/AbstractVoterTest.php
@@ -50,6 +50,7 @@ class AbstractVoterTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(AbstractVoter::ACCESS_ABSTAIN, null, array(), 'ACCESS_ABSTAIN for null objects'),
+            array(AbstractVoter::ACCESS_ABSTAIN, 'foo', array(), 'ACCESS_ABSTAIN for strings and other scalar values'),
             array(AbstractVoter::ACCESS_ABSTAIN, new UnsupportedObjectFixture(), array(), 'ACCESS_ABSTAIN for objects with unsupported class'),
             array(AbstractVoter::ACCESS_ABSTAIN, new ObjectFixture(), array(), 'ACCESS_ABSTAIN for no attributes'),
             array(AbstractVoter::ACCESS_ABSTAIN, new ObjectFixture(), array('foobar'), 'ACCESS_ABSTAIN for unsupported attributes'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

I have a couple of voters in place that don't vote on Doctrine entities or other objects, but on string values instead. The new `AbstractVoter` class was not made for this purpose, which is absolutely fine. But there's one problem: If a vote on a string value gets to a voter derived from `AbstractVoter`, that voter will issue a warning although it should simply abstain the vote like it does with unsupported objects. This small PR adds a test reproducing the warning and fixes this issue.
