### PR TITLE
[DependencyInjection] resolve class parameters in service factories

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -39,6 +39,13 @@ class ResolveParameterPlaceHoldersPass implements CompilerPassInterface
                 $definition->setArguments($parameterBag->resolveValue($definition->getArguments()));
                 $definition->setFactoryClass($parameterBag->resolveValue($definition->getFactoryClass()));
 
+                $factory = $definition->getFactory();
+
+                if (is_array($factory) && isset($factory[0])) {
+                    $factory[0] = $parameterBag->resolveValue($factory[0]);
+                    $definition->setFactory($factory);
+                }
+
                 $calls = array();
                 foreach ($definition->getMethodCalls() as $name => $arguments) {
                     $calls[$parameterBag->resolveValue($name)] = $parameterBag->resolveValue($arguments);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -38,6 +38,11 @@ class ResolveParameterPlaceHoldersPassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('FooFactory', $this->fooDefinition->getFactoryClass());
     }
 
+    public function testClassOfFactoryParametersShouldBeResolved()
+    {
+        $this->assertSame(array('FooFactory', 'getFoo'), $this->fooDefinition->getFactory());
+    }
+
     public function testArgumentParametersShouldBeResolved()
     {
         $this->assertSame(array('bar', 'baz'), $this->fooDefinition->getArguments());
@@ -79,6 +84,7 @@ class ResolveParameterPlaceHoldersPassTest extends \PHPUnit_Framework_TestCase
 
         $fooDefinition = $containerBuilder->register('foo', '%foo.class%');
         $fooDefinition->setFactoryClass('%foo.factory.class%');
+        $fooDefinition->setFactory(array('%foo.factory.class%', 'getFoo'));
         $fooDefinition->setArguments(array('%foo.arg1%', '%foo.arg2%'));
         $fooDefinition->addMethodCall('%foo.method%', array('%foo.arg1%', '%foo.arg2%'));
         $fooDefinition->setProperty('%foo.property.name%', '%foo.property.value%');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This is based on the parameter resolving for factories from #13519 and makes the necessary changes for the new factory syntax introduced in Symfony 2.6.

@fabian In #13519, you also updated the `PhpDumper` to make use of `dumpValue()`. Should I do the same here (or in this case reopen #13455)?
