### PR TITLE
[PhpUnitBridge] do not replace but require-dev in symfony/symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
         "symfony/locale": "self.version",
         "symfony/monolog-bridge": "self.version",
         "symfony/options-resolver": "self.version",
-        "symfony/phpunit-bridge": "self.version",
         "symfony/process": "self.version",
         "symfony/property-access": "self.version",
         "symfony/proxy-manager-bridge": "self.version",
@@ -69,6 +68,7 @@
         "symfony/yaml": "self.version"
     },
     "require-dev": {
+        "symfony/phpunit-bridge": "self.version",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.2",
         "doctrine/orm": "~2.2,>=2.2.3",
@@ -80,15 +80,20 @@
         "egulias/email-validator": "~1.2"
     },
     "autoload": {
-        "psr-0": { "Symfony\\": "src/" },
+        "psr-0": {
+            "Symfony\\Bridge\\Doctrine\\": "src/",
+            "Symfony\\Bridge\\Monolog\\": "src/",
+            "Symfony\\Bridge\\ProxyManager\\": "src/",
+            "Symfony\\Bridge\\Swiftmailer\\": "src/",
+            "Symfony\\Bridge\\Twig\\": "src/",
+            "Symfony\\Bundle\\": "src/",
+            "Symfony\\Component\\": "src/"
+        },
         "classmap": [
             "src/Symfony/Component/HttpFoundation/Resources/stubs",
             "src/Symfony/Component/Intl/Resources/stubs"
         ],
         "files": [ "src/Symfony/Component/Intl/Resources/stubs/functions.php" ]
-    },
-    "autoload-dev": {
-        "files": [ "src/Symfony/Bridge/PhpUnit/bootstrap.php" ]
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13805, #13854 |
| License | MIT |
| Doc PR | - |

This splits the PhpUnit bridge from the symfony/symfony package, so that everyone are equals : everyone will now have to explicitly opt in to the bridge by adding symfony/phpunit-bridge in require-dev
