### PR TITLE
Enforce UTF-8 charset for core controllers

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -51,7 +51,7 @@ class ExceptionController
 
         $code = $exception->getStatusCode();
 
-        return new Response($this->twig->render(
+        return Response::create($this->twig->render(
             (string) $this->findTemplate($request, $request->getRequestFormat(), $code, $this->debug),
             array(
                 'status_code' => $code,
@@ -60,7 +60,7 @@ class ExceptionController
                 'logger' => $logger,
                 'currentContent' => $currentContent,
             )
-        ));
+        ))->setCharset('UTF-8');
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -39,6 +39,7 @@ class ExceptionControllerTest extends TestCase
         $request->headers->set('X-Php-Ob-Level', 1);
 
         $controller = new ExceptionController($twig, false);
-        $controller->showAction($request, $flatten);
+        $response = $controller->showAction($request, $flatten);
+        $this->assertEquals('UTF-8', $response->getCharset(), 'Request charset is explicitly set to UTF-8');
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
@@ -62,16 +62,17 @@ class ExceptionController
 
         $code = $exception->getStatusCode();
 
-        return new Response($this->twig->render(
-            $template,
-            array(
+        return Response::create(
+            $this->twig->render($template, array(
                 'status_code' => $code,
                 'status_text' => Response::$statusTexts[$code],
                 'exception' => $exception,
                 'logger' => null,
                 'currentContent' => '',
-            )
-        ), 200, array('Content-Type' => 'text/html'));
+            )),
+            200,
+            array('Content-Type' => 'text/html')
+        )->setCharset('UTF-8');
     }
 
     /**
@@ -97,10 +98,14 @@ class ExceptionController
         if (!$this->templateExists($template)) {
             $handler = new ExceptionHandler();
 
-            return new Response($handler->getStylesheet($exception), 200, array('Content-Type' => 'text/css'));
+            $response = new Response($handler->getStylesheet($exception), 200, array('Content-Type' => 'text/css'));
+        } else {
+            $response = new Response($this->twig->render('@WebProfiler/Collector/exception.css.twig'), 200, array('Content-Type' => 'text/css'));
         }
 
-        return new Response($this->twig->render('@WebProfiler/Collector/exception.css.twig'), 200, array('Content-Type' => 'text/css'));
+        $response->setCharset('UTF-8');
+
+        return $response;
     }
 
     protected function getTemplate()

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -99,16 +99,20 @@ class ProfilerController
             throw new NotFoundHttpException(sprintf('Panel "%s" is not available for token "%s".', $panel, $token));
         }
 
-        return new Response($this->twig->render($this->getTemplateManager()->getName($profile, $panel), array(
-            'token' => $token,
-            'profile' => $profile,
-            'collector' => $profile->getCollector($panel),
-            'panel' => $panel,
-            'page' => $page,
-            'request' => $request,
-            'templates' => $this->getTemplateManager()->getTemplates($profile),
-            'is_ajax' => $request->isXmlHttpRequest(),
-        )), 200, array('Content-Type' => 'text/html'));
+        return Response::create(
+            $this->twig->render($this->getTemplateManager()->getName($profile, $panel), array(
+                'token' => $token,
+                'profile' => $profile,
+                'collector' => $profile->getCollector($panel),
+                'panel' => $panel,
+                'page' => $page,
+                'request' => $request,
+                'templates' => $this->getTemplateManager()->getTemplates($profile),
+                'is_ajax' => $request->isXmlHttpRequest(),
+            )),
+            200,
+            array('Content-Type' => 'text/html')
+        )->setCharset('UTF-8');
     }
 
     /**
@@ -147,9 +151,13 @@ class ProfilerController
 
         $this->profiler->disable();
 
-        return new Response($this->twig->render('@WebProfiler/Profiler/info.html.twig', array(
-            'about' => $about,
-        )), 200, array('Content-Type' => 'text/html'));
+        return Response::create(
+            $this->twig->render('@WebProfiler/Profiler/info.html.twig', array(
+                'about' => $about,
+            )),
+            200,
+            array('Content-Type' => 'text/html')
+        )->setCharset('UTF-8');
     }
 
     /**
@@ -197,13 +205,17 @@ class ProfilerController
             // the profiler is not enabled
         }
 
-        return new Response($this->twig->render('@WebProfiler/Profiler/toolbar.html.twig', array(
-            'position' => $position,
-            'profile' => $profile,
-            'templates' => $this->getTemplateManager()->getTemplates($profile),
-            'profiler_url' => $url,
-            'token' => $token,
-        )), 200, array('Content-Type' => 'text/html'));
+        return Response::create(
+            $this->twig->render('@WebProfiler/Profiler/toolbar.html.twig', array(
+                'position' => $position,
+                'profile' => $profile,
+                'templates' => $this->getTemplateManager()->getTemplates($profile),
+                'profiler_url' => $url,
+                'token' => $token,
+            )),
+            200,
+            array('Content-Type' => 'text/html')
+        )->setCharset('UTF-8');
     }
 
     /**
@@ -241,15 +253,19 @@ class ProfilerController
             $token = $session->get('_profiler_search_token');
         }
 
-        return new Response($this->twig->render('@WebProfiler/Profiler/search.html.twig', array(
-            'token' => $token,
-            'ip' => $ip,
-            'method' => $method,
-            'url' => $url,
-            'start' => $start,
-            'end' => $end,
-            'limit' => $limit,
-        )), 200, array('Content-Type' => 'text/html'));
+        return Response::create(
+            $this->twig->render('@WebProfiler/Profiler/search.html.twig', array(
+                'token' => $token,
+                'ip' => $ip,
+                'method' => $method,
+                'url' => $url,
+                'start' => $start,
+                'end' => $end,
+                'limit' => $limit,
+            )),
+            200,
+            array('Content-Type' => 'text/html')
+        )->setCharset('UTF-8');
     }
 
     /**
@@ -279,18 +295,22 @@ class ProfilerController
         $end = $request->query->get('end', null);
         $limit = $request->query->get('limit');
 
-        return new Response($this->twig->render('@WebProfiler/Profiler/results.html.twig', array(
-            'token' => $token,
-            'profile' => $profile,
-            'tokens' => $this->profiler->find($ip, $url, $limit, $method, $start, $end),
-            'ip' => $ip,
-            'method' => $method,
-            'url' => $url,
-            'start' => $start,
-            'end' => $end,
-            'limit' => $limit,
-            'panel' => null,
-        )), 200, array('Content-Type' => 'text/html'));
+        return Response::create(
+            $this->twig->render('@WebProfiler/Profiler/results.html.twig', array(
+                'token' => $token,
+                'profile' => $profile,
+                'tokens' => $this->profiler->find($ip, $url, $limit, $method, $start, $end),
+                'ip' => $ip,
+                'method' => $method,
+                'url' => $url,
+                'start' => $start,
+                'end' => $end,
+                'limit' => $limit,
+                'panel' => null,
+            )),
+            200,
+            array('Content-Type' => 'text/html')
+        )->setCharset('UTF-8');
     }
 
     /**
@@ -364,7 +384,7 @@ class ProfilerController
         phpinfo();
         $phpinfo = ob_get_clean();
 
-        return new Response($phpinfo, 200, array('Content-Type' => 'text/html'));
+        return Response::create($phpinfo, 200, array('Content-Type' => 'text/html'))->setCharset('UTF-8');
     }
 
     /**

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -68,10 +68,14 @@ class RouterController
 
         $request = $profile->getCollector('request');
 
-        return new Response($this->twig->render('@WebProfiler/Router/panel.html.twig', array(
-            'request' => $request,
-            'router' => $profile->getCollector('router'),
-            'traces' => $matcher->getTraces($request->getPathInfo()),
-        )), 200, array('Content-Type' => 'text/html'));
+        return Response::create(
+            $this->twig->render('@WebProfiler/Router/panel.html.twig', array(
+                'request' => $request,
+                'router' => $profile->getCollector('router'),
+                'traces' => $matcher->getTraces($request->getPathInfo()),
+            )),
+            200,
+            array('Content-Type' => 'text/html')
+        )->setCharset('UTF-8');
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -69,6 +69,7 @@ class ProfilerControllerTest extends \PHPUnit_Framework_TestCase
 
         $response = $controller->toolbarAction(Request::create('/_wdt/found'), 'found');
         $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('UTF-8', $response->getCharset(), 'Request charset is explicitly set to UTF-8');
 
         $response = $controller->toolbarAction(Request::create('/_wdt/notFound'), 'notFound');
         $this->assertEquals(404, $response->getStatusCode());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7532 |
| License | MIT |
| Doc PR | - |

See https://github.com/symfony/symfony/issues/7617 and https://github.com/symfony/symfony/pull/7532 for the context of this PR.
