### PR TITLE
[Console] Added support for lazy-loaded commands (with Command resolver)

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console;
 
+use Symfony\Component\Console\Command\CommandConfiguration;
+use Symfony\Component\Console\Command\Resolver\CommandResolverInterface;
 use Symfony\Component\Console\Descriptor\TextDescriptor;
 use Symfony\Component\Console\Descriptor\XmlDescriptor;
 use Symfony\Component\Console\Helper\DebugFormatterHelper;
@@ -60,6 +62,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class Application
 {
     private $commands = array();
+    private $commandResolver;
     private $wantHelps = false;
     private $runningCommand;
     private $name;
@@ -93,9 +96,20 @@ class Application
         }
     }
 
+    /**
+     * @param EventDispatcherInterface $dispatcher
+     */
     public function setDispatcher(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * @param CommandResolverInterface $commandResolver
+     */
+    public function setCommandResolver(CommandResolverInterface $commandResolver)
+    {
+        $this->commandResolver = $commandResolver;
     }
 
     /**
@@ -402,6 +416,21 @@ class Application
         }
 
         return $command;
+    }
+
+    /**
+     * Adds command configuration.
+     *
+     * @param CommandConfiguration $configuration
+     * @return Command
+     */
+    public function addCommandConfiguration(CommandConfiguration $configuration)
+    {
+        if (null === $this->commandResolver) {
+            throw new \RuntimeException('You have to specify command resolver in order to register separate command configuration');
+        }
+
+        return $this->add(Command::registerLazyLoaded($configuration, $this->commandResolver));
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -50,13 +50,14 @@ class Command
     final public static function registerLazyLoaded(CommandConfiguration $configuration, CommandResolverInterface $resolver)
     {
         $proxyCommand = new self(null, $configuration);
+
         $proxyCommand->setCode(function ($input, $output) use ($configuration, $resolver, $proxyCommand) {
             $command = $resolver->resolve($configuration->getName());
 
             if ($command instanceof Command) {
-                $command->application = $proxyCommand->application;
-                $command->configuration = $proxyCommand->configuration;
-                $command->helperSet = $proxyCommand->helperSet;
+                $command->setApplication($proxyCommand->getApplication());
+                $command->setConfiguration($proxyCommand->getConfiguration());
+                $command->setHelperSet($proxyCommand->getHelperSet());
 
                 return $command->doRun($input, $output);
             }
@@ -120,6 +121,16 @@ class Command
     }
 
     /**
+     * Sets command configuration.
+     *
+     * @param CommandConfiguration $configuration
+     */
+    public function setConfiguration(CommandConfiguration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
      * Sets the helper set.
      *
      * @param HelperSet $helperSet A HelperSet instance
@@ -149,6 +160,16 @@ class Command
     public function getApplication()
     {
         return $this->application;
+    }
+
+    /**
+     * Gets command configuration.
+     *
+     * @return CommandConfiguration
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
     }
 
     /**
@@ -653,11 +674,12 @@ class Command
     }
 
     /**
+     * @internal
      * @param InputInterface $input
      * @param OutputInterface $output
      * @return int
      */
-    private function doRun(InputInterface $input, OutputInterface $output)
+    public function doRun(InputInterface $input, OutputInterface $output)
     {
         if ($input->isInteractive()) {
             $this->interact($input, $output);

--- a/src/Symfony/Component/Console/Command/CommandConfiguration.php
+++ b/src/Symfony/Component/Console/Command/CommandConfiguration.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+use Symfony\Component\Console\Input\InputDefinition;
+
+/**
+ * Configuration of a command.
+ *
+ * @author Nikita Konstantinov
+ *
+ * @api
+ */
+final class CommandConfiguration
+{
+    private $name;
+    private $aliases = array();
+    private $definition;
+    private $enabled;
+    private $processTitle;
+    private $help;
+    private $description;
+    private $synopsis;
+
+    /**
+     * @param $name
+     * @param InputDefinition $definition
+     * @param string[] $aliases
+     * @param $enabled
+     * @param $processTitle
+     * @param $help
+     * @param $description
+     * @param $synopsis
+     */
+    public function __construct(
+        $name = null,
+        InputDefinition $definition = null,
+        array $aliases = array(),
+        $enabled = true,
+        $processTitle = null,
+        $help = null,
+        $description = null,
+        $synopsis = null
+    )
+    {
+        if ($name !== null) {
+            $this->validateName($name);
+        }
+
+        foreach ($aliases as $alias) {
+            $this->validateName($alias);
+        }
+
+        $this->name = $name;
+        $this->aliases = $aliases;
+        $this->definition = $definition ?: new InputDefinition();
+        $this->enabled = $enabled;
+        $this->processTitle = $processTitle;
+        $this->help = $help;
+        $this->description = $description;
+        $this->synopsis = $synopsis;
+    }
+
+    /**
+     * Whether the command is enabled or not in the current environment.
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param InputDefinition $definition
+     * @return CommandConfiguration
+     */
+    public function withDefinition(InputDefinition $definition)
+    {
+        $configuration = clone $this;
+        $configuration->definition = $definition;
+
+        return $configuration;
+    }
+
+    /**
+     * Gets the InputDefinition attached to this Command.
+     *
+     * @return InputDefinition An InputDefinition instance
+     *
+     * @api
+     */
+    public function getDefinition()
+    {
+        return $this->definition;
+    }
+
+    /**
+     * @param string $title
+     * @return CommandConfiguration
+     */
+    public function withProcessTitle($title)
+    {
+        $configuration = clone $this;
+        $configuration->processTitle = $title;
+
+        return $configuration;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProcessTitle()
+    {
+        return $this->processTitle;
+    }
+
+    /**
+     * @param string $name
+     * @return CommandConfiguration
+     */
+    public function withName($name)
+    {
+        $this->validateName($name);
+
+        $configuration = clone $this;
+        $configuration->name = $name;
+
+        return $configuration;
+    }
+
+    /**
+     * Returns the command name.
+     *
+     * @return string The command name
+     *
+     * @api
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $description
+     * @return CommandConfiguration
+     */
+    public function withDescription($description)
+    {
+        $configuration = clone $this;
+        $configuration->description = $description;
+
+        return $configuration;
+    }
+
+    /**
+     * Returns the description for the command.
+     *
+     * @return string The description for the command
+     *
+     * @api
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $help
+     * @return CommandConfiguration
+     */
+    public function withHelp($help)
+    {
+        $configuration = clone $this;
+        $configuration->help = $help;
+
+        return $configuration;
+    }
+
+    /**
+     * Returns the help for the command.
+     *
+     * @return string The help for the command
+     *
+     * @api
+     */
+    public function getHelp()
+    {
+        return $this->help;
+    }
+
+    /**
+     * Returns the processed help for the command replacing the %command.name% and
+     * %command.full_name% patterns with the real values dynamically.
+     *
+     * @return string The processed help for the command
+     */
+    public function getProcessedHelp()
+    {
+        $name = $this->name;
+
+        $placeholders = array(
+            '%command.name%',
+            '%command.full_name%',
+        );
+        $replacements = array(
+            $name,
+            $_SERVER['PHP_SELF'].' '.$name,
+        );
+
+        return str_replace($placeholders, $replacements, $this->getHelp());
+    }
+
+    /**
+     * @param string[] $aliases
+     * @return CommandConfiguration
+     */
+    public function withAliases(array $aliases)
+    {
+        foreach ($aliases as $alias) {
+            $this->validateName($alias);
+        }
+
+        $configuration = clone $this;
+        $configuration->aliases = $aliases;
+
+        return $configuration;
+    }
+
+    /**
+     * Returns the aliases for the command.
+     *
+     * @return array An array of aliases for the command
+     *
+     * @api
+     */
+    public function getAliases()
+    {
+        return $this->aliases;
+    }
+
+    /**
+     * Returns the synopsis for the command.
+     *
+     * @return string The synopsis
+     */
+    public function getSynopsis()
+    {
+        if (null === $this->synopsis) {
+            $this->synopsis = trim(sprintf('%s %s', $this->name, $this->definition->getSynopsis()));
+        }
+
+        return $this->synopsis;
+    }
+
+    /**
+     * Validates a command name.
+     *
+     * It must be non-empty and parts can optionally be separated by ":".
+     *
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException When the name is invalid
+     */
+    private function validateName($name)
+    {
+        if (!preg_match('/^[^\:]++(\:[^\:]++)*$/', $name)) {
+            throw new \InvalidArgumentException(sprintf('Command name "%s" is invalid.', $name));
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Command/CommandConfiguration.php
+++ b/src/Symfony/Component/Console/Command/CommandConfiguration.php
@@ -32,14 +32,23 @@ final class CommandConfiguration
     private $synopsis;
 
     /**
-     * @param $name
+     * @param string $name
+     * @return CommandConfiguration
+     */
+    public static function create($name)
+    {
+        return new self($name);
+    }
+
+    /**
+     * @param string $name
      * @param InputDefinition $definition
      * @param string[] $aliases
-     * @param $enabled
-     * @param $processTitle
-     * @param $help
-     * @param $description
-     * @param $synopsis
+     * @param bool $enabled
+     * @param string $processTitle
+     * @param string $help
+     * @param string $description
+     * @param string $synopsis
      */
     public function __construct(
         $name = null,
@@ -50,8 +59,7 @@ final class CommandConfiguration
         $help = null,
         $description = null,
         $synopsis = null
-    )
-    {
+    ) {
         if ($name !== null) {
             $this->validateName($name);
         }

--- a/src/Symfony/Component/Console/Command/Resolver/ClosureCommandResolver.php
+++ b/src/Symfony/Component/Console/Command/Resolver/ClosureCommandResolver.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command\Resolver;
+
+/**
+ * @author Nikita Konstantinov
+ *
+ * @api
+ */
+final class ClosureCommandResolver implements CommandResolverInterface
+{
+    /**
+     * @var \Closure
+     */
+    private $closure;
+
+    /**
+     * @param \Closure $closure
+     */
+    public function __construct(\Closure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($commandName)
+    {
+        $command = call_user_func($this->closure, $commandName);
+
+        if (null === $command) {
+            throw new CommandResolutionException(sprintf('Command "%s" could not be resolved', $commandName));
+        }
+
+        return $command;
+    }
+}

--- a/src/Symfony/Component/Console/Command/Resolver/CommandResolutionException.php
+++ b/src/Symfony/Component/Console/Command/Resolver/CommandResolutionException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command\Resolver;
+
+/**
+ * @author Nikita Konstantinov
+ */
+class CommandResolutionException extends \Exception
+{
+}

--- a/src/Symfony/Component/Console/Command/Resolver/CommandResolverInterface.php
+++ b/src/Symfony/Component/Console/Command/Resolver/CommandResolverInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command\Resolver;
+
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Command resolver allows to get instance of a Command (or any callable) by name.
+ *
+ * @author Nikita Konstantinov
+ *
+ * @api
+ */
+interface CommandResolverInterface
+{
+    /**
+     * @param string $commandName
+     * @return Command|callable
+     * @throws CommandResolutionException
+     */
+    public function resolve($commandName);
+}

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests;
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\CommandConfiguration;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -1018,6 +1019,27 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $inputStream = $application->getHelperSet()->get('question')->getInputStream();
         $this->assertEquals($tester->getInput()->isInteractive(), @posix_isatty($inputStream));
+    }
+
+    public function testAddingSeparateConfiguration()
+    {
+        $resolver = $this->getMockForAbstractClass('Symfony\Component\Console\Command\Resolver\CommandResolverInterface');
+
+        $application = new Application();
+        $application->setCommandResolver($resolver);
+        $application->addCommandConfiguration(CommandConfiguration::create('foo:bar'));
+
+        $this->assertTrue($application->has('foo:bar'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage You have to specify command resolver in order to register separate command configuration
+     */
+    public function testAddingSeparateConfigurationWithoutResolver()
+    {
+        $application = new Application();
+        $application->addCommandConfiguration(CommandConfiguration::create('foo:bar'));
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandConfigurationTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandConfigurationTest.php
@@ -24,7 +24,7 @@ class CommandConfigurationTest  extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($configuration, $newConfiguration, '->withName() does not mutate original configuration');
 
         $configuration = $newConfiguration;
-        $newConfiguration = $configuration->withAliases(['bar:foo']);
+        $newConfiguration = $configuration->withAliases(array('bar:foo'));
         $this->assertNotSame($configuration, $newConfiguration, '->withAliases() does not mutate original configuration');
 
         $configuration = $newConfiguration;
@@ -51,8 +51,8 @@ class CommandConfigurationTest  extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo:bar', $configuration->getName(), '->getName() returns correct command name');
         $this->assertSame('bar:foo', $configuration->withName('bar:foo')->getName(), '->withName() returns configuration with new name');
 
-        $this->assertSame([], $configuration->getAliases());
-        $this->assertSame(['bar:baz'], $configuration->withAliases(['bar:baz'])->getAliases(), '->withAliases() returns configuration with new aliases');
+        $this->assertSame(array(), $configuration->getAliases());
+        $this->assertSame(array('bar:baz'), $configuration->withAliases(array('bar:baz'))->getAliases(), '->withAliases() returns configuration with new aliases');
 
         $this->assertNull($configuration->getProcessTitle());
         $this->assertSame('title', $configuration->withProcessTitle('title')->getProcessTitle(), '->getProcessTitle() returns configuration with new title');

--- a/src/Symfony/Component/Console/Tests/Command/CommandConfigurationTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandConfigurationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Command;
+
+use Symfony\Component\Console\Command\CommandConfiguration;
+use Symfony\Component\Console\Input\InputDefinition;
+
+class CommandConfigurationTest  extends \PHPUnit_Framework_TestCase
+{
+    public function testImmutablity()
+    {
+        $configuration = new CommandConfiguration('foo:bar');
+
+        $newConfiguration = $configuration->withName('foo:baz');
+        $this->assertNotSame($configuration, $newConfiguration, '->withName() does not mutate original configuration');
+
+        $configuration = $newConfiguration;
+        $newConfiguration = $configuration->withAliases(['bar:foo']);
+        $this->assertNotSame($configuration, $newConfiguration, '->withAliases() does not mutate original configuration');
+
+        $configuration = $newConfiguration;
+        $newConfiguration = $configuration->withDefinition(new InputDefinition());
+        $this->assertNotSame($configuration, $newConfiguration, '->withDefinition() does not mutate original configuration');
+
+        $configuration = $newConfiguration;
+        $newConfiguration = $configuration->withProcessTitle('title');
+        $this->assertNotSame($configuration, $newConfiguration, '->withProcessTitle() does not mutate original configuration');
+
+        $configuration = $newConfiguration;
+        $newConfiguration = $configuration->withHelp('help');
+        $this->assertNotSame($configuration, $newConfiguration, '->withHelp() does not mutate original configuration');
+
+        $configuration = $newConfiguration;
+        $newConfiguration = $configuration->withDescription('description');
+        $this->assertNotSame($configuration, $newConfiguration, '->withDescription() does not mutate original configuration');
+    }
+
+    public function testFactories()
+    {
+        $configuration = new CommandConfiguration('foo:bar');
+
+        $this->assertSame('foo:bar', $configuration->getName(), '->getName() returns correct command name');
+        $this->assertSame('bar:foo', $configuration->withName('bar:foo')->getName(), '->withName() returns configuration with new name');
+
+        $this->assertSame([], $configuration->getAliases());
+        $this->assertSame(['bar:baz'], $configuration->withAliases(['bar:baz'])->getAliases(), '->withAliases() returns configuration with new aliases');
+
+        $this->assertNull($configuration->getProcessTitle());
+        $this->assertSame('title', $configuration->withProcessTitle('title')->getProcessTitle(), '->getProcessTitle() returns configuration with new title');
+
+        $this->assertNull($configuration->getHelp());
+        $this->assertSame('help', $configuration->withHelp('help')->getHelp(), '->withHelp() returns configuration with new help');
+
+        $this->assertNull($configuration->getDescription());
+        $this->assertSame('description', $configuration->withDescription('description')->getDescription(), '->withDescription() returns configuration with new description');
+    }
+
+    /**
+     * @dataProvider provideInvalidCommandNames
+     */
+    public function testInvalidCommandNames($name)
+    {
+        $this->setExpectedException('InvalidArgumentException', sprintf('Command name "%s" is invalid.', $name));
+
+        new CommandConfiguration($name);
+    }
+
+    public function provideInvalidCommandNames()
+    {
+        return array(
+            array(''),
+            array('foo:'),
+        );
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandConfiguration;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -45,7 +46,8 @@ class CommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testCommandNameCannotBeEmpty()
     {
-        new Command();
+        $command = new Command();
+        $command->getName();
     }
 
     public function testSetApplication()
@@ -94,25 +96,6 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $ret = $command->setName('foobar:bar');
         $this->assertEquals($command, $ret, '->setName() implements a fluent interface');
         $this->assertEquals('foobar:bar', $command->getName(), '->setName() sets the command name');
-    }
-
-    /**
-     * @dataProvider provideInvalidCommandNames
-     */
-    public function testInvalidCommandNames($name)
-    {
-        $this->setExpectedException('InvalidArgumentException', sprintf('Command name "%s" is invalid.', $name));
-
-        $command = new \TestCommand();
-        $command->setName($name);
-    }
-
-    public function provideInvalidCommandNames()
-    {
-        return array(
-            array(''),
-            array('foo:'),
-        );
     }
 
     public function testGetSetDescription()
@@ -344,5 +327,13 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $tester = new CommandTester($command);
         $tester->execute(array('command' => $command->getName()));
         $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/command_asxml.txt', $command->asXml(), '->asXml() returns an XML representation of the command');
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInconsistentDefinition()
+    {
+        new Command('foo', new CommandConfiguration('bar'));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/Resolver/ClosureCommandResolverTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/Resolver/ClosureCommandResolverTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Command\Resolver;
+
+use Symfony\Component\Console\Command\Resolver\ClosureCommandResolver;
+
+class ClosureCommandResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatItResolvesCommand()
+    {
+        $command = function () {
+            return 42;
+        };
+
+        $resolver = new ClosureCommandResolver(function ($name) use ($command) {
+            if ($name === 'foo:bar') {
+                return $command;
+            }
+        });
+
+        $this->assertSame($command, $resolver->resolve('foo:bar'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Console\Command\Resolver\CommandResolutionException
+     * @expectedExceptionMessage Command "foo:bar" could not be resolved
+     */
+    public function testThatItThrowsExceptionInCaseOfFailure()
+    {
+        $resolver = new ClosureCommandResolver(function () {
+            return;
+        });
+
+        $resolver->resolve('foo:bar');
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/TestCommandWithSeparateConfiguration.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/TestCommandWithSeparateConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestCommandWithSeparateConfiguration extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln(sprintf('Hello, %s', $input->getArgument('name')));
+        $output->writeln(sprintf('Command name: %s', $this->getName()));
+        $output->writeln(sprintf('Description %s', $this->getDescription()));
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('interact called');
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12063 |
| License | MIT |
| Doc PR | - |

This PR is an alternative (well, I treat it more like PoC and I didn't bother to add tests for now) to the #13946. Example of usage:

``` php
class GreetCommand extends Command
{
    public function __construct()
    {
        sleep(3);
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $output->writeln('Hello, world');
    }
}

$application = new Application();

$application->setCommandResolver(new ClosureCommandResolver(function ($name) {
    switch ($name) {
        case 'foo:bar':
            return new GreetCommand();
    }
}));

$application->addCommandConfiguration(
    CommandConfiguration::create('foo:bar')
        ->withDescription('Foo and Bar')
        ->withHelp('Help message')
        ->withDefinition(
            new InputDefinition([
                new InputOption('baz', 'b', InputOption::VALUE_REQUIRED)
            ])
        )
);

$application->run();
```

Note that I didn't call parent constructor in the `GreetCommand` on purpose. Given it's all about [commands as services](http://symfony.com/doc/current/cookbook/console/commands_as_services.html), I don't want to call parent constructor every time.

 Thoughts?

/cc @mnapoli
