### PR TITLE
[2.6] Changed visibility of setUp() and tearDown to protected

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -98,12 +98,12 @@ class LintCommandTest extends \PHPUnit_Framework_TestCase
         return $filename;
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->files = array();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
@@ -20,7 +20,7 @@ class GlobalVariablesTest extends TestCase
     private $container;
     private $globals;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = new Container();
         $this->globals = new GlobalVariables($this->container);

--- a/src/Symfony/Component/ClassLoader/Tests/LegacyUniversalClassLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/LegacyUniversalClassLoaderTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\ClassLoader\UniversalClassLoader;
 
 class LegacyUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Component/Console/Tests/Helper/LegacyDialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/LegacyDialogHelperTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 class LegacyDialogHelperTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Component/Console/Tests/Helper/LegacyProgressHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/LegacyProgressHelperTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 class LegacyProgressHelperTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/LegacyContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LegacyContainerBuilderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class LegacyContainerBuilderTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/DataCollectorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/DataCollectorExtensionTest.php
@@ -28,7 +28,7 @@ class DataCollectorExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private $dataCollector;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->dataCollector = $this->getMock('Symfony\Component\Form\Extension\DataCollector\FormDataCollectorInterface');
         $this->extension = new DataCollectorExtension($this->dataCollector);

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
@@ -24,7 +24,7 @@ class DataCollectorTypeExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private $dataCollector;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->dataCollector = $this->getMock('Symfony\Component\Form\Extension\DataCollector\FormDataCollectorInterface');
         $this->extension = new DataCollectorTypeExtension($this->dataCollector);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -22,7 +22,7 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
 {
     private $requestStack;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->requestStack = $this->getMock('Symfony\Component\HttpFoundation\RequestStack', array(), array(), '', false);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -19,7 +19,7 @@ class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
 {
     private $requestStack;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->requestStack = $this->getMockBuilder('Symfony\\Component\\HttpFoundation\\RequestStack')
             ->disableOriginalConstructor()

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/LegacyApacheMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/LegacyApacheMatcherDumperTest.php
@@ -24,7 +24,7 @@ class LegacyApacheMatcherDumperTest extends \PHPUnit_Framework_TestCase
         self::$fixturesPath = realpath(__DIR__.'/../../Fixtures/');
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -21,7 +21,7 @@ class AuthorizationCheckerTest extends \PHPUnit_Framework_TestCase
     private $authorizationChecker;
     private $tokenStorage;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
         $this->accessDecisionManager = $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface');

--- a/src/Symfony/Component/Security/Core/Tests/SecurityContextTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/SecurityContextTest.php
@@ -21,7 +21,7 @@ class SecurityContextTest extends \PHPUnit_Framework_TestCase
     private $authorizationChecker;
     private $securityContext;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         $this->authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -31,7 +31,7 @@ class SimpleAuthenticationHandlerTest extends \PHPUnit_Framework_TestCase
 
     private $response;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->successHandler = $this->getMock('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface');
         $this->failureHandler = $this->getMock('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface');

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Voter/AbstractVoterTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Voter/AbstractVoterTest.php
@@ -25,7 +25,7 @@ class AbstractVoterTest extends \PHPUnit_Framework_TestCase
 
     private $token;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->voter = new VoterFixture();
 

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -25,7 +25,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         $this->deleteTmpDir();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->deleteTmpDir();
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
