### PR TITLE
Update Parser.php

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -317,8 +317,9 @@ class Parser
                     $token->type !== Token::NUMBER_TYPE
                     &&
                     // operators line "not" are valid method or property names
-                    ($token->type !== Token::OPERATOR_TYPE && preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A', $token->value))
+                    ($token->type !== Token::OPERATOR_TYPE || !preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A', $token->value))
                 ) {
+                    // 
                     throw new SyntaxError('Expected name or number', $token->cursor);
                 }
 


### PR DESCRIPTION
I think the correct logic should be: 

If the name of an 'operator' can also be used as an object's property or method name, then we should NOT throw the exception here, because 'OPERATOR' is processed by the lexer prior to 'NAME', so property/method like 'A.not', 'A.not()' will be recognized as "OPERATOR" instead of "NAME". 

So in other words, an exception should be thrown if either the token is NOT an operator, or the name is not a valid property/method name.

So the code should be changed to: 

``` PHP
$token->type !== Token::OPERATOR_TYPE || !preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A', $token->value)
```
