### PR TITLE
CS: Use "self" keyword instead of class name if possible

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -224,7 +224,7 @@ class ExprBuilder
     public static function buildExpressions(array $expressions)
     {
         foreach ($expressions as $k => $expr) {
-            if ($expr instanceof ExprBuilder) {
+            if ($expr instanceof self) {
                 $if = $expr->ifPart;
                 $then = $expr->thenPart;
                 $expressions[$k] = function ($v) use ($if, $then) {

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -82,7 +82,7 @@ abstract class FileLoader extends Loader
         try {
             $loader = $this->resolve($resource, $type);
 
-            if ($loader instanceof FileLoader && null !== $this->currentDir) {
+            if ($loader instanceof self && null !== $this->currentDir) {
                 // we fallback to the current locator to keep BC
                 // as some some loaders do not call the parent __construct()
                 // @deprecated should be removed in 3.0

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -139,7 +139,7 @@ class File extends \SplFileInfo
 
         $target = rtrim($directory, '/\\').DIRECTORY_SEPARATOR.(null === $name ? $this->getBasename() : $this->getName($name));
 
-        return new File($target, false);
+        return new self($target, false);
     }
 
     /**

--- a/src/Symfony/Component/Intl/Intl.php
+++ b/src/Symfony/Component/Intl/Intl.php
@@ -117,7 +117,7 @@ final class Intl
     {
         if (null === self::$currencyBundle) {
             self::$currencyBundle = new CurrencyBundle(
-                self::getDataDirectory().'/'.Intl::CURRENCY_DIR,
+                self::getDataDirectory().'/'.self::CURRENCY_DIR,
                 self::getEntryReader(),
                 self::getLocaleBundle()
             );
@@ -135,11 +135,11 @@ final class Intl
     {
         if (null === self::$languageBundle) {
             self::$languageBundle = new LanguageBundle(
-                self::getDataDirectory().'/'.Intl::LANGUAGE_DIR,
+                self::getDataDirectory().'/'.self::LANGUAGE_DIR,
                 self::getEntryReader(),
                 self::getLocaleBundle(),
                 new ScriptDataProvider(
-                    self::getDataDirectory().'/'.Intl::SCRIPT_DIR,
+                    self::getDataDirectory().'/'.self::SCRIPT_DIR,
                     self::getEntryReader()
                 )
             );
@@ -157,7 +157,7 @@ final class Intl
     {
         if (null === self::$localeBundle) {
             self::$localeBundle = new LocaleBundle(
-                self::getDataDirectory().'/'.Intl::LOCALE_DIR,
+                self::getDataDirectory().'/'.self::LOCALE_DIR,
                 self::getEntryReader()
             );
         }
@@ -174,7 +174,7 @@ final class Intl
     {
         if (null === self::$regionBundle) {
             self::$regionBundle = new RegionBundle(
-                self::getDataDirectory().'/'.Intl::REGION_DIR,
+                self::getDataDirectory().'/'.self::REGION_DIR,
                 self::getEntryReader(),
                 self::getLocaleBundle()
             );

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -76,7 +76,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     public function __construct($propertyPath)
     {
         // Can be used as copy constructor
-        if ($propertyPath instanceof PropertyPath) {
+        if ($propertyPath instanceof self) {
             /* @var PropertyPath $propertyPath */
             $this->elements = $propertyPath->elements;
             $this->singulars = $propertyPath->singulars;

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
@@ -50,7 +50,7 @@ class DumperCollection implements \IteratorAggregate
      */
     public function add($child)
     {
-        if ($child instanceof DumperCollection) {
+        if ($child instanceof self) {
             $child->setParent($this);
         }
         $this->children[] = $child;
@@ -64,7 +64,7 @@ class DumperCollection implements \IteratorAggregate
     public function setAll(array $children)
     {
         foreach ($children as $child) {
-            if ($child instanceof DumperCollection) {
+            if ($child instanceof self) {
                 $child->setParent($this);
             }
         }

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
@@ -66,7 +66,7 @@ class DumperPrefixCollection extends DumperCollection
 
             // Prefix starts with route's prefix
             if ('' === $collection->prefix || 0 === strpos($prefix, $collection->prefix)) {
-                $child = new DumperPrefixCollection();
+                $child = new self();
                 $child->setPrefix(substr($prefix, 0, strlen($collection->prefix) + 1));
                 $collection->add($child);
 

--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -52,7 +52,7 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      */
     public function equals(SecurityIdentityInterface $sid)
     {
-        if (!$sid instanceof RoleSecurityIdentity) {
+        if (!$sid instanceof self) {
             return false;
         }
 

--- a/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
@@ -102,7 +102,7 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
      */
     public function equals(SecurityIdentityInterface $sid)
     {
-        if (!$sid instanceof UserSecurityIdentity) {
+        if (!$sid instanceof self) {
             return false;
         }
 

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -154,7 +154,7 @@ abstract class Constraint
      */
     public function addImplicitGroupName($group)
     {
-        if (in_array(Constraint::DEFAULT_GROUP, $this->groups) && !in_array($group, $this->groups)) {
+        if (in_array(self::DEFAULT_GROUP, $this->groups) && !in_array($group, $this->groups)) {
             $this->groups[] = $group;
         }
     }

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -91,7 +91,7 @@ class Parser
                 // array
                 if (!isset($values['value']) || '' == trim($values['value'], ' ') || 0 === strpos(ltrim($values['value'], ' '), '#')) {
                     $c = $this->getRealCurrentLineNb() + 1;
-                    $parser = new Parser($c);
+                    $parser = new self($c);
                     $parser->refs = &$this->refs;
                     $data[] = $parser->parse($this->getNextEmbedBlock(null, true), $exceptionOnInvalidType, $objectSupport);
                 } else {
@@ -100,7 +100,7 @@ class Parser
                     ) {
                         // this is a compact notation element, add to next block and parse
                         $c = $this->getRealCurrentLineNb();
-                        $parser = new Parser($c);
+                        $parser = new self($c);
                         $parser->refs = &$this->refs;
 
                         $block = $values['value'];
@@ -143,7 +143,7 @@ class Parser
                             $value = $this->getNextEmbedBlock();
                         }
                         $c = $this->getRealCurrentLineNb() + 1;
-                        $parser = new Parser($c);
+                        $parser = new self($c);
                         $parser->refs = &$this->refs;
                         $parsed = $parser->parse($value, $exceptionOnInvalidType, $objectSupport);
 
@@ -180,7 +180,7 @@ class Parser
                         $data[$key] = null;
                     } else {
                         $c = $this->getRealCurrentLineNb() + 1;
-                        $parser = new Parser($c);
+                        $parser = new self($c);
                         $parser->refs = &$this->refs;
                         $data[$key] = $parser->parse($this->getNextEmbedBlock(), $exceptionOnInvalidType, $objectSupport);
                     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Fixes provided by new fixer: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1116

If this pr is merged I would change the level of the fixer to `symfony`.
