### PR TITLE
[Serializer] Test that normalizers ignore non-existing attributes.

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -429,7 +429,10 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 
     public function testDenormalizeNonExistingAttribute()
     {
-        $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\PropertyDummy');
+        $this->assertEquals(
+            new PropertyDummy(),
+            $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\PropertyDummy')
+        );
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -426,6 +426,11 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
     }
+
+    public function testDenormalizeNonExistingAttribute()
+    {
+        $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\PropertyDummy');
+    }
 }
 
 class GetSetDummy

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -336,7 +336,10 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
 
     public function testDenormalizeNonExistingAttribute()
     {
-        $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\PropertyDummy');
+        $this->assertEquals(
+            new PropertyDummy(),
+            $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\PropertyDummy')
+        );
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -333,6 +333,11 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
         $expected = array('me' => 'Symfony\Component\Serializer\Tests\Fixtures\PropertyCircularReferenceDummy');
         $this->assertEquals($expected, $this->normalizer->normalize($obj));
     }
+
+    public function testDenormalizeNonExistingAttribute()
+    {
+        $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\PropertyDummy');
+    }
 }
 
 class PropertyDummy


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Test the behavior of normalizers when an attribute doesn't exist.
