### PR TITLE
Fixed absolute_url for absolute paths

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
@@ -67,10 +67,10 @@ class HttpFoundationExtension extends \Twig_Extension
                 $prefix = substr($prefix, 0, $pos).'/';
             }
 
-            $path = $prefix.$path;
+            return $request->getUriForPath($prefix.$path);
         }
 
-        return $request->getUriForPath($path);
+        return $request->getSchemeAndHttpHost().$path;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
@@ -43,6 +43,21 @@ class HttpFoundationExtensionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGenerateAbsoluteUrlWithScriptFileName()
+    {
+        $request = Request::create('http://localhost/app/web/app_dev.php');
+        $request->server->set('SCRIPT_FILENAME', '/var/www/app/web/app_dev.php');
+
+        $stack = new RequestStack();
+        $stack->push($request);
+        $extension = new HttpFoundationExtension($stack);
+
+        $this->assertEquals(
+            'http://localhost/app/web/bundles/framework/css/structure.css',
+            $extension->generateAbsoluteUrl('/app/web/bundles/framework/css/structure.css')
+        );
+    }
+
     /**
      * @dataProvider getGenerateRelativePathData()
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/13724 |
| License | MIT |

The issue is that `asset()` and `absolute_url()` cannot be composed because `asset()` already returns an absolute path (using the `PathPackage`) and `absolute_url()` still prepends the base path. So the resulting url contains the base path twice.

So this PR removes appending the base path to absolute paths (starting with `/`) passed to `absolute_url()`.
