### PR TITLE
[ExpressionLanguage] fixed issues when parsing postfix expressions

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -161,4 +161,37 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     {
         return new Node\GetAttrNode($node, new Node\ConstantNode($item), new Node\ArgumentsNode(), $type);
     }
+
+    /**
+     * @dataProvider getInvalidPostfixData
+     * @expectedException \Symfony\Component\ExpressionLanguage\SyntaxError
+     */
+    public function testParseWithInvalidPostfixData($expr, $names = array())
+    {
+        $lexer = new Lexer();
+        $parser = new Parser(array());
+        $parser->parse($lexer->tokenize($expr), $names);
+    }
+
+    public function getInvalidPostfixData()
+    {
+        return array(
+            array(
+                'foo."#"',
+                array('foo'),
+            ),
+            array(
+                'foo."bar"',
+                array('foo'),
+            ),
+            array(
+                'foo.**',
+                array('foo'),
+            ),
+            array(
+                'foo.123',
+                array('foo'),
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Exception shall be thrown when parsing the following expressions:

foo."#", foo."bar", foo.**, foo.123

The original parser didn't throw exception for foo."#", foo.*\* and
foo.123

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
