### PR TITLE
CS: Unary operators should be placed adjacent to their operands

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -60,7 +60,7 @@ abstract class DoctrineType extends AbstractType
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $choiceListCache = & $this->choiceListCache;
+        $choiceListCache = &$this->choiceListCache;
         $registry = $this->registry;
         $propertyAccessor = $this->propertyAccessor;
         $type = $this;

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
@@ -49,7 +49,7 @@ class LazyServiceProjectServiceContainer extends Container
             $container = $this;
 
             return $this->services['foo'] = new stdClass_c1d194250ee2e2b7d2eab8b8212368a8(
-                function (& $wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) use ($container) {
+                function (&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) use ($container) {
                     $wrappedInstance = $container->getFooService(false);
 
                     $proxy->setProxyInitializer(null);

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -33,16 +33,16 @@ class FormFieldRegistry
     {
         $segments = $this->getSegments($field->getName());
 
-        $target = & $this->fields;
+        $target = &$this->fields;
         while ($segments) {
             if (!is_array($target)) {
                 $target = array();
             }
             $path = array_shift($segments);
             if ('' === $path) {
-                $target = & $target[];
+                $target = &$target[];
             } else {
-                $target = & $target[$path];
+                $target = &$target[$path];
             }
         }
         $target = $field;
@@ -58,13 +58,13 @@ class FormFieldRegistry
     public function remove($name)
     {
         $segments = $this->getSegments($name);
-        $target = & $this->fields;
+        $target = &$this->fields;
         while (count($segments) > 1) {
             $path = array_shift($segments);
             if (!array_key_exists($path, $target)) {
                 return;
             }
-            $target = & $target[$path];
+            $target = &$target[$path];
         }
         unset($target[array_shift($segments)]);
     }
@@ -82,13 +82,13 @@ class FormFieldRegistry
     public function &get($name)
     {
         $segments = $this->getSegments($name);
-        $target = & $this->fields;
+        $target = &$this->fields;
         while ($segments) {
             $path = array_shift($segments);
             if (!array_key_exists($path, $target)) {
                 throw new \InvalidArgumentException(sprintf('Unreachable field "%s"', $path));
             }
-            $target = & $target[$path];
+            $target = &$target[$path];
         }
 
         return $target;
@@ -123,7 +123,7 @@ class FormFieldRegistry
      */
     public function set($name, $value)
     {
-        $target = & $this->get($name);
+        $target = &$this->get($name);
         if (!is_array($value) || $target instanceof Field\ChoiceFormField) {
             $target->setValue($value);
         } else {

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -160,7 +160,7 @@ class ChoiceType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $choiceListCache = & $this->choiceListCache;
+        $choiceListCache = &$this->choiceListCache;
 
         $choiceList = function (Options $options) use (&$choiceListCache) {
             // Harden against NULL values (like in EntityType and ModelType)

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
@@ -73,7 +73,7 @@ class NamespacedAttributeBag extends AttributeBag
      */
     public function set($name, $value)
     {
-        $attributes = & $this->resolveAttributePath($name, true);
+        $attributes = &$this->resolveAttributePath($name, true);
         $name = $this->resolveKey($name);
         $attributes[$name] = $value;
     }
@@ -84,7 +84,7 @@ class NamespacedAttributeBag extends AttributeBag
     public function remove($name)
     {
         $retval = null;
-        $attributes = & $this->resolveAttributePath($name);
+        $attributes = &$this->resolveAttributePath($name);
         $name = $this->resolveKey($name);
         if (null !== $attributes && array_key_exists($name, $attributes)) {
             $retval = $attributes[$name];
@@ -106,7 +106,7 @@ class NamespacedAttributeBag extends AttributeBag
      */
     protected function &resolveAttributePath($name, $writeContext = false)
     {
-        $array = & $this->attributes;
+        $array = &$this->attributes;
         $name = (strpos($name, $this->namespaceCharacter) === 0) ? substr($name, 1) : $name;
 
         // Check if there is anything to do, else return
@@ -132,7 +132,7 @@ class NamespacedAttributeBag extends AttributeBag
                 $array[$part] = $writeContext ? array() : null;
             }
 
-            $array = & $array[$part];
+            $array = &$array[$part];
         }
 
         return $array;

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/AbstractProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/AbstractProfilerStorageTest.php
@@ -17,7 +17,7 @@ abstract class AbstractProfilerStorageTest extends \PHPUnit_Framework_TestCase
 {
     public function testStore()
     {
-        for ($i = 0; $i < 10; $i ++) {
+        for ($i = 0; $i < 10; $i++) {
             $profile = new Profile('token_'.$i);
             $profile->setIp('127.0.0.1');
             $profile->setUrl('http://foo.bar');

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -44,7 +44,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             $propertyPath = new PropertyPath($propertyPath);
         }
 
-        $propertyValues = & $this->readPropertiesUntil($objectOrArray, $propertyPath, $propertyPath->getLength());
+        $propertyValues = &$this->readPropertiesUntil($objectOrArray, $propertyPath, $propertyPath->getLength());
 
         return $propertyValues[count($propertyValues) - 1][self::VALUE];
     }
@@ -58,7 +58,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             $propertyPath = new PropertyPath($propertyPath);
         }
 
-        $propertyValues = & $this->readPropertiesUntil($objectOrArray, $propertyPath, $propertyPath->getLength() - 1);
+        $propertyValues = &$this->readPropertiesUntil($objectOrArray, $propertyPath, $propertyPath->getLength() - 1);
         $overwrite = true;
 
         // Add the root object to the list
@@ -68,7 +68,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         ));
 
         for ($i = count($propertyValues) - 1; $i >= 0; --$i) {
-            $objectOrArray = & $propertyValues[$i][self::VALUE];
+            $objectOrArray = &$propertyValues[$i][self::VALUE];
 
             if ($overwrite) {
                 $property = $propertyPath->getElement($i);
@@ -82,7 +82,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 }
             }
 
-            $value = & $objectOrArray;
+            $value = &$objectOrArray;
             $overwrite = !$propertyValues[$i][self::IS_REF];
         }
     }
@@ -122,19 +122,19 @@ class PropertyAccessor implements PropertyAccessorInterface
             }
 
             if ($isIndex) {
-                $propertyValue = & $this->readIndex($objectOrArray, $property);
+                $propertyValue = &$this->readIndex($objectOrArray, $property);
             } else {
-                $propertyValue = & $this->readProperty($objectOrArray, $property);
+                $propertyValue = &$this->readProperty($objectOrArray, $property);
             }
 
-            $objectOrArray = & $propertyValue[self::VALUE];
+            $objectOrArray = &$propertyValue[self::VALUE];
 
             // the final value of the path must not be validated
             if ($i + 1 < $propertyPath->getLength() && !is_object($objectOrArray) && !is_array($objectOrArray)) {
                 throw new UnexpectedTypeException($objectOrArray, 'object or array');
             }
 
-            $propertyValues[] = & $propertyValue;
+            $propertyValues[] = &$propertyValue;
         }
 
         return $propertyValues;
@@ -164,7 +164,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         if (isset($array[$index])) {
             if (is_array($array)) {
-                $result[self::VALUE] = & $array[$index];
+                $result[self::VALUE] = &$array[$index];
                 $result[self::IS_REF] = true;
             } else {
                 $result[self::VALUE] = $array[$index];
@@ -216,7 +216,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         } elseif ($reflClass->hasMethod('__get') && $reflClass->getMethod('__get')->isPublic()) {
             $result[self::VALUE] = $object->$property;
         } elseif ($classHasProperty && $reflClass->getProperty($property)->isPublic()) {
-            $result[self::VALUE] = & $object->$property;
+            $result[self::VALUE] = &$object->$property;
             $result[self::IS_REF] = true;
         } elseif (!$classHasProperty && property_exists($object, $property)) {
             // Needed to support \stdClass instances. We need to explicitly
@@ -224,7 +224,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             // a *protected* property was found on the class, property_exists()
             // returns true, consequently the following line will result in a
             // fatal error.
-            $result[self::VALUE] = & $object->$property;
+            $result[self::VALUE] = &$object->$property;
             $result[self::IS_REF] = true;
         } elseif ($this->magicCall && $reflClass->hasMethod('__call') && $reflClass->getMethod('__call')->isPublic()) {
             // we call the getter and hope the __call do the job

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -507,8 +507,8 @@ QUERY;
         $acls = $aces = $emptyArray = array();
         $oidCache = $oidLookup;
         $result = new \SplObjectStorage();
-        $loadedAces = & $this->loadedAces;
-        $loadedAcls = & $this->loadedAcls;
+        $loadedAces = &$this->loadedAces;
+        $loadedAcls = &$this->loadedAcls;
         $permissionGrantingStrategy = $this->permissionGrantingStrategy;
 
         // we need these to set protected properties on hydrated objects

--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -405,7 +405,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      */
     private function deleteAce($property, $index)
     {
-        $aces = & $this->$property;
+        $aces = &$this->$property;
         if (!isset($aces[$index])) {
             throw new \OutOfBoundsException(sprintf('The index "%d" does not exist.', $index));
         }
@@ -431,7 +431,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      */
     private function deleteFieldAce($property, $index, $field)
     {
-        $aces = & $this->$property;
+        $aces = &$this->$property;
         if (!isset($aces[$field][$index])) {
             throw new \OutOfBoundsException(sprintf('The index "%d" does not exist.', $index));
         }
@@ -477,7 +477,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
             }
         }
 
-        $aces = & $this->$property;
+        $aces = &$this->$property;
         $oldValue = $this->$property;
         if (isset($aces[$index])) {
             $this->$property = array_merge(
@@ -527,7 +527,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
             }
         }
 
-        $aces = & $this->$property;
+        $aces = &$this->$property;
         if (!isset($aces[$field])) {
             $aces[$field] = array();
         }
@@ -565,7 +565,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      */
     private function updateAce($property, $index, $mask, $strategy = null)
     {
-        $aces = & $this->$property;
+        $aces = &$this->$property;
         if (!isset($aces[$index])) {
             throw new \OutOfBoundsException(sprintf('The index "%d" does not exist.', $index));
         }
@@ -626,7 +626,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
             throw new \InvalidArgumentException('$field cannot be empty.');
         }
 
-        $aces = & $this->$property;
+        $aces = &$this->$property;
         if (!isset($aces[$field][$index])) {
             throw new \OutOfBoundsException(sprintf('The index "%d" does not exist.', $index));
         }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -252,7 +252,7 @@ abstract class AbstractToken implements TokenInterface
         }
 
         if ($this->user instanceof EquatableInterface) {
-            return ! (bool) $this->user->isEqualTo($user);
+            return !(bool) $this->user->isEqualTo($user);
         }
 
         if ($this->user->getPassword() !== $user->getPassword()) {

--- a/src/Symfony/Component/Translation/Loader/ArrayLoader.php
+++ b/src/Symfony/Component/Translation/Loader/ArrayLoader.php
@@ -53,7 +53,7 @@ class ArrayLoader implements LoaderInterface
     private function flatten(array &$messages, array $subnode = null, $path = null)
     {
         if (null === $subnode) {
-            $subnode = & $messages;
+            $subnode = &$messages;
         }
         foreach ($subnode as $key => $value) {
             if (is_array($value)) {

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -103,7 +103,7 @@ abstract class Constraint
                     $invalidOptions[] = $option;
                 }
             }
-        } elseif (null !== $options && ! (is_array($options) && count($options) === 0)) {
+        } elseif (null !== $options && !(is_array($options) && count($options) === 0)) {
             $option = $this->getDefaultOption();
 
             if (null === $option) {

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -92,7 +92,7 @@ class Parser
                 if (!isset($values['value']) || '' == trim($values['value'], ' ') || 0 === strpos(ltrim($values['value'], ' '), '#')) {
                     $c = $this->getRealCurrentLineNb() + 1;
                     $parser = new Parser($c);
-                    $parser->refs = & $this->refs;
+                    $parser->refs = &$this->refs;
                     $data[] = $parser->parse($this->getNextEmbedBlock(null, true), $exceptionOnInvalidType, $objectSupport);
                 } else {
                     if (isset($values['leadspaces'])
@@ -101,7 +101,7 @@ class Parser
                         // this is a compact notation element, add to next block and parse
                         $c = $this->getRealCurrentLineNb();
                         $parser = new Parser($c);
-                        $parser->refs = & $this->refs;
+                        $parser->refs = &$this->refs;
 
                         $block = $values['value'];
                         if ($this->isNextLineIndented()) {
@@ -144,7 +144,7 @@ class Parser
                         }
                         $c = $this->getRealCurrentLineNb() + 1;
                         $parser = new Parser($c);
-                        $parser->refs = & $this->refs;
+                        $parser->refs = &$this->refs;
                         $parsed = $parser->parse($value, $exceptionOnInvalidType, $objectSupport);
 
                         $merged = array();
@@ -181,7 +181,7 @@ class Parser
                     } else {
                         $c = $this->getRealCurrentLineNb() + 1;
                         $parser = new Parser($c);
-                        $parser->refs = & $this->refs;
+                        $parser->refs = &$this->refs;
                         $data[$key] = $parser->parse($this->getNextEmbedBlock(), $exceptionOnInvalidType, $objectSupport);
                     }
                 } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Update before upcoming changes on PHP CS Fixer 1.7

To keep fabbot.io happy ;)
