### PR TITLE
[FrameworkBundle] Fixed server:start --router relative path issue #14124

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -217,11 +217,10 @@ EOF
      * @param string          $address      IP address and port to listen to
      * @param string          $documentRoot The application's document root
      * @param string          $router       The router filename
-     * @param int             $timeout      Process timeout
      *
      * @return Process The process
      */
-    private function createServerProcess(OutputInterface $output, $address, $documentRoot, $router, $timeout = null)
+    private function createServerProcess(OutputInterface $output, $address, $documentRoot, $router)
     {
         $finder = new PhpExecutableFinder();
         if (false === $binary = $finder->find()) {
@@ -237,6 +236,6 @@ EOF
             $router,
         )));
 
-        return new Process('exec '.$script, $documentRoot, null, null, $timeout);
+        return new Process('exec '.$script, $documentRoot, null, null, null);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -182,7 +182,8 @@ EOF
     }
 
     /**
-     * Determine the absolute file path for the router script based on user input and the environment.
+     * Determine the absolute file path for the router script, using the environment to choose a standard script
+     * if no custom router script is specified.
      *
      * @param string|null     $router File path of the custom router script, if set by the user; otherwise null
      * @param string          $env    The application environment
@@ -198,13 +199,15 @@ EOF
                 ->get('kernel')
                 ->locateResource(sprintf('@FrameworkBundle/Resources/config/router_%s.php', $env))
             ;
-        } elseif (!file_exists($router)) {
+        }
+
+        if (false === $path = realpath($router)) {
             $output->writeln(sprintf('<error>The given router script "%s" does not exist</error>', $router));
 
             return false;
         }
 
-        return realpath($router);
+        return $path;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -92,7 +92,7 @@ EOF
 
         $env = $this->getContainer()->getParameter('kernel.environment');
 
-        if (false === $router = $this->determineRouterScript($input, $output, $env)) {
+        if (false === $router = $this->determineRouterScript($input->getOption('router'), $env, $output)) {
             return 1;
         }
 
@@ -184,28 +184,24 @@ EOF
     /**
      * Determine the absolute file path for the router script based on user input and the environment.
      *
-     * @param InputInterface  $input  An InputInterface instance
-     * @param OutputInterface $output An OutputInterface instance
+     * @param string|null     $router File path of the custom router script, if set by the user; otherwise null
      * @param string          $env    The application environment
+     * @param OutputInterface $output An OutputInterface instance
      *
      * @return string|bool The absolute file path of the router script, or false on failure
      */
-    private function determineRouterScript(InputInterface $input, OutputInterface $output, $env)
+    private function determineRouterScript($router, $env, OutputInterface $output)
     {
-        $router = $input->getOption('router');
-
         if (null === $router) {
             $router = $this
                 ->getContainer()
                 ->get('kernel')
                 ->locateResource(sprintf('@FrameworkBundle/Resources/config/router_%s.php', $env))
             ;
-        } else {
-            if (!file_exists($router)) {
-                $output->writeln(sprintf('<error>The given router script "%s" does not exist</error>', $router));
+        } elseif (!file_exists($router)) {
+            $output->writeln(sprintf('<error>The given router script "%s" does not exist</error>', $router));
 
-                return false;
-            }
+            return false;
         }
 
         return realpath($router);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -91,6 +91,11 @@ EOF
         }
 
         $env = $this->getContainer()->getParameter('kernel.environment');
+
+        if (false === $router = $this->determineRouterScript($input, $output, $env)) {
+            return 1;
+        }
+
         $address = $input->getArgument('address');
 
         if (false === strpos($address, ':')) {
@@ -129,7 +134,7 @@ EOF
             return 1;
         }
 
-        if (null === $process = $this->createServerProcess($output, $address, $documentRoot, $input->getOption('router'), $env, null)) {
+        if (null === $process = $this->createServerProcess($output, $address, $documentRoot, $router, null)) {
             return 1;
         }
 
@@ -177,25 +182,48 @@ EOF
     }
 
     /**
+     * Determine the absolute file path for the router script based on user input and the environment.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     * @param string          $env    The application environment
+     *
+     * @return string|bool The absolute file path of the router script, or false on failure
+     */
+    private function determineRouterScript(InputInterface $input, OutputInterface $output, $env)
+    {
+        $router = $input->getOption('router');
+
+        if (null === $router) {
+            $router = $this
+                ->getContainer()
+                ->get('kernel')
+                ->locateResource(sprintf('@FrameworkBundle/Resources/config/router_%s.php', $env))
+            ;
+        } else {
+            if (!file_exists($router)) {
+                $output->writeln(sprintf('<error>The given router script "%s" does not exist</error>', $router));
+
+                return false;
+            }
+        }
+
+        return realpath($router);
+    }
+
+    /**
      * Creates a process to start PHP's built-in web server.
      *
      * @param OutputInterface $output       A OutputInterface instance
      * @param string          $address      IP address and port to listen to
      * @param string          $documentRoot The application's document root
      * @param string          $router       The router filename
-     * @param string          $env          The application environment
      * @param int             $timeout      Process timeout
      *
      * @return Process The process
      */
-    private function createServerProcess(OutputInterface $output, $address, $documentRoot, $router, $env, $timeout = null)
+    private function createServerProcess(OutputInterface $output, $address, $documentRoot, $router, $timeout = null)
     {
-        $router = $router ?: $this
-            ->getContainer()
-            ->get('kernel')
-            ->locateResource(sprintf('@FrameworkBundle/Resources/config/router_%s.php', $env))
-        ;
-
         $finder = new PhpExecutableFinder();
         if (false === $binary = $finder->find()) {
             $output->writeln('<error>Unable to find PHP binary to start server</error>');

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -134,7 +134,7 @@ EOF
             return 1;
         }
 
-        if (null === $process = $this->createServerProcess($output, $address, $documentRoot, $router, null)) {
+        if (null === $process = $this->createServerProcess($output, $address, $documentRoot, $router)) {
             return 1;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14124 |
| License | MIT |
| Doc PR | - |

This ensures that a relative path can be used to specify the router script, and that if the router script cannot be found an error is reported and the command fails.

The file path for the router script is now determined and checked prior to the child process being forked, which seems cleaner.  The same change could be made in ServerRunCommand.php, or possibly in the ServerCommand base class; to keep the scope small, though, this wasn't done as part of this bug fix.
