### PR TITLE
Marked the ResolveParameterPlaceHoldersPassTest as legacy

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -38,6 +38,7 @@ class ResolveParameterPlaceHoldersPass implements CompilerPassInterface
                 $definition->setFile($parameterBag->resolveValue($definition->getFile()));
                 $definition->setArguments($parameterBag->resolveValue($definition->getArguments()));
                 $definition->setFactoryClass($parameterBag->resolveValue($definition->getFactoryClass()));
+                $definition->setFactory($parameterBag->resolveValue($definition->getFactory()));
 
                 $calls = array();
                 foreach ($definition->getMethodCalls() as $name => $arguments) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/LegacyResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/LegacyResolveParameterPlaceHoldersPassTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @group legacy
+ */
+class LegacyResolveParameterPlaceHoldersPassTest extends \PHPUnit_Framework_TestCase
+{
+    private $compilerPass;
+    private $container;
+    private $fooDefinition;
+
+    protected function setUp()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+        $this->compilerPass = new ResolveParameterPlaceHoldersPass();
+        $this->container = $this->createContainerBuilder();
+        $this->compilerPass->process($this->container);
+        $this->fooDefinition = $this->container->getDefinition('foo');
+    }
+
+    private function createContainerBuilder()
+    {
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('foo.class', 'Foo');
+        $containerBuilder->setParameter('foo.factory.class', 'FooFactory');
+        $fooDefinition = $containerBuilder->register('foo', '%foo.class%');
+        $fooDefinition->setFactoryClass('%foo.factory.class%');
+
+        return $containerBuilder;
+    }
+
+    public function testFactoryClassParametersShouldBeResolved()
+    {
+        $this->assertSame('FooFactory', $this->fooDefinition->getFactoryClass());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -33,9 +33,9 @@ class ResolveParameterPlaceHoldersPassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Foo', $this->fooDefinition->getClass());
     }
 
-    public function testFactoryClassParametersShouldBeResolved()
+    public function testFactoryParametersShouldBeResolved()
     {
-        $this->assertSame('FooFactory', $this->fooDefinition->getFactoryClass());
+        $this->assertSame(array('FooFactory', 'bar'), $this->fooDefinition->getFactory());
     }
 
     public function testArgumentParametersShouldBeResolved()
@@ -78,7 +78,7 @@ class ResolveParameterPlaceHoldersPassTest extends \PHPUnit_Framework_TestCase
         $containerBuilder->setParameter('alias.id', 'bar');
 
         $fooDefinition = $containerBuilder->register('foo', '%foo.class%');
-        $fooDefinition->setFactoryClass('%foo.factory.class%');
+        $fooDefinition->setFactory(array('%foo.factory.class%', 'bar'));
         $fooDefinition->setArguments(array('%foo.arg1%', '%foo.arg2%'));
         $fooDefinition->addMethodCall('%foo.method%', array('%foo.arg1%', '%foo.arg2%'));
         $fooDefinition->setProperty('%foo.property.name%', '%foo.property.value%');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kinda |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Since the last merge of 2.6 in 2.7, the tests are not ok. (https://github.com/symfony/symfony/compare/a003380c39eb...17ad6fd90c69)
