### PR TITLE
[2.7][Translation] generate translation cache at warmup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added possibility to extract translation messages from a file or files besides extracting from a directory
+ * Added `TranslationsCacheWarmer` to create catalogues at warmup
 
 2.6.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TranslationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TranslationsCacheWarmer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Generates the catalogues for translations.
+ *
+ * @author Xavier Leune <xavier.leune@gmail.com>
+ */
+class TranslationsCacheWarmer implements CacheWarmerInterface
+{
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        if ($this->translator instanceof WarmableInterface) {
+            $this->translator->warmUp($cacheDir);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
@@ -38,6 +39,7 @@ class LoggingTranslatorPass implements CompilerPassInterface
             $refClass = new \ReflectionClass($class);
             if ($refClass->implementsInterface('Symfony\Component\Translation\TranslatorInterface') && $refClass->implementsInterface('Symfony\Component\Translation\TranslatorBagInterface')) {
                 $container->getDefinition('translator.logging')->setDecoratedService('translator');
+                $container->getDefinition('translation.warmer')->replaceArgument(0, new Reference('translator.logging.inner'));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -705,12 +705,22 @@ class FrameworkExtension extends Extension
                 ->in($dirs)
             ;
 
+            $locales = array();
             foreach ($finder as $file) {
                 list($domain, $locale, $format) = explode('.', $file->getBasename(), 3);
-                $files[] = (string) $file;
+                if (!isset($files[$locale])) {
+                    $files[$locale] = array();
+                }
+
+                $files[$locale][] = (string) $file;
             }
 
-            $translator->replaceArgument(4, $files);
+            $options = array_merge(
+                $translator->getArgument(3),
+                array('resource_files' => $files)
+            );
+
+            $translator->replaceArgument(3, $options);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -152,5 +152,10 @@
         <service id="translation.extractor" class="%translation.extractor.class%"/>
 
         <service id="translation.writer" class="%translation.writer.class%"/>
+
+        <service id="translation.warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\TranslationsCacheWarmer" public="false">
+            <argument type="service" id="translator" />
+            <tag name="kernel.cache_warmer" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggingTranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggingTranslatorPassTest.php
@@ -35,7 +35,7 @@ class LoggingTranslatorPassTest extends \PHPUnit_Framework_TestCase
             ->method('getAlias')
             ->will($this->returnValue('translation.default'));
 
-        $container->expects($this->exactly(2))
+        $container->expects($this->exactly(3))
             ->method('getDefinition')
             ->will($this->returnValue($definition));
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -223,9 +223,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('full');
         $this->assertTrue($container->hasDefinition('translator.default'), '->registerTranslatorConfiguration() loads translation.xml');
         $this->assertEquals('translator.default', (string) $container->getAlias('translator'), '->registerTranslatorConfiguration() redefines translator service from identity to real translator');
-        $resources = $container->getDefinition('translator.default')->getArgument(4);
+        $options = $container->getDefinition('translator.default')->getArgument(3);
 
-        $files = array_map(function ($resource) { return realpath($resource); }, $resources);
+        $files = array_map(function ($resource) { return realpath($resource); }, $options['resource_files']['en']);
         $ref = new \ReflectionClass('Symfony\Component\Validator\Validation');
         $this->assertContains(
             strtr(dirname($ref->getFileName()).'/Resources/translations/validators.en.xlf', '/', DIRECTORY_SEPARATOR),

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Translation;
 
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Translation\Translator as BaseTranslator;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -20,16 +21,21 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Translator extends BaseTranslator
+class Translator extends BaseTranslator implements WarmableInterface
 {
     protected $container;
     protected $loaderIds;
-    protected $resourceFiles;
 
     protected $options = array(
         'cache_dir' => null,
         'debug' => false,
+        'resource_files' => array(),
     );
+
+    /**
+     * @var array
+     */
+    private $resourceLocales;
 
     /**
      * Constructor.
@@ -38,20 +44,19 @@ class Translator extends BaseTranslator
      *
      *   * cache_dir: The cache directory (or null to disable caching)
      *   * debug:     Whether to enable debugging or not (false by default)
+     *   * resource_files: List of translation resources available grouped by locale.
      *
-     * @param ContainerInterface $container     A ContainerInterface instance
-     * @param MessageSelector    $selector      The message selector for pluralization
-     * @param array              $loaderIds     An array of loader Ids
-     * @param array              $options       An array of options
-     * @param array              $resourceFiles An array of resource directories
+     * @param ContainerInterface $container A ContainerInterface instance
+     * @param MessageSelector    $selector  The message selector for pluralization
+     * @param array              $loaderIds An array of loader Ids
+     * @param array              $options   An array of options
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array(), $resourceFiles = array())
+    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array())
     {
         $this->container = $container;
         $this->loaderIds = $loaderIds;
-        $this->resourceFiles = $resourceFiles;
 
         // check option names
         if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
@@ -59,11 +64,22 @@ class Translator extends BaseTranslator
         }
 
         $this->options = array_merge($this->options, $options);
+        $this->resourceLocales = array_keys($this->options['resource_files']);
         if (null !== $this->options['cache_dir'] && $this->options['debug']) {
             $this->loadResources();
         }
 
         parent::__construct(null, $selector, $this->options['cache_dir'], $this->options['debug']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        foreach ($this->resourceLocales as $locale) {
+            $this->loadCatalogue($locale);
+        }
     }
 
     /**
@@ -87,11 +103,13 @@ class Translator extends BaseTranslator
 
     private function loadResources()
     {
-        foreach ($this->resourceFiles as $key => $file) {
-            // filename is domain.locale.format
-            list($domain, $locale, $format) = explode('.', basename($file), 3);
-            $this->addResource($format, $file, $locale, $domain);
-            unset($this->resourceFiles[$key]);
+        foreach ($this->options['resource_files'] as $locale => $files) {
+            foreach ($files as $key => $file) {
+                // filename is domain.locale.format
+                list($domain, $locale, $format) = explode('.', basename($file), 3);
+                $this->addResource($format, $file, $locale, $domain);
+                unset($this->options['resource_files'][$locale][$key]);
+            }
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13919 |
| License | MIT |
| Doc PR | NA |

This PR uses the parameters "locale" and "fallback_locales" to generate the catalogues at warmup, avoiding the creation of files at runtime.
