### PR TITLE
[2.3] Static Code Analysis for Components 

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -93,6 +93,7 @@ class Cookie
             $dateTime = \DateTime::createFromFormat('U', $this->expires, new \DateTimeZone('GMT'));
 
             if ($dateTime === false) {
+                // this throw will provoke PHP fatal
                 throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.'), $this->expires);
             }
 

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -144,9 +144,11 @@ class ApplicationDescription
         }
         ksort($namespacedCommands);
 
-        foreach ($namespacedCommands as &$commands) {
-            ksort($commands);
+        foreach ($namespacedCommands as &$commandsSet) {
+            ksort($commandsSet);
         }
+        // unset reference to keep scope clear
+        unset($commandsSet);
 
         return $namespacedCommands;
     }

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -71,7 +71,7 @@ class DialogHelper extends Helper
                 if (empty($choices[$value])) {
                     throw new \InvalidArgumentException(sprintf($errorMessage, $value));
                 }
-                array_push($multiselectChoices, $value);
+                $multiselectChoices[] = $value;
             }
 
             if ($multiselect) {

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -148,7 +148,7 @@ class TableHelper extends Helper
         reset($this->rows);
 
         foreach ($row as $key => $cellValue) {
-            if (!strstr($cellValue, "\n")) {
+            if (false === strpos($cellValue, "\n")) {
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -39,7 +39,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $this->compiler = $container->getCompiler();
         $this->formatter = $this->compiler->getLoggingFormatter();
 
-        foreach (array_keys($container->getDefinitions()) as $id) {
+        foreach ($container->getDefinitions() as $id => $definition) {
             // yes, we are specifically fetching the definition from the
             // container to ensure we are not operating on stale data
             $definition = $container->getDefinition($id);

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -312,7 +312,7 @@ class Container implements IntrospectableContainerInterface
                 }
 
                 $alternatives = array();
-                foreach (array_keys($this->services) as $key) {
+                foreach ($this->services as $key => $associatedService) {
                     $lev = levenshtein($id, $key);
                     if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {
                         $alternatives[] = $key;

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -304,7 +304,7 @@ class YamlFileLoader extends FileLoader
             throw new InvalidArgumentException(sprintf('The service file "%s" is not valid. It should contain an array. Check your YAML syntax.', $file));
         }
 
-        foreach (array_keys($content) as $namespace) {
+        foreach ($content as $namespace => $data) {
             if (in_array($namespace, array('imports', 'parameters', 'services'))) {
                 continue;
             }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -98,7 +98,7 @@ class ParameterBag implements ParameterBagInterface
             }
 
             $alternatives = array();
-            foreach (array_keys($this->parameters) as $key) {
+            foreach ($this->parameters as $key => $parameterValue) {
                 $lev = levenshtein($name, $key);
                 if ($lev <= strlen($name) / 3 || false !== strpos($key, $name)) {
                     $alternatives[] = $key;

--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -163,7 +163,7 @@ class Link
             if ('..' === $segment) {
                 array_pop($output);
             } elseif ('.' !== $segment) {
-                array_push($output, $segment);
+                $output[] = $segment;
             }
         }
 

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -124,7 +124,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     public function getListeners($eventName = null)
     {
         if (null === $eventName) {
-            foreach (array_keys($this->listenerIds) as $serviceEventName) {
+            foreach ($this->listenerIds as $serviceEventName => $args) {
                 $this->lazyLoad($serviceEventName);
             }
         } else {

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -68,7 +68,7 @@ class EventDispatcher implements EventDispatcherInterface
             return $this->sorted[$eventName];
         }
 
-        foreach (array_keys($this->listeners) as $eventName) {
+        foreach ($this->listeners as $eventName => $eventListeners) {
             if (!isset($this->sorted[$eventName])) {
                 $this->sortListeners($eventName);
             }

--- a/src/Symfony/Component/Finder/Tests/Iterator/IteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/IteratorTestCase.php
@@ -51,7 +51,7 @@ abstract class IteratorTestCase extends \PHPUnit_Framework_TestCase
         foreach ($expected as $subarray) {
             $temp = array();
             while (count($values) && count($temp) < count($subarray)) {
-                array_push($temp, array_shift($values));
+                $temp[] = array_shift($values);
             }
             sort($temp);
             sort($subarray);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -40,11 +40,11 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
      */
     public function __construct($inputTimezone = null, $outputTimezone = null)
     {
-        if (!is_string($inputTimezone) && null !== $inputTimezone) {
+        if (null !== $inputTimezone && !is_string($inputTimezone)) {
             throw new UnexpectedTypeException($inputTimezone, 'string');
         }
 
-        if (!is_string($outputTimezone) && null !== $outputTimezone) {
+        if (null !== $outputTimezone && !is_string($outputTimezone)) {
             throw new UnexpectedTypeException($outputTimezone, 'string');
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -99,6 +99,8 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
                 // remove leading zeros
                 $entry = (string) (int) $entry;
             }
+            // unset reference to keep scope clear
+            unset($entry);
         }
 
         return $result;

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -74,7 +74,7 @@ class MergeCollectionListener implements EventSubscriberInterface
         }
 
         // If we are not allowed to change anything, return immediately
-        if ((!$this->allowAdd && !$this->allowDelete) || $data === $dataToMergeInto) {
+        if ($data === $dataToMergeInto || (!$this->allowAdd && !$this->allowDelete)) {
             $event->setData($dataToMergeInto);
 
             return;

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1546,8 +1546,8 @@ class Request
 
         $languages = AcceptHeader::fromString($this->headers->get('Accept-Language'))->all();
         $this->languages = array();
-        foreach (array_keys($languages) as $lang) {
-            if (strstr($lang, '-')) {
+        foreach ($languages as $lang => $acceptHeaderItem) {
+            if (false !== strpos($lang, '-')) {
                 $codes = explode('-', $lang);
                 if ('i' === $codes[0]) {
                     // Language not listed in ISO 639 that are not variants

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -472,9 +472,9 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
         // get the original listener
         if (is_object($listener)) {
             if (null === $eventId) {
-                foreach (array_keys($this->wrappedListeners) as $eventId) {
-                    if (isset($this->wrappedListeners[$eventId][$listener])) {
-                        return $this->wrappedListeners[$eventId][$listener];
+                foreach ($this->wrappedListeners as $eventId => $eventListeners) {
+                    if (isset($eventListeners[$listener])) {
+                        return $eventListeners[$listener];
                     }
                 }
             } elseif (isset($this->wrappedListeners[$eventId][$listener])) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Static Code Analysis with Php Inspections (EA Extended), no functional changes:
- array_keys/array_values usage as foreach array
- foreach value by reference - added unsets to keep scope clear
- strstr usage as strpos fixed
- array_push miss-use resolved
