### PR TITLE
[Console] Added support for lazy-loaded commands

### DIFF
--- a/src/Symfony/Component/Console/Command/CommandConfiguration.php
+++ b/src/Symfony/Component/Console/Command/CommandConfiguration.php
@@ -1,0 +1,391 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Configuration of a command.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ *
+ * @api
+ */
+class CommandConfiguration
+{
+    private $enabled = true;
+    private $name;
+    private $processTitle;
+    private $aliases = array();
+    private $definition;
+    private $help;
+    private $description;
+    private $synopsis;
+    /**
+     * @var Command|callable|null
+     */
+    private $command;
+
+    /**
+     * @param Command|callable|null $command
+     */
+    public function __construct($command = null)
+    {
+        $this->definition = new InputDefinition();
+        if ($command) {
+            $this->setCommand($command);
+        }
+    }
+
+    /**
+     * Set the Command instance or a callable returning the Command instance.
+     *
+     * Provide a callable if you want the Command to be instantiated lazily.
+     *
+     * @param Command|callable $command
+     *
+     * @api
+     */
+    public function setCommand($command)
+    {
+        if ((!$command instanceof Command) && !is_callable($command)) {
+            throw new \LogicException('The command must be a Command instance or a callable returning a Command instance');
+        }
+
+        $this->command = $command;
+    }
+
+    /**
+     * @return Command
+     *
+     * @api
+     */
+    public function getCommand()
+    {
+        if ($this->command instanceof Command) {
+            return $this->command;
+        }
+
+        if (null === $this->command) {
+            throw new \LogicException('No command was set');
+        }
+
+        $this->setCommand(call_user_func($this->command, $this));
+
+        return $this->command;
+    }
+
+    /**
+     * Set whether the command is enabled or not in the current environment.
+     *
+     * Set this to false if the command can not run properly under the current conditions.
+     *
+     * @param $enabled
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * Whether the command is enabled or not in the current environment.
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Gets the InputDefinition attached to this Command.
+     *
+     * @return InputDefinition An InputDefinition instance
+     *
+     * @api
+     */
+    public function getDefinition()
+    {
+        return $this->definition;
+    }
+
+    /**
+     * Sets an array of argument and option instances.
+     *
+     * @param array|InputDefinition $definition An array of argument and option instances or a definition instance
+     *
+     * @return CommandConfiguration The current instance
+     *
+     * @api
+     */
+    public function setDefinition($definition)
+    {
+        if ($definition instanceof InputDefinition) {
+            $this->definition = $definition;
+        } else {
+            $this->definition->setDefinition($definition);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds an argument.
+     *
+     * @param string $name        The argument name
+     * @param int    $mode        The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
+     * @param string $description A description text
+     * @param mixed  $default     The default value (for InputArgument::OPTIONAL mode only)
+     *
+     * @return CommandConfiguration The current instance
+     *
+     * @api
+     */
+    public function addArgument($name, $mode = null, $description = '', $default = null)
+    {
+        $this->definition->addArgument(new InputArgument($name, $mode, $description, $default));
+
+        return $this;
+    }
+
+    /**
+     * Adds an option.
+     *
+     * @param string $name        The option name
+     * @param string $shortcut    The shortcut (can be null)
+     * @param int    $mode        The option mode: One of the InputOption::VALUE_* constants
+     * @param string $description A description text
+     * @param mixed  $default     The default value (must be null for InputOption::VALUE_REQUIRED or InputOption::VALUE_NONE)
+     *
+     * @return CommandConfiguration The current instance
+     *
+     * @api
+     */
+    public function addOption($name, $shortcut = null, $mode = null, $description = '', $default = null)
+    {
+        $this->definition->addOption(new InputOption($name, $shortcut, $mode, $description, $default));
+
+        return $this;
+    }
+
+    /**
+     * Sets the name of the command.
+     *
+     * This method can set both the namespace and the name if
+     * you separate them by a colon (:)
+     *
+     *     $command->setName('foo:bar');
+     *
+     * @param string $name The command name
+     *
+     * @return CommandConfiguration The current instance
+     *
+     * @throws \InvalidArgumentException When the name is invalid
+     *
+     * @api
+     */
+    public function setName($name)
+    {
+        $this->validateName($name);
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Sets the process title of the command.
+     *
+     * This feature should be used only when creating a long process command,
+     * like a daemon.
+     *
+     * PHP 5.5+ or the proctitle PECL library is required
+     *
+     * @param string $title The process title
+     *
+     * @return CommandConfiguration The current instance
+     */
+    public function setProcessTitle($title)
+    {
+        $this->processTitle = $title;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProcessTitle()
+    {
+        return $this->processTitle;
+    }
+
+    /**
+     * Returns the command name.
+     *
+     * @return string The command name
+     *
+     * @api
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Sets the description for the command.
+     *
+     * @param string $description The description for the command
+     *
+     * @return CommandConfiguration The current instance
+     *
+     * @api
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Returns the description for the command.
+     *
+     * @return string The description for the command
+     *
+     * @api
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Sets the help for the command.
+     *
+     * @param string $help The help for the command
+     *
+     * @return CommandConfiguration The current instance
+     *
+     * @api
+     */
+    public function setHelp($help)
+    {
+        $this->help = $help;
+
+        return $this;
+    }
+
+    /**
+     * Returns the help for the command.
+     *
+     * @return string The help for the command
+     *
+     * @api
+     */
+    public function getHelp()
+    {
+        return $this->help;
+    }
+
+    /**
+     * Returns the processed help for the command replacing the %command.name% and
+     * %command.full_name% patterns with the real values dynamically.
+     *
+     * @return string The processed help for the command
+     */
+    public function getProcessedHelp()
+    {
+        $name = $this->name;
+
+        $placeholders = array(
+            '%command.name%',
+            '%command.full_name%',
+        );
+        $replacements = array(
+            $name,
+            $_SERVER['PHP_SELF'].' '.$name,
+        );
+
+        return str_replace($placeholders, $replacements, $this->getHelp());
+    }
+
+    /**
+     * Sets the aliases for the command.
+     *
+     * @param string[] $aliases An array of aliases for the command
+     *
+     * @return CommandConfiguration The current instance
+     *
+     * @throws \InvalidArgumentException When an alias is invalid
+     *
+     * @api
+     */
+    public function setAliases($aliases)
+    {
+        if (!is_array($aliases) && !$aliases instanceof \Traversable) {
+            throw new \InvalidArgumentException('$aliases must be an array or an instance of \Traversable');
+        }
+
+        foreach ($aliases as $alias) {
+            $this->validateName($alias);
+        }
+
+        $this->aliases = $aliases;
+
+        return $this;
+    }
+
+    /**
+     * Returns the aliases for the command.
+     *
+     * @return array An array of aliases for the command
+     *
+     * @api
+     */
+    public function getAliases()
+    {
+        return $this->aliases;
+    }
+
+    /**
+     * Returns the synopsis for the command.
+     *
+     * @return string The synopsis
+     */
+    public function getSynopsis()
+    {
+        if (null === $this->synopsis) {
+            $this->synopsis = trim(sprintf('%s %s', $this->name, $this->definition->getSynopsis()));
+        }
+
+        return $this->synopsis;
+    }
+
+    /**
+     * Validates a command name.
+     *
+     * It must be non-empty and parts can optionally be separated by ":".
+     *
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException When the name is invalid
+     */
+    private function validateName($name)
+    {
+        if (!preg_match('/^[^\:]++(\:[^\:]++)*$/', $name)) {
+            throw new \InvalidArgumentException(sprintf('Command name "%s" is invalid.', $name));
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -62,7 +62,7 @@ EOF
      *
      * @param Command $command The command to set
      */
-    public function setCommand(Command $command)
+    public function setTargetCommand(Command $command)
     {
         $this->command = $command;
     }

--- a/src/Symfony/Component/Console/Tests/Command/CommandConfigurationTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandConfigurationTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandConfiguration;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class CommandConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructor()
+    {
+        $command = new Command('foo');
+        $configuration = new CommandConfiguration($command);
+        $this->assertSame($command, $configuration->getCommand(), '__construct() takes the command as its first argument');
+    }
+
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage No command was set
+     */
+    public function testCommandMustBeSet()
+    {
+        $configuration = new CommandConfiguration();
+        $configuration->getCommand();
+    }
+
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage The command must be a Command instance or a callable returning a Command instance
+     */
+    public function testSetInvalidCommand()
+    {
+        $configuration = new CommandConfiguration();
+        $configuration->setCommand(new \stdClass());
+    }
+
+    public function testSetGetCommandInstance()
+    {
+        $commandInstance = new Command('foo');
+        $configuration = new CommandConfiguration();
+        $configuration->setCommand($commandInstance);
+        $this->assertSame($commandInstance, $configuration->getCommand());
+    }
+
+    public function testSetGetCommandResolver()
+    {
+        $commandInstance = new Command('foo');
+        $configuration = new CommandConfiguration();
+        $configuration->setCommand(function () use ($commandInstance) {
+            return $commandInstance;
+        });
+        $this->assertSame($commandInstance, $configuration->getCommand());
+    }
+
+    public function testCommandResolverOnlyCalledOnce()
+    {
+        $configuration = new CommandConfiguration();
+        $configuration->setCommand(function () {
+            return new Command('foo');
+        });
+        $this->assertSame($configuration->getCommand(), $configuration->getCommand());
+    }
+
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage The command must be a Command instance or a callable returning a Command instance
+     */
+    public function testCommandResolverMustReturnCommand()
+    {
+        $configuration = new CommandConfiguration();
+        $configuration->setCommand(function () {
+            return;
+        });
+        $configuration->getCommand();
+    }
+
+    public function testSetGetDefinition()
+    {
+        $configuration = new CommandConfiguration();
+        $ret = $configuration->setDefinition($definition = new InputDefinition());
+        $this->assertEquals($configuration, $ret, '->setDefinition() implements a fluent interface');
+        $this->assertEquals($definition, $configuration->getDefinition(), '->setDefinition() sets the current InputDefinition instance');
+        $configuration->setDefinition(array(new InputArgument('foo'), new InputOption('bar')));
+        $this->assertTrue($configuration->getDefinition()->hasArgument('foo'), '->setDefinition() also takes an array of InputArguments and InputOptions as an argument');
+        $this->assertTrue($configuration->getDefinition()->hasOption('bar'), '->setDefinition() also takes an array of InputArguments and InputOptions as an argument');
+        $configuration->setDefinition(new InputDefinition());
+    }
+
+    public function testAddArgument()
+    {
+        $configuration = new CommandConfiguration();
+        $ret = $configuration->addArgument('foo');
+        $this->assertSame($configuration, $ret, '->addArgument() implements a fluent interface');
+        $this->assertTrue($configuration->getDefinition()->hasArgument('foo'), '->addArgument() adds an argument to the command');
+    }
+
+    public function testAddOption()
+    {
+        $configuration = new CommandConfiguration();
+        $ret = $configuration->addOption('foo');
+        $this->assertSame($configuration, $ret, '->addOption() implements a fluent interface');
+        $this->assertTrue($configuration->getDefinition()->hasOption('foo'), '->addOption() adds an option to the command');
+    }
+
+    public function testGetNamespaceGetNameSetName()
+    {
+        $configuration = new CommandConfiguration();
+        $this->assertNull($configuration->getName(), '->getName() returns the command name');
+        $configuration->setName('foo');
+        $this->assertEquals('foo', $configuration->getName(), '->setName() sets the command name');
+
+        $ret = $configuration->setName('foobar:bar');
+        $this->assertSame($configuration, $ret, '->setName() implements a fluent interface');
+        $this->assertEquals('foobar:bar', $configuration->getName(), '->setName() sets the command name');
+    }
+
+    /**
+     * @dataProvider provideInvalidCommandNames
+     */
+    public function testInvalidCommandNames($name)
+    {
+        $this->setExpectedException('InvalidArgumentException', sprintf('Command name "%s" is invalid.', $name));
+
+        $configuration = new CommandConfiguration();
+        $configuration->setName($name);
+    }
+
+    public function provideInvalidCommandNames()
+    {
+        return array(
+            array(''),
+            array('foo:'),
+        );
+    }
+
+    public function testGetSetDescription()
+    {
+        $configuration = new CommandConfiguration();
+        $ret = $configuration->setDescription('description1');
+        $this->assertSame($configuration, $ret, '->setDescription() implements a fluent interface');
+        $this->assertEquals('description1', $configuration->getDescription(), '->setDescription() sets the description');
+    }
+
+    public function testGetSetProcessTitle()
+    {
+        $configuration = new CommandConfiguration();
+        $ret = $configuration->setProcessTitle('foo');
+        $this->assertSame($configuration, $ret, '->setProcessTitle() implements a fluent interface');
+        $this->assertEquals('foo', $configuration->getProcessTitle(), '->setProcessTitle() sets the process title');
+    }
+
+    public function testGetSetHelp()
+    {
+        $configuration = new CommandConfiguration();
+        $ret = $configuration->setHelp('help1');
+        $this->assertSame($configuration, $ret, '->setHelp() implements a fluent interface');
+        $this->assertEquals('help1', $configuration->getHelp(), '->setHelp() sets the help');
+    }
+
+    public function testGetProcessedHelp()
+    {
+        $configuration = new CommandConfiguration();
+        $configuration->setName('namespace:name');
+        $configuration->setHelp('The %command.name% command does... Example: php %command.full_name%.');
+        $this->assertContains('The namespace:name command does...', $configuration->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly');
+        $this->assertNotContains('%command.full_name%', $configuration->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name%');
+    }
+
+    public function testGetSetAliases()
+    {
+        $configuration = new CommandConfiguration();
+        $ret = $configuration->setAliases(array('name'));
+        $this->assertSame($configuration, $ret, '->setAliases() implements a fluent interface');
+        $this->assertEquals(array('name'), $configuration->getAliases(), '->setAliases() sets the aliases');
+    }
+
+    public function testGetSynopsis()
+    {
+        $configuration = new CommandConfiguration();
+        $configuration->setName('namespace:name');
+        $configuration->addOption('foo');
+        $configuration->addArgument('foo');
+        $this->assertEquals('namespace:name [--foo] [foo]', $configuration->getSynopsis(), '->getSynopsis() returns the synopsis');
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandConfiguration;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -66,96 +67,6 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($command->getDefinition()->hasArgument('foo'), '->setDefinition() also takes an array of InputArguments and InputOptions as an argument');
         $this->assertTrue($command->getDefinition()->hasOption('bar'), '->setDefinition() also takes an array of InputArguments and InputOptions as an argument');
         $command->setDefinition(new InputDefinition());
-    }
-
-    public function testAddArgument()
-    {
-        $command = new \TestCommand();
-        $ret = $command->addArgument('foo');
-        $this->assertEquals($command, $ret, '->addArgument() implements a fluent interface');
-        $this->assertTrue($command->getDefinition()->hasArgument('foo'), '->addArgument() adds an argument to the command');
-    }
-
-    public function testAddOption()
-    {
-        $command = new \TestCommand();
-        $ret = $command->addOption('foo');
-        $this->assertEquals($command, $ret, '->addOption() implements a fluent interface');
-        $this->assertTrue($command->getDefinition()->hasOption('foo'), '->addOption() adds an option to the command');
-    }
-
-    public function testGetNamespaceGetNameSetName()
-    {
-        $command = new \TestCommand();
-        $this->assertEquals('namespace:name', $command->getName(), '->getName() returns the command name');
-        $command->setName('foo');
-        $this->assertEquals('foo', $command->getName(), '->setName() sets the command name');
-
-        $ret = $command->setName('foobar:bar');
-        $this->assertEquals($command, $ret, '->setName() implements a fluent interface');
-        $this->assertEquals('foobar:bar', $command->getName(), '->setName() sets the command name');
-    }
-
-    /**
-     * @dataProvider provideInvalidCommandNames
-     */
-    public function testInvalidCommandNames($name)
-    {
-        $this->setExpectedException('InvalidArgumentException', sprintf('Command name "%s" is invalid.', $name));
-
-        $command = new \TestCommand();
-        $command->setName($name);
-    }
-
-    public function provideInvalidCommandNames()
-    {
-        return array(
-            array(''),
-            array('foo:'),
-        );
-    }
-
-    public function testGetSetDescription()
-    {
-        $command = new \TestCommand();
-        $this->assertEquals('description', $command->getDescription(), '->getDescription() returns the description');
-        $ret = $command->setDescription('description1');
-        $this->assertEquals($command, $ret, '->setDescription() implements a fluent interface');
-        $this->assertEquals('description1', $command->getDescription(), '->setDescription() sets the description');
-    }
-
-    public function testGetSetHelp()
-    {
-        $command = new \TestCommand();
-        $this->assertEquals('help', $command->getHelp(), '->getHelp() returns the help');
-        $ret = $command->setHelp('help1');
-        $this->assertEquals($command, $ret, '->setHelp() implements a fluent interface');
-        $this->assertEquals('help1', $command->getHelp(), '->setHelp() sets the help');
-    }
-
-    public function testGetProcessedHelp()
-    {
-        $command = new \TestCommand();
-        $command->setHelp('The %command.name% command does... Example: php %command.full_name%.');
-        $this->assertContains('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly');
-        $this->assertNotContains('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name%');
-    }
-
-    public function testGetSetAliases()
-    {
-        $command = new \TestCommand();
-        $this->assertEquals(array('name'), $command->getAliases(), '->getAliases() returns the aliases');
-        $ret = $command->setAliases(array('name1'));
-        $this->assertEquals($command, $ret, '->setAliases() implements a fluent interface');
-        $this->assertEquals(array('name1'), $command->getAliases(), '->setAliases() sets the aliases');
-    }
-
-    public function testGetSynopsis()
-    {
-        $command = new \TestCommand();
-        $command->addOption('foo');
-        $command->addArgument('foo');
-        $this->assertEquals('namespace:name [--foo] [foo]', $command->getSynopsis(), '->getSynopsis() returns the synopsis');
     }
 
     public function testGetHelper()
@@ -344,5 +255,30 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $tester = new CommandTester($command);
         $tester->execute(array('command' => $command->getName()));
         $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/command_asxml.txt', $command->asXml(), '->asXml() returns an XML representation of the command');
+    }
+
+    public function testSetConfiguration()
+    {
+        $configuration = new CommandConfiguration();
+        $configuration
+            ->setName('foo:bar')
+            ->setAliases(array('name'))
+            ->setDescription('description')
+            ->setHelp('help');
+
+        // Via constructor
+        $command = new Command(null, $configuration);
+        $this->assertEquals('foo:bar', $command->getName());
+        $this->assertEquals(array('name'), $command->getAliases());
+        $this->assertEquals('description', $command->getDescription());
+        $this->assertEquals('help', $command->getHelp());
+
+        // Via setter
+        $command = new Command('foo');
+        $command->setConfiguration($configuration);
+        $this->assertEquals('foo:bar', $command->getName());
+        $this->assertEquals(array('name'), $command->getAliases());
+        $this->assertEquals('description', $command->getDescription());
+        $this->assertEquals('help', $command->getHelp());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -31,7 +31,7 @@ class HelpCommandTest extends \PHPUnit_Framework_TestCase
     {
         $command = new HelpCommand();
         $commandTester = new CommandTester($command);
-        $command->setCommand(new ListCommand());
+        $command->setTargetCommand(new ListCommand());
         $commandTester->execute(array());
         $this->assertRegExp('/list \[--xml\] \[--raw\] \[--format="\.\.\."\] \[namespace\]/', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
     }
@@ -40,7 +40,7 @@ class HelpCommandTest extends \PHPUnit_Framework_TestCase
     {
         $command = new HelpCommand();
         $commandTester = new CommandTester($command);
-        $command->setCommand(new ListCommand());
+        $command->setTargetCommand(new ListCommand());
         $commandTester->execute(array('--format' => 'xml'));
         $this->assertRegExp('/<command/', $commandTester->getDisplay(), '->execute() returns an XML help text if --xml is passed');
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12063 |
| License | MIT |
| Doc PR | TBD |

This PR adds support for lazy-loaded commands in the Console component (#12063).

I had to refactor the commands to extract the configuration into a separate class. That allows to define the configuration of a command separately from the command itself, which means we don't have to instantiate it. The command is then loaded only when being used. This is particularly useful when writing an application with a dependency injection container.

Backward compatibility is kept (if not it's a bug to fix) as `Command` extend from the new `CommandConfiguration` class (i.e. current commands _are their own configuration_). I wish they didn't as composition would be better instead of inheritance here, suggestions are welcome. Maybe we can break BC if we are targeting 3.0 and the change is deemed good enough?

To define a lazy-loaded command, here is a simple example:

``` php
$application = new Application();

$configuration = new CommandConfiguration();
$configuration
    ->setName('foo:bar')
    ->setDescription('description')
    ->setHelp('help');
$configuration->setCommand(function ($configuration) {
    // You might want to use a DI container here
    return new GreetCommand(null, $configuration);
});

$application->addCommandConfiguration($configuration);
$application->run();
```

Lazy-loaded commands don't have to define `configure()`:

``` php
class GreetCommand extends Command
{
    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $output->writeln('Hello');
    }
}
```

I hesitated between using closures that return the Command instance, or introducing a `CommandResolver`. I went with the simpler solution.

As explained in #12063, the current implementation forces to create all the Command instances which has the following problems for example:
- a large part of the application might be instantiated for nothing
- any error happening in the init of the instantiated objects will prevent the application from starting at all
- any misconfiguration in the DI container will prevent the application from starting at all
- admin and troubleshooting commands cannot be run if the application doesn't start (e.g. clear caches, start/stop server, show debug information, install the app, disable modules, …)
- any logic in the object's initialization will be run, which may require external services (database, remote cache, webservice, …) or may have side-effects (which is not good obviously, but it can happen)

The impact and reality of those problems depend a lot of your application obviously. But just like an application shouldn't load _every controller and their dependencies_ on each request, the console application shouldn't load every command and their dependencies on each execution if that can be avoided.

I don't believe this change has any impact on the Symfony full-stack framework but maybe it will give you some ideas.
