### PR TITLE
[DependencyInjection] don't try to declare fixture class twice

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container14.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container14.php
@@ -4,8 +4,10 @@ namespace Container14;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ProjectServiceContainer extends ContainerBuilder
-{
+if (!class_exists('Container14\ProjectServiceContainer')) {
+    class ProjectServiceContainer extends ContainerBuilder
+    {
+    }
 }
 
 return new ProjectServiceContainer();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

In #13914, I missed the fact that one of the fixture files declares a class. Thus leading to aborted tests when the file is loaded for the second time (`PHP Fatal error:  Cannot redeclare class Container14\ProjectServiceContainer`).
