### PR TITLE
[YamlLintCommand] [FrameworkBundle] Add option --exclude_dir

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -37,7 +37,7 @@ class YamlLintCommand extends Command
             ->setDescription('Lints a file and outputs encountered errors')
             ->addArgument('filename', null, 'A file or a directory or STDIN')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'txt')
-            ->addOption('exclude_dir', null, InputOption::VALUE_OPTIONAL, 'Exclude a list of directory', '')
+            ->addOption('exclude_dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Exclude a  directory')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command lints a YAML file and outputs to STDOUT
 the first encountered syntax error.
@@ -50,7 +50,7 @@ Or of a whole directory:
 
   <info>php %command.full_name% dirname</info>
   <info>php %command.full_name% dirname --format=json</info>
-  <info>php %command.full_name% dirname --exclude_dir=dir1,dir2</info>
+  <info>php %command.full_name% dirname --exclude_dir=dir1 --exclude_dir=dir2</info>
 
 Or all YAML files in a bundle:
 
@@ -86,7 +86,7 @@ EOF
             throw new \RuntimeException(sprintf('File or directory "%s" is not readable', $filename));
         }
 
-        $dirToExclude = explode(',', $input->getOption('exclude_dir'));
+        $dirToExclude = $input->getOption('exclude_dir');
 
         $files = array();
         if (is_file($filename)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -37,6 +37,7 @@ class YamlLintCommand extends Command
             ->setDescription('Lints a file and outputs encountered errors')
             ->addArgument('filename', null, 'A file or a directory or STDIN')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'txt')
+            ->addOption('exclude_dir', null, InputOption::VALUE_OPTIONAL, 'Exclude a list of directory', '')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command lints a YAML file and outputs to STDOUT
 the first encountered syntax error.
@@ -49,6 +50,7 @@ Or of a whole directory:
 
   <info>php %command.full_name% dirname</info>
   <info>php %command.full_name% dirname --format=json</info>
+  <info>php %command.full_name% dirname --exclude_dir=dir1,dir2</info>
 
 Or all YAML files in a bundle:
 
@@ -84,14 +86,16 @@ EOF
             throw new \RuntimeException(sprintf('File or directory "%s" is not readable', $filename));
         }
 
+        $dirToExclude = explode(',', $input->getOption('exclude_dir'));
+
         $files = array();
         if (is_file($filename)) {
             $files = array($filename);
         } elseif (is_dir($filename)) {
-            $files = Finder::create()->files()->in($filename)->name('*.yml');
+            $files = Finder::create()->files()->in($filename)->exclude($dirToExclude)->name('*.yml');
         } else {
             $dir = $this->getApplication()->getKernel()->locateResource($filename);
-            $files = Finder::create()->files()->in($dir)->name('*.yml');
+            $files = Finder::create()->files()->in($dir)->exclude($dirToExclude)->name('*.yml');
         }
 
         $filesInfo = array();

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -37,7 +37,7 @@ class YamlLintCommand extends Command
             ->setDescription('Lints a file and outputs encountered errors')
             ->addArgument('filename', null, 'A file or a directory or STDIN')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'txt')
-            ->addOption('exclude_dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Exclude a  directory')
+            ->addOption('exclude-dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Exclude a  directory')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command lints a YAML file and outputs to STDOUT
 the first encountered syntax error.
@@ -50,7 +50,7 @@ Or of a whole directory:
 
   <info>php %command.full_name% dirname</info>
   <info>php %command.full_name% dirname --format=json</info>
-  <info>php %command.full_name% dirname --exclude_dir=dir1 --exclude_dir=dir2</info>
+  <info>php %command.full_name% dirname --exclude-dir=dir1 --exclude-dir=dir2</info>
 
 Or all YAML files in a bundle:
 
@@ -86,7 +86,7 @@ EOF
             throw new \RuntimeException(sprintf('File or directory "%s" is not readable', $filename));
         }
 
-        $dirToExclude = $input->getOption('exclude_dir');
+        $dirToExclude = $input->getOption('exclude-dir');
 
         $files = array();
         if (is_file($filename)) {


### PR DESCRIPTION
Hi,

With this option you can exclude some directories.

``` sh
$ console yaml:lint src --exclude-dir=dir1 --exclude-dir=dir2
```

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | symfony/symfony-docs |
