### PR TITLE
[VarDumper] add caster for MongoCursor objects

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/MongoCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/MongoCaster.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Casts classes from the MongoDb extension to array representation.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class MongoCaster
+{
+    public static function castCursor(\MongoCursorInterface $cursor, array $a, Stub $stub, $isNested)
+    {
+        $prefix = "\0~\0";
+
+        if ($info = $cursor->info()) {
+            foreach ($info as $k => $v) {
+                $a[$prefix.$k] = $v;
+            }
+        }
+        $a[$prefix.'dead'] = $cursor->dead();
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -76,6 +76,8 @@ abstract class AbstractCloner implements ClonerInterface
         'SplObjectStorage' => 'Symfony\Component\VarDumper\Caster\SplCaster::castObjectStorage',
         'SplPriorityQueue' => 'Symfony\Component\VarDumper\Caster\SplCaster::castHeap',
 
+        'MongoCursorInterface' => 'Symfony\Component\VarDumper\Caster\MongoCaster::castCursor',
+
         ':curl' => 'Symfony\Component\VarDumper\Caster\ResourceCaster::castCurl',
         ':dba' => 'Symfony\Component\VarDumper\Caster\ResourceCaster::castDba',
         ':dba persistent' => 'Symfony\Component\VarDumper\Caster\ResourceCaster::castDba',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This one is inspired from [PsySH's equivalent](https://github.com/bobthecow/psysh/blob/master/src/Psy/Presenter/MongoCursorPresenter.php).
Looking at the interface of the Mongo extension, the other classes may need a caster too.
So if a real Mongo user can write casters for them, that'd be great! (in an other PR, on top of this one)
