### PR TITLE
[2.6] Marked the ResolveParameterPlaceHoldersPassTest as legacy

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/LegacyResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/LegacyResolveParameterPlaceHoldersPassTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @group legacy
+ */
+class LegacyResolveParameterPlaceHoldersPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFactoryClassParametersShouldBeResolved()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $compilerPass = new ResolveParameterPlaceHoldersPass();
+
+        $container = new ContainerBuilder();
+        $container->setParameter('foo.factory.class', 'FooFactory');
+        $fooDefinition = $container->register('foo', '%foo.factory.class%');
+        $fooDefinition->setFactoryClass('%foo.factory.class%');
+        $compilerPass->process($container);
+        $fooDefinition = $container->getDefinition('foo');
+
+        $this->assertSame('FooFactory', $fooDefinition->getFactoryClass());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -33,12 +33,7 @@ class ResolveParameterPlaceHoldersPassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Foo', $this->fooDefinition->getClass());
     }
 
-    public function testFactoryClassParametersShouldBeResolved()
-    {
-        $this->assertSame('FooFactory', $this->fooDefinition->getFactoryClass());
-    }
-
-    public function testClassOfFactoryParametersShouldBeResolved()
+    public function testFactoryParametersShouldBeResolved()
     {
         $this->assertSame(array('FooFactory', 'getFoo'), $this->fooDefinition->getFactory());
     }
@@ -83,7 +78,6 @@ class ResolveParameterPlaceHoldersPassTest extends \PHPUnit_Framework_TestCase
         $containerBuilder->setParameter('alias.id', 'bar');
 
         $fooDefinition = $containerBuilder->register('foo', '%foo.class%');
-        $fooDefinition->setFactoryClass('%foo.factory.class%');
         $fooDefinition->setFactory(array('%foo.factory.class%', 'getFoo'));
         $fooDefinition->setArguments(array('%foo.arg1%', '%foo.arg2%'));
         $fooDefinition->addMethodCall('%foo.method%', array('%foo.arg1%', '%foo.arg2%'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container14.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container14.php
@@ -4,8 +4,14 @@ namespace Container14;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ProjectServiceContainer extends ContainerBuilder
-{
+/**
+ * This file is included in Tests\Dumper\GraphvizDumperTest::testDumpWithFrozenCustomClassContainer
+ * and Tests\Dumper\XmlDumperTest::testCompiledContainerCanBeDumped.
+ */
+if (!class_exists('Container14\ProjectServiceContainer')) {
+    class ProjectServiceContainer extends ContainerBuilder
+    {
+    }
 }
 
 return new ProjectServiceContainer();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Splitted the ResolveParameterPlaceHoldersPassTest to obtain a legacy test to avoid deprecation rise.
