### PR TITLE
[WebProfilerBundle] Update ajax calls in toolbar to add the css error class

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -90,6 +90,9 @@
                             rows.appendChild(row);
 
                             var methodCell = document.createElement('td');
+                            if (request.error) {
+                                methodCell.className = 'sf-ajax-request-error';
+                            }
                             methodCell.textContent = request.method;
                             row.appendChild(methodCell);
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -315,7 +315,7 @@
     text-align: right;
 }
 .sf-ajax-request-error {
-    color: #a33;
+    color: #a33 !important;
 }
 .sf-ajax-request-loading {
     -webkit-animation: sf-blink .5s ease-in-out infinite;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Minor change to improve the toolbar usability. The request method is red when an error response is received:

![toolbar ajax error](https://cloud.githubusercontent.com/assets/195745/6475331/2b390a26-c209-11e4-8dee-ef2e973b57c0.png)
