### PR TITLE
[DomCrawler] Invalid uri created from forms if base tag present

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -755,7 +755,7 @@ class Crawler extends \SplObjectStorage
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        $form = new Form($this->getNode(0), $this->uri, $method);
+        $form = new Form($this->getNode(0), $this->uri, $method, $this->baseHref);
 
         if (null !== $values) {
             $form->setValues($values);

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -34,19 +34,26 @@ class Form extends Link implements \ArrayAccess
     private $fields;
 
     /**
+     * @var string
+     */
+    private $baseHref;
+
+    /**
      * Constructor.
      *
      * @param \DOMNode $node       A \DOMNode instance
      * @param string   $currentUri The URI of the page where the form is embedded
      * @param string   $method     The method to use for the link (if null, it defaults to the method defined by the form)
+     * @param string   $baseHref   The URI of the <base> used for relative links, but not for empty action
      *
      * @throws \LogicException if the node is not a button inside a form tag
      *
      * @api
      */
-    public function __construct(\DOMNode $node, $currentUri, $method = null)
+    public function __construct(\DOMNode $node, $currentUri, $method = null, $baseHref = null)
     {
         parent::__construct($node, $currentUri, $method);
+        $this->baseHref = $baseHref;
 
         $this->initialize();
     }
@@ -441,6 +448,10 @@ class Form extends Link implements \ArrayAccess
             foreach ($fieldNodes as $node) {
                 $this->addField($node);
             }
+        }
+
+        if ($this->baseHref && '' !== $this->node->getAttribute('action')) {
+            $this->currentUri = $this->baseHref;
         }
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -853,9 +853,12 @@ HTML;
     public function getBaseTagWithFormData()
     {
         return array(
+            array('https://base.com/', 'link/', 'https://base.com/link/', 'https://base.com/link/', '<base> tag does work with a path and relative form action'),
             array('/basepath', '/registration', 'http://domain.com/registration', 'http://domain.com/registration', '<base> tag does work with a path and form action'),
             array('/basepath', '', 'http://domain.com/registration', 'http://domain.com/registration', '<base> tag does work with a path and empty form action'),
+            array('http://base.com/', '/registration', 'http://base.com/registration', 'http://domain.com/registration', '<base> tag does work with a URL and form action'),
             array('http://base.com', '', 'http://domain.com/path/form', 'http://domain.com/path/form', '<base> tag does work with a URL and an empty form action'),
+            array('http://base.com/path', '/registration', 'http://base.com/registration', 'http://domain.com/path/form', '<base> tag does work with a URL and form action'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Since #13145 was merged the provided testcase does not work anymore and creates an invalid link

This affects the latest versions of 2.3, 2.5, 2.6 and 2.7

Right now this PR only includes the failing test, as I could no easy find a fix. If someone immediately knows whats the problem, give me a hint please.
