### PR TITLE
[2.7] [FrameworkBundle] bugfix in configuration for assets

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -65,7 +65,7 @@ class Configuration implements ConfigurationInterface
 
                         // convert the old configuration to the new one
                         if (isset($v['assets'])) {
-                            throw new LogicException('You cannot use assets settings under "templating.templating" and "assets" configurations in the same project.');
+                            throw new \LogicException('You cannot use assets settings under "framework.templating" and "assets" configurations in the same project.');
                         }
 
                         $v['assets'] = array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -86,6 +86,25 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage You cannot use assets settings under "framework.templating" and "assets" configurations in the same project.
+     */
+    public function testInvalidValueAssets()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $processor->processConfiguration($configuration, array(
+            array(
+                'templating' => array(
+                    'engines' => null,
+                    'assets_base_urls' => '//example.com',
+                ),
+                'assets' => null,
+            ),
+        ));
+    }
+
     protected static function getBundleDefaultConfig()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

If both of configurations are defined, the exception breaks because it isn't
defined properly (missing backslash in FQCN for `\LogicException`).
Also, the message was wrong (it's referred to "templating.templating" instead of
"framework.templating").
