### PR TITLE
[2.3][Process] Fixed PhpProcess::getCommandLine() result

### DIFF
--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -26,8 +26,6 @@ use Symfony\Component\Process\Exception\RuntimeException;
  */
 class PhpProcess extends Process
 {
-    private $executableFinder;
-
     /**
      * Constructor.
      *
@@ -41,9 +39,12 @@ class PhpProcess extends Process
      */
     public function __construct($script, $cwd = null, array $env = array(), $timeout = 60, array $options = array())
     {
-        parent::__construct(null, $cwd, $env, $script, $timeout, $options);
+        $executableFinder = new PhpExecutableFinder();
+        if (false === $php = $executableFinder->find()) {
+            $php = null;
+        }
 
-        $this->executableFinder = new PhpExecutableFinder();
+        parent::__construct($php, $cwd, $env, $script, $timeout, $options);
     }
 
     /**
@@ -62,10 +63,7 @@ class PhpProcess extends Process
     public function start($callback = null)
     {
         if (null === $this->getCommandLine()) {
-            if (false === $php = $this->executableFinder->find()) {
-                throw new RuntimeException('Unable to find the PHP executable.');
-            }
-            $this->setCommandLine($php);
+            throw new RuntimeException('Unable to find the PHP executable.');
         }
 
         parent::start($callback);

--- a/src/Symfony/Component/Process/Tests/PhpProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpProcessTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Process\Tests;
 
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\PhpProcess;
 
 class PhpProcessTest extends \PHPUnit_Framework_TestCase
@@ -25,5 +26,24 @@ PHP
         $process->start();
         $process->wait();
         $this->assertEquals($expected, $process->getOutput());
+    }
+
+    public function testCommandLine()
+    {
+        $process = new PhpProcess(<<<PHP
+<?php echo 'foobar';
+PHP
+        );
+
+        $f = new PhpExecutableFinder();
+        $commandLine = $f->find();
+
+        $this->assertSame($commandLine, $process->getCommandLine(), '::getCommandLine() returns the command line of PHP before start');
+
+        $process->start();
+        $this->assertSame($commandLine, $process->getCommandLine(), '::getCommandLine() returns the command line of PHP after start');
+
+        $process->wait();
+        $this->assertSame($commandLine, $process->getCommandLine(), '::getCommandLine() returns the command line of PHP after wait');
     }
 }


### PR DESCRIPTION
The `PhpProcess::getCommandLine()` return `null` if `PhpProcess::start()` was not called.

``` php
$process = new PhpProcess(<<<PHP
<?php echo "foobar";
PHP
);

$process->getCommandLine(); // return null
$process->start();
$process->getCommandLine(); // return the PHP binary path
```

This PR fix the problem.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | - |
