### PR TITLE
[Form] Remove renderEnctype() from AbstractLayoutTest to make it compatible with 3.0

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -58,6 +58,34 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTest
         $this->extension = null;
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('file', 'file')
+            ->getForm();
+
+        $this->assertEquals('enctype="multipart/form-data"', $this->renderEnctype($form->createView()));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyNoEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('text', 'text')
+            ->getForm();
+
+        $this->assertEquals('', $this->renderEnctype($form->createView()));
+    }
+
     protected function renderForm(FormView $view, array $vars = array())
     {
         return (string) $this->extension->renderer->renderBlock($view, 'form', $vars);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -137,6 +137,34 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
         $this->assertSame($expected, $this->extension->isSelectedChoice($choice, $value));
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('file', 'file')
+            ->getForm();
+
+        $this->assertEquals('enctype="multipart/form-data"', $this->renderEnctype($form->createView()));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyNoEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('text', 'text')
+            ->getForm();
+
+        $this->assertEquals('', $this->renderEnctype($form->createView()));
+    }
+
     protected function renderForm(FormView $view, array $vars = array())
     {
         return (string) $this->extension->renderer->renderBlock($view, 'form', $vars);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -59,6 +59,34 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
         $this->extension = null;
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('file', 'file')
+            ->getForm();
+
+        $this->assertEquals('enctype="multipart/form-data"', $this->renderEnctype($form->createView()));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyNoEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('text', 'text')
+            ->getForm();
+
+        $this->assertEquals('', $this->renderEnctype($form->createView()));
+    }
+
     protected function renderForm(FormView $view, array $vars = array())
     {
         return (string) $this->extension->renderer->renderBlock($view, 'form', $vars);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -57,6 +57,34 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
         parent::tearDown();
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('file', 'file')
+            ->getForm();
+
+        $this->assertEquals('enctype="multipart/form-data"', $this->renderEnctype($form->createView()));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyNoEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('text', 'text')
+            ->getForm();
+
+        $this->assertEquals('', $this->renderEnctype($form->createView()));
+    }
+
     protected function renderForm(FormView $view, array $vars = array())
     {
         return (string) $this->engine->get('form')->form($view, $vars);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -58,6 +58,34 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
         parent::tearDown();
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('file', 'file')
+            ->getForm();
+
+        $this->assertEquals('enctype="multipart/form-data"', $this->renderEnctype($form->createView()));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyNoEnctype()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('text', 'text')
+            ->getForm();
+
+        $this->assertEquals('', $this->renderEnctype($form->createView()));
+    }
+
     protected function renderForm(FormView $view, array $vars = array())
     {
         return (string) $this->engine->get('form')->form($view, $vars);

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -107,11 +107,6 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     abstract protected function renderForm(FormView $view, array $vars = array());
 
-    protected function renderEnctype(FormView $view)
-    {
-        $this->markTestSkipped(sprintf('Legacy %s::renderEnctype() is not implemented.', get_class($this)));
-    }
-
     abstract protected function renderLabel(FormView $view, $label = null, array $vars = array());
 
     abstract protected function renderErrors(FormView $view);
@@ -127,34 +122,6 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     abstract protected function renderEnd(FormView $view, array $vars = array());
 
     abstract protected function setTheme(FormView $view, array $themes);
-
-    /**
-     * @group legacy
-     */
-    public function testLegacyEnctype()
-    {
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
-
-        $form = $this->factory->createNamedBuilder('name', 'form')
-            ->add('file', 'file')
-            ->getForm();
-
-        $this->assertEquals('enctype="multipart/form-data"', $this->renderEnctype($form->createView()));
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testLegacyNoEnctype()
-    {
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
-
-        $form = $this->factory->createNamedBuilder('name', 'form')
-            ->add('text', 'text')
-            ->getForm();
-
-        $this->assertEquals('', $this->renderEnctype($form->createView()));
-    }
 
     public function testLabel()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This allows testing twig-bridge 3.0 with form 2.7 providing the abstracts test classes (and thus make master green again after merging)
