### PR TITLE
Small syntax fix in CHANGELOG

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 2.6.2
 -----
 
-* Added back the `model_timezone` and `view_timezone` options for `TimeType`, `DateType`
-  and `BirthdayType`
+ * Added back the `model_timezone` and `view_timezone` options for `TimeType`, `DateType`
+   and `BirthdayType`
 
 2.6.0
 -----


### PR DESCRIPTION
Markdown list items have to start with a space (both render correctly, but this is the standard and consistent with the rest of the file).

| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |
