### PR TITLE
[Security] InMemoryUserProvider now concerns whether user's password is changed when refreshing

### DIFF
--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
@@ -67,17 +67,9 @@ class InMemoryUserProvider implements UserProviderInterface
      */
     public function loadUserByUsername($username)
     {
-        if (!isset($this->users[strtolower($username)])) {
-            $ex = new UsernameNotFoundException(sprintf('Username "%s" does not exist.', $username));
-            $ex->setUsername($username);
+        $user = $this->getUser($username);
 
-            throw $ex;
-        }
-
-        $user = $this->users[strtolower($username)];
-
-        return new User($user->getUsername(), $user->getPassword(), $user->getRoles(), $user->isEnabled(), $user->isAccountNonExpired(),
-                $user->isCredentialsNonExpired(), $user->isAccountNonLocked());
+        return new User($user->getUsername(), $user->getPassword(), $user->getRoles(), $user->isEnabled(), $user->isAccountNonExpired(), $user->isCredentialsNonExpired(), $user->isAccountNonLocked());
     }
 
     /**
@@ -89,7 +81,9 @@ class InMemoryUserProvider implements UserProviderInterface
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
         }
 
-        return $this->loadUserByUsername($user->getUsername());
+        $storedUser = $this->getUser($user->getUsername());
+
+        return new User($storedUser->getUsername(), $storedUser->getPassword(), $storedUser->getRoles(), $storedUser->isEnabled(), $storedUser->isAccountNonExpired(), $storedUser->isCredentialsNonExpired() && $storedUser->getPassword() === $user->getPassword(), $storedUser->isAccountNonLocked());
     }
 
     /**
@@ -98,5 +92,26 @@ class InMemoryUserProvider implements UserProviderInterface
     public function supportsClass($class)
     {
         return $class === 'Symfony\Component\Security\Core\User\User';
+    }
+
+    /**
+     * Returns the user by given username.
+     *
+     * @param  string $username The username.
+     *
+     * @return User
+     *
+     * @throws UsernameNotFoundException If user whose given username does not exist.
+     */
+    private function getUser($username)
+    {
+        if (!isset($this->users[strtolower($username)])) {
+            $ex = new UsernameNotFoundException(sprintf('Username "%s" does not exist.', $username));
+            $ex->setUsername($username);
+
+            throw $ex;
+        }
+
+        return $this->users[strtolower($username)];
     }
 }

--- a/src/Symfony/Component/Security/Tests/Core/User/InMemoryUserProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/User/InMemoryUserProviderTest.php
@@ -18,18 +18,39 @@ class InMemoryUserProviderTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()
     {
-        $provider = new InMemoryUserProvider(array(
+        $provider = $this->createProvider();
+
+        $user = $provider->loadUserByUsername('fabien');
+        $this->assertEquals('foo', $user->getPassword());
+        $this->assertEquals(array('ROLE_USER'), $user->getRoles());
+        $this->assertFalse($user->isEnabled());
+    }
+
+    public function testRefresh()
+    {
+        $user = new User('fabien', 'bar');
+
+        $provider = $this->createProvider();
+
+        $refreshedUser = $provider->refreshUser($user);
+        $this->assertEquals('foo', $refreshedUser->getPassword());
+        $this->assertEquals(array('ROLE_USER'), $refreshedUser->getRoles());
+        $this->assertFalse($refreshedUser->isEnabled());
+        $this->assertFalse($refreshedUser->isCredentialsNonExpired());
+    }
+
+    /**
+     * @return InMemoryUserProvider
+     */
+    protected function createProvider()
+    {
+        return new InMemoryUserProvider(array(
             'fabien' => array(
                 'password' => 'foo',
                 'enabled' => false,
                 'roles' => array('ROLE_USER'),
             ),
         ));
-
-        $user = $provider->loadUserByUsername('fabien');
-        $this->assertEquals('foo', $user->getPassword());
-        $this->assertEquals(array('ROLE_USER'), $user->getRoles());
-        $this->assertFalse($user->isEnabled());
     }
 
     public function testCreateUser()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When a user has changed own password, I want to logout any sessions which is authenticated by its user except changer itself.

[DaoAuthenticationManager::checkAuthentication()](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php#L59) method seems to concern about it.

But, this situation actually never happens because both users that will be passed to this method are always identical in re-authentication.
It's because the token refreshes own user via [ContextListener](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L90) before re-authentication.
