### PR TITLE
[Process] prefix should not be escaped

### DIFF
--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -67,7 +67,7 @@ class ProcessBuilder
     }
 
     /**
-     * Adds an unescaped prefix to the command string.
+     * Adds a prefix to the command string.
      *
      * The prefix is preserved when resetting arguments.
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12826 |
| License | MIT |
| Doc PR | - |

The phpdoc of `ProcessBuilder#setPrefix` says:

```
Adds an unescaped prefix to the command string.
```

But in the current implementation, the prefix is merged with arguments array and then is escaped which seems wrong.
