### PR TITLE
[SecurityBundle] UserPasswordEncoderCommand: fix help arguments order.

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -60,7 +60,7 @@ The command allows you to provide your own <comment>salt</comment>. If you don't
 the command will take care about that for you.
 
 You can also use the non interactive way by typing the following command:
-    <info>php %command.full_name% [password] [salt] [user-class]</info>
+    <info>php %command.full_name% [password] [user-class] [salt]</info>
 
 EOF
             )


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | ✘ |
| License | MIT |

A very small fix about the newly introduced command to encode a user password (#12818).
The help message states the command looks like:

```
security:encode-password [password] [salt] [user-class]
```

but is the following instead:

```
security:encode-password [password] [user-class] [salt]
```
