### PR TITLE
[Validator] Fix wrong visible type in FileValidator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -30,7 +30,7 @@ class FileValidator extends ConstraintValidator
     const KIB_BYTES = 1024;
     const MIB_BYTES = 1048576;
 
-    private static $suffices = array(
+    protected static $suffices = array(
         1 => 'bytes',
         self::KB_BYTES => 'kB',
         self::MB_BYTES => 'MB',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | now |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I changed the visible type from the `$suffices` property because the `ImageValidator` inherits from the `FileValidator` and with private i get this error message `Error: Cannot access property Symfony\Component\Validator\Constraints\ImageValidator::$suffices in`.
