### PR TITLE
[VarDumper] Fix dumping references as properties

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -199,18 +199,19 @@ abstract class AbstractCloner implements ClonerInterface
         }
 
         if ($classInfo[1]) {
-            $p = $this->callCaster(function ($obj) {return $obj->__debugInfo();}, $obj, array(), null, $isNested);
+            $a = $this->callCaster(function ($obj) {return $obj->__debugInfo();}, $obj, array(), null, $isNested);
         } else {
-            $p = (array) $obj;
+            $a = (array) $obj;
         }
 
-        $a = array();
-        foreach ($p as $k => $p) {
-            if (!isset($k[0]) || ("\0" !== $k[0] && !$classInfo[2]->hasProperty($k))) {
-                $a["\0+\0".$k] = $p;
-            } else {
-                $a[$k] = $p;
+        if ($a) {
+            $p = array_keys($a);
+            foreach ($p as $i => $k) {
+                if (!isset($k[0]) || ("\0" !== $k[0] && !$classInfo[2]->hasProperty($k))) {
+                    $p[$i] = "\0+\0".$k;
+                }
             }
+            $a = array_combine($p, $a);
         }
 
         foreach ($classInfo[3] as $p) {

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -160,6 +160,34 @@ EOTXT
         );
     }
 
+    public function testRefsInProperties()
+    {
+        $var = (object) array('foo' => 'foo');
+        $var->bar =& $var->foo;
+
+        $dumper = new CliDumper();
+        $dumper->setColors(false);
+        $cloner = new VarCloner();
+
+        $out = fopen('php://memory', 'r+b');
+        $data = $cloner->cloneVar($var);
+        $dumper->dump($data, $out);
+        rewind($out);
+        $out = stream_get_contents($out);
+
+        $this->assertStringMatchesFormat(
+            <<<EOTXT
+{#%d
+  +"foo": &1 "foo"
+  +"bar": &1 "foo"
+}
+
+EOTXT
+            ,
+            $out
+        );
+    }
+
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Just discovered this while reviewing an other PR.
Using `array_combine()` preserves references now.
