### PR TITLE
Fix the AJAX profiling

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -196,7 +196,7 @@
         }
 
         {% if excluded_ajax_paths is defined %}
-            if (window.XMLHttpRequest && XMLHttpRequest.addEventListener) {
+            if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
                 var proxied = XMLHttpRequest.prototype.open;
 
                 XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | reported in https://github.com/symfony/symfony/issues/13447#issuecomment-88849938 |
| License | MIT |
| Doc PR | n/a |

The fix for IE8 (#13978) which does not have the addEventListener method on XMLHttpRequest broke the feature for modern browsers because it was checking the existence on the wrong object. It is a method on the instance, not on the "class", and so should be checked on the prototype.
