### PR TITLE
made the assets optional

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -49,7 +49,6 @@ class FrameworkExtension extends Extension
         $loader->load('web.xml');
         $loader->load('services.xml');
         $loader->load('fragment_renderer.xml');
-        $loader->load('assets.xml');
 
         // A translator must always be registered (as support is included by
         // default in the Form component). If disabled, an identity translator
@@ -562,6 +561,8 @@ class FrameworkExtension extends Extension
      */
     private function registerAssetsConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
+        $loader->load('assets.xml');
+
         $defaultVersion = $this->createVersion($container, $config['version'], $config['version_format'], '_default');
 
         $defaultPackage = $this->createPackageDefinition($config['base_path'], $config['base_urls'], $defaultVersion);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Resources/views/base.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Resources/views/base.html.twig
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <title>{% block title %}Welcome!{% endblock %}</title>
         {% block stylesheets %}{% endblock %}
-        <link rel="shortcut icon" href="{{ asset('favicon.ico') }}" />
     </head>
     <body>
         {% block body %}{% endblock %}

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -78,6 +78,10 @@ class ExtensionPass implements CompilerPassInterface
             $container->setDefinition('twig.loader.filesystem', $loader);
         }
 
+        if ($container->has('assets.packages')) {
+            $loader->addTag('twig.extension');
+        }
+
         if (method_exists('Symfony\Bridge\Twig\AppVariable', 'setContainer')) {
             // we are on Symfony <3.0, where the setContainer method exists
             $container->getDefinition('twig.app_variable')->addMethodCall('setContainer', array(new Reference('service_container')));

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -86,7 +86,6 @@
         </service>
 
         <service id="twig.extension.assets" class="Symfony\Bridge\Twig\Extension\AssetExtension" public="false">
-            <tag name="twig.extension" />
             <argument type="service" id="assets.packages" />
             <argument type="service" id="twig.extension.httpfoundation" />
         </service>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Right now, the assets configuration is optional (and the dependency as well on FramewokrBundle), but the asset services and the Asset extension is always loaded. This PR fixes this inconsistency, which will make tests pass again.
