### PR TITLE
[Form] Add flexibility for EntityType

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -69,7 +69,6 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
     public function getEntities()
     {
         if (null === $this->queryBuilder) {
-            
             return array();
         }
         
@@ -82,7 +81,6 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
     public function getEntitiesByIds($identifier, array $values)
     {
         if (null === $this->queryBuilder) {
-            
             return array();
         }
         

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -27,7 +27,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
      *
      * This property should only be accessed through queryBuilder.
      *
-     * @var QueryBuilder
+     * @var QueryBuilder|null
      */
     private $queryBuilder;
 

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -55,7 +55,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
 
             $queryBuilder = $queryBuilder($manager->getRepository($class));
 
-            if (!$queryBuilder instanceof QueryBuilder) {
+            if (null !== $queryBuilder && !$queryBuilder instanceof QueryBuilder) {
                 throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder');
             }
         }
@@ -68,6 +68,11 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
      */
     public function getEntities()
     {
+        if (null === $this->queryBuilder) {
+            
+            return array();
+        }
+        
         return $this->queryBuilder->getQuery()->execute();
     }
 
@@ -76,6 +81,11 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
      */
     public function getEntitiesByIds($identifier, array $values)
     {
+        if (null === $this->queryBuilder) {
+            
+            return array();
+        }
+        
         $qb = clone ($this->queryBuilder);
         $alias = current($qb->getRootAliases());
         $parameter = 'ORMQueryBuilderLoader_getEntitiesByIds_'.$identifier;

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -196,6 +196,19 @@ class EntityTypeTest extends TypeTestCase
 
         $field->submit('2');
     }
+    
+    public function testConfigureQueryBuilderWithClosureReturningNull()
+    {
+        $field = $this->factory->createNamed('name', 'entity', null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'query_builder' => function () {
+                return null;
+            },
+        ));
+
+        $this->assertEquals(array(), $field->createView()->vars['choices']);
+    }
 
     public function testSetDataSingleNull()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Sometimes it can be usefull to return null rather than a QueryBuilder from the closure attached to the `query_builder` attribute of an EntityType.

For example, if I have the following method in a "DelegateRepository", which can return a QueryBuilder or null:

``` php
public function getQbForOfficers()
{
    $permanentMeeting = $this->getEntityManager()->getRepository('MyBundle:PermanentMeeting')->findOneBy(array());

    if ($permanentMeeting === null || $permanentMeeting->getMeeting() === null) {
        return null;
    }

    $qb = $this->getEntityManager()->createQueryBuilder();
    $qb->select('p')
        ->from('MyBundle:Delegate', 'p')
        ->andWhere('p.meeting = :meetingId')
        ->setParameter('meetingId', $permanentMeeting->getMeeting()->getId());

    return $qb;
}
```

To be able to present a list without entries when creating an entity field like this:

``` php
$event->getForm()->add('officers', 'entity', array(
    'class' => 'MyBundle:Delegate',
    'property' => 'fullName',
    'query_builder' => function(EntityRepository $er) use ($meeting, $delegationId) {
        return $er->getQbForOfficers();
    }
)));
```

Rather than using the "choices" attributes (more verbose and which requires the injection of the entityManager):

``` php
$qb = $this->entityManager->getRepository('PTCNoventoBundle:Delegate')->getQbForOfficers();

$officers = ($qb !== null) ? $qb->getQuery()->getResult() : array();

$event->getForm()->add('officers', 'entity', array(
    'class' => 'PTCNoventoBundle:Delegate',
    'property' => 'fullName',
    'choices' => $officers,
));
```
