### PR TITLE
Fix the toolbar JS for IE

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -173,7 +173,8 @@
 
         var addEventListener;
 
-        if (document.attachEvent) {
+        var el = document.createElement('div');
+        if (!'addEventListener' in el) {
             addEventListener = function (element, eventName, callback) {
                 element.attachEvent('on' + eventName, callback);
             };
@@ -184,40 +185,42 @@
         }
 
         {% if excluded_ajax_paths is defined %}
-            var proxied = XMLHttpRequest.prototype.open;
+            if (window.XMLHttpRequest) {
+                var proxied = XMLHttpRequest.prototype.open;
 
-            XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
-                var self = this;
+                XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+                    var self = this;
 
-                /* prevent logging AJAX calls to static and inline files, like templates */
-                if (url.substr(0, 1) === '/' && !url.match(new RegExp("{{ excluded_ajax_paths }}"))) {
-                    var stackElement = {
-                        loading: true,
-                        error: false,
-                        url: url,
-                        method: method,
-                        start: new Date()
-                    };
+                    /* prevent logging AJAX calls to static and inline files, like templates */
+                    if (url.substr(0, 1) === '/' && !url.match(new RegExp("{{ excluded_ajax_paths }}"))) {
+                        var stackElement = {
+                            loading: true,
+                            error: false,
+                            url: url,
+                            method: method,
+                            start: new Date()
+                        };
 
-                    requestStack.push(stackElement);
+                        requestStack.push(stackElement);
 
-                    addEventListener(this, 'readystatechange', function() {
-                        if (self.readyState == 4) {
-                            stackElement.duration = new Date() - stackElement.start;
-                            stackElement.loading = false;
-                            stackElement.error = self.status < 200 || self.status >= 400;
-                            stackElement.profile = self.getResponseHeader("X-Debug-Token");
-                            stackElement.profilerUrl = self.getResponseHeader("X-Debug-Token-Link");
+                        this.addEventListener('readystatechange', function() {
+                            if (self.readyState == 4) {
+                                stackElement.duration = new Date() - stackElement.start;
+                                stackElement.loading = false;
+                                stackElement.error = self.status < 200 || self.status >= 400;
+                                stackElement.profile = self.getResponseHeader("X-Debug-Token");
+                                stackElement.profilerUrl = self.getResponseHeader("X-Debug-Token-Link");
 
-                            Sfjs.renderAjaxRequests();
-                        }
-                    });
+                                Sfjs.renderAjaxRequests();
+                            }
+                        }, false);
 
-                    Sfjs.renderAjaxRequests();
-                }
+                        Sfjs.renderAjaxRequests();
+                    }
 
-                proxied.apply(this, Array.prototype.slice.call(arguments));
-            };
+                    proxied.apply(this, Array.prototype.slice.call(arguments));
+                };
+            }
         {% endif %}
 
         return {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | n/a |
- fix the binding of listeners on XMLHttpRequest to always use the addEventListener method. It does not make sense to change it to attachEvent as it is about binding listeners on DOM elements.
- fix the feature detection for the event binding on DOM elements:
  - the attachEvent and addEventListener methods are on DOM elements, not on the document object
  - the standard method should be preferred in IE versions supporting both methods
- avoid JS errors when XMLHttpRequest is not defined by avoiding to override its open method when the object is not there (old IE versions will still not intercept ajax calls though)

this is the complete fix for the code submitted in #13636 (the fix in https://github.com/symfony/symfony/pull/13684 was incomplete).
