### PR TITLE
[2.6]  [Console] [OptionsResolver] static code analysis, code cleanup

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -208,7 +208,7 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
     protected function getInputStream($input)
     {
         $stream = fopen('php://memory', 'r+', false);
-        fputs($stream, $input);
+        fwrite($stream, $input);
         rewind($stream);
 
         return $stream;

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -657,14 +657,8 @@ class OptionsResolver implements Options, OptionsResolverInterface
         }
 
         foreach ((array) $optionNames as $option) {
-            unset($this->defined[$option]);
-            unset($this->defaults[$option]);
-            unset($this->required[$option]);
-            unset($this->resolved[$option]);
-            unset($this->lazy[$option]);
-            unset($this->normalizers[$option]);
-            unset($this->allowedTypes[$option]);
-            unset($this->allowedValues[$option]);
+            unset($this->defined[$option], $this->defaults[$option], $this->required[$option], $this->resolved[$option]);
+            unset($this->lazy[$option], $this->normalizers[$option], $this->allowedTypes[$option], $this->allowedValues[$option]);
         }
 
         return $this;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Split <a href="https://github.com/symfony/symfony/pull/13813">PR 13813</a>: part 2 - targeting v2.6

Following is included (no functional changes, found with <a href="https://plugins.jetbrains.com/plugin/7622?pr=phpStorm">Php Inspections (EA Extended)</a>):
- Unset calls can be merged inspection fixes
- Alias functions usage inspection fixes
