### PR TITLE
[travis] Test with local components instead of waiting for the subtree-splitter when possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ phpunit.xml
 composer.lock
 composer.phar
 autoload.php
+package*.tar
+packages.json
 /vendor/

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,25 @@
+branch=$1
+if [ -z "$branch" ]; then
+    echo 'Usage: branch dir1 dir2 ... dirN'
+    exit 1
+fi
+shift
+components=$*
+if [ -z "$components" ]; then
+    echo 'Usage: branch dir1 dir2 ... dirN'
+    exit 1
+fi
+echo '{"packages": {' > packages.json
+components=$(
+    for c in $components; do
+        sed -i ':a;N;$!ba;s#^{\n\(\s*\)\("name"\)#{\n\1"repositories": \[{ "type": "composer", "url": "file://'$(pwd)'/" }\],\n\1\2#' $c/composer.json
+        n=$(php -r '$n=json_decode(file_get_contents("'$c'/composer.json"));echo $n->name;')
+        echo '"'$n'": {"'$branch'.x-dev": ' >> packages.json
+        cat $c/composer.json >> packages.json
+        echo '"version": "'$branch.x-dev'",\n    "dist": {"type": "tar", "url": "file://'$(pwd)/$c'/package'$branch'.tar"}\n}},' >> packages.json
+        echo $c
+    done;
+)
+sed -i ':a;N;$!ba;s/\n}\n"/,\n    "/g' packages.json
+sed -i ':a;N;$!ba;s/}},$/\n}}\n}}/' packages.json
+echo "$components" | parallel --gnu "cd {}; tar -cf package$branch.tar --exclude='package*.tar' *"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,10 @@ before_install:
 
 install:
     - if [ "$deps" = "no" ]; then composer --prefer-source install; fi;
+    - components=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n')
+    - if [ "$deps" != "no" ]; then sh .travis.sh $TRAVIS_BRANCH $components; fi;
 
 script:
-    - components=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n')
     - if [ "$deps" = "no" ]; then echo "$components" | parallel --gnu --keep-order 'echo -e "\\nRunning {} tests"; phpunit --exclude-group tty,benchmark,intl-data {} || (echo -e "\\e[41mKO\\e[0m {}" && $(exit 1));'; fi;
     - if [ "$deps" = "no" ]; then echo -e "\\nRunning tests requiring tty"; phpunit --group tty || (echo -e "\\e[41mKO\\e[0m tty group" && $(exit 1)); fi;
     - if [ "$deps" = "high" ]; then echo "$components" | parallel --gnu --keep-order -j25% 'echo -e "\\nRunning {} tests"; cd {}; composer --prefer-source update; phpunit --exclude-group tty,benchmark,intl-data,legacy || (echo -e "\\e[41mKO\\e[0m {}" && $(exit 1));'; fi;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Should be ready - a first step that allows testing PR with the proposed patch. Works only when deps are resolved to the same branch. But this opens the way for further improvements.
