### PR TITLE
[Process] Remove outdated docblock @return on Process->start()

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -254,8 +254,6 @@ class Process
      * @param callable|null $callback A PHP callback to run whenever there is some
      *                                output available on STDOUT or STDERR
      *
-     * @return Process The process itself
-     *
      * @throws RuntimeException When process can't be launched
      * @throws RuntimeException When process is already running
      * @throws LogicException   In case a callback is provided and output has been disabled


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #14004 |
| License | MIT |

The original commit that introduced fluent interface for `Process->start()` was https://github.com/symfony/symfony/pull/8723 before Symfony 2.4. I couldn't find exactly where in history the start() `return $this` line was removed but it's not in v2.4.0 or any other stable branch.

Docs do not show start() as having a fluent interface: http://symfony.com/doc/current/components/process.html

Targeting 2.6 as currently maintained version.

:rocket: 
