### PR TITLE
[console][ArrayInput] avoid return array value for getFirstArgument.

### DIFF
--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -49,7 +49,7 @@ class ArrayInput extends Input
     public function getFirstArgument()
     {
         foreach ($this->parameters as $key => $value) {
-            if ($key && '-' === $key[0]) {
+            if (($key && '-' === $key[0]) || !is_string($value)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -24,7 +24,7 @@ class ArrayInputTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($input->getFirstArgument(), '->getFirstArgument() returns null if no argument were passed');
         $input = new ArrayInput(array('name' => 'Fabien'));
         $this->assertEquals('Fabien', $input->getFirstArgument(), '->getFirstArgument() returns the first passed argument');
-        $input = new ArrayInput(array('--foo' => 'bar', 'name' => 'Fabien'));
+        $input = new ArrayInput(array('--foo' => 'bar', 'names' => array('Fabien'), 'name' => 'Fabien'));
         $this->assertEquals('Fabien', $input->getFirstArgument(), '->getFirstArgument() returns the first passed argument');
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #14116 |
| Tests pass? | yes |
| License | MIT |
