### PR TITLE
Show a better message if the port is already in use

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php
@@ -41,4 +41,25 @@ abstract class ServerCommand extends ContainerAwareCommand
     {
         return sys_get_temp_dir().'/'.strtr($address, '.:', '--').'.pid';
     }
+
+    protected function isOtherServerProcessRunning($address)
+    {
+        $lockFile = $this->getLockFile($address);
+
+        if (file_exists($lockFile)) {
+            return true;
+        }
+
+        list($hostname, $port) = explode(':', $address);
+
+        $fp = @fsockopen($hostname, $port, $errno, $errstr, 5);
+
+        if (false !== $fp) {
+            fclose($fp);
+
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Process\ProcessBuilder;
  *
  * @author Michał Pipa <michal.pipa.xsolve@gmail.com>
  */
-class ServerRunCommand extends ContainerAwareCommand
+class ServerRunCommand extends ServerCommand
 {
     /**
      * {@inheritdoc}
@@ -96,15 +96,28 @@ EOF
         }
 
         $env = $this->getContainer()->getParameter('kernel.environment');
+        $address = $input->getArgument('address');
+
+        if (false === strpos($address, ':')) {
+            $output->writeln('The address has to be of the form <comment>bind-address:port</comment>.');
+
+            return 1;
+        }
+
+        if ($this->isOtherServerProcessRunning($address)) {
+            $output->writeln(sprintf('<error>A process is already listening on http://%s.</error>', $address));
+
+            return 1;
+        }
 
         if ('prod' === $env) {
             $output->writeln('<error>Running PHP built-in server in production environment is NOT recommended!</error>');
         }
 
-        $output->writeln(sprintf("Server running on <info>http://%s</info>\n", $input->getArgument('address')));
+        $output->writeln(sprintf("Server running on <info>http://%s</info>\n", $address));
         $output->writeln('Quit the server with CONTROL-C.');
 
-        if (null === $builder = $this->createPhpProcessBuilder($input, $output, $env)) {
+        if (null === $builder = $this->createPhpProcessBuilder($output, $address, $input->getOption('router'), $env)) {
             return 1;
         }
 
@@ -131,9 +144,9 @@ EOF
         return $process->getExitCode();
     }
 
-    private function createPhpProcessBuilder(InputInterface $input, OutputInterface $output, $env)
+    private function createPhpProcessBuilder(OutputInterface $output, $address, $router, $env)
     {
-        $router = $input->getOption('router') ?: $this
+        $router = $router ?: $this
             ->getContainer()
             ->get('kernel')
             ->locateResource(sprintf('@FrameworkBundle/Resources/config/router_%s.php', $env))
@@ -154,6 +167,6 @@ EOF
             return;
         }
 
-        return new ProcessBuilder(array($binary, '-S', $input->getArgument('address'), $router));
+        return new ProcessBuilder(array($binary, '-S', $address, $router));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -160,27 +160,6 @@ EOF
         }
     }
 
-    private function isOtherServerProcessRunning($address)
-    {
-        $lockFile = $this->getLockFile($address);
-
-        if (file_exists($lockFile)) {
-            return true;
-        }
-
-        list($hostname, $port) = explode(':', $address);
-
-        $fp = @fsockopen($hostname, $port, $errno, $errstr, 5);
-
-        if (false !== $fp) {
-            fclose($fp);
-
-            return true;
-        }
-
-        return false;
-    }
-
     /**
      * Determine the absolute file path for the router script, using the environment to choose a standard script
      * if no custom router script is specified.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14275 |
| License | MIT |
| Doc PR | - |

When you run `server:run` and another process is already listening on the same port the command returns:

```
A process is already listening on http://127.0.0.1:8000.
```

instead of

```
Server running on http://127.0.0.1:8000

Quit the server with CONTROL-C.
Built-in server terminated unexpectedly
Run the command again with -v option for more details
```

Also, when you run `server:run 127.0.0.1` prints

```
The address has to be of the form bind-address:port.
```

instead of

```
Server running on http://127.0.0.1:8000

Quit the server with CONTROL-C.
Built-in server terminated unexpectedly
Run the command again with -v option for more details
```
