### PR TITLE
[HttpKernel] UriSigner::buildUrl - default params for http_build_query 

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -42,9 +42,6 @@ class UriSignerTest extends \PHPUnit_Framework_TestCase
         $this->iniSet('arg_separator.output', '&amp;');
         $signer = new UriSigner('foobar');
 
-        $this->assertTrue($signer->check($signer->sign('http://example.com/foo')));
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
-
-        $this->assertTrue($signer->sign('http://example.com/foo?foo=bar&bar=foo') === $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -36,4 +36,15 @@ class UriSignerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($signer->sign('http://example.com/foo?foo=bar&bar=foo') === $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
     }
+
+    public function testCheckWithDifferentArgSeparator()
+    {
+        $this->iniSet('arg_separator.output', '&amp;');
+        $signer = new UriSigner('foobar');
+
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo')));
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
+
+        $this->assertTrue($signer->sign('http://example.com/foo?foo=bar&bar=foo') === $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -42,6 +42,10 @@ class UriSignerTest extends \PHPUnit_Framework_TestCase
         $this->iniSet('arg_separator.output', '&amp;');
         $signer = new UriSigner('foobar');
 
+        $this->assertSame(
+            "http://example.com/foo?baz=bay&foo=bar&_hash=rIOcC%2FF3DoEGo%2FvnESjSp7uU9zA9S%2F%2BOLhxgMexoPUM%3D",
+            $signer->sign('http://example.com/foo?foo=bar&baz=bay')
+        );
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
     }
 }

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -92,7 +92,7 @@ class UriSigner
     private function buildUrl(array $url, array $params = array())
     {
         ksort($params);
-        $url['query'] = http_build_query($params);
+        $url['query'] = http_build_query($params, '', '&');
 
         $scheme   = isset($url['scheme']) ? $url['scheme'].'://' : '';
         $host     = isset($url['host']) ? $url['host'] : '';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

UriSigner fail to verify hash when custom ini setting arg_separator.output is used.
It was introduced in https://github.com/symfony/symfony/pull/12574 
