### PR TITLE
Finder Class attributes visibility

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -85,6 +85,18 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Get lookup directories
+     *
+     * @return array List of directories
+     *
+     * @api
+     */
+    public static function getDirs()
+    {
+        return $this->dirs;
+    }
+
+    /**
      * Creates a new Finder.
      *
      * @return Finder A new Finder instance


### PR DESCRIPTION
This PR is not meant to be merged now, but isn't it having class attributes `protected` instead of `private` better. At least we should have some getter to retrieve attributes. In my case i want to retrieve the `$dirs` attribute and its private!
