### PR TITLE
[Form] respect `trueValue` for `reverseTransform`

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -30,13 +30,22 @@ class BooleanToStringTransformer implements DataTransformerInterface
     private $trueValue;
 
     /**
+     * Perform strict value comparison
+     *
+     * @var bool
+     */
+    private $strict;
+
+    /**
      * Sets the value emitted upon transform if the input is true.
      *
      * @param string $trueValue
+     * @param bool $strict
      */
-    public function __construct($trueValue)
+    public function __construct($trueValue, $strict = false)
     {
         $this->trueValue = $trueValue;
+        $this->strict = $strict;
     }
 
     /**
@@ -80,6 +89,6 @@ class BooleanToStringTransformer implements DataTransformerInterface
             throw new TransformationFailedException('Expected a string.');
         }
 
-        return true;
+        return $this->strict ? $value === $this->trueValue : true;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -32,7 +32,7 @@ class CheckboxType extends AbstractType
         // We cannot solve this case via overriding the "data" option, because
         // doing so also calls setDataLocked(true).
         $builder->setData(isset($options['data']) ? $options['data'] : false);
-        $builder->addViewTransformer(new BooleanToStringTransformer($options['value']));
+        $builder->addViewTransformer(new BooleanToStringTransformer($options['value'], !$options['accept_any_value']));
     }
 
     /**
@@ -57,6 +57,7 @@ class CheckboxType extends AbstractType
 
         $resolver->setDefaults(array(
             'value' => '1',
+            'accept_any_value' => true,
             'empty_data' => $emptyData,
             'compound' => false,
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -22,14 +22,21 @@ class BooleanToStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     protected $transformer;
 
+    /**
+     * @var BooleanToStringTransformer
+     */
+    protected $transformerStrict;
+
     protected function setUp()
     {
         $this->transformer = new BooleanToStringTransformer(self::TRUE_VALUE);
+        $this->transformerStrict = new BooleanToStringTransformer(self::TRUE_VALUE, true);
     }
 
     protected function tearDown()
     {
         $this->transformer = null;
+        $this->transformerStrict = null;
     }
 
     public function testTransform()
@@ -60,11 +67,31 @@ class BooleanToStringTransformerTest extends \PHPUnit_Framework_TestCase
         $this->transformer->reverseTransform(1);
     }
 
-    public function testReverseTransform()
+    /**
+     * @dataProvider reverseTransformDataProvider
+     */
+    public function testReverseTransform($value, $assertion, $strict)
     {
-        $this->assertTrue($this->transformer->reverseTransform(self::TRUE_VALUE));
-        $this->assertTrue($this->transformer->reverseTransform('foobar'));
-        $this->assertTrue($this->transformer->reverseTransform(''));
-        $this->assertFalse($this->transformer->reverseTransform(null));
+        $transformer = $strict ? $this->transformerStrict : $this->transformer;
+
+        if ($assertion) {
+            $this->assertTrue($transformer->reverseTransform($value));
+        } else {
+            $this->assertFalse($transformer->reverseTransform($value));
+        }
+    }
+
+    public function reverseTransformDataProvider()
+    {
+        return array(
+            array(self::TRUE_VALUE, true, false),
+            array('foobar', true, false),
+            array('', true, false),
+            array(null, false, false),
+            array(self::TRUE_VALUE, true, true),
+            array('foobar', false, true),
+            array('', false, true),
+            array(null, false, true),
+        );
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -81,6 +81,18 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertEquals('foobar', $form->getViewData());
     }
 
+    public function testSubmitWithRandomValueCheckedStrict()
+    {
+        $form = $this->factory->create('checkbox', null, array(
+            'value' => 'foobar',
+            'accept_any_value' => false,
+        ));
+        $form->submit('krixikraxi');
+
+        $this->assertFalse($form->getData());
+        $this->assertNull($form->getViewData());
+    }
+
     public function testSubmitWithValueUnchecked()
     {
         $form = $this->factory->create('checkbox', null, array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The current behavior of the `BooleanToStringTransformer` perfectly fits the need of the `CheckBoxType`and how browsers handle form submissions of checkbox-values.
The downside is that any value e.g. "0" will transform to `true` even if the `trueValue`is set to "1". Due to this it may cause trouble when you want to handle form-submission by Javascript. For a JS-Dev is may not be 100% clear that "0" will transform to `true`in the backend. 
This PR introduces a new option to the `CheckboxType` which allows the `strict` comparison of the submitted values to make it possible to uncheck values without omitting the form-field in the post-data.
