### PR TITLE
[FrameworkBundle] Fix title and placeholder rendering in php form templates

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -6,5 +6,5 @@ name="<?php echo $view->escape($full_name) ?>"
 <?php if ($max_length): ?>maxlength="<?php echo $view->escape($max_length) ?>" <?php endif ?>
 <?php if ($pattern): ?>pattern="<?php echo $view->escape($pattern) ?>" <?php endif ?>
 <?php foreach ($attr as $k => $v): ?>
-    <?php printf('%s="%s" ', $view->escape($k), $view->escape(in_array($v, array('placeholder', 'title')) ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
+    <?php printf('%s="%s" ', $view->escape($k), $view->escape(in_array($k, array('placeholder', 'title')) ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
 <?php endforeach; ?>

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1898,4 +1898,18 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
         $this->assertSame('<form method="get" action="http://example.com/directory" class="foobar">', $html);
     }
+
+    public function testTranslatedAttributes()
+    {
+        $view = $this->factory->createNamedBuilder('name', 'form')
+            ->add('firstName', 'text', array('attr' => array('title' => 'Foo')))
+            ->add('lastName', 'text', array('attr' => array('placeholder' => 'Bar')))
+            ->getForm()
+            ->createView();
+
+        $html = $this->renderForm($view);
+
+        $this->assertMatchesXpath($html, '/form//input[@title="[trans]Foo[/trans]"]');
+        $this->assertMatchesXpath($html, '/form//input[@placeholder="[trans]Bar[/trans]"]');
+    }
 }


### PR DESCRIPTION
Small fix for rendering placeholder on widgets in php templates.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is a test case for #13290, including a fix applied on 2.3, since that's the earliest supported branch the bug exist.

In 2.6 the template is a bit different, and unfortunately I couldn't re-use #13290's fix.

When this is merged into 2.3, and then to 2.6 I think we can also merge #13290.
