### PR TITLE
Fix special chapters for EmailValidator

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -91,6 +91,7 @@ class EmailValidatorTest extends AbstractConstraintValidatorTest
             array('example'),
             array('example@'),
             array('example@localhost'),
+            array('/example@example.co.uk'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [no] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [] |

I think "/example@example.co.uk" this is not valid email address. Does I need to fix it?

internal php FILTER_VALIDATE_EMAIL allows many chapters that can't be in email addresses
!#$%&'_+-/=?^_`{|}~@.[]
http://php.net/manual/ru/filter.filters.sanitize.php
So we need more strict validation like this regx:
^[_a-z0-9-]+(.[_a-z0-9-]+)_@[a-z0-9-]+(.[a-z0-9-]+)*(.[a-z]{2,3})$
