### PR TITLE
[PropertyAccess] stop overwriting once a reference is reached (3rd)

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -70,7 +70,6 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         $propertyValues = & $this->readPropertiesUntil($objectOrArray, $propertyPath, $propertyPath->getLength() - 1);
-        $overwrite = true;
 
         // Add the root object to the list
         array_unshift($propertyValues, array(
@@ -81,16 +80,16 @@ class PropertyAccessor implements PropertyAccessorInterface
         for ($i = count($propertyValues) - 1; $i >= 0; --$i) {
             $objectOrArray = & $propertyValues[$i][self::VALUE];
 
-            if ($overwrite) {
-                $property = $propertyPath->getElement($i);
+            $property = $propertyPath->getElement($i);
 
-                if ($propertyPath->isIndex($i)) {
-                    $this->writeIndex($objectOrArray, $property, $value);
-                } else {
-                    $this->writeProperty($objectOrArray, $property, $value);
-                }
+            if ($propertyPath->isIndex($i)) {
+                $this->writeIndex($objectOrArray, $property, $value);
+            } else {
+                $this->writeProperty($objectOrArray, $property, $value);
+            }
 
-                $overwrite = !$propertyValues[$i][self::IS_REF];
+            if ($propertyValues[$i][self::IS_REF]) {
+                return;
             }
 
             $value = & $objectOrArray;
@@ -128,7 +127,6 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         try {
             $propertyValues = $this->readPropertiesUntil($objectOrArray, $propertyPath, $propertyPath->getLength() - 1);
-            $overwrite = true;
 
             // Add the root object to the list
             array_unshift($propertyValues, array(
@@ -139,20 +137,20 @@ class PropertyAccessor implements PropertyAccessorInterface
             for ($i = count($propertyValues) - 1; $i >= 0; --$i) {
                 $objectOrArray = $propertyValues[$i][self::VALUE];
 
-                if ($overwrite) {
-                    $property = $propertyPath->getElement($i);
+                $property = $propertyPath->getElement($i);
 
-                    if ($propertyPath->isIndex($i)) {
-                        if (!$objectOrArray instanceof \ArrayAccess && !is_array($objectOrArray)) {
-                            return false;
-                        }
-                    } else {
-                        if (!$this->isPropertyWritable($objectOrArray, $property)) {
-                            return false;
-                        }
+                if ($propertyPath->isIndex($i)) {
+                    if (!$objectOrArray instanceof \ArrayAccess && !is_array($objectOrArray)) {
+                        return false;
                     }
+                } else {
+                    if (!$this->isPropertyWritable($objectOrArray, $property)) {
+                        return false;
+                    }
+                }
 
-                    $overwrite = !$propertyValues[$i][self::IS_REF];
+                if ($propertyValues[$i][self::IS_REF]) {
+                    return true;
                 }
             }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -89,10 +89,11 @@ class PropertyAccessor implements PropertyAccessorInterface
                 } else {
                     $this->writeProperty($objectOrArray, $property, $value);
                 }
+
+                $overwrite = !$propertyValues[$i][self::IS_REF];
             }
 
             $value = & $objectOrArray;
-            $overwrite = !$propertyValues[$i][self::IS_REF];
         }
     }
 
@@ -150,9 +151,9 @@ class PropertyAccessor implements PropertyAccessorInterface
                             return false;
                         }
                     }
-                }
 
-                $overwrite = !$propertyValues[$i][self::IS_REF];
+                    $overwrite = !$propertyValues[$i][self::IS_REF];
+                }
             }
 
             return true;

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
@@ -169,7 +169,8 @@ class TestClass
         return 'foobar';
     }
 
-    public function getPublicGetter() {
+    public function getPublicGetter()
+    {
         return $this->publicGetter;
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
@@ -25,6 +25,7 @@ class TestClass
     private $publicAccessorWithMoreRequiredParameters;
     private $publicIsAccessor;
     private $publicHasAccessor;
+    private $publicGetter;
 
     public function __construct($value)
     {
@@ -37,6 +38,7 @@ class TestClass
         $this->publicAccessorWithMoreRequiredParameters = $value;
         $this->publicIsAccessor = $value;
         $this->publicHasAccessor = $value;
+        $this->publicGetter = $value;
     }
 
     public function setPublicAccessor($value)
@@ -165,5 +167,9 @@ class TestClass
     private function hasPrivateHasAccessor()
     {
         return 'foobar';
+    }
+
+    public function getPublicGetter() {
+        return $this->publicGetter;
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -430,4 +430,12 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('foobar', $object->getProperty());
     }
+
+    public function testPublicGetter()
+    {
+        $this->propertyAccessor = new PropertyAccessor(true);
+
+        $this->assertTrue($this->propertyAccessor->isReadable(new TestClass('foo'), 'publicGetter'));
+        $this->assertEquals('foo', $this->propertyAccessor->getValue(new TestClass('foo'), 'publicGetter'));
+    }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -419,6 +419,14 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
             array(array('index' => array('%!@$§.' => 'Bernhard')), '[index][%!@$§.]', 'Bernhard'),
             array((object) array('%!@$§' => 'Bernhard'), '%!@$§', 'Bernhard'),
             array((object) array('property' => (object) array('%!@$§' => 'Bernhard')), 'property.%!@$§', 'Bernhard'),
+
+            // nested objects and arrays
+            array(array('foo' => new TestClass('bar')), '[foo].publicGetSetter', 'bar'),
+            array(new TestClass(array('foo' => 'bar')), 'publicGetSetter[foo]', 'bar'),
+            array(new TestClass(new TestClass('bar')), 'publicGetter.publicGetSetter', 'bar'),
+            array(new TestClass(array('foo' => new TestClass('bar'))), 'publicGetter[foo].publicGetSetter', 'bar'),
+            array(new TestClass(new TestClass(new TestClass('bar'))), 'publicGetter.publicGetter.publicGetSetter', 'bar'),
+            array(new TestClass(array('foo' => array('baz' => new TestClass('bar')))), 'publicGetter[foo][baz].publicGetSetter', 'bar'),
         );
     }
 
@@ -429,13 +437,5 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->propertyAccessor->setValue($object, 'property', 'foobar');
 
         $this->assertEquals('foobar', $object->getProperty());
-    }
-
-    public function testPublicGetter()
-    {
-        $this->propertyAccessor = new PropertyAccessor(true);
-
-        $this->assertTrue($this->propertyAccessor->isReadable(new TestClass('foo'), 'publicGetter'));
-        $this->assertEquals('foo', $this->propertyAccessor->getValue(new TestClass('foo'), 'publicGetter'));
     }
 }


### PR DESCRIPTION
I commited with a different email address in [PR 13831](https://github.com/symfony/symfony/pull/13831), so here is the third attempt. Also removed unnecessary test as suggested by @Tobion 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [13731](https://github.com/symfony/symfony/issues/13731) |
| License | MIT |
| Doc PR | none |

I added test cases for the scenario described in my issue. After looking through the PropertyAccessor source my conclusion was that there is no reason to overwrite parents of references, so I changed that. None of the previous test cases disagreed and my new tests also passed.

Or maybe I got it all wrong, I'm willing to learn.
