### PR TITLE
[TWIG] App var: Changed deprecated SecurityContext

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -91,7 +91,7 @@ class AppVariable
                 throw new \RuntimeException('The "app.user" variable is not available.');
             }
 
-            $this->tokenStorage = $this->container->get('security.context');
+            $this->tokenStorage = $this->container->get('security.token_storage');
         }
 
         if (!$token = $this->tokenStorage->getToken()) {


### PR DESCRIPTION
As of [this deprecation](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Security/Core/SecurityContext.php#L14), shouldn't the `security.context` be changed to the new `security.token_storage` ?
