### PR TITLE
[Console] fixed ArrayInput, if array contains 0 key.

### DIFF
--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -100,8 +100,10 @@ class ArrayInput extends Input
         $values = (array) $values;
 
         foreach ($this->parameters as $k => $v) {
-            if (is_int($k) && in_array($v, $values)) {
-                return true;
+            if (is_int($k)) {
+                if (in_array($v, $values)) {
+                    return true;
+                }
             } elseif (in_array($k, $values)) {
                 return $v;
             }

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -38,6 +38,15 @@ class ArrayInputTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($input->hasParameterOption('--foo'), '->hasParameterOption() returns true if an option is present in the passed parameters');
     }
 
+    public function testGetParameterOption()
+    {
+        $input = new ArrayInput(array('name' => 'Fabien', '--foo' => 'bar'));
+        $this->assertEquals('bar', $input->getParameterOption('--foo'), '->getParameterOption() returns the option of specified name');
+
+        $input = new ArrayInput(array('Fabien', '--foo' => 'bar'));
+        $this->assertEquals('bar', $input->getParameterOption('--foo'), '->getParameterOption() returns the option of specified name');
+    }
+
     public function testParseArguments()
     {
         $input = new ArrayInput(array('name' => 'foo'), new InputDefinition(array(new InputArgument('name'))));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

``` php
$input = new ArrayInput(array('Fabien', '--foo' => 'bar'));
var_dump($input->getParameterOption('--foo')); // this is 'Fabien'.
```

Because `in_array` third argument's default is `false`.
`in_array(0, $values)` returns `true` in many cases.
