### PR TITLE
[WebProfiler] Fix partial search on url in list

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -15,7 +15,7 @@
         </select>
         <div class="clear-fix"></div>
         <label for="url">URL</label>
-        <input type="url" name="url" id="url" value="{{ url }}" placeholder="e.g. {{ request.baseUrl }}">
+        <input type="text" name="url" id="url" value="{{ url }}" placeholder="e.g. {{ request.baseUrl }}">
         <div class="clear-fix"></div>
         <label for="token">Token</label>
         <input type="text" name="token" id="token" value="{{ token }}" placeholder="e.g. 1f321b">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Removed the url type from the url form field as browser validation makes it impossible to do partial text search on the url as the browser will not submit the form because it does not validate as a url.
