### PR TITLE
[HttpKernel] Embed the original exception as previous to bounced exceptions

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -62,7 +62,18 @@ class ExceptionListener implements EventSubscriberInterface
             // set handling to false otherwise it wont be able to handle further more
             $handling = false;
 
-            // throwing $e, not $exception, is on purpose: fixing error handling code paths is the most important
+            $wrapper = $e;
+
+            while ($prev = $wrapper->getPrevious()) {
+                if ($exception === $wrapper = $prev) {
+                    throw $e;
+                }
+            }
+
+            $prev = new \ReflectionProperty('Exception', 'previous');
+            $prev->setAccessible(true);
+            $prev->setValue($wrapper, $exception);
+
             throw $e;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -57,6 +57,7 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
             $this->fail('RuntimeException expected');
         } catch (\RuntimeException $e) {
             $this->assertSame('bar', $e->getMessage());
+            $this->assertSame('foo', $e->getPrevious()->getMessage());
         }
     }
 
@@ -77,6 +78,7 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
             $this->fail('RuntimeException expected');
         } catch (\RuntimeException $e) {
             $this->assertSame('bar', $e->getMessage());
+            $this->assertSame('foo', $e->getPrevious()->getMessage());
         }
 
         $this->assertEquals(3, $logger->countErrors());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14073 |
| License | MIT |
| Doc PR | - |
