### PR TITLE
[Security] [Acl] Improve PermissionMap and MaskBuilder

### DIFF
--- a/src/Symfony/Component/Security/Acl/Permission/AbstractMaskBuilder.php
+++ b/src/Symfony/Component/Security/Acl/Permission/AbstractMaskBuilder.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Symfony\Component\Security\Acl\Permission;
+
+abstract class AbstractMaskBuilder implements MaskBuilderInterface
+{
+    /**
+     * @var int
+     */
+    protected $mask;
+
+    /**
+     * Constructor.
+     *
+     * @param int $mask optional; defaults to 0
+     */
+    public function __construct($mask = 0)
+    {
+        $this->set($mask);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($mask)
+    {
+        if (!is_int($mask)) {
+            throw new \InvalidArgumentException('$mask must be an integer.');
+        }
+
+        $this->mask = $mask;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return $this->mask;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($mask)
+    {
+        $this->mask |= $this->resolveMask($mask);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($mask)
+    {
+        $this->mask &= ~$this->resolveMask($mask);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->mask = 0;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Security/Acl/Permission/AbstractMaskBuilder.php
+++ b/src/Symfony/Component/Security/Acl/Permission/AbstractMaskBuilder.php
@@ -1,7 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Security\Acl\Permission;
 
+/**
+ * This abstract class implements nearly all the MaskBuilderInterface methods
+ */
 abstract class AbstractMaskBuilder implements MaskBuilderInterface
 {
     /**

--- a/src/Symfony/Component/Security/Acl/Permission/BasicPermissionMap.php
+++ b/src/Symfony/Component/Security/Acl/Permission/BasicPermissionMap.php
@@ -28,6 +28,9 @@ class BasicPermissionMap implements PermissionMapInterface
     const PERMISSION_MASTER = 'MASTER';
     const PERMISSION_OWNER = 'OWNER';
 
+    /**
+     * @var array
+     */
     protected $map;
 
     public function __construct()
@@ -104,5 +107,13 @@ class BasicPermissionMap implements PermissionMapInterface
     public function contains($permission)
     {
         return isset($this->map[$permission]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMaskBuilder()
+    {
+        return new MaskBuilder();
     }
 }

--- a/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
+++ b/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
@@ -42,7 +42,7 @@ namespace Symfony\Component\Security\Acl\Permission;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class MaskBuilder
+class MaskBuilder extends AbstractMaskBuilder
 {
     const MASK_VIEW = 1;           // 1 << 0
     const MASK_CREATE = 2;         // 1 << 1
@@ -67,50 +67,6 @@ class MaskBuilder
     const OFF = '.';
     const ON = '*';
 
-    private $mask;
-
-    /**
-     * Constructor.
-     *
-     * @param int $mask optional; defaults to 0
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function __construct($mask = 0)
-    {
-        if (!is_int($mask)) {
-            throw new \InvalidArgumentException('$mask must be an integer.');
-        }
-
-        $this->mask = $mask;
-    }
-
-    /**
-     * Adds a mask to the permission.
-     *
-     * @param mixed $mask
-     *
-     * @return MaskBuilder
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function add($mask)
-    {
-        $this->mask |= $this->getMask($mask);
-
-        return $this;
-    }
-
-    /**
-     * Returns the mask of this permission.
-     *
-     * @return int
-     */
-    public function get()
-    {
-        return $this->mask;
-    }
-
     /**
      * Returns a human-readable representation of the permission.
      *
@@ -133,34 +89,6 @@ class MaskBuilder
         }
 
         return $pattern;
-    }
-
-    /**
-     * Removes a mask from the permission.
-     *
-     * @param mixed $mask
-     *
-     * @return MaskBuilder
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function remove($mask)
-    {
-        $this->mask &= ~$this->getMask($mask);
-
-        return $this;
-    }
-
-    /**
-     * Resets the PermissionBuilder.
-     *
-     * @return MaskBuilder
-     */
-    public function reset()
-    {
-        $this->mask = 0;
-
-        return $this;
     }
 
     /**
@@ -204,7 +132,7 @@ class MaskBuilder
      *
      * @throws \InvalidArgumentException
      */
-    private function getMask($code)
+    public function resolveMask($code)
     {
         if (is_string($code)) {
             if (!defined($name = sprintf('static::MASK_%s', strtoupper($code)))) {

--- a/src/Symfony/Component/Security/Acl/Permission/MaskBuilderInterface.php
+++ b/src/Symfony/Component/Security/Acl/Permission/MaskBuilderInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Symfony\Component\Security\Acl\Permission;
+
+interface MaskBuilderInterface
+{
+    /**
+     * Set the mask of this permission
+     *
+     * @param int $mask
+     *
+     * @return MaskBuilderInterface
+     * @throws \InvalidArgumentException if $mask is not an integer
+     */
+    public function set($mask);
+
+    /**
+     * Returns the mask of this permission.
+     *
+     * @return int
+     */
+    public function get();
+
+    /**
+     * Adds a mask to the permission.
+     *
+     * @param mixed $mask
+     *
+     * @return MaskBuilderInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function add($mask);
+
+    /**
+     * Removes a mask from the permission.
+     *
+     * @param mixed $mask
+     *
+     * @return MaskBuilderInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function remove($mask);
+
+    /**
+     * Resets the PermissionBuilder.
+     *
+     * @return MaskBuilderInterface
+     */
+    public function reset();
+
+    /**
+     * Returns the mask for the passed code
+     *
+     * @param mixed $code
+     *
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function resolveMask($code);
+}

--- a/src/Symfony/Component/Security/Acl/Permission/MaskBuilderInterface.php
+++ b/src/Symfony/Component/Security/Acl/Permission/MaskBuilderInterface.php
@@ -1,7 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Security\Acl\Permission;
 
+/**
+ * This is the interface that must be implemented by mask builders.
+ */
 interface MaskBuilderInterface
 {
     /**

--- a/src/Symfony/Component/Security/Acl/Permission/PermissionMapInterface.php
+++ b/src/Symfony/Component/Security/Acl/Permission/PermissionMapInterface.php
@@ -39,4 +39,11 @@ interface PermissionMapInterface
      * @return bool
      */
     public function contains($permission);
+
+    /**
+     * Returns a new instance of the MaskBuilder used in the permissionMap
+     *
+     * @return MaskBuilderInterface
+     */
+    public function getMaskBuilder();
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13566 |
| License | MIT |
| Doc PR | I'll do it if needed |

As the issue i opened (https://github.com/symfony/symfony/issues/13566) did not get any answers, i provide this PR so you can see what i really mean.

When we work with symfony/ACL, sometimes it can be usefull to customize the PermissionMap and/or to use a different MaskBuilder.
The PermissionMapInterface::getMaskBuilder methods allows us to retrieve a new instance of the MaskBuilder used in our application, even if it's a custom one.
I also added a MaskBuilderInterface and an AbstractMaskBuilder which can be a great helper.
