### PR TITLE
[Serializer] Added normalizeName method to AbstractNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -200,6 +200,30 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
     }
 
     /**
+     * Converts a value for denormalization. If no name converter is set, the plain value is returned
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function denormalizeName($name)
+    {
+        return $this->nameConverter ? $this->nameConverter->denormalize($name) : $name;
+    }
+
+    /**
+     * Converts a value for normalization. If no name converter is set, the plain value is returned
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function normalizeName($name)
+    {
+        return $this->nameConverter ? $this->nameConverter->normalize($name) : $name;
+    }
+
+    /**
      * Format an attribute name, for example to convert a snake_case name to camelCase.
      *
      * @deprecated Deprecated since version 2.7, to be removed in 3.0. Use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter instead.

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -79,9 +79,7 @@ class GetSetMethodNormalizer extends AbstractNormalizer
                     $attributeValue = $this->serializer->normalize($attributeValue, $format, $context);
                 }
 
-                if ($this->nameConverter) {
-                    $attributeName = $this->nameConverter->normalize($attributeName);
-                }
+                $attributeName = $this->normalizeName($attributeName);
 
                 $attributes[$attributeName] = $attributeValue;
             }

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -58,7 +58,7 @@ class PropertyNormalizer extends AbstractNormalizer
             }
 
             // Override visibility
-            if (! $property->isPublic()) {
+            if (!$property->isPublic()) {
                 $property->setAccessible(true);
             }
 
@@ -71,10 +71,7 @@ class PropertyNormalizer extends AbstractNormalizer
                 $attributeValue = $this->serializer->normalize($attributeValue, $format, $context);
             }
 
-            $propertyName = $property->name;
-            if ($this->nameConverter) {
-                $propertyName = $this->nameConverter->normalize($propertyName);
-            }
+            $propertyName = $this->normalizeName($property->name);
 
             $attributes[$propertyName] = $attributeValue;
         }
@@ -96,9 +93,7 @@ class PropertyNormalizer extends AbstractNormalizer
         $object = $this->instantiateObject($data, $class, $context, $reflectionClass, $allowedAttributes);
 
         foreach ($data as $propertyName => $value) {
-            if ($this->nameConverter) {
-                $propertyName = $this->nameConverter->denormalize($propertyName);
-            }
+            $propertyName = $this->denormalizeName($propertyName);
 
             $allowed = $allowedAttributes === false || in_array($propertyName, $allowedAttributes);
             $ignored = in_array($propertyName, $this->ignoredAttributes);
@@ -106,7 +101,7 @@ class PropertyNormalizer extends AbstractNormalizer
                 $property = $reflectionClass->getProperty($propertyName);
 
                 // Override visibility
-                if (! $property->isPublic()) {
+                if (!$property->isPublic()) {
                     $property->setAccessible(true);
                 }
 
@@ -146,7 +141,7 @@ class PropertyNormalizer extends AbstractNormalizer
 
         // We look for at least one non-static property
         foreach ($class->getProperties() as $property) {
-            if (! $property->isStatic()) {
+            if (!$property->isStatic()) {
                 return true;
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This moves the logic of preparing an attribute name for normalization to its own method.
