### PR TITLE
[HttpKernel] Fixed DumpDataCollector: dump.name for Windows file paths

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -115,7 +115,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
         if (false === $name) {
             $name = strtr($file, '\\', '/');
-            $name = substr($file, strrpos($file, '/') + 1);
+            $name = substr($name, strrpos($name, '/') + 1);
         }
 
         $this->data[] = compact('data', 'name', 'file', 'line', 'fileExcerpt');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes? |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When using VarDumper on Windows files, the automatic "dump.name" generated wrong names.
`dump()` call in:

```
F:\HtDocs\demo\src\Acme\Controller\DemoController.php
```

Displayed:

```
dump()
in :\HtDocs\demo\src\Acme\Controller\DemoController.php line 35
```

Expected result is:

```
dump()
in DemoController.php line 35
```

The existing code in line 118 didn't use the variable from the previous line.
