### PR TITLE
[PhpunitBridge] Trim final stop from deprecation message

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -105,7 +105,7 @@ class DeprecationErrorHandler
                         uasort($deprecations[$group], $cmp);
 
                         foreach ($deprecations[$group] as $msg => $notices) {
-                            echo "\n", $msg, ': ', $notices['count'], "x\n";
+                            echo "\n", rtrim($msg, '.'), ': ', $notices['count'], "x\n";
 
                             arsort($notices);
 


### PR DESCRIPTION
**Before**

```
The "_method" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the
setMethods() method instead or the "methods" option in the route definition.: 18x
```

**After**

```
The "_method" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the
setMethods() method instead or the "methods" option in the route definition: 18x
```

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
