### PR TITLE
[HttpFoundation] MongoDbSessionHandler::read() now checks for valid session age

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -140,8 +140,11 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function read($sessionId)
     {
+        $timeoutThreshold = new \MongoDate(time() - (int) ini_get('session.gc_maxlifetime'));
+
         $dbData = $this->getCollection()->findOne(array(
-            $this->options['id_field'] => $sessionId,
+            $this->options['id_field']   => $sessionId,
+            $this->options['time_field'] => array('$gt' => $timeoutThreshold),
         ));
 
         return null === $dbData ? '' : $dbData[$this->options['data_field']]->bin;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -42,6 +42,24 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      *  * id_field: The field name for storing the session id [default: _id]
      *  * data_field: The field name for storing the session data [default: data]
      *  * time_field: The field name for storing the timestamp [default: time]
+     *  * expiry_field: The field name for storing the expiry-timestamp [default: expires_at]
+     *
+     * It is strongly recommended to put an index on the `expiry_field` for
+     * garbage-collection. Alternatively it's possible to automatically expire
+     * the sessions in the database as described below:
+     *
+     * A TTL collections can be used on MongoDB 2.2+ to cleanup expired sessions
+     * automatically. Such an index can for example look like this:
+     *
+     *     db.<session-collection>.ensureIndex(
+     *         { "<expiry-field>": 1 },
+     *         { "expireAfterSeconds": 0 }
+     *     )
+     *
+     * More details on: http://docs.mongodb.org/manual/tutorial/expire-data/
+     *
+     * If you use such an index, you can drop `gc_probability` to 0 since
+     * no garbage-collection is required.
      *
      * @param \Mongo|\MongoClient $mongo   A MongoClient or Mongo instance
      * @param array               $options An associative array of field options
@@ -65,6 +83,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
             'id_field' => '_id',
             'data_field' => 'data',
             'time_field' => 'time',
+            'expiry_field' => 'expires_at',
         ), $options);
     }
 
@@ -101,18 +120,8 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function gc($maxlifetime)
     {
-        /* Note: MongoDB 2.2+ supports TTL collections, which may be used in
-         * place of this method by indexing the "time_field" field with an
-         * "expireAfterSeconds" option. Regardless of whether TTL collections
-         * are used, consider indexing this field to make the remove query more
-         * efficient.
-         *
-         * See: http://docs.mongodb.org/manual/tutorial/expire-data/
-         */
-        $time = new \MongoDate(time() - $maxlifetime);
-
         $this->getCollection()->remove(array(
-            $this->options['time_field'] => array('$lt' => $time),
+            $this->options['expiry_field'] => array('$lt' => new \MongoDate()),
         ));
 
         return true;
@@ -123,12 +132,17 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function write($sessionId, $data)
     {
+        $expiry = new \MongoDate(time() + (int) ini_get('session.gc_maxlifetime'));
+
+        $fields = array(
+            $this->options['data_field'] => new \MongoBinData($data, \MongoBinData::BYTE_ARRAY),
+            $this->options['time_field'] => new \MongoDate(),
+            $this->options['expiry_field'] => $expiry,
+        );
+
         $this->getCollection()->update(
             array($this->options['id_field'] => $sessionId),
-            array('$set' => array(
-                $this->options['data_field'] => new \MongoBinData($data, \MongoBinData::BYTE_ARRAY),
-                $this->options['time_field'] => new \MongoDate(),
-            )),
+            array('$set' => $fields),
             array('upsert' => true, 'multiple' => false)
         );
 
@@ -140,11 +154,9 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function read($sessionId)
     {
-        $timeoutThreshold = new \MongoDate(time() - (int) ini_get('session.gc_maxlifetime'));
-
         $dbData = $this->getCollection()->findOne(array(
             $this->options['id_field']   => $sessionId,
-            $this->options['time_field'] => array('$gt' => $timeoutThreshold),
+            $this->options['expiry_field'] => array('$gte' => new \MongoDate()),
         ));
 
         return null === $dbData ? '' : $dbData[$this->options['data_field']]->bin;


### PR DESCRIPTION
This PR is a follow-up to #12516 and replaces the old one.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | TODO |

As discussed there: Sessions which are older than GC age should never be read. 
This PR adds the expiry-datetime on session-write and changes session-read and session-gc accordingly.

We still need to update the documentation with some clarifications, as described here:
- https://github.com/symfony/symfony/pull/12516#issuecomment-65028144
- https://github.com/symfony/symfony/pull/12516#issuecomment-69087996

My experience with the Symfony Docs from a developer perspective is very limited, so help would be very appreciated.
