### PR TITLE
[Serializer] Supports hassers and setters for groups annotations

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -54,7 +54,7 @@ class AnnotationLoader implements LoaderInterface
                 $classMetadata->addAttributeMetadata($attributesMetadata[$property->name]);
             }
 
-            if ($property->getDeclaringClass()->name == $className) {
+            if ($property->getDeclaringClass()->name === $className) {
                 foreach ($this->reader->getPropertyAnnotations($property) as $groups) {
                     if ($groups instanceof Groups) {
                         foreach ($groups->getGroups() as $group) {
@@ -68,10 +68,10 @@ class AnnotationLoader implements LoaderInterface
         }
 
         foreach ($reflectionClass->getMethods() as $method) {
-            if ($method->getDeclaringClass()->name == $className) {
+            if ($method->getDeclaringClass()->name === $className) {
                 foreach ($this->reader->getMethodAnnotations($method) as $groups) {
                     if ($groups instanceof Groups) {
-                        if (preg_match('/^(get|is)(.+)$/i', $method->name, $matches)) {
+                        if (preg_match('/^(get|is|has|set)(.+)$/i', $method->name, $matches)) {
                             $attributeName = lcfirst($matches[2]);
 
                             if (isset($attributesMetadata[$attributeName])) {
@@ -85,7 +85,7 @@ class AnnotationLoader implements LoaderInterface
                                 $attributeMetadata->addGroup($group);
                             }
                         } else {
-                            throw new MappingException(sprintf('Groups on "%s::%s" cannot be added. Groups can only be added on methods beginning with "get" or "is".', $className, $method->name));
+                            throw new MappingException(sprintf('Groups on "%s::%s" cannot be added. Groups can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                         }
                     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummy.php
@@ -22,18 +22,21 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
      * @Groups({"a"})
      */
     private $foo;
-    /**
-     * @Groups({"b", "c"})
-     */
     protected $bar;
     private $fooBar;
     private $symfony;
 
+    /**
+     * @Groups({"b"})
+     */
     public function setBar($bar)
     {
         $this->bar = $bar;
     }
 
+    /**
+     * @Groups({"c"})
+     */
     public function getBar()
     {
         return $this->bar;
@@ -57,7 +60,7 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     /**
      * @Groups({"a", "b"})
      */
-    public function getFooBar()
+    public function isFooBar()
     {
         return $this->fooBar;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

For more coherence with the new `ObjectNormalizer` (#13257), this PR allows to add `@Groups` annotations on hasser and setter methods too.
