### PR TITLE
[HttpKernel] Do not enable HtmlDumper if the request is issued by curl

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/Configuration.php
@@ -41,6 +41,11 @@ class Configuration implements ConfigurationInterface
                     ->min(-1)
                     ->defaultValue(-1)
                 ->end()
+                ->scalarNode('disable_html_for')
+                    ->info('Disable HTMLdumper in favor of CliDumper based on an expression')
+                    ->example("0 === strpos(request.headers.get('user-agent'), 'curl/')")
+                    ->defaultNull()
+                ->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\DebugBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -37,6 +38,13 @@ class DebugExtension extends Extension
         $container->getDefinition('var_dumper.cloner')
             ->addMethodCall('setMaxItems',  array($config['max_items']))
             ->addMethodCall('setMaxString', array($config['max_string_length']));
+
+        if ($config['disable_html_for']) {
+            $container->getDefinition('debug.dump_listener')
+                ->replaceArgument(2, new Definition('Symfony\Bundle\DebugBundle\ExpressionLanguage'))
+                ->replaceArgument(3, $config['disable_html_for'])
+            ;
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/DebugBundle/ExpressionLanguage.php
+++ b/src/Symfony/Bundle/DebugBundle/ExpressionLanguage.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DebugBundle;
+
+use Symfony\Component\Security\Core\Authorization\ExpressionLanguage as BaseExpressionLanguage;
+
+/**
+ * Adds some functions to the default Symfony Debug ExpressionLanguage.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class ExpressionLanguage extends BaseExpressionLanguage
+{
+    protected function registerFunctions()
+    {
+        parent::registerFunctions();
+        $this->register('strpos', function ($haystack, $needle) {
+            return sprintf('strpos(%s, %s)', $haystack, $needle);
+        }, function (array $variables, $haystack, $needle) {
+            return strpos($haystack, $needle);
+        });
+    }
+}

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -21,6 +21,8 @@
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="var_dumper.cloner" />
             <argument type="service" id="data_collector.dump" />
+            <argument>null</argument><!-- Expression language -->
+            <argument>null</argument><!-- Expression -->
         </service>
 
         <service id="var_dumper.cloner" class="Symfony\Component\VarDumper\Cloner\VarCloner" />

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 use Symfony\Component\VarDumper\VarDumper;
 
@@ -37,8 +39,16 @@ class DumpListener implements EventSubscriberInterface
         $this->dumper = $dumper;
     }
 
-    public function configure()
+    public function configure(GetResponseEvent $event)
     {
+        // if the request is issued by curl, we do not enable HTML dumper;
+        if (0 === strpos($event->getRequest()->headers->get('user-agent'), 'curl/')) {
+            CliDumper::$defaultColors = true;
+            CliDumper::$defaultOutput = 'php://output';
+
+            return;
+        }
+
         $cloner = $this->cloner;
         $dumper = $this->dumper;
 

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
@@ -28,25 +30,37 @@ class DumpListener implements EventSubscriberInterface
 {
     private $cloner;
     private $dumper;
+    private $expressionLanguage;
+    private $expression;
 
     /**
-     * @param ClonerInterface     $cloner Cloner service.
-     * @param DataDumperInterface $dumper Dumper service.
+     * @param ClonerInterface         $cloner             Cloner service.
+     * @param DataDumperInterface     $dumper             Dumper service.
+     * @param ExpressionLanguage|null $expressionLanguage Expression Language service.
+     * @param string|null             $expression         The expression.
      */
-    public function __construct(ClonerInterface $cloner, DataDumperInterface $dumper)
+    public function __construct(ClonerInterface $cloner, DataDumperInterface $dumper, ExpressionLanguage $expressionLanguage = null, $expression = null)
     {
+        if (null !== $expression && null === $expressionLanguage) {
+            throw new \RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+        }
+
         $this->cloner = $cloner;
         $this->dumper = $dumper;
+        $this->expressionLanguage = $expressionLanguage;
+        $this->expression = $expression;
     }
 
     public function configure(GetResponseEvent $event)
     {
-        // if the request is issued by curl, we do not enable HTML dumper;
-        if (0 === strpos($event->getRequest()->headers->get('user-agent'), 'curl/')) {
-            CliDumper::$defaultColors = true;
-            CliDumper::$defaultOutput = 'php://output';
+        if ($this->expression) {
+            $result = $this->expressionLanguage->evaluate($this->expression, array('request' => $event->getRequest()));
+            if ($result) {
+                CliDumper::$defaultColors = true;
+                CliDumper::$defaultOutput = 'php://output';
 
-            return;
+                return;
+            }
         }
 
         $cloner = $this->cloner;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\EventListener\DumpListener;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -45,8 +47,20 @@ class DumpListenerTest extends \PHPUnit_Framework_TestCase
         $exception = null;
         $listener = new DumpListener($cloner, $dumper);
 
+        $response = new Response();
+        $event = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($response))
+        ;
+
         try {
-            $listener->configure();
+            $listener->configure($event);
 
             VarDumper::dump('foo');
             VarDumper::dump('bar');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

If the request is issue by curl the output of `dump` function is in HTML, and so it's "dirty".

So, with this patch and the following code, I could get:

``` php
        die(dump([
            'key' => 'value',
            'date' => new \DateTime(),
        ]));
```

In web:

![screenshot10](https://cloud.githubusercontent.com/assets/408368/6624899/b3e95990-c8ec-11e4-9bdf-99ce448cd778.png)

in cli:

![screenshot12](https://cloud.githubusercontent.com/assets/408368/6624900/b9d5cfbe-c8ec-11e4-8d30-1a661559e93e.png)

\o/
