### PR TITLE
remove useless tests that fail in php 7

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -67,16 +67,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_Error
-     */
-    public function testChoicesOptionExpectsArray()
-    {
-        $this->factory->create('choice', null, array(
-            'choices' => new \ArrayObject(),
-        ));
-    }
-
-    /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testChoiceListOptionExpectsChoiceListInterface()

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Token/RememberMeTokenTest.php
@@ -52,23 +52,6 @@ class RememberMeTokenTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     * @dataProvider getUserArguments
-     */
-    public function testConstructorUserCannotBeNull($user)
-    {
-        new RememberMeToken($user, 'foo', 'foo');
-    }
-
-    public function getUserArguments()
-    {
-        return array(
-            array(null),
-            array('foo'),
-        );
-    }
-
     protected function getUser($roles = array('ROLE_FOO'))
     {
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14086 for Security and Form component |
| License | MIT |
| Doc PR | - |

`@expectedException \PHPUnit_Framework_Error` doesn't catch php fatal errors for wrong types in php 7. But these test are also pretty useless anyway. Then we would have to add a lot of tests for all arguments that are typehinted. Let's just remove these tests.
