### PR TITLE
[RFC] Logger component

### DIFF
--- a/src/Symfony/Component/Logger/Handler/SimpleFileLogger.php
+++ b/src/Symfony/Component/Logger/Handler/SimpleFileLogger.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @author Gonzalo Vilaseca <gonzalo.vilaseca@reiss.com>
+ * @date 23/03/15
+ * @copyright Copyright (c) Reiss Clothing Ltd.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace symfony\symfony\src\Symfony\Component\Logger\Handler;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+class SimpleFileLogger implements LoggerInterface
+{
+    protected $logfile;
+
+    protected $eof = '\n';
+
+    public function setLogFile($logfile)
+    {
+        $this->logfile = $logfile;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function emergency($message, array $context = array())
+    {
+        $this->log($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function alert($message, array $context = array())
+    {
+        $this->log($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function critical($message, array $context = array())
+    {
+        $this->log($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error($message, array $context = array())
+    {
+        $this->log($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warning($message, array $context = array())
+    {
+        $this->log($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function notice($message, array $context = array())
+    {
+        $this->log($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function info($message, array $context = array())
+    {
+        $this->log($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function debug($message, array $context = array())
+    {
+        $this->log($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = array())
+    {
+        if (!$this->logfile) {
+            throw new \Exception('SimpleFileLogger must be initialized with a detination filename.');
+        }
+        return file_put_contents($this->logfile, $message . $this->eof);
+    }
+}

--- a/src/Symfony/Component/Logger/LICENSE
+++ b/src/Symfony/Component/Logger/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2015 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Logger/Logger.php
+++ b/src/Symfony/Component/Logger/Logger.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Logger;
+
+use symfony\symfony\src\Symfony\Component\Logger\Handler\SimpleFileLogger;
+use Psr\Log\LoggerInterface;
+
+// Load the global varLog() function
+require_once __DIR__.'/Resources/functions/varLog.php';
+
+class Logger
+{
+    private static $logger;
+    private static $preArgs = array();
+    private static $postArgs = array();
+
+    public static function varLog($var, $channel)
+    {
+        if (null === self::$logger) {
+            self::$logger = new SimpleFileLogger();
+        }
+
+        $params = array_merge(self::$preArgs, array($var), self::$postArgs);
+
+        return call_user_func_array(array(self::$logger, $channel), $params);
+    }
+
+    public static function setLogger(LoggerInterface $logger)
+    {
+        self::$logger = $logger;
+    }
+
+    /**
+     * @param mixed $postArgs
+     */
+    public function setPostArgs($postArgs)
+    {
+        self::$postArgs = $postArgs;
+    }
+
+    /**
+     * @param mixed $preArgs
+     */
+    public function setPreArgs($preArgs)
+    {
+        self::$preArgs = $preArgs;
+    }
+}

--- a/src/Symfony/Component/Logger/Resources/functions/varLog.php
+++ b/src/Symfony/Component/Logger/Resources/functions/varLog.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Logger\Logger;
+
+if (!function_exists('varLog')) {
+    function varLog($var, $channel = 'log')
+    {
+            Logger::varLog($var, $channel);
+    }
+}


### PR DESCRIPTION
```
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
```

Not sure if this will be usefull for the community, but in our project we needed a way to be able to temporarily add logging to some parts of our app, we didn't wanted to go the injection way, so we're using this. 
Usage is simple:

```
Logger::setLogger(fooBarLogger);
```

Then in the app it's used:

```
varLog('Log this message');
```

or

```
varLog('Log this message', 'alert');
```

Integration with symfony is easily done with a config listener.

Please don't review the code yet, as it's just there to demonstrate the concept. If this is interesting for the community I will do a proper PR.
