### PR TITLE
[FrameworkBundle] Allow to disable Kernel reboot

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -29,6 +29,7 @@ class Client extends BaseClient
 {
     private $hasPerformedRequest = false;
     private $profiler = false;
+    private $reboot = true;
 
     /**
      * {@inheritdoc}
@@ -85,6 +86,26 @@ class Client extends BaseClient
     }
 
     /**
+     * By default, the Client reboots the Kernel for each request. This method
+     * allows to keep the same kernel across requests.
+     */
+    public function disableReboot()
+    {
+        $this->reboot = false;
+    }
+
+    /**
+     * Enable the kernel reboot behaviour.
+     *
+     * If the kernel reboot was previously disabled, you can re-enable it with
+     * this method.
+     */
+    public function enableReboot()
+    {
+        $this->reboot = true;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @param Request $request A Request instance
@@ -95,7 +116,7 @@ class Client extends BaseClient
     {
         // avoid shutting down the Kernel if no request has been performed yet
         // WebTestCase::createClient() boots the Kernel but do not handle a request
-        if ($this->hasPerformedRequest) {
+        if ($this->hasPerformedRequest && $this->reboot) {
             $this->kernel->shutdown();
         } else {
             $this->hasPerformedRequest = true;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ClientTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ClientTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class ClientTest extends WebTestCase
+{
+    public function testRebootKernelBetweenRequests()
+    {
+        $mock = $this->getKernelMock();
+        $mock->expects($this->once())->method('shutdown');
+
+        $client = new Client($mock);
+        $client->request('GET', '/');
+        $client->request('GET', '/');
+    }
+
+    public function testDisabledRebootKernel()
+    {
+        $mock = $this->getKernelMock();
+        $mock->expects($this->never())->method('shutdown');
+
+        $client = new Client($mock);
+        $client->disableReboot();
+        $client->request('GET', '/');
+        $client->request('GET', '/');
+    }
+
+    public function testEnableRebootKernel()
+    {
+        $mock = $this->getKernelMock();
+        $mock->expects($this->once())->method('shutdown');
+
+        $client = new Client($mock);
+        $client->disableReboot();
+        $client->request('GET', '/');
+        $client->request('GET', '/');
+        $client->enableReboot();
+        $client->request('GET', '/');
+    }
+
+    private function getKernelMock()
+    {
+        $mock = $this->getMockBuilder($this->getKernelClass())
+            ->setMethods(array('shutdown', 'boot', 'handle'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock->expects($this->any())->method('handle')->willReturn(new Response('foo'));
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This PR introduce a `disableReboot` method on `Client` class.

A use case of this method is to prevent rebooting kernel if we manually rebooted it before the request to manipulate registered services.
