### PR TITLE
[StringUtil] Fixed singularification of 'movies'

### DIFF
--- a/src/Symfony/Component/PropertyAccess/StringUtil.php
+++ b/src/Symfony/Component/PropertyAccess/StringUtil.php
@@ -60,6 +60,9 @@ class StringUtil
         // indices (index), appendices (appendix), prices (price)
         array('seci', 4, false, true, array('ex', 'ix', 'ice')),
 
+        // movies (movie)
+        array('seivom', 6, true, true, 'movie'),
+
         // babies (baby)
         array('sei', 3, false, true, 'y'),
 

--- a/src/Symfony/Component/PropertyAccess/Tests/StringUtilTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/StringUtilTest.php
@@ -99,6 +99,7 @@ class StringUtilTest extends \PHPUnit_Framework_TestCase
             array('men', 'man'),
             array('mice', 'mouse'),
             array('moves', 'move'),
+            array('movies', 'movie'),
             array('nebulae', 'nebula'),
             array('neuroses', array('neuros', 'neurose', 'neurosis')),
             array('oases', array('oas', 'oase', 'oasis')),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14189 |
| License | MIT |
| Doc PR | n/a |

The word 'movies' was singularified to 'movy'. There seem to be only two
words ending in 'ovies', which are 'movies' and 'anchovies'. The singular
of the latter is 'anchovy'. All other words ending in 'vies' singularify to
'vy', so the word 'movies' is an exception to the general rule.
