### PR TITLE
[Form] Back ported AbstractType::configureOptions()

### DIFF
--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -43,6 +44,15 @@ abstract class AbstractType implements FormTypeInterface
      * {@inheritdoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+    /**
+     * Configures the options for this type.
+     *
+     * @param OptionsResolver $resolver The resolver for the options.
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
     }
 


### PR DESCRIPTION
We would like to start using this method on the current version.

It does not include everything from https://github.com/symfony/symfony/commit/3d43caef88db7226986d43ec98313cb3b5ee600c, but hopefully enough to maintain BC and prepare code for 2.7.
