### PR TITLE
[Console] assertion for ArgvInput::getFirstArgument() with no arguments

### DIFF
--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -257,7 +257,7 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
     public function testGetFirstArgument()
     {
         $input = new ArgvInput(array('cli.php', '-fbbar'));
-        $this->assertEquals('', $input->getFirstArgument(), '->getFirstArgument() returns the first argument from the raw input');
+        $this->assertNull($input->getFirstArgument(), '->getFirstArgument() returns null when there is no arguments');
 
         $input = new ArgvInput(array('cli.php', '-fbbar', 'foo'));
         $this->assertEquals('foo', $input->getFirstArgument(), '->getFirstArgument() returns the first argument from the raw input');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |
