### PR TITLE
[Translation][Loader] Creation of new class XliffUtils.

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,10 +1,15 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * added XliffUtils class with utility methods for operations with xliff files
+
 2.7.0
 -----
 
- * added DataCollectorTranslator for collecting the translated messages.
+ * added DataCollectorTranslator for collecting the translated messages
 
 2.6.0
 -----

--- a/src/Symfony/Component/Translation/Tests/Util/XliffUtilsTest.php
+++ b/src/Symfony/Component/Translation/Tests/Util/XliffUtilsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Symfony\Component\Translation\Tests\Util;
+
+use Symfony\Component\Translation\Util\XliffUtils;
+
+class XliffUtilsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLoadResource()
+    {
+        $resource = __DIR__.'/../fixtures/resources.xlf';
+        $result = XliffUtils::loadFile($resource);
+
+        $this->assertResultOk($result);
+    }
+
+    public function testLoadResourceWithSchema()
+    {
+        $resource = __DIR__.'/../fixtures/resources.xlf';
+        $result = XliffUtils::loadFile($resource, function (\DOMDocument $dom) {
+            return true;
+        });
+
+        $this->assertResultOk($result);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
+     */
+    public function testLoadInvalidResource()
+    {
+        $resource = __DIR__.'/../fixtures/resources.php';
+        XliffUtils::loadFile($resource.'resources.php');
+    }
+
+    private function assertResultOk($result)
+    {
+        $this->assertInstanceOf('\DomDocument', $result);
+        $this->assertSame(array(), libxml_get_errors());
+    }
+}

--- a/src/Symfony/Component/Translation/Util/XliffUtils.php
+++ b/src/Symfony/Component/Translation/Util/XliffUtils.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Util;
+
+use Symfony\Component\Config\Util\XmlUtils;
+use Symfony\Component\Translation\Exception\InvalidResourceException;
+
+/**
+ * XliffUtils is a bunch of utility methods to Xliff operations.
+ *
+ * This class contains static methods only and is not meant to be instantiated.
+ *
+ * @author Marcos D. Sánchez <marcosdsanchez@gmail.com>
+ */
+class XliffUtils
+{
+    /**
+     * This class should not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Loads a Xliff file.
+     *
+     * @param string               $file             A Xliff file path
+     * @param string|callable|null $schemaOrCallable An XSD schema file path, a callable, or null to disable validation
+     *
+     * @return \DOMDocument
+     *
+     * @throws \InvalidArgumentException When loading of Xliff file returns error
+     */
+    public static function loadFile($file, $schemaOrCallable = null)
+    {
+        $location = str_replace('\\', '/', __DIR__).'/../Loader/schema/dic/xliff-core/xml.xsd';
+        $parts = explode('/', $location);
+        if (0 === stripos($location, 'phar://')) {
+            $tmpfile = tempnam(sys_get_temp_dir(), 'sf2');
+            if ($tmpfile) {
+                copy($location, $tmpfile);
+                $parts = explode('/', str_replace('\\', '/', $tmpfile));
+            }
+        }
+        $drive = '\\' === DIRECTORY_SEPARATOR ? array_shift($parts).'/' : '';
+        $location = 'file:///'.$drive.implode('/', array_map('rawurlencode', $parts));
+
+        $source = file_get_contents(__DIR__.'/../Loader/schema/dic/xliff-core/xliff-core-1.2-strict.xsd');
+        $source = str_replace('http://www.w3.org/2001/xml.xsd', $location, $source);
+
+        if (null === $schemaOrCallable) {
+            $schemaOrCallable = function (\DOMDocument $dom) use ($source) {
+                return @$dom->schemaValidateSource($source);
+            };
+        }
+
+        try {
+            $dom = XmlUtils::loadFile($file, $schemaOrCallable);
+        } catch (\InvalidArgumentException $e) {
+            throw new InvalidResourceException(sprintf('Unable to load "%s": %s', $file, $e->getMessage()), $e->getCode(), $e);
+        }
+
+        $dom->normalizeDocument();
+
+        return $dom;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

I needed to parse Xliff files and noticed that XliffFileLoader did the parsing but didn't expose the methods to do that.
Applied "Extract class" refactor to XliffFileLoader extracting xliff file parsing to the new XliffUtils class. XliffUtils reuses funtionality with XmlUtils.
