### PR TITLE
[ChoiceValidator] Fix can't validate against an empty choices array & only allow array in choices option

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -32,8 +32,12 @@ class ChoiceValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!$constraint->choices && !$constraint->callback) {
+        if (in_array($constraint->choices, array(null, false), true) && !$constraint->callback) {
             throw new ConstraintDefinitionException('Either "choices" or "callback" must be specified on constraint Choice');
+        }
+
+        if (!$constraint->callback && !is_array($constraint->choices)) {
+            throw new UnexpectedTypeException($constraint->choices, 'array');
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -270,4 +270,54 @@ class ChoiceValidatorTest extends AbstractConstraintValidatorTest
             ->setParameter('{{ value }}', '"3"')
             ->assertRaised();
     }
+
+    public function testValidEmptyChoiceArray()
+    {
+        $constraint = new Choice(array(
+            'choices' => array(),
+        ));
+
+        $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidEmptyChoiceArrayWithMultipleChoices()
+    {
+        $constraint = new Choice(array(
+            'choices' => array(),
+            'multiple' => true,
+        ));
+
+        $this->validator->validate(array(), $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidChoiceMultipleWithEmptyChoiceArray()
+    {
+        $constraint = new Choice(array(
+            'choices' => array(),
+            'multipleMessage' => 'myMessage',
+            'multiple' => true,
+        ));
+
+        $this->validator->validate(array('foo'), $constraint);
+
+        $this->buildViolation('myMessage')
+             ->setParameter('{{ value }}', '"foo"')
+             ->assertRaised();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
+    public function testExpectArrayForChoicesOption()
+    {
+        $constraint = new Choice(array(
+            'choices' => 'foo',
+        ));
+
+        $this->validator->validate('foo', $constraint);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13853 |
| License | MIT |

The Choice constraint now accepts empty choices array (previously sending a `ConstraintDefinitionException`) :

``` php
new Choice(array(
    'choices' =>  array(),
    'multiple' => true
))
```

and will only allow arrays, otherwise an `UnexpectedTypeException` is thrown.  BC break as this exception wasn't thrown before (But the behavior when anything but an array is passed wasn't intended and triggered a warning).
