### PR TITLE
[DependencyInjection] do not inline service factories

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -65,9 +65,6 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
 
             $configurator = $this->inlineArguments($container, array($definition->getConfigurator()));
             $definition->setConfigurator($configurator[0]);
-
-            $factory = $this->inlineArguments($container, array($definition->getFactory()));
-            $definition->setFactory($factory[0]);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -237,6 +237,23 @@ class InlineServiceDefinitionsPassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($ref, $calls[0][1][0]);
     }
 
+    public function testProcessDoesNotInlineFactories()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo.factory')
+            ->setPublic(false)
+        ;
+        $container
+            ->register('foo')
+            ->setFactory(array(new Reference('foo.factory'), 'getFoo'))
+        ;
+        $this->process($container);
+
+        $factory = $container->getDefinition('foo')->getFactory();
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $factory[0]);
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $repeatedPass = new RepeatedPass(array(new AnalyzeServiceReferencesPass(), new InlineServiceDefinitionsPass()));

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -131,4 +131,26 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
 ", include $fixturesPath.'/containers/container16.php'),
         );
     }
+
+    /**
+     * @dataProvider provideCompiledContainerData
+     */
+    public function testCompiledContainerCanBeDumped($containerFile)
+    {
+        $fixturesPath = __DIR__.'/../Fixtures';
+        $container = require $fixturesPath.'/containers/'.$containerFile.'.php';
+        $container->compile();
+        $dumper = new XmlDumper($container);
+        $dumper->dump();
+    }
+
+    public function provideCompiledContainerData()
+    {
+        return array(
+            array('container8'),
+            array('container11'),
+            array('container12'),
+            array('container14'),
+        );
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -47,6 +47,7 @@ class ProjectServiceContainer extends Container
             'foo_bar' => 'getFooBarService',
             'foo_with_inline' => 'getFooWithInlineService',
             'method_call1' => 'getMethodCall1Service',
+            'new_factory' => 'getNewFactoryService',
             'new_factory_service' => 'getNewFactoryServiceService',
             'request' => 'getRequestService',
             'service_from_static_method' => 'getServiceFromStaticMethodService',
@@ -282,10 +283,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getNewFactoryServiceService()
     {
-        $a = new \FactoryClass();
-        $a->foo = 'bar';
-
-        $this->services['new_factory_service'] = $instance = $a->getInstance();
+        $this->services['new_factory_service'] = $instance = $this->get('new_factory')->getInstance();
 
         $instance->foo = 'bar';
 
@@ -326,6 +324,27 @@ class ProjectServiceContainer extends Container
         if ($this->initialized('depends_on_request')) {
             $this->get('depends_on_request')->setRequest($this->get('request', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
+    }
+
+    /**
+     * Gets the 'new_factory' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * This service is private.
+     * If you want to be able to request this service from the container directly,
+     * make it public, otherwise you might end up with broken code.
+     *
+     * @return \FactoryClass A FactoryClass instance.
+     */
+    protected function getNewFactoryService()
+    {
+        $this->services['new_factory'] = $instance = new \FactoryClass();
+
+        $instance->foo = 'bar';
+
+        return $instance;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13913 |
| License | MIT |
| Doc PR |  |

The `XmlDumper`, which is used in the full-stack framework to dump the
used container, is not capable to dump inlined factories.
