### PR TITLE
[WebProfilerBundle] Move AjaxCollector for use without framework bundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/AjaxDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/AjaxDataCollector.php
@@ -11,24 +11,13 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DataCollector;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\AjaxDataCollector as BaseAjaxDataCollector;
 
 /**
  * AjaxDataCollector.
  *
  * @author Bart van den Burg <bart@burgov.nl>
  */
-class AjaxDataCollector extends DataCollector
+class AjaxDataCollector extends BaseAjaxDataCollector
 {
-    public function collect(Request $request, Response $response, \Exception $exception = null)
-    {
-        // all collecting is done client side
-    }
-
-    public function getName()
-    {
-        return 'ajax';
-    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -26,7 +26,7 @@
             <tag name="data_collector" template="@WebProfiler/Collector/request.html.twig" id="request" priority="255" />
         </service>
 
-        <service id="data_collector.ajax" class="Symfony\Bundle\FrameworkBundle\DataCollector\AjaxDataCollector" public="false">
+        <service id="data_collector.ajax" class="Symfony\Component\HttpKernel\DataCollector\AjaxDataCollector" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/ajax.html.twig" id="ajax" priority="255" />
         </service>
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/AjaxDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/AjaxDataCollector.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\DataCollector;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * AjaxDataCollector.
+ *
+ * @author Bart van den Burg <bart@burgov.nl>
+ */
+class AjaxDataCollector extends DataCollector
+{
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+        // all collecting is done client side
+    }
+
+    public function getName()
+    {
+        return 'ajax';
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (something is broken in 2.6 but it was broken already) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR moves the AjaxDataCollector from the FrameworkBundle to the HttpKernel Component where most of the other DataCollectors are. This would allow applications which are not base on symfony/framework-bundle to use the collector. Like for instance applications based on silex or symfony components.
