### PR TITLE
[PhpUnitBridge] ease bootstrapping the PhpUnitBridge

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/PhpUnitBridge.php
+++ b/src/Symfony/Bridge/PhpUnit/PhpUnitBridge.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+/**
+ * Bootstrap class for the PhpUnitBridge.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+final class PhpUnitBridge
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Returns the actual path to the bootstrap file.
+     *
+     * @return string
+     */
+    public static function getBootstrapFilePath()
+    {
+        return __DIR__.'/bootstrap.php';
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/README.md
+++ b/src/Symfony/Bridge/PhpUnit/README.md
@@ -39,6 +39,9 @@ Add this bridge to the `require-dev` section of your composer.json file
 (not in `require`) with e.g.
 `composer require --dev "symfony/phpunit-bridge"`.
 
+Make sure that the `bootstrap.php` file is loaded. You can use the `PhpUnitBridge::getBootstrapFilePath()`
+method to obtain the actual file path depending on your environment.
+
 When running `phpunit`, you will see a summary of deprecation notices at the end
 of the test suite.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13805 |
| License | MIT |
| Doc PR | TODO |

The actual path to the `bootstrap.php` file from the PhpUnitBridge
differs depending on the package the user installed (`symfony/symfony`
vs. `symfony/phpunit-bridge`).

To bootstrap the bridge, you would have to do something like this:

``` php
$bootstrapLocations = array(
    __DIR__.'vendor/symfony/symfony/src/Symfony/Bridge/PhpUnit/bootstrap.php',
    __DIR__.'vendor/symfony/phpunit-bridge/bootstrap.php',
);

foreach ($bootstrapLocations as $path) {
    if (file_exists($path)) {
        require_once $path;
        break;
    }
}
```

Now, the same can be achieved with one method call:

``` php
use Symfony\Bridge\PhpUnit\PhpUnitBridge;

require_once PhpUnitBridge::bgetBootstrapFilePath();
```

ping @WouterJ @nicolas-grekas 
