### PR TITLE
[VarDumper] Add catch-all-objects hook for casters

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -192,7 +192,7 @@ abstract class AbstractCloner implements ClonerInterface
                 $class,
                 method_exists($class, '__debugInfo'),
                 new \ReflectionClass($class),
-                array_reverse(array($class => $class) + class_parents($class) + class_implements($class)),
+                array_reverse(array('*' => '*', $class => $class) + class_parents($class) + class_implements($class)),
             );
 
             $this->classInfo[$class] = $classInfo;

--- a/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
@@ -134,4 +134,54 @@ Symfony\Component\VarDumper\Cloner\Data Object
 EOTXT;
         $this->assertStringMatchesFormat($expected, print_r($clone, true));
     }
+
+    public function testCaster()
+    {
+        $cloner = new VarCloner(array(
+            '*' => function ($obj, $array) {
+                $array['foo'] = 123;
+
+                return $array;
+            },
+            __CLASS__ => function ($obj, $array) {
+                return array();
+            },
+        ));
+        $clone = $cloner->cloneVar($this);
+
+        $expected = <<<EOTXT
+Symfony\Component\VarDumper\Cloner\Data Object
+(
+    [data:Symfony\Component\VarDumper\Cloner\Data:private] => Array
+        (
+            [0] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => object
+                            [class] => %s
+                            [value] => 
+                            [cut] => 0
+                            [handle] => %d
+                            [refCount] => 0
+                            [position] => 1
+                        )
+
+                )
+
+            [1] => Array
+                (
+                    [foo] => 123
+                )
+
+        )
+
+    [maxDepth:Symfony\Component\VarDumper\Cloner\Data:private] => 20
+    [maxItemsPerDepth:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+    [useRefHandles:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+)
+
+EOTXT;
+        $this->assertStringMatchesFormat($expected, print_r($clone, true));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Allows to create generic casters for any type of objects
