### PR TITLE
[Security] Improve entropy of generated salt

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -153,7 +153,7 @@ EOF
         $container = $this->getContainer();
         $saltQuestion->setValidator(function ($value) use ($output, $container) {
             if ('' === trim($value)) {
-                $value = hash('sha512', $container->get('security.secure_random')->nextBytes(30));
+                $value = base64_encode($container->get('security.secure_random')->nextBytes(30));
 
                 $output->writeln("\n<comment>The salt has been generated: </comment>".$value);
                 $output->writeln(sprintf("<comment>Make sure that your salt storage field fits this salt length: %s chars.</comment>\n", strlen($value)));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Using a hash as a salt provides unnecessarily low entropy, especially when using Symfony's recommended password encoder (bcrypt) which truncates salt at 22 chars, giving only 16^22 bits entropy. Using base64 instead provides _up to_ 256^30 bits (256^16 to bcrypt).

This change doesn't break compatibility with the built-in PasswordEncoderInterface implementations (message-digest, pbkdf2, bcrypt, plaintext), but it _might_ not work with some custom encoders if they've been assuming hexit salts. On balance I think it's fine since the commit this patches was only merged a few hours ago :D
