### PR TITLE
[FrameworkBundle] Update assets configuration tests 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -86,27 +86,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage You cannot use assets settings under "framework.templating" and "assets" configurations in the same project.
-     */
-    public function testLegacyInvalidValueAssets()
-    {
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
-
-        $processor = new Processor();
-        $configuration = new Configuration(true);
-        $processor->processConfiguration($configuration, array(
-            array(
-                'templating' => array(
-                    'engines' => null,
-                    'assets_base_urls' => '//example.com',
-                ),
-                'assets' => null,
-            ),
-        ));
-    }
-
     protected static function getBundleDefaultConfig()
     {
         return array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -86,6 +86,23 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testAssetsCanBeEnabled()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $config = $processor->processConfiguration($configuration, array(array('assets' => null)));
+
+        $defaultConfig = array(
+            'version' => null,
+            'version_format' => '%%s?%%s',
+            'base_path' => '',
+            'base_urls' => array(),
+            'packages' => array(),
+        );
+
+        $this->assertEquals($defaultConfig, $config['assets']);
+    }
+
     protected static function getBundleDefaultConfig()
     {
         return array(
@@ -144,13 +161,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'property_access' => array(
                 'magic_call' => false,
                 'throw_exception_on_invalid_index' => false,
-            ),
-            'assets' => array(
-                'version' => null,
-                'version_format' => '%%s?%%s',
-                'base_path' => '',
-                'base_urls' => array(),
-                'packages' => array(),
             ),
         );
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -4,6 +4,7 @@ framework:
         enabled: true
     router:        { resource: "%kernel.root_dir%/%kernel.test_case%/routing.yml" }
     validation:    { enabled: true, enable_annotations: true }
+    assets: ~
     form: ~
     test: ~
     default_locale: en

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -134,7 +134,7 @@ class SimpleFormTest extends AbstractFormTest
         $config->addEventListener(FormEvents::PRE_SUBMIT, array($mock, 'preSubmit'));
         $form = new Form($config);
 
-        $form->bind(false);
+        $form->submit(false);
 
         $this->assertTrue($form->isValid());
         $this->assertNull($form->getData());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Previously, assets where enabled if `templating` didn't contain asset configuration. This has been removed in #13666. 

Instead of enabling it back I propose to keep it disabled and update the tests instead, since we already discussed disabling all FrameworkBundle features by default for 3.0 (#13703).
