### PR TITLE
[DomCrawler] Improve namespace discovery performance

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1027,7 +1027,7 @@ class Crawler extends \SplObjectStorage
      */
     private function findNamespacePrefixes($xpath)
     {
-        if (preg_match_all('/(?P<prefix>[a-z_][a-z_0-9\-\.]*):[^"\/]/i', $xpath, $matches)) {
+        if (preg_match_all('/(?P<prefix>[a-z_][a-z_0-9\-\.]*):[^"\/:]/i', $xpath, $matches)) {
             return array_unique($matches['prefix']);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12298 |
| License | MIT |
| Doc PR | - |

Before this quick-fix, xpath axes like `child::*` or `descendant-or-self::*` were considered namespaces. As a result, far too many xpath queries were being executed during namespace discovery.

Here's a full blackfire before/after comparision of @salaman's script:  https://blackfire.io/profiles/compare/a80b9e77-8e55-45d3-a348-7d34a51053b6/graph

![domcrawler-xpath-query](https://cloud.githubusercontent.com/assets/190447/6767384/ba93c57a-d024-11e4-84e1-e58dd7527f03.png)
