### PR TITLE
[PropertyAccess] StringUtil miss-singularize some "ee" words

### DIFF
--- a/src/Symfony/Component/PropertyAccess/StringUtil.php
+++ b/src/Symfony/Component/PropertyAccess/StringUtil.php
@@ -112,6 +112,11 @@ class StringUtil
     );
 
     /**
+     * @var string[]
+     */
+    private static $allowedEes = array('Fleet', 'Street');
+
+    /**
      * This class should not be instantiated.
      */
     private function __construct()
@@ -197,7 +202,7 @@ class StringUtil
         }
 
         // Convert teeth to tooth, feet to foot
-        if (false !== ($pos = strpos($plural, 'ee')) && strlen($plural) > 3) {
+        if (false !== ($pos = strpos($plural, 'ee')) && strlen($plural) > 3 ! in_array($plural, self::$allowedEes)) {
             return substr_replace($plural, 'oo', $pos, 2);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | n/a |

Fixes misspelling of words like:
- street => stroot
- fleet => floot

See exception:

![screenshot from 2015-02-17 13 35 37](https://cloud.githubusercontent.com/assets/924196/6228208/3b5b9060-b6a9-11e4-8d8d-e780484884d6.png)

Is this proper way to fix this?

Can add tests if required.
