### PR TITLE
Translator component has default domain for null implemented

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -90,19 +90,11 @@ class TranslationExtension extends \Twig_Extension
 
     public function trans($message, array $arguments = array(), $domain = null, $locale = null)
     {
-        if (null === $domain) {
-            $domain = 'messages';
-        }
-
         return $this->translator->trans($message, $arguments, $domain, $locale);
     }
 
     public function transchoice($message, $count, array $arguments = array(), $domain = null, $locale = null)
     {
-        if (null === $domain) {
-            $domain = 'messages';
-        }
-
         return $this->translator->transChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -57,7 +57,7 @@ abstract class BaseType extends AbstractType
                 $uniqueBlockPrefix = '_'.$blockName;
             }
 
-            if (!$translationDomain) {
+            if (null === $translationDomain) {
                 $translationDomain = $view->parent->vars['translation_domain'];
             }
 
@@ -80,10 +80,6 @@ abstract class BaseType extends AbstractType
             array_unshift($blockPrefixes, $type->getName());
         }
         $blockPrefixes[] = $uniqueBlockPrefix;
-
-        if (!$translationDomain) {
-            $translationDomain = 'messages';
-        }
 
         $view->vars = array_replace($view->vars, array(
             'form' => $view,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -112,7 +112,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             ->getForm()
             ->createView();
 
-        $this->assertEquals('messages', $view['child']->vars['translation_domain']);
+        $this->assertNull($view['child']->vars['translation_domain']);
     }
 
     public function testPassLabelToView()


### PR DESCRIPTION
no need to have default translation domain logic in 3 different places

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | hopefully |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
