### PR TITLE
[FrameworkBundle] Enable assets by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -54,6 +54,26 @@ class Configuration implements ConfigurationInterface
                 })
             ->end()
             ->validate()
+                ->ifTrue(function ($v) { return !isset($v['assets']); })
+                ->then(function ($v) {
+                    if (!$v['templating']['assets_version']
+                        && !count($v['templating']['assets_base_urls']['http'])
+                        && !count($v['templating']['assets_base_urls']['ssl'])
+                        && !count($v['templating']['packages'])
+                    ) {
+                        $v['assets'] = array(
+                            'version' => null,
+                            'version_format' => '%%s?%%s',
+                            'base_path' => '',
+                            'base_urls' => array(),
+                            'packages' => array(),
+                        );
+                    }
+
+                    return $v;
+                })
+            ->end()
+            ->validate()
                 ->ifTrue(function ($v) { return isset($v['templating']); })
                 ->then(function ($v) {
                     if ($v['templating']['assets_version']

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -145,6 +145,13 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'magic_call' => false,
                 'throw_exception_on_invalid_index' => false,
             ),
+            'assets' => array(
+                'version' => null,
+                'version_format' => '%%s?%%s',
+                'base_path' => '',
+                'base_urls' => array(),
+                'packages' => array(),
+            ),
         );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
+        "symfony/asset": "~2.7|~3.0.0",
         "symfony/dependency-injection" : "~2.6,>=2.6.2",
         "symfony/config" : "~2.4",
         "symfony/event-dispatcher": "~2.5|~3.0.0",
@@ -48,7 +49,6 @@
         "symfony/yaml": "~2.0,>=2.0.5|~3.0.0"
     },
     "suggest": {
-        "symfony/asset": "",
         "symfony/console": "For using the console commands",
         "symfony/finder": "For using the translation loader and cache warmer",
         "symfony/form": "For using forms",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13667 |
| License | MIT |
| Doc PR | - |

This should make the tests pass again. 

There are two templates from TwigBundle that are used with functional tests, and require the asset() helper:
- src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception_full.html.twig
- src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
