### PR TITLE
Read validation contraints from Resources/config/validation/ sub-dir

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -792,6 +792,17 @@ class FrameworkExtension extends Extension
                 $files[1][] = realpath($file);
                 $container->addResource(new FileResource($file));
             }
+
+            if (is_dir($dir = $dirname.'/Resources/config/validation')) {
+                foreach (Finder::create()->files()->in($dir)->name('*.xml') as $file) {
+                    $files[0][] = $file->getRealpath();
+                }
+                foreach (Finder::create()->files()->in($dir)->name('*.yml') as $file) {
+                    $files[1][] = $file->getRealpath();
+                }
+
+                $container->addResource(new DirectoryResource($dir));
+            }
         }
 
         return $files;


### PR DESCRIPTION
When a bundle contains many entities/documents and it uses YAML or XML format instead of annotations, it is convenient to split the validation constraints into several small files. 

With this simple PR, every files in the `validation` sub-directory will be loaded by the validator like it's done for doctrine mapping.

```
Resources/
    config/
        doctrine/
            Author.orm.yml
            Post.orm.yml
        validation/
            Author.yml
            Post.yml
```

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [How to split validation yaml files](http://stackoverflow.com/questions/24064813/how-to-split-validation-yaml-files-in-symfony-2-5/24210501#24210501) |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/5060 |

Read more: http://blog.kevingomez.fr/2013/10/14/split-symfony2-yaml-validation-configuration-file/
