### PR TITLE
[Debug] Updated the default log level when a PHP error occurs

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -71,9 +71,9 @@ class ErrorHandler
     private $loggers = array(
         E_DEPRECATED => array(null, LogLevel::INFO),
         E_USER_DEPRECATED => array(null, LogLevel::INFO),
-        E_NOTICE => array(null, LogLevel::NOTICE),
-        E_USER_NOTICE => array(null, LogLevel::NOTICE),
-        E_STRICT => array(null, LogLevel::NOTICE),
+        E_NOTICE => array(null, LogLevel::WARNING),
+        E_USER_NOTICE => array(null, LogLevel::WARNING),
+        E_STRICT => array(null, LogLevel::WARNING),
         E_WARNING => array(null, LogLevel::WARNING),
         E_USER_WARNING => array(null, LogLevel::WARNING),
         E_COMPILE_WARNING => array(null, LogLevel::WARNING),

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -141,9 +141,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $loggers = array(
                 E_DEPRECATED => array(null, LogLevel::INFO),
                 E_USER_DEPRECATED => array(null, LogLevel::INFO),
-                E_NOTICE => array($logger, LogLevel::NOTICE),
+                E_NOTICE => array($logger, LogLevel::WARNING),
                 E_USER_NOTICE => array($logger, LogLevel::CRITICAL),
-                E_STRICT => array(null, LogLevel::NOTICE),
+                E_STRICT => array(null, LogLevel::WARNING),
                 E_WARNING => array(null, LogLevel::WARNING),
                 E_USER_WARNING => array(null, LogLevel::WARNING),
                 E_COMPILE_WARNING => array(null, LogLevel::WARNING),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

According to https://github.com/Seldaek/monolog#log-levels
the level `NOTICE` means "Normal but significant events".

So when a PHP notice occurs, it's not a "normal" event,
but an error.

That's why all PHP errors should use at least the `WARNING` error
level.
