### PR TITLE
[FrameworkBundle] [HttpKernel] Fixed InvalidArgumentException for certain commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -127,7 +127,7 @@ EOF
         $safeTempKernel = str_replace('\\', '\\\\', get_class($tempKernel));
         $realKernelFQN = get_class($realKernel);
 
-        foreach (Finder::create()->files()->name('*.meta')->in($warmupDir) as $file) {
+        foreach (Finder::create()->files()->name('/.*\.meta$/')->in($warmupDir) as $file) {
             file_put_contents($file, preg_replace(
                 '/(C\:\d+\:)"'.$safeTempKernel.'"/',
                 sprintf('$1"%s"', $realKernelFQN),
@@ -146,7 +146,7 @@ EOF
         // fix references to kernel/container related classes
         $search = $tempKernel->getName().ucfirst($tempKernel->getEnvironment());
         $replace = $realKernel->getName().ucfirst($realKernel->getEnvironment());
-        foreach (Finder::create()->files()->name($search.'*')->in($warmupDir) as $file) {
+        foreach (Finder::create()->files()->name('/^'.$search.'.*/')->in($warmupDir) as $file) {
             $content = str_replace($search, $replace, file_get_contents($file));
             file_put_contents(str_replace($search, $replace, $file), $content);
             unlink($file);

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -179,7 +179,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
         }
 
         $finder = new Finder();
-        $finder->files()->name('*Command.php')->in($dir);
+        $finder->files()->name('/.*Command.php/')->in($dir);
 
         $prefix = $this->getNamespace().'\\Command';
         foreach ($finder as $file) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | #13765 |
| License | MIT |
| Doc PR | [x] |

It's a simple quickfix to 13765 ticket, that provides regexes instead of wildcard in function parameters that goes to Expression component.
