### PR TITLE
[FrameworkBundle] allow parameter with value NULL in route configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -144,6 +144,10 @@ class Router extends BaseRouter implements WarmableInterface
 
         $container = $this->container;
 
+        if (preg_match('/^%[^%\s]+%$/', $value)) {
+            return $container->getParameter(trim($value, '%'));
+        }
+
         $escapedValue = preg_replace_callback('/%%|%([^%\s]++)%/', function ($match) use ($container, $value) {
             // skip %%
             if (!isset($match[1])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -152,6 +152,24 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testParametersNull()
+    {
+        $routes = new RouteCollection();
+
+        $route = new Route('foo');
+        $route->setHost('%parameter.foo%');
+
+        $routes->add('foo', $route);
+
+        $sc = $this->getServiceContainer($routes);
+        $sc->setParameter('parameter.foo', null);
+
+        $router = new Router($sc, 'foo');
+        $route = $router->getRouteCollection()->get('foo');
+
+        $this->assertNull($route->getHost());
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException
      * @expectedExceptionMessage You have requested a non-existent parameter "nope".


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently it is not allowed to use a parameter with value NULL in the Route configuration. This might be desirable if you want to fix certain routes on specific hosts on one environment, but not on an other.

This pull requests allows NULL values in parameters if (and only if) the parameter is not suffixed or prefixed with anything else in the configuration.
