### PR TITLE
[VarDumper] Fix tests typo

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -214,7 +214,7 @@ array:3 [
 
 EOTXT
             ,
-            $out
+            $var
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ✘ |
| License | MIT |
| Doc PR | ✘ |

I guess there is a typo here, Travis reported (php >=5.6, see https://travis-ci.org/symfony/symfony/jobs/56527757 for instance):

> 1) Symfony\Component\VarDumper\Tests\CliDumperTest::testSpecialVars56
> Undefined variable: out
> /home/travis/build/symfony/symfony/vendor/symfony/phpunit-bridge/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php:38
> /home/travis/build/symfony/symfony/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php:218
