### PR TITLE
[Routing] Annotated routes with a variadic parameter

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/VariadicClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/VariadicClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
+
+class VariadicClass
+{
+    public function routeAction(...$params)
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use Symfony\Component\Routing\Loader\AnnotationFileLoader;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Annotation\Route;
 
 class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
 {
@@ -32,6 +33,19 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader->expects($this->once())->method('getClassAnnotation');
 
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/FooClass.php');
+    }
+
+    /**
+     * @requires PHP 5.6
+     */
+    public function testLoadVariadic()
+    {
+        $route = new Route(["path" => "/path/to/{id}"]);
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+        $this->reader->expects($this->once())->method('getMethodAnnotations')
+            ->will($this->returnValue([$route]));
+
+        $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/VariadicClass.php');
     }
 
     public function testSupports()


### PR DESCRIPTION
I add a test the should show a problem that occurs if you try to use variadics with annotated routes.

I don't know if anybody could be interested in this issue. But if you try to use annotated routes with variadics functions, php raise a fatal error like:

```
1) Symfony\Component\Routing\Tests\Loader\AnnotationFileLoaderTest::testLoadVariadic
ReflectionException: Internal error: Failed to retrieve the default value

/data/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php:143
/data/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php:125
/data/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php:65
/data/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php:48
```

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I get this error playing around with symfony2 components not in a sf2 project.
In particular using:

```
$routeLoader = new RouteAnnotationClassLoader($reader);
$loader = new AnnotationDirectoryLoader(new FileLocator([__DIR__.'/../app']), $routeLoader);
$routes = $loader->load(__DIR__.'/../app');
```

and annotated routes like

```
class My
{
  /**
   * @Route("/path/{id}/other/{other}")
   */
  public function aRoute(...$params)
  {
    //...
  }
}
```
