### PR TITLE
[2.3] [HttpFoundation] fixed param order for Nginx's x-accel-mapping

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -194,12 +194,13 @@ class BinaryFileResponse extends Response
             $path = $this->file->getRealPath();
             if (strtolower($type) == 'x-accel-redirect') {
                 // Do X-Accel-Mapping substitutions.
+                // @link http://wiki.nginx.org/X-accel#X-Accel-Redirect
                 foreach (explode(',', $request->headers->get('X-Accel-Mapping', '')) as $mapping) {
                     $mapping = explode('=', $mapping, 2);
 
                     if (2 == count($mapping)) {
-                        $location = trim($mapping[0]);
-                        $pathPrefix = trim($mapping[1]);
+                        $pathPrefix = trim($mapping[0]);
+                        $location = trim($mapping[1]);
 
                         if (substr($path, 0, strlen($pathPrefix)) == $pathPrefix) {
                             $path = $location.substr($path, strlen($pathPrefix));

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -222,8 +222,8 @@ class BinaryFileResponseTest extends ResponseTestCase
     public function getSampleXAccelMappings()
     {
         return array(
-            array('/var/www/var/www/files/foo.txt', '/files/=/var/www/', '/files/var/www/files/foo.txt'),
-            array('/home/foo/bar.txt', '/files/=/var/www/,/baz/=/home/foo/', '/baz/bar.txt'),
+            array('/var/www/var/www/files/foo.txt', '/var/www/=/files/', '/files/var/www/files/foo.txt'),
+            array('/home/foo/bar.txt', '/var/www/=/files/,/home/foo/=/baz/', '/baz/bar.txt'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | kinda |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13502 |
| License | MIT |
| Doc PR | n/a |

Inverted path and location directives for x-accel-mapping header (fixes #13502).

Before:
`proxy_set_header X-Accel-Mapping /internal/=/var/www/example.com/`

After:
`proxy_set_header X-Accel-Mapping /var/www/example.com/=/internal/`

It could be a BC break since the response will fail if someone sends this header
honoring the previous signature, thus I need some feedback in order to choose the right branch for this change.
