### PR TITLE
Fix small coding style

### DIFF
--- a/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
+++ b/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Translation\PluralizationRules;
  *
  * @author Clemens Tolboom clemens@build2be.nl
  */
-class PluralizationRulesTest  extends \PHPUnit_Framework_TestCase
+class PluralizationRulesTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * We test failed langcode here.


### PR DESCRIPTION
[Component] [Translation] [Tests] [PluralizationRulesTest.php] Remove extra space from `PluralizationRulesTest` class declaration.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
