### PR TITLE
[FrameworkBundle] Remove asset from require-dev

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -34,7 +34,6 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7|~3.0.0",
-        "symfony/asset": "~2.7|~3.0.0",
         "symfony/browser-kit": "~2.4|~3.0.0",
         "symfony/console": "~2.6|~3.0.0",
         "symfony/css-selector": "~2.0,>=2.0.5|~3.0.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Not needed because already in `require`.
