### PR TITLE
[DX]|Validator] Add PHPUnit hint in AbstractConstraintValidatorTest

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -244,7 +244,7 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
 
     protected function assertNoViolation()
     {
-        $this->assertCount(0, $this->context->getViolations());
+        $this->assertSame(0, $violationsCount = count($this->context->getViolations()), sprintf('0 violation expected. Got %u.', $violationsCount));
     }
 
     /**
@@ -417,7 +417,7 @@ class ConstraintViolationAssertion
 
         $violations = iterator_to_array($this->context->getViolations());
 
-        \PHPUnit_Framework_Assert::assertCount(count($expected), $violations);
+        \PHPUnit_Framework_Assert::assertSame($expectedCount = count($expected), $violationsCount = count($violations), sprintf('%u violation(s) expected. Got %u.', $expectedCount, $violationsCount));
 
         reset($violations);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | ~ |
| Tests pass? | ~ |
| License | MIT |

When one extends AbstractConstraintValidatorTest, If test fails
the output is not very easy to understand because all "magic"
is done in the parent class. So we have to read the code of the
parent class to understand what happened.
