### PR TITLE
[WebProfilerBundle] Fix for broken profiler layout

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -24,7 +24,7 @@
     <div id="sfToolbarClearer-{{ token }}" style="clear: both; height: 38px;"></div>
 {% endif %}
 
-<div id="sfToolbarMainContent-{{ token }}" class="sf-toolbarreset" data-no-turbolink>
+<div id="sfToolbarMainContent-{{ token }}" class="sf-toolbarreset clear-fix" data-no-turbolink>
     {% for name, template in templates %}
         {{ template.renderblock('toolbar', {
             'collector': profile.getcollector(name),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

With the latest 2.6 the profiler layout is broken:

![screen](https://cloud.githubusercontent.com/assets/127811/6192633/17f7f192-b382-11e4-90c9-2595fd6079af.png)

I am not sure what broke it...
