### PR TITLE
[Console] [Helper] [Table] Columns styles

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -554,6 +554,36 @@ TABLE;
         $this->assertEquals($table, $table->addRow(new TableSeparator()), 'fluent interface on addRow() with a single TableSeparator() works');
     }
 
+    public function testColumnStyle()
+    {
+        $table = new Table($output = $this->getOutputStream());
+        $table
+            ->setHeaders(array('ISBN', 'Title', 'Author', 'Price'))
+            ->setRows(array(
+                array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
+                array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'),
+            ));
+
+        $style = new TableStyle();
+        $style->setPadType(STR_PAD_LEFT);
+        $table->setColumnStyle(3, $style);
+
+        $table->render();
+
+        $expected =
+            <<<TABLE
++---------------+----------------------+-----------------+--------+
+| ISBN          | Title                | Author          |  Price |
++---------------+----------------------+-----------------+--------+
+| 99921-58-10-7 | Divine Comedy        | Dante Alighieri |   9.95 |
+| 9971-5-0210-0 | A Tale of Two Cities | Charles Dickens | 139.25 |
++---------------+----------------------+-----------------+--------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
     protected function getOutputStream()
     {
         return new StreamOutput($this->stream, StreamOutput::VERBOSITY_NORMAL, false);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR introduces ability to set styles for individual columns in table. For example, we can apply STR_PAD_LEFT for the last column (useful for money, file size etc).

Code:

``` php
use Symfony\Component\Finder\Finder;
use Symfony\Component\Console\Helper\Table;
use Symfony\Component\Console\Helper\TableStyle;

$table = new Table($output);
$table->setHeaders(['#', 'Path', 'Size']);

$style = new TableStyle();
$style->setPadType(STR_PAD_LEFT);

$table->setColumnStyle(2, $style);

$finder = new Finder();
$finder->files()->in("/path/to/dir")->name('*.php')
$counter = 0;
foreach ($finder as $file) {
    $counter++;
    $table->addRow([$counter, $file->getRealPath(), number_format($file->getSize(), 0, '.', ' ')]);
}

$table->render();
```

Output:

```
+---+---------------------+--------+
| # | Path                |   Size |
+---+---------------------+--------+
| 1 | autoload.php        |    183 |
| 2 | ApplicationTest.php | 47 794 |
| 3 | CommandTest.php     | 14 965 |
| 4 | ListCommandTest.php |  2 369 |
+---+---------------------+--------+
```
