### PR TITLE
Tweaked some console command styles

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -97,7 +97,7 @@ class SymfonyStyle extends OutputStyle
      */
     public function title($message)
     {
-        $this->writeln(sprintf("\n<fg=blue>%s</fg=blue>\n<fg=blue>%s</fg=blue>\n", $message, str_repeat('=', strlen($message))));
+        $this->writeln(sprintf("\n<comment>%s</>\n<comment>%s</>\n", $message, str_repeat('=', strlen($message))));
     }
 
     /**
@@ -105,7 +105,7 @@ class SymfonyStyle extends OutputStyle
      */
     public function section($message)
     {
-        $this->writeln(sprintf("<fg=blue>%s</fg=blue>\n<fg=blue>%s</fg=blue>\n", $message, str_repeat('-', strlen($message))));
+        $this->writeln(sprintf("<comment>%s</>\n<comment>%s</>\n", $message, str_repeat('-', strlen($message))));
     }
 
     /**
@@ -119,7 +119,7 @@ class SymfonyStyle extends OutputStyle
             $elements
         );
 
-        $this->writeln(implode("\n\n", $elements)."\n");
+        $this->writeln(implode("\n", $elements)."\n");
     }
 
     /**
@@ -183,6 +183,8 @@ class SymfonyStyle extends OutputStyle
      */
     public function table(array $headers, array $rows)
     {
+        $headers = array_map(function ($value) { return sprintf('<info>%s</>', $value); } , $headers);
+
         $table = new Table($this);
         $table->setHeaders($headers);
         $table->setRows($rows);

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -183,7 +183,7 @@ class SymfonyStyle extends OutputStyle
      */
     public function table(array $headers, array $rows)
     {
-        $headers = array_map(function ($value) { return sprintf('<info>%s</>', $value); } , $headers);
+        $headers = array_map(function ($value) { return sprintf('<info>%s</>', $value); }, $headers);
 
         $table = new Table($this);
         $table->setHeaders($headers);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14174 |
| License | MIT |
| Doc PR | - |

As discussed, after updating the first console commands to the new style guide, we were going to introduce the needed tweaks. This PR is the first one with those tweaks.
### Tables

Headers now are displayed in the usual green color used frequently by Symfony commands:

![table_header](https://cloud.githubusercontent.com/assets/73419/6980286/a126e8cc-d9ef-11e4-8d1e-9a5be21564eb.png)
### Command tiles and section titles

I see these titles in a beautiful blue color ... but lots of people use color schemes which make them almost unreadable. Now they use the yellow color frequently used by Symfony commands:

![command_section_titles](https://cloud.githubusercontent.com/assets/73419/6980292/b499627c-d9ef-11e4-9940-e134ee0eb02f.png)
### Listings

Elements in a listing no longer add an extra blank line. See #14174 for the rationale.
