### PR TITLE
[Console] add missing description to command on text format

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -113,9 +113,12 @@ class TextDescriptor extends Descriptor
      */
     protected function describeCommand(Command $command, array $options = array())
     {
+        $messages = array('<comment>Description:</comment>', ' '.$command->getDescription(), '');
+
         $command->getSynopsis();
         $command->mergeApplicationDefinition(false);
-        $messages = array('<comment>Usage:</comment>', ' '.$command->getSynopsis(), '');
+        $messages[] = '<comment>Usage:</comment>';
+        $messages[] = ' '.str_replace("\n", "\n ", $command->getSynopsis())."\n";
 
         if ($command->getAliases()) {
             $messages[] = '<comment>Aliases:</comment> <info>'.implode(', ', $command->getAliases()).'</info>';

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -1,3 +1,6 @@
+Description:
+ Displays help for a command
+
 Usage:
  help [--xml] [--format="..."] [--raw] [command_name]
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -1,3 +1,6 @@
+Description:
+ Lists commands
+
 Usage:
  list [--xml] [--raw] [--format="..."] [namespace]
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.txt
@@ -1,3 +1,6 @@
+<comment>Description:</comment>
+ command 1 description
+
 <comment>Usage:</comment>
  descriptor:command1
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
@@ -1,3 +1,6 @@
+<comment>Description:</comment>
+ command 2 description
+
 <comment>Usage:</comment>
  descriptor:command2 [-o|--option_name] argument_name
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_astext.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_astext.txt
@@ -1,3 +1,6 @@
+<comment>Description:</comment>
+ description
+
 <comment>Usage:</comment>
  namespace:name
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | y |
| New Feature? | n |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | y |
| Fixed Tickets | #13943 |
| License | MIT |
| Doc PR |  |
