### PR TITLE
[ServerBag] Handled bearer authorization header in REDIRECT_ form

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -75,6 +75,13 @@ class ServerBag extends ParameterBag
                     // In some circumstances PHP_AUTH_DIGEST needs to be set
                     $headers['PHP_AUTH_DIGEST'] = $authorizationHeader;
                     $this->parameters['PHP_AUTH_DIGEST'] = $authorizationHeader;
+                } elseif (0 === stripos($authorizationHeader, 'bearer ')) {
+                    /*
+                     * XXX: Since there is no PHP_AUTH_BEARER in PHP predefined variables,
+                     *      I'll just set $headers['AUTHORIZATION'] here.
+                     *      http://php.net/manual/en/reserved.variables.server.php
+                     */
+                    $headers['AUTHORIZATION'] = $authorizationHeader;
                 }
             }
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
@@ -141,4 +141,14 @@ class ServerBagTest extends \PHPUnit_Framework_TestCase
             'AUTHORIZATION' => $headerContent,
         ), $bag->getHeaders());
     }
+
+    public function testOAuthBearerAuthWithRedirect()
+    {
+        $headerContent = 'Bearer L-yLEOr9zhmUYRkzN1jwwxwQ-PBNiKDc8dgfB4hTfvo';
+        $bag = new ServerBag(array('REDIRECT_HTTP_AUTHORIZATION' => $headerContent));
+
+        $this->assertEquals(array(
+            'AUTHORIZATION' => $headerContent,
+        ), $bag->getHeaders());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Apache rewrite module renames client request
header (`HTTP_`) by prepending `REDIRECT_` to
it. http basic authentication and http digest
authentication are properly processed in
REDIRECT_ form, while bearer is processed in
HTTP_ form, but dropped in REDIRECT_ form.

Example:
The following auth headers are handled in ServerBag,

```
HTTP_AUTHORIZATION => Basic aGVsbG86d29ybGQ=
REDIREDCT_HTTP_AUTHOIZATION => Basic aGVsbG86d29ybGQ=
HTTP_AUTHORIZATION => Digest blah
REDIRECT_HTTP_AUTHORIZATION => Digest blah
HTTP_AUTHORIZATION => Bearer mF_9.B5f-4.1JqM
```

while

```
REDIRECT_HTTP_AUTHORIZATION => Bearer mF_9.B5f-4.1JqM
```

is dropped.
