### PR TITLE
StringUtils security enhancement

### DIFF
--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -45,8 +45,8 @@ class StringUtils
             return hash_equals($knownString, $userInput);
         }
 
-        $knownLen = strlen($knownString);
-        $userLen = strlen($userInput);
+        $knownLen = self::safeStrlen($knownString);
+        $userLen = self::safeStrlen($userInput);
 
         // Extend the known string to avoid uninitialized string offsets
         $knownString .= $userInput;
@@ -62,5 +62,19 @@ class StringUtils
 
         // They are only identical strings if $result is exactly 0...
         return 0 === $result;
+    }
+    
+    /**
+     * Return the number of bytes in a string
+     * 
+     * @param string $string The string whose length we wish to obtain
+     * @return int
+     */
+    public static function safeStrlen($string)
+    {
+        if (function_exists('mb_strlen')) {
+            return mb_strlen($string, '8bit');
+        }
+        return strlen($string);
     }
 }


### PR DESCRIPTION
When `mbstring.func_overload` is set in php.ini, the standard `strlen()` and `substr()` are replaced by `mb_strlen()` and `mb_substr()`
