### PR TITLE
[DependencyInjection] Highest precedence for user parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -50,10 +50,10 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
             $extension->load($config, $tmpContainer);
 
             $container->merge($tmpContainer);
+            $container->getParameterBag()->add($parameters);
         }
 
         $container->addDefinitions($definitions);
         $container->addAliases($aliases);
-        $container->getParameterBag()->add($parameters);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUserParametersAreMostImportantThanDefaultOne()
+    {
+        $container = new ContainerBuilder();
+        $container->getParameterBag()->set('key', 'user_value');
+        $container->registerExtension(new ExtensionA());
+        $container->loadFromExtension('a');
+        $container->registerExtension($b = new ExtensionB());
+        $container->loadFromExtension('b');
+
+        $pass = new MergeExtensionConfigurationPass();
+        $pass->process($container);
+
+        $this->assertSame('user_value', $container->getParameter('key'));
+        $this->assertSame('user_value', $b->parameterKey);
+    }
+}
+
+abstract class Extension implements ExtensionInterface
+{
+    public function getNamespace()
+    {
+        return 'http://example.org/schema/dic/'.$this->getAlias();
+    }
+
+    public function getXsdValidationBasePath()
+    {
+        return false;
+    }
+}
+
+class ExtensionA extends Extension
+{
+    public function load(array $config, ContainerBuilder $container)
+    {
+        $container->getParameterBag()->set('key', 'default_value');
+    }
+
+    public function getAlias()
+    {
+        return 'a';
+    }
+}
+
+class ExtensionB extends Extension
+{
+    public $parameterKey;
+
+    public function load(array $config, ContainerBuilder $container)
+    {
+        $this->parameterKey = $container->getParameter('key');
+    }
+
+    public function getAlias()
+    {
+        return 'b';
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

If `router.request_context.host` is defined in `parameters.yml` and if this
key is used in `globals` section of twig bundle then the value registered in the
DIC/parameters is the default value (`localhost`).

It occurs because generally the framework bundle is defined before the twig
bundle. So after the first loop, the (user) value registered in the
`ContainerBuilder` is overridden by the default value of the framework bundle.
And so, when it comes the time to process twig bundle, the last one gets the
default value, and not the user value.

This patch force the merge of default value, but give an highest precedence of
user parameters for each extensions.
