### PR TITLE
[Console] make an assertion more precise in testGetOptionDefaults

### DIFF
--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -341,7 +341,7 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
             new InputOption('foo7', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, '', array(1, 2)),
         ));
         $defaults = array(
-            'foo1' => null,
+            'foo1' => false,
             'foo2' => null,
             'foo3' => 'default',
             'foo4' => null,
@@ -349,7 +349,7 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
             'foo6' => array(),
             'foo7' => array(1, 2),
         );
-        $this->assertEquals($defaults, $definition->getOptionDefaults(), '->getOptionDefaults() returns the default values for all options');
+        $this->assertSame($defaults, $definition->getOptionDefaults(), '->getOptionDefaults() returns the default values for all options');
     }
 
     public function testGetSynopsis()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |

Minor fix, the default values expected in the test were not exactly the same as what is actually returned.
