### PR TITLE
[Dependency Injection] Improve PhpDumper Performance for huge Containers

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1241,7 +1241,7 @@ EOF;
      *
      * @return bool
      */
-    private function hasReference($id, array $arguments, $deep = false, array $visited = array())
+    private function hasReference($id, array $arguments, $deep = false, array &$visited = array())
     {
         foreach ($arguments as $argument) {
             if (is_array($argument)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

After making public services private, the dumping of the DIC takes much longer. This is due to the reference lookup method. Using the visited lookup as reference speeds up the whole dump (in our case by a factor of ~40).

Some stats from our DIC:
before: 32 sec. for dumping
after: 0.9 sec.
