### PR TITLE
[WebProfilerBundle] Fix javascript toolbar on IE8

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -4,6 +4,17 @@
 
         var noop = function() {},
 
+            collectionToArray = function (collection) {
+                var length = collection.length || 0,
+                    results = new Array(length);
+
+                while (length--) {
+                    results[length] = collection[length];
+                }
+
+                return results;
+            },
+
             profilerStorageKey = 'sf2/profiler/',
 
             request = function(url, onSuccess, onError, payload, options) {
@@ -131,13 +142,13 @@
                                 }
                             } else if (request.loading) {
                                 requestState = 'loading';
-                                state = 'loading'
+                                state = 'loading';
                             }
                             row.className = 'sf-ajax-request sf-ajax-request-' + requestState;
                         }
 
                         var infoSpan = document.querySelectorAll(".sf-toolbar-ajax-info")[0];
-                        var children = Array.prototype.slice.call(tbody.children);
+                        var children = collectionToArray(tbody.children);
                         for (var i = 0; i < children.length; i++) {
                             tbody.removeChild(children[i]);
                         }
@@ -185,7 +196,7 @@
         }
 
         {% if excluded_ajax_paths is defined %}
-            if (window.XMLHttpRequest) {
+            if (window.XMLHttpRequest && XMLHttpRequest.addEventListener) {
                 var proxied = XMLHttpRequest.prototype.open;
 
                 XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
@@ -262,9 +273,7 @@
             },
 
             toggle: function(selector, elOn, elOff) {
-                var i,
-                    style,
-                    tmp = elOn.style.display,
+                var tmp = elOn.style.display,
                     el = document.getElementById(selector);
 
                 elOn.style.display = elOff.style.display;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -33,10 +33,10 @@
                 Sfjs.renderAjaxRequests();
 
                 /* Handle toolbar-info position */
-                var toolbarBlocks = document.getElementsByClassName('sf-toolbar-block');
+                var toolbarBlocks = document.querySelectorAll('.sf-toolbar-block');
                 for (var i = 0; i < toolbarBlocks.length; i += 1) {
                     toolbarBlocks[i].onmouseover = function () {
-                        var toolbarInfo = this.getElementsByClassName('sf-toolbar-info')[0];
+                        var toolbarInfo = this.querySelectorAll('.sf-toolbar-info')[0];
                         var pageWidth = document.body.clientWidth;
                         var elementWidth = toolbarInfo.offsetWidth;
                         var leftValue = (elementWidth + this.offsetLeft) - pageWidth;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
- `Array.prototype.slice.call(tbody.children);` called on HTMLCollection throws an error on IE8
- `XMLHttpRequest` has no event handler on IE8 
- `document.getElementsByClassName` does not exist on IE8
