### PR TITLE
Fix XSS in Debug exception handler

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -131,6 +131,7 @@ class ExceptionHandler
         }
 
         $content = '';
+        $flags = PHP_VERSION_ID >= 50400 ? ENT_QUOTES | ENT_SUBSTITUTE : ENT_QUOTES;
         if ($this->debug) {
             try {
                 $count = count($exception->getAllPrevious());
@@ -138,7 +139,7 @@ class ExceptionHandler
                 foreach ($exception->toArray() as $position => $e) {
                     $ind = $count - $position + 1;
                     $class = $this->abbrClass($e['class']);
-                    $message = nl2br($e['message']);
+                    $message = nl2br(htmlspecialchars($e['message'], $flags, $this->charset));
                     $content .= sprintf(<<<EOF
                         <div class="block_exception clear_fix">
                             <h2><span>%d/%d</span> %s: %s</h2>
@@ -169,7 +170,7 @@ EOF
             } catch (\Exception $e) {
                 // something nasty happened and we cannot throw an exception anymore
                 if ($this->debug) {
-                    $title = sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage());
+                    $title = sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), htmlspecialchars($e->getMessage(), $flags, $this->charset));
                 } else {
                     $title = 'Whoops, looks like something went wrong.';
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This XSS issue has been reported to security@symfony.com but after discussing this issue, we decided to treat it as a regular bug as the debug mode **must** never be enabled on production servers (as it can leak many sensitive information coming from arguments displayed in the stack trace for instance -- even more information is leaked when used with the Symfony full-stack framework).
