### PR TITLE
[SECURITY][ACL] fixed Base ACL exceptions on the RuntimeException

### DIFF
--- a/src/Symfony/Component/Security/Acl/Exception/Exception.php
+++ b/src/Symfony/Component/Security/Acl/Exception/Exception.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Security\Acl\Exception;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class Exception extends \Exception
+class Exception extends \RuntimeException
 {
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13154 |
| License | MIT |
| Doc PR | n/a |

As said in the ticket issue #13154 "change to \RuntimeException, as this is a more detailed exception, giving users the opportunity to deal with the exceptions in a cleaner way (easier distinguish between runtime and logic exceptions for one)"
