### PR TITLE
[Security] Fix expectation in a test.

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -220,8 +220,8 @@ class ContextListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $event->expects($this->any())
-            ->method('getRequestType')
-            ->will($this->returnValue(HttpKernelInterface::MASTER_REQUEST));
+            ->method('isMasterRequest')
+            ->will($this->returnValue(true));
         $event->expects($this->any())
             ->method('getRequest')
             ->will($this->returnValue($request));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is related to #13466, which worked perfectly fine in 2.3. It breaks in 2.6 since we've changed the way we check for master request.
