### PR TITLE
[DependencyInjection] prevent inlining service configurators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -62,9 +62,6 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             $definition->setProperties(
                 $this->inlineArguments($container, $definition->getProperties())
             );
-
-            $configurator = $this->inlineArguments($container, array($definition->getConfigurator()));
-            $definition->setConfigurator($configurator[0]);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -254,6 +254,23 @@ class InlineServiceDefinitionsPassTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $factory[0]);
     }
 
+    public function testProcessDoesNotInlineConfigurators()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo.configurator')
+            ->setPublic(false)
+        ;
+        $container
+            ->register('foo')
+            ->setConfigurator(array(new Reference('foo.configurator'), 'getFoo'))
+        ;
+        $this->process($container);
+
+        $configurator = $container->getDefinition('foo')->getConfigurator();
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $configurator[0]);
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $repeatedPass = new RepeatedPass(array(new AnalyzeServiceReferencesPass(), new InlineServiceDefinitionsPass()));

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -145,6 +145,7 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('container8'),
+            array('container9'),
             array('container11'),
             array('container12'),
             array('container14'),

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -37,6 +37,7 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'bar' => 'getBarService',
             'baz' => 'getBazService',
+            'configurator_service' => 'getConfiguratorServiceService',
             'configured_service' => 'getConfiguredServiceService',
             'decorator_service' => 'getDecoratorServiceService',
             'decorator_service_with_name' => 'getDecoratorServiceWithNameService',
@@ -113,12 +114,9 @@ class ProjectServiceContainer extends Container
      */
     protected function getConfiguredServiceService()
     {
-        $a = new \ConfClass();
-        $a->setFoo($this->get('baz'));
-
         $this->services['configured_service'] = $instance = new \stdClass();
 
-        $a->configureStdClass($instance);
+        $this->get('configurator_service')->configureStdClass($instance);
 
         return $instance;
     }
@@ -324,6 +322,27 @@ class ProjectServiceContainer extends Container
         if ($this->initialized('depends_on_request')) {
             $this->get('depends_on_request')->setRequest($this->get('request', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
+    }
+
+    /**
+     * Gets the 'configurator_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * This service is private.
+     * If you want to be able to request this service from the container directly,
+     * make it public, otherwise you might end up with broken code.
+     *
+     * @return \ConfClass A ConfClass instance.
+     */
+    protected function getConfiguratorServiceService()
+    {
+        $this->services['configurator_service'] = $instance = new \ConfClass();
+
+        $instance->setFoo($this->get('baz'));
+
+        return $instance;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently, only the `PhpDumper` is able to dump inlined service
configurators. Since Symfony applications dump the compiled container
in XML, inlined configurators will break this process.

We did something similar before with service factories in #13914.
