### PR TITLE
[Twig] bootstrap_3_layout.html.twig is traitable

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -1,4 +1,4 @@
-{% extends "form_div_layout.html.twig" %}
+{% use "form_div_layout.html.twig" %}
 
 {# Widgets #}
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #13639 |
| License | MIT |

bootstrap_3_layout.html.twig is now traitable in the same way as form_table_layout.html.twig
