### PR TITLE
[Form] Update AbstractType/AbstractTypeExtension::setDefaultOptions deprecation detection

### DIFF
--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -205,20 +205,26 @@ class ResolvedFormType implements ResolvedFormTypeInterface
 
             $this->innerType->setDefaultOptions($this->optionsResolver);
 
-            $reflector = new \ReflectionMethod($this->innerType, 'setDefaultOptions');
-            $isOverwritten = ($reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType');
+            $setDefaultOptionsReflector = new \ReflectionMethod($this->innerType, 'setDefaultOptions');
+            $isSetDefaultOptionsOverwritten = ($setDefaultOptionsReflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType');
 
-            if (true === $isOverwritten) {
+            $configureOptionsReflector = new \ReflectionMethod($this->innerType, 'configureOptions');
+            $isConfigureOptionsOverwritten = ($configureOptionsReflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType');
+
+            if ($isSetDefaultOptionsOverwritten && !$isConfigureOptionsOverwritten) {
                 trigger_error('The FormTypeInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeInterface with Symfony 3.0.', E_USER_DEPRECATED);
             }
 
             foreach ($this->typeExtensions as $extension) {
                 $extension->setDefaultOptions($this->optionsResolver);
 
-                $reflector = new \ReflectionMethod($extension, 'setDefaultOptions');
-                $isOverwritten = ($reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension');
+                $setDefaultOptionsReflector = new \ReflectionMethod($extension, 'setDefaultOptions');
+                $isSetDefaultOptionsOverwritten = ($setDefaultOptionsReflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension');
 
-                if (true === $isOverwritten) {
+                $configureOptionsReflector = new \ReflectionMethod($extension, 'configureOptions');
+                $isConfigureOptionsOverwritten = ($configureOptionsReflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension');
+
+                if ($isSetDefaultOptionsOverwritten && !$isConfigureOptionsOverwritten) {
                     trigger_error('The FormTypeExtensionInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeExtensionInterface with Symfony 3.0.', E_USER_DEPRECATED);
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Hey!

I'm facing an issue when trying to fix some deprecation in one of my bundle (See egeloen/IvoryCKEditorBundle#162). The idea is to prepare the bundle for the upcoming 2.7 release but at the same time still being compatible with lower versions. Then, I introduce a BC layer in order to use the less deprecated feature as much quicky as possible in order to ease the upgrade for the 3.0 release. In the PR, I implement both (`setDefaultOptions` and `configureOptions`) but since the deprecation is based on the presence of the `setDefaultOptions`, the fact that I have implemented the `configureOptions` is ignored. So, this PR updated the code to detect if the `configureOptions` exists to trigger the deprecation.

What do you think?
