### PR TITLE
[Debug] Deprecations exception for Symfony internals

### DIFF
--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -193,7 +193,7 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
         $e = error_reporting(0);
         trigger_error('', E_USER_NOTICE);
 
-        class_exists(__NAMESPACE__.'\Fixtures\ExtendsDeprecatedParent', true);
+        class_exists('Symfony\Bridge\Debug\Tests\Fixtures\ExtendsDeprecatedParent', true);
 
         error_reporting($e);
         restore_error_handler();
@@ -239,8 +239,8 @@ class ClassLoader
             return __DIR__.'/Fixtures/notPsr0Bis.php';
         } elseif (__NAMESPACE__.'\Fixtures\DeprecatedInterface' === $class) {
             return __DIR__.'/Fixtures/DeprecatedInterface.php';
-        } elseif (__NAMESPACE__.'\Fixtures\ExtendsDeprecatedParent' === $class) {
-            eval('namespace '.__NAMESPACE__.'\Fixtures; class ExtendsDeprecatedParent extends DeprecatedClass {}');
+        } elseif ('Symfony\Bridge\Debug\Tests\Fixtures\ExtendsDeprecatedParent' === $class) {
+            eval('namespace Symfony\Bridge\Debug\Tests\Fixtures; class ExtendsDeprecatedParent extends \\'.__NAMESPACE__.'\Fixtures\DeprecatedClass {}');
         } elseif ('Test\\'.__NAMESPACE__.'\DeprecatedParentClass' === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class DeprecatedParentClass extends \\'.__NAMESPACE__.'\Fixtures\DeprecatedClass {}');
         } elseif ('Test\\'.__NAMESPACE__.'\DeprecatedInterfaceClass' === $class) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13764 |
| License | MIT |
| Doc PR | - |

Allowing 1st level check of the `Symfony\` namespace prevents trigerring deprecation notices for internal things, but keeps notices enabled for `Symfony\Cmf\` classes
