### PR TITLE
[translation][initialize cache] Remove dead code.

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -351,12 +351,6 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
             return;
         }
 
-        if (null === $this->cacheDir) {
-            $this->initialize();
-
-            return $this->loadCatalogue($locale);
-        }
-
         $this->assertValidLocale($locale);
         $cache = new ConfigCache($this->cacheDir.'/catalogue.'.$locale.'.php', $this->debug);
         if (!$cache->isFresh()) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | ~ |
| Tests pass? | yes |
| License | MIT |

I see two issues here:
1- initialize function doesn't exist in Translator class.
2- initializeCacheCatalogue is only called when cache is not null
