### PR TITLE
[WebProfilerBundle] Added feedback about the current symfony version

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -9,7 +9,18 @@
                 {% if collector.applicationname %}
                     {{ collector.applicationname }} {{ collector.applicationversion }}
                 {% else %}
-                    {{ collector.symfonyversion }}
+                    {% if 'unknown' == collector.symfonyState -%}
+                    <span class="sf-toolbar-status sf-toolbar-info-piece-additional" title="Unable to retrieve information about the Symfony version.">
+                    {%- elseif 'eol' == collector.symfonyState -%}
+                    <span class="sf-toolbar-status sf-toolbar-status-red" title="This Symfony version will no longer receive security fixes.">
+                    {%- elseif 'eom' == collector.symfonyState -%}
+                    <span class="sf-toolbar-status sf-toolbar-status-yellow" title="This Symfony version will only receive security fixes.">
+                    {%- elseif 'dev' == collector.symfonyState -%}
+                    <span class="sf-toolbar-status sf-toolbar-status-yellow" title="This Symfony version is still in the development phase.">
+                    {%- else -%}
+                    <span class="sf-toolbar-status sf-toolbar-status-green">
+                    {%- endif -%}
+                    {{ collector.symfonyversion }}</span>
                 {% endif %}
             </span>
         </a>

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -23,6 +23,7 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
     {
         $kernel = new KernelForTest('test', true);
         $c = new ConfigDataCollector();
+        $c->setCacheVersionInfo(false);
         $c->setKernel($kernel);
         $c->collect(new Request(), new Response());
 


### PR DESCRIPTION
## Description

This PR adds some visual and textual information about the Symfony version that is currently used. It'll indicate when the used version has reached eom or eol. I hope this will make people more aware of the fact that they should update (as I've seen quite some people using completely outdated Symfony versions).
## Screenshot

![sf-toolbar-version-info](https://cloud.githubusercontent.com/assets/749025/6099512/da59c99e-affa-11e4-8093-173857901769.png)
## PR Information

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (didn't test though) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
