### PR TITLE
[Form] Improve triggering of the setDefaultOptions deprecation error

### DIFF
--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -206,9 +206,12 @@ class ResolvedFormType implements ResolvedFormTypeInterface
             $this->innerType->setDefaultOptions($this->optionsResolver);
 
             $reflector = new \ReflectionMethod($this->innerType, 'setDefaultOptions');
-            $isOverwritten = ($reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType');
+            $isOldOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType';
 
-            if (true === $isOverwritten) {
+            $reflector = new \ReflectionMethod($this->innerType, 'configureOptions');
+            $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType';
+
+            if ($isOldOverwritten && !$isNewOverwritten) {
                 trigger_error('The FormTypeInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeInterface with Symfony 3.0.', E_USER_DEPRECATED);
             }
 
@@ -216,9 +219,12 @@ class ResolvedFormType implements ResolvedFormTypeInterface
                 $extension->setDefaultOptions($this->optionsResolver);
 
                 $reflector = new \ReflectionMethod($extension, 'setDefaultOptions');
-                $isOverwritten = ($reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension');
+                $isOldOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension';
 
-                if (true === $isOverwritten) {
+                $reflector = new \ReflectionMethod($extension, 'configureOptions');
+                $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension';
+
+                if ($isOldOverwritten && !$isNewOverwritten) {
                     trigger_error('The FormTypeExtensionInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeExtensionInterface with Symfony 3.0.', E_USER_DEPRECATED);
                 }
             }


### PR DESCRIPTION
Bundles wanting to support both Sf 2.3 and Sf 2.7 (which is a common requirement as both have at least 2 more years of maintaince) would have custom form types with both option methods defined (`setDefaultOptions` for <2.7 support and `configureOptions` for >2.7,>3.0 support). In such case, I don't think there is anything wrong with the code and a deprecation error shouldn't be triggered.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
