### PR TITLE
[2.7] Changed visibility of setUp() and tearDown to protected

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LegacyFragmentRendererPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LegacyFragmentRendererPassTest.php
@@ -17,7 +17,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FragmentRenderer
 
 class LegacyFragmentRendererPassTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LegacyTemplatingAssetHelperPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LegacyTemplatingAssetHelperPassTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class LegacyTemplatingAssetHelperPassTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Extension/LegacyAssetsExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Extension/LegacyAssetsExtensionTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\RequestContext;
  */
 class LegacyAssetsExtensionTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/LegacyDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LegacyDefinitionTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class LegacyDefinitionTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -92,7 +92,7 @@ class SimplePreAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $listener->handle($this->event);
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager')
             ->disableOriginalConstructor()
@@ -115,7 +115,7 @@ class SimplePreAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $this->token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->authenticationManager = null;
         $this->dispatcher = null;

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -29,7 +29,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
      */
     private $metadata;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->loader = new XmlFileLoader(__DIR__.'/../../Fixtures/serialization.xml');
         $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -29,7 +29,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
      */
     private $metadata;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->loader = new YamlFileLoader(__DIR__.'/../../Fixtures/serialization.yml');
         $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');

--- a/src/Symfony/Component/Templating/Tests/Helper/LegacyAssetsHelperTest.php
+++ b/src/Symfony/Component/Templating/Tests/Helper/LegacyAssetsHelperTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Templating\Helper\AssetsHelper;
 
 class LegacyAssetsHelperTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
