### PR TITLE
Automatically start server:run if server:start failed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -74,6 +75,12 @@ EOF
         if (!extension_loaded('pcntl')) {
             $output->writeln('<error>This command needs the pcntl extension to run.</error>');
             $output->writeln('You can either install it or use the <info>server:run</info> command instead to run the built-in web server.');
+
+            if ($this->getHelper('question')->ask($input, $output, new ConfirmationQuestion('Do you want to start <info>server:run</info> immediately? [Yn] ', true))) {
+                $command = $this->getApplication()->find('server:run');
+
+                return $command->run($input, $output);
+            }
 
             return 1;
         }


### PR DESCRIPTION
After this PR, `server:start` will ask the user if it wants to start `server:run` automatically. If yes, the `server:run` command is executed and the server is started. If no, the command exits with `1`.

Example of Yes:

```
$ php app/console server:start
This command needs the pcntl extension to run.
You can either install it or use the server:run command instead to run the built-in web server.
Do you want to start server:run immediately? [Yn]
Server running on http://127.0.0.1:8000

Quit the server with CONTROL-C.
```

Example of No:

```
$ php app/console server:start
This command needs the pcntl extension to run.
You can either install it or use the server:run command instead to run the built-in web server.
Do you want to start server:run immediately? [Yn] n

$ ...
```

I've created this PR, because documentation currently still has to promote `server:run` to be safe. You don't want to tell people, "use `server:start`" and have them getting an error immediately (please note that starting the server is probably the first action with Symfony). Example: https://github.com/symfony/symfony-demo/pull/17

| Q | A |
| --- | --- |
| Bug fix? | somewhat |
| New feature? | somewhat |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
