### PR TITLE
[2.3] [Config] [Console] [DependencyInjection] [DomCrawler] [Form] [HttpKernel] [PropertyAccess] [Security] [Translation] [Yaml] static code analysis, code cleanup

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -480,7 +480,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
                 );
             }
 
-            if (null !== $this->key && (null === $this->addDefaultChildren || is_integer($this->addDefaultChildren) && $this->addDefaultChildren > 0)) {
+            if (null !== $this->key && (null === $this->addDefaultChildren || is_int($this->addDefaultChildren) && $this->addDefaultChildren > 0)) {
                 throw new InvalidDefinitionException(
                     sprintf('->addDefaultChildrenIfNoneSet() should set default children names as ->useAttributeAsKey() is used at path "%s"', $path)
                 );

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -131,7 +131,7 @@ class PrototypedArrayNode extends ArrayNode
         if (null === $children) {
             $this->defaultChildren = array('defaults');
         } else {
-            $this->defaultChildren = is_integer($children) && $children > 0 ? range(1, $children) : (array) $children;
+            $this->defaultChildren = is_int($children) && $children > 0 ? range(1, $children) : (array) $children;
         }
     }
 

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -215,7 +215,7 @@ class XmlUtils
                 LIBXML_ERR_WARNING == $error->level ? 'WARNING' : 'ERROR',
                 $error->code,
                 trim($error->message),
-                $error->file ? $error->file : 'n/a',
+                $error->file ?: 'n/a',
                 $error->line,
                 $error->column
             );

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -149,7 +149,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
             ));
         }
 
-        if (false === array_search(static::$availableOptions[$option], $this->options)) {
+        if (!in_array(static::$availableOptions[$option], $this->options)) {
             $this->options[] = static::$availableOptions[$option];
         }
     }

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -159,7 +159,7 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
     protected function getInputStream($input)
     {
         $stream = fopen('php://memory', 'r+', false);
-        fputs($stream, $input);
+        fwrite($stream, $input);
         rewind($stream);
 
         return $stream;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1087,7 +1087,7 @@ EOF;
                     $behavior[$id] = $argument->getInvalidBehavior();
                 }
 
-                $calls[$id] += 1;
+                ++$calls[$id];
             }
         }
     }
@@ -1345,12 +1345,12 @@ EOF;
             }
 
             while ($i > 0) {
-                $i -= 1;
+                --$i;
                 $name .= $nonFirstChars[$i%$nonFirstCharsLength];
                 $i = intval($i/$nonFirstCharsLength);
             }
 
-            $this->variableCount += 1;
+            ++$this->variableCount;
 
             // check that the name is not reserved
             if (in_array($name, $this->reservedVariables, true)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -259,7 +259,8 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $builder->setResourceTracking(false);
         $builderCompilerPasses = $builder->getCompiler()->getPassConfig()->getPasses();
         $builder->addCompilerPass($this->getMock('Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface'));
-        $this->assertEquals(sizeof($builderCompilerPasses) + 1, sizeof($builder->getCompiler()->getPassConfig()->getPasses()));
+
+        $this->assertCount(count($builder->getCompiler()->getPassConfig()->getPasses()) - 1, $builderCompilerPasses);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -89,8 +89,8 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
 
         $container = new ContainerBuilder();
         $container->setDefinition('test', $definition);
-        $container->setParameter('foo', 'wiz'.dirname(dirname(__FILE__)));
-        $container->setParameter('bar', dirname(__FILE__));
+        $container->setParameter('foo', 'wiz'.dirname(__DIR__));
+        $container->setParameter('bar', __DIR__);
         $container->setParameter('baz', '%bar%/PhpDumperTest.php');
         $container->setParameter('buz', dirname(dirname(__DIR__)));
         $container->compile();

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -316,7 +316,7 @@ EOF
     {
         $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');
         $nodes = $crawler->reduce(function ($node, $i) {
-            return $i == 1 ? false : true;
+            return $i !== 1;
         });
         $this->assertNotSame($nodes, $crawler, '->reduce() returns a new instance of a crawler');
         $this->assertInstanceOf('Symfony\\Component\\DomCrawler\\Crawler', $nodes, '->reduce() returns a new instance of a crawler');

--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -67,8 +67,7 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
         // Unset instead of resetting to an empty array, in order to allow
         // implementations (like TwigRendererEngine) to check whether $cacheKey
         // is set at all.
-        unset($this->resources[$cacheKey]);
-        unset($this->resourceHierarchyLevels[$cacheKey]);
+        unset($this->resources[$cacheKey], $this->resourceHierarchyLevels[$cacheKey]);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -138,8 +138,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
             throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
-        unset($this->unresolvedChildren[$name]);
-        unset($this->children[$name]);
+        unset($this->unresolvedChildren[$name], $this->children[$name]);
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -279,8 +279,7 @@ class FormRenderer implements FormRendererInterface
         // Clear the caches if they were filled for the first time within
         // this function call
         if ($hierarchyInit) {
-            unset($this->blockNameHierarchyMap[$viewAndSuffixCacheKey]);
-            unset($this->hierarchyLevelMap[$viewAndSuffixCacheKey]);
+            unset($this->blockNameHierarchyMap[$viewAndSuffixCacheKey], $this->hierarchyLevelMap[$viewAndSuffixCacheKey]);
         }
 
         if ($varInit) {

--- a/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
@@ -54,7 +54,7 @@ abstract class FormPerformanceTestCase extends FormIntegrationTestCase
      */
     public function setMaxRunningTime($maxRunningTime)
     {
-        if (is_integer($maxRunningTime) && $maxRunningTime >= 0) {
+        if (is_int($maxRunningTime) && $maxRunningTime >= 0) {
             $this->maxRunningTime = $maxRunningTime;
         } else {
             throw new \InvalidArgumentException();

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -107,8 +107,7 @@ class RouterListener implements EventSubscriberInterface
             }
 
             $request->attributes->add($parameters);
-            unset($parameters['_route']);
-            unset($parameters['_controller']);
+            unset($parameters['_route'], $parameters['_controller']);
             $request->attributes->set('_route_params', $parameters);
         } catch (ResourceNotFoundException $e) {
             $message = sprintf('No route found for "%s %s"', $request->getMethod(), $request->getPathInfo());

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -32,7 +32,7 @@ class LoggerDataCollectorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('logger', $c->getName());
         $this->assertSame($nb, $c->countErrors());
-        $this->assertSame($expectedLogs ? $expectedLogs : $logs, $c->getLogs());
+        $this->assertSame($expectedLogs ?: $logs, $c->getLogs());
         $this->assertSame($expectedDeprecationCount, $c->countDeprecations());
     }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -264,8 +264,7 @@ class PropertyPathBuilder
 
             // All remaining elements should be removed
             for (; $i < $length; ++$i) {
-                unset($this->elements[$i]);
-                unset($this->isIndex[$i]);
+                unset($this->elements[$i], $this->isIndex[$i]);
             }
         } else {
             $diff = $insertionLength - $cutLength;

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -173,7 +173,8 @@ class AclProvider implements AclProviderInterface
             }
 
             // Is it time to load the current batch?
-            if ((self::MAX_BATCH_SIZE === count($currentBatch) || ($i + 1) === $c) && count($currentBatch) > 0) {
+            $currentBatchesCount = count($currentBatch);
+            if ($currentBatchesCount > 0 && (self::MAX_BATCH_SIZE === $currentBatchesCount || ($i + 1) === $c)) {
                 try {
                     $loadedBatch = $this->lookupObjectIdentities($currentBatch, $sids, $oidLookup);
                 } catch (AclNotFoundException $aclNotFoundexception) {
@@ -557,10 +558,11 @@ QUERY;
                 // attach ACL to the result set; even though we do not enforce that every
                 // object identity has only one instance, we must make sure to maintain
                 // referential equality with the oids passed to findAcls()
-                if (!isset($oidCache[$objectIdentifier.$classType])) {
-                    $oidCache[$objectIdentifier.$classType] = $acl->getObjectIdentity();
+                $oidCacheKey = $objectIdentifier.$classType;
+                if (!isset($oidCache[$oidCacheKey])) {
+                    $oidCache[$oidCacheKey] = $acl->getObjectIdentity();
                 }
-                $result->attach($oidCache[$objectIdentifier.$classType], $acl);
+                $result->attach($oidCache[$oidCacheKey], $acl);
             // so, this hasn't been hydrated yet
             } else {
                 // create object identity if we haven't done so yet
@@ -668,7 +670,7 @@ QUERY;
             // let's see if we have already hydrated this
             if (isset($acls[$parentId])) {
                 $aclParentAclProperty->setValue($acl, $acls[$parentId]);
-                $processed += 1;
+                ++$processed;
 
                 continue;
             }

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderBenchmarkTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderBenchmarkTest.php
@@ -122,7 +122,7 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
 
         if ($id === 1000 || ($id < 1500 && rand(0, 1))) {
             $this->insertClassStmt->execute(array($id, $this->getRandomString(rand(20, 100), 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\\_')));
-            $id += 1;
+            ++$id;
 
             return $id-1;
         } else {
@@ -148,7 +148,7 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->generateAces($classId, $id);
-        $id += 1;
+        ++$id;
 
         return $id-1;
     }
@@ -163,7 +163,7 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
                 $this->getRandomString(rand(5, 30)),
                 rand(0, 1),
             ));
-            $id += 1;
+            ++$id;
 
             return $id-1;
         } else {
@@ -215,7 +215,7 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
                 rand(0, 1),
             ));
 
-            $id += 1;
+            ++$id;
         }
     }
 

--- a/src/Symfony/Component/Security/Tests/Core/Util/SecureRandomTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Util/SecureRandomTest.php
@@ -41,7 +41,7 @@ class SecureRandomTest extends \PHPUnit_Framework_TestCase
 
         for ($j = 1; $j <= 5000; $j++) {
             $k = 4 * $j - 1;
-            $c[8 * $b[$k - 3] + 4 * $b[$k - 2] + 2 * $b[$k - 1] + $b[$k]] += 1;
+            ++$c[8 * $b[$k - 3] + 4 * $b[$k - 2] + 2 * $b[$k - 1] + $b[$k]];
         }
 
         $f = 0;
@@ -73,14 +73,14 @@ class SecureRandomTest extends \PHPUnit_Framework_TestCase
                 $run = 6;
             }
 
-            $runs[$run] += 1;
+            ++$runs[$run];
         };
 
         $currentRun = 0;
         $lastBit = null;
         for ($i = 0; $i < 20000; $i++) {
             if ($lastBit === $b[$i]) {
-                $currentRun += 1;
+                ++$currentRun;
             } else {
                 if ($currentRun > 0) {
                     $addRun($currentRun);
@@ -115,7 +115,7 @@ class SecureRandomTest extends \PHPUnit_Framework_TestCase
         $lastBit = null;
         for ($i = 0; $i < 20000; $i++) {
             if ($lastBit === $b[$i]) {
-                $currentRun += 1;
+                ++$currentRun;
             } else {
                 if ($currentRun > $longestRun) {
                     $longestRun = $currentRun;

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/ExceptionListenerTest.php
@@ -177,9 +177,9 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
     private function createExceptionListener(SecurityContextInterface $context = null, AuthenticationTrustResolverInterface $trustResolver = null, HttpUtils $httpUtils = null, AuthenticationEntryPointInterface $authenticationEntryPoint = null, $errorPage = null, AccessDeniedHandlerInterface $accessDeniedHandler = null)
     {
         return new ExceptionListener(
-            $context ? $context : $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface'),
-            $trustResolver ? $trustResolver : $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface'),
-            $httpUtils ? $httpUtils : $this->getMock('Symfony\Component\Security\Http\HttpUtils'),
+            $context ?: $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface'),
+            $trustResolver ?: $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface'),
+            $httpUtils ?: $this->getMock('Symfony\Component\Security\Http\HttpUtils'),
             'key',
             $authenticationEntryPoint,
             $errorPage,

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -137,7 +137,7 @@ class XliffFileLoader implements LoaderInterface
                 LIBXML_ERR_WARNING == $error->level ? 'WARNING' : 'ERROR',
                 $error->code,
                 trim($error->message),
-                $error->file ? $error->file : 'n/a',
+                $error->file ?: 'n/a',
                 $error->line,
                 $error->column
             );

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -273,7 +273,7 @@ class Inline
     {
         $output = array();
         $len = strlen($sequence);
-        $i += 1;
+        ++$i;
 
         // [foo, bar, ...]
         while ($i < $len) {
@@ -332,7 +332,7 @@ class Inline
     {
         $output = array();
         $len = strlen($mapping);
-        $i += 1;
+        ++$i;
 
         // {foo: bar, bar:foo, ...}
         while ($i < $len) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Split <a href="https://github.com/symfony/symfony/pull/13813">PR 13813</a>: part 1 - targeting v2.3

Following is included (no functional changes, found with <a href="https://plugins.jetbrains.com/plugin/7622?pr=phpStorm">Php Inspections (EA Extended)</a>):
- Fixed couple of concatenation as array index warnings
- Unset calls can be merged inspection fixes
- array_search in in_array context inspection fixes
- Is null usage inspection fixes
- Prefixed increment/decrement inspection fixes
- Elvis operator can be used inspection fixes
- Alias functions usage inspection fixes
- Ternary operator simplification inspection fixes
- _ _ DIR _ _ equivalent inspection fixes
