### PR TITLE
Fixing wrong variable name from #13519

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1223,7 +1223,7 @@ EOF;
                 if (null !== $value->getFactoryClass()) {
                     return sprintf("call_user_func(array(%s, '%s')%s)", $this->dumpValue($value->getFactoryClass()), $value->getFactoryMethod(), count($arguments) > 0 ? ', '.implode(', ', $arguments) : '');
                 } elseif (null !== $value->getFactoryService()) {
-                    $service = $this->dumpValue($definition->getFactoryService());
+                    $service = $this->dumpValue($value->getFactoryService());
 
                     return sprintf("%s->%s(%s)", 0 === strpos($service, '$') ? sprintf('$this->get(%s)', $service) : $this->getServiceCall($value->getFactoryService()), $value->getFactoryMethod(), implode(', ', $arguments));
                 } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13519 |
| License | MIT |
| Doc PR | n/a |

Hi guys!

I'm currently seeing an undefined variable in the `PhpDumper` on all branches. I think it was added inadvertently in #13519, so unless I'm totally missing something, this should be an easy merge.

Thanks!
