### PR TITLE
[Console] Allow console listing to be with/without space

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -119,7 +119,7 @@ class SymfonyStyle extends OutputStyle
             $elements
         );
 
-        $this->writeln(implode("\n\n", $elements)."\n");
+        $this->writeln(implode("\n", $elements)."\n");
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | *https://github.com/symfony/symfony/pull/14057 |

https://github.com/symfony/symfony/pull/14057 is full of new ideas; when testing I thought that a list without space could be useful.

```
$output->listing(array('A', 'B', 'C'));
 * A

 * B

 * C
$output->listing(array('1', '2', '3',), false);
 * 1
 * 2
 * 3
```
