### PR TITLE
[WIP] Explicitly Declare Twig "Paths", deprecate old syntaxes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Bundle/Bundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Bundle/Bundle.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Bundle;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle as BaseBundle;
+
+class Bundle extends BaseBundle
+{
+    private $twigPaths = array();
+
+    protected function addTwigPath($templateDirectory, $namespace)
+    {
+        $this->twigPaths[$namespace] = $templateDirectory;
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        foreach ($this->twigPaths as $namespace => $directory) {
+            if (!is_dir($directory)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Directory "%s" does not exist, so it cannot be added as a Twig path', $directory
+                ));
+            }
+
+            $container->prependExtensionConfig('twig', array(
+                'paths' => array($directory => $namespace)
+            ));
+        }
+    }
+
+
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -62,9 +62,13 @@ class TemplateLocator implements FileLocatorInterface
      *
      * @throws \InvalidArgumentException When the template is not an instance of TemplateReferenceInterface
      * @throws \InvalidArgumentException When the template file can not be found
+     *
+     * @deprecated since version 2.8, to be removed in 3.0.
      */
     public function locate($template, $currentPath = null, $first = true)
     {
+        trigger_error('The '.__METHOD__.' is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
         if (!$template instanceof TemplateReferenceInterface) {
             throw new \InvalidArgumentException('The template must be an instance of TemplateReferenceInterface.');
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
@@ -20,6 +20,7 @@ use Symfony\Component\Templating\TemplateNameParser as BaseTemplateNameParser;
  * "bundle:section:template.format.engine" to TemplateReferenceInterface
  * instances.
  *
+ * @deprecated since version 2.8, to be removed in 3.0
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class TemplateNameParser extends BaseTemplateNameParser
@@ -47,6 +48,8 @@ class TemplateNameParser extends BaseTemplateNameParser
         } elseif (isset($this->cache[$name])) {
             return $this->cache[$name];
         }
+
+        trigger_error('The "bundle:section:template.format.engine" syntax is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
 
         // normalize name
         $name = str_replace(':/', ':', preg_replace('#/{2,}#', '/', strtr($name, '\\', '/')));

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -64,6 +64,12 @@ class TwigExtension extends Extension
             if (!$namespace) {
                 $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path));
             } else {
+                // register the "override" path
+                $twigFilesystemLoaderDefinition->addMethodCall('addPath', array(
+                    $container->getParameter('kernel.root_dir').'/Resources/'.$namespace.'/views',
+                    $namespace
+                ));
+
                 $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
             }
         }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -65,10 +65,9 @@ class TwigExtension extends Extension
                 $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path));
             } else {
                 // register the "override" path
-                $twigFilesystemLoaderDefinition->addMethodCall('addPath', array(
-                    $container->getParameter('kernel.root_dir').'/Resources/'.$namespace.'/views',
-                    $namespace
-                ));
+                if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$namespace.'/views')) {
+                    $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir, $namespace));
+                }
 
                 $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
             }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -74,7 +74,7 @@ class TwigExtension extends Extension
             }
         }
 
-        // register bundles as Twig namespaces
+        // register bundles as Twig namespaces (deprecated)
         foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {
             if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
                 $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
@@ -126,6 +126,9 @@ class TwigExtension extends Extension
         ));
     }
 
+    /**
+     * @deprecated The automatic @AcmeDemo (for AcmeDemoBundle) Twig path was deprecated in 2.8 and will be removed in 3.0
+     */
     private function addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle)
     {
         $name = $bundle;

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -78,7 +78,7 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         } catch (\Twig_Error_Loader $e) {
             $previous = $e;
 
-            // for BC
+            // deprecated - supports the bundle:directory:filename.format.engine format
             try {
                 $template = $this->parser->parse($template);
                 $file = $this->locator->locate($template);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | TODO |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | TODO |

Hallo!

Comments warmly appreciated. Actually, that's the whole point of pushing this early :).

1) Deprecated the `AcmeDemoBundle:Foo:default.html.twig` syntax.

2) Deprecated the automatic `@AcmeDemo`-style Twig namespace functionality

3) Added a way for bundles to _explicitly_ add a namespaced path. Usage:

``` php

use Symfony\Bundle\FrameworkBundle\Bundle\Bundle;

class FOSFooBundle extends Bundle
{
    public function __construct()
    {
        $this->addTwigPath(__DIR__.'/Resources/views', 'FOSFooBundle');
    }
}
```

then (because this is how Twig paths already work):

``` php
// renders @FOSFooBundle/Resources/views/product/list.html.twig
return $this->render('@FOSFooBundle/product/list.html.twig');
```

This is a lot more flexible than the "automatic" mapping and a lot more clear (because it's explicit) . It still maintains the "fallback" functionality (e.g. put something in `app/Resources/AcmeDemoBundle/...` to override) and everything works the same if the bundle decides to use a namespace that matches its bundle name.

This is a small step to removing some "automatic" magic that bundles give us. I'd like to see things more explicit in the bundle - e.g. `$this->addPublicDirectory(__DIR__.'/Resources/public', 'fos_foo')` and even translation resource loading, validation metadata, etc.
### TODO
- [ ] The [TemplateFinder](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php) (used _only_ by the `TemplatePathsCacheWarmer`) is currently (before this PR) broken, as it doesn't take into account Twig namespace paths.
- [ ] These new paths are "stuck" inside Twig. So if I want to get the location of some non-Twig template (fake code `$templateLocator->find('@FOSFooBundle/smarty/ohno.tpl')` - I can't do that. If we agree, we can move the "path" functionality into some templating service that Twig uses.
- [ ] Tests
- [ ] Docs

Thanks!
