### PR TITLE
[Debug] Renamed "context" key to "scope_vars" to avoid any ambiguity

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -399,7 +399,7 @@ class ErrorHandler
 
         if ($type & $level) {
             if ($this->scopedErrors & $type) {
-                $e['context'] = $context;
+                $e['scope_vars'] = $context;
                 if ($trace) {
                     $e['stack'] = debug_backtrace(true); // Provide object
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

As seen with @nicolas-grekas ; the current key is ambiguous because the 2nd parameter in `Psr\LoggerInterface::info()` is already `context`. So when we "export" logs, it's confusing.

More over, now, the meaning is more accurate.
