### PR TITLE
[Security] [Core] String utils refactor

### DIFF
--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -82,7 +82,7 @@ class StringUtils
         if ($func_exists === null) {
             $func_exists = function_exists('mb_strlen');
         }
-        
+
         if ($func_exists) {
             return mb_strlen($string, '8bit');
         }

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -38,25 +38,29 @@ class StringUtils
      */
     public static function equals($knownString, $userInput)
     {
-        $knownString = (string) $knownString;
-        $userInput = (string) $userInput;
-
         if (function_exists('hash_equals')) {
             return hash_equals($knownString, $userInput);
+        }
+
+        // Avoid making unnecessary duplications of secret data
+        if (!is_string($knownString)) {
+            $knownString = (string) $knownString;
+        }
+
+        if (!is_string($userInput)) {
+            $userInput = (string) $userInput;
         }
 
         $knownLen = self::safeStrlen($knownString);
         $userLen = self::safeStrlen($userInput);
 
-        // Extend the known string to avoid uninitialized string offsets
-        $knownString .= $userInput;
-
         // Set the result to the difference between the lengths
         $result = $knownLen - $userLen;
 
-        // Note that we ALWAYS iterate over the user-supplied length
-        // This is to mitigate leaking length information
-        for ($i = 0; $i < $userLen; $i++) {
+        // Always iterate over the minimum length possible.
+        $iterationLen = min($knownLen, $userLen);
+
+        for ($i = 0; $i < $iterationLen; $i++) {
             $result |= (ord($knownString[$i]) ^ ord($userInput[$i]));
         }
 

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -45,8 +45,8 @@ class StringUtils
             return hash_equals($knownString, $userInput);
         }
 
-        $knownLen = strlen($knownString);
-        $userLen = strlen($userInput);
+        $knownLen = self::safeStrlen($knownString);
+        $userLen = self::safeStrlen($userInput);
 
         // Extend the known string to avoid uninitialized string offsets
         $knownString .= $userInput;
@@ -62,5 +62,19 @@ class StringUtils
 
         // They are only identical strings if $result is exactly 0...
         return 0 === $result;
+    }
+    
+    /**
+     * Return the number of bytes in a string
+     * 
+     * @param string $string The string whose length we wish to obtain
+     * @return int
+     */
+    public static function safeStrlen($string)
+    {
+        if (function_exists('mb_strlen')) {
+            return mb_strlen($string, '8bit');
+        }
+        return strlen($string);
     }
 }

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -72,7 +72,14 @@ class StringUtils
      */
     public static function safeStrlen($string)
     {
-        if (function_exists('mb_strlen')) {
+        // Premature optimization
+        // Since this cannot be changed at runtime, we can cache it
+        static $func_exists = null;
+        if ($func_exists === null) {
+            $func_exists = function_exists('mb_strlen');
+        }
+        
+        if ($func_exists) {
             return mb_strlen($string, '8bit');
         }
 

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -38,10 +38,6 @@ class StringUtils
      */
     public static function equals($knownString, $userInput)
     {
-        if (function_exists('hash_equals')) {
-            return hash_equals($knownString, $userInput);
-        }
-
         // Avoid making unnecessary duplications of secret data
         if (!is_string($knownString)) {
             $knownString = (string) $knownString;
@@ -51,16 +47,20 @@ class StringUtils
             $userInput = (string) $userInput;
         }
 
+        if (function_exists('hash_equals')) {
+            return hash_equals($knownString, $userInput);
+        }
+
         $knownLen = self::safeStrlen($knownString);
         $userLen = self::safeStrlen($userInput);
 
-        // Set the result to the difference between the lengths
-        $result = $knownLen - $userLen;
+		if ($userLen != $knownLen) {
+            return false;
+        }
 
-        // Always iterate over the minimum length possible.
-        $iterationLen = min($knownLen, $userLen);
+        $result = 0;
 
-        for ($i = 0; $i < $iterationLen; $i++) {
+        for ($i = 0; $i < $knownLen; $i++) {
             $result |= (ord($knownString[$i]) ^ ord($userInput[$i]));
         }
 

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -63,10 +63,10 @@ class StringUtils
         // They are only identical strings if $result is exactly 0...
         return 0 === $result;
     }
-    
+
     /**
      * Return the number of bytes in a string
-     * 
+     *
      * @param string $string The string whose length we wish to obtain
      * @return int
      */
@@ -75,6 +75,7 @@ class StringUtils
         if (function_exists('mb_strlen')) {
             return mb_strlen($string, '8bit');
         }
+
         return strlen($string);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This supersedes #13984 (it includes it, but also includes additional refactoring).

Since length information is leaked in any case, preventing unnecessary duplication of secrets is important. Since casting will _always_ make a copy, we only cast if absolutely necessary. Additionally, appending will create a new copy of the secret, so we avoid doing that, but instead only iterate over the minimum of the two strings.
