### PR TITLE
[2.3] Changed visibility of setUp() and tearDown to protected

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
@@ -31,7 +31,7 @@ class RuntimeInstantiatorTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->instantiator = new RuntimeInstantiator();
     }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -31,7 +31,7 @@ class ProxyDumperTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->dumper = new ProxyDumper();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -29,7 +29,7 @@ class ControllerNameParserTest extends TestCase
         $this->loader->register();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         spl_autoload_unregister(array($this->loader, 'loadClass'));
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -26,7 +26,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $this->deleteTmpDir();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->deleteTmpDir();
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -29,7 +29,7 @@ class TwigLoaderPassTest extends \PHPUnit_Framework_TestCase
      */
     private $pass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->builder = $this->getMock(
             'Symfony\Component\DependencyInjection\ContainerBuilder',

--- a/src/Symfony/Bundle/TwigBundle/Tests/TokenParser/LegacyRenderTokenParserTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TokenParser/LegacyRenderTokenParserTest.php
@@ -17,7 +17,7 @@ use Symfony\Bundle\TwigBundle\Node\RenderNode;
 
 class LegacyRenderTokenParserTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -41,7 +41,7 @@ class TemplateManagerTest extends TestCase
      */
     protected $templateManager;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -22,7 +22,7 @@ class ConfigCacheTest extends \PHPUnit_Framework_TestCase
 
     private $metaFile = null;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->resourceFile = tempnam(sys_get_temp_dir(), '_resource');
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'config_');
@@ -32,7 +32,7 @@ class ConfigCacheTest extends \PHPUnit_Framework_TestCase
         $this->generateMetaFile();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $files = array($this->cacheFile, $this->metaFile, $this->resourceFile);
 

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -26,13 +26,13 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
      */
     protected $errorReporting;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->errorReporting = error_reporting(E_ALL | E_STRICT);
         $this->iniSet('display_errors', '1');
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         error_reporting($this->errorReporting);
     }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -47,7 +47,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->umask = umask(0);
         $this->filesystem = new Filesystem();
@@ -56,7 +56,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->workspace = realpath($this->workspace);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->clean($this->workspace);
         umask($this->umask);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
@@ -38,7 +38,7 @@ class AutoExpireFlashBagTest extends \PHPUnit_Framework_TestCase
         $this->bag->initialize($this->array);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->bag = null;
         parent::tearDown();

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -38,7 +38,7 @@ class FlashBagTest extends \PHPUnit_Framework_TestCase
         $this->bag->initialize($this->array);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->bag = null;
         parent::tearDown();

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -20,7 +20,7 @@ class ExecutableFinderTest extends \PHPUnit_Framework_TestCase
 {
     private $path;
 
-    public function tearDown()
+    protected function tearDown()
     {
         if ($this->path) {
             // Restore path if it was changed.

--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -17,7 +17,7 @@ class SimpleProcessTest extends AbstractProcessTest
 {
     private $enabledSigchild = false;
 
-    public function setUp()
+    protected function setUp()
     {
         ob_start();
         phpinfo(INFO_GENERAL);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
