### PR TITLE
[FrameworkBundle] Added domain column when debugging translations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -139,7 +139,7 @@ EOF
         $table = new Table($output);
 
         // Display header line
-        $headers = array('State(s)', 'Id', sprintf('Message Preview (%s)', $locale));
+        $headers = array('State(s)', 'Domain', 'Id', sprintf('Message Preview (%s)', $locale));
         foreach ($fallbackCatalogues as $fallbackCatalogue) {
             $headers[] = sprintf('Fallback Message Preview (%s)', $fallbackCatalogue->getLocale());
         }
@@ -172,7 +172,7 @@ EOF
                     }
                 }
 
-                $row = array($this->formatStates($states), $this->formatId($messageId), $this->sanitizeString($value));
+                $row = array($this->formatStates($states), $domain, $this->formatId($messageId), $this->sanitizeString($value));
                 foreach ($fallbackCatalogues as $fallbackCatalogue) {
                     $row[] = $this->sanitizeString($fallbackCatalogue->get($messageId, $domain));
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | Will create if approved. |

This is my first PR. If I do anything wrong, please let me know and I'll try to fix it. 
## Possible TODO:

```
[ ] Update relevant documentation
```
## Explanation for the PR:

While editing a web application, I was changing a LOT of translation files. The debug:translation command helps a lot, but it is hard to find out in which domain the missing/unused translations are located. By adding an extra column with the name of the domain, I get more information about the translations in the table. 
## New output:

```
+----------+------------+---------------------+----------------------+
| State(s) | Domain     | Id                  | Message Preview (nl) |
+----------+------------+---------------------+----------------------+
| x        | user_admin | user.iban.incorrect | user.iban.incorrect  |
+----------+------------+---------------------+----------------------+

Legend:
 x Missing message
 o Unused message
 = Same as the fallback message
```
