### PR TITLE
Fixed the line length of the new Symfony Styles

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -34,7 +34,6 @@ class SymfonyStyle extends OutputStyle
     private $input;
     private $questionHelper;
     private $progressBar;
-    private $terminalWidth;
     private $lineLength;
 
     /**
@@ -313,10 +312,6 @@ class SymfonyStyle extends OutputStyle
 
     private function getTerminalWidth()
     {
-        if ($this->terminalWidth) {
-            return $this->terminalWidth;
-        }
-
         if ('\\' === DIRECTORY_SEPARATOR) {
             // extract [w, H] from "wxh (WxH)"
             if (preg_match('/^(\d+)x\d+ \(\d+x(\d+)\)$/', trim(getenv('ANSICON')), $matches)) {
@@ -338,8 +333,6 @@ class SymfonyStyle extends OutputStyle
                 return (int) $matches[2];
             }
         }
-
-        return;
     }
 
     /**
@@ -384,7 +377,7 @@ class SymfonyStyle extends OutputStyle
             fclose($pipes[2]);
             proc_close($process);
 
-            if (preg_match('/--------+\r?\n.+?(\d+)\r?\n.+?(\d+)\r?\n/', $info, $matches)) {
+            if (preg_match('/-{8}+\r?\n.+?(\d+)\r?\n.+?(\d+)\r?\n/', $info, $matches)) {
                 return $matches[2].'x'.$matches[1];
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

**After/Before screenshots**

![example_1](https://cloud.githubusercontent.com/assets/73419/6919599/be6b2cc4-d7b8-11e4-99dc-0848a3cb94cf.png)

![example_2](https://cloud.githubusercontent.com/assets/73419/6919603/c031478c-d7b8-11e4-9887-13dcd8635434.png)

![example_3](https://cloud.githubusercontent.com/assets/73419/6919606/c2498ab6-d7b8-11e4-89ef-1e0e5db9425a.png)

And now my question: is there any way to get the terminal dimensions from SymfonyStyles class without having to copy/paste the code found on \Console\Application?
