### PR TITLE
[Config] Add equivalent of YAML sequence in XML.

### DIFF
--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -186,6 +186,35 @@ class XmlUtilsTest extends \PHPUnit_Framework_TestCase
         // should not throw an exception
         XmlUtils::loadFile(__DIR__.'/../Fixtures/Util/valid.xml', __DIR__.'/../Fixtures/Util/schema.xsd');
     }
+
+    /**
+     * @dataProvider getDataForCreateSequenceIfNotExists
+     */
+    public function testCreateSequenceIfNotExists($expected, $xml, $root = false, $checkPrefix = true)
+    {
+        $dom = new \DOMDocument();
+        $dom->loadXML($root ? $xml : '<root>'.$xml.'</root>');
+
+        $this->assertSame($expected, XmlUtils::convertDomElementToArray($dom->documentElement, $checkPrefix));
+    }
+
+    public function getDataForCreateSequenceIfNotExists()
+    {
+        return array(
+            array(array('parameter' => array('name' => 'name001','value' => 'value001')),
+                  '<parameter><name>name001</name><value>value001</value></parameter>', ),
+            array(array('parameter' => array(array('name' => 'name001','value' => 'value001'))),
+                  '<parameter create-sequence-if-not-exists="true"><name>name001</name><value>value001</value></parameter>', ),
+            array(array('parameter' => array(array('name' => 'name001','value' => 'value001'),array('name' => 'name002','value' => 'value002'))),
+                  '<parameter create-sequence-if-not-exists="true"><name>name001</name><value>value001</value></parameter><parameter create-sequence-if-not-exists="true"><name>name002</name><value>value002</value></parameter>', ),
+            array(array('parameter' => array(array('name' => 'name001','value' => 'value001'),array('name' => 'name002','value' => 'value002'))),
+                  '<parameter><name>name001</name><value>value001</value></parameter><parameter create-sequence-if-not-exists="true"><name>name002</name><value>value002</value></parameter>', ),
+            array(array('parameter' => array(array('name' => 'name001','value' => 'value001'),array('name' => 'name002','value' => 'value002'))),
+                  '<parameter create-sequence-if-not-exists="true"><name>name001</name><value>value001</value></parameter><parameter><name>name002</name><value>value002</value></parameter>', ),
+            array(array('parameter' => array(array('name' => 'name001','value' => 'value001'),array('name' => 'name002','value' => 'value002'))),
+                  '<parameter><name>name001</name><value>value001</value></parameter><parameter><name>name002</name><value>value002</value></parameter>', ),
+        );
+    }
 }
 
 interface Validator


### PR DESCRIPTION
In YAML, new sequences can be defined by the '-' directive, which is not
possible in XML. This breaks the rule of using YAML and XML as
configuration files interchangeably.

This could be an issue if ONLY ONE concrete child node of a prototyped array
node is defined in configuation files:
## YAML:

``` yaml
parameter:
    - name: name001
      value: value001
```
## XML:

``` xml
<root>
    <parameter>
        <name>name001</name>
        <value>value001</value>
    </parameter>
</root>
```

The YAML and XML files will be converted to different php objects:
## YAML php object:

``` php
array(
    'parameter' => array(
        array(
            'name' => 'name001',
            'value' => 'value001'
        )
    )
)
```
## XML php object:

``` php
array(
    'parameter' => array(
        'name' => 'name001',
        'value' => 'value001'
    )
)
```

The XML php object will cause subsequent processing error because it's
not valid for a prototyped array node.

This issue does not occur when multiple child nodes are found, because
the wrapper array will be created:
## YAML:

``` yaml
parameter:
    - name: name001
      value: value001
    - name: name002
      value: value002
```
## XML:

``` xml
<root>
    <parameter>
        <name>name001</name>
        <value>value001</value>
    </parameter>
    <parameter>
        <name>name002</name>
        <value>value002</value>
    </parameter>
</root>
```

The XML and YAML files will be converted to the same php object as
follows:
## YAML and XML php object:

``` php
array(
    'parameter' => array(
        array(
            'name' => 'name001',
            'value' => 'value001'
        ),
        array(
            'name' => 'name002',
            'value' => 'value002'
        ),
    )
)
```

To support the sequence directive in XML, a special tag attribute - "create-sequence-if-not-exists" is introduced:
## XML:

``` xml
<root>
    <parameter create-sequence-if-not-exists="true">
        <name>name001</name>
        <value>value001</value>
    </parameter>
</root>
```
## YAML:

``` yaml
parameter:
    - name: name001
      value: value001
```

Now, the XML and YAML files will be converted to the same php object as
follows.
## YAML and XML php object:

``` php
array(
    'parameter' => array(
        array(
            'name' => 'name001',
            'value' => 'value001'
        )
    )
)
```

If multiple child nodes are found, using this attribute will neither
cause any errors nor have any effect. So the following files are
equivalent:
## XML:

``` xml
<root>
    <parameter create-sequence-if-not-exists="true">
        <name>name001</name>
        <value>value001</value>
    </parameter>
    <parameter create-sequence-if-not-exists="true">
        <name>name002</name>
        <value>value002</value>
    </parameter>
</root>
```
## XML:

``` xml
<root>
    <parameter create-sequence-if-not-exists="true">
        <name>name001</name>
        <value>value001</value>
    </parameter>
    <parameter>
        <name>name002</name>
        <value>value002</value>
    </parameter>
</root>
```
## XML:

``` xml
<root>
    <parameter>
        <name>name001</name>
        <value>value001</value>
    </parameter>
    <parameter create-sequence-if-not-exists="true">
        <name>name002</name>
        <value>value002</value>
    </parameter>
</root>
```
## XML:

``` xml
<root>
    <parameter>
        <name>name001</name>
        <value>value001</value>
    </parameter>
    <parameter>
        <name>name002</name>
        <value>value002</value>
    </parameter>
</root>
```
## YAML:

``` yaml
parameter:
    - name: name001
      value: value001
    - name: name002
      value: value002
```

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
