### PR TITLE
[Form] Moved deprecation notice triggers to file level

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\Doctrine\Form\ChoiceList;
 
+trigger_error('The '.__NAMESPACE__.'\EntityChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader instead.', E_USER_DEPRECATED);
+
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Form\Exception\RuntimeException;
@@ -129,8 +131,6 @@ class EntityChoiceList extends ObjectChoiceList
         }
 
         parent::__construct($entities, $labelPath, $preferredEntities, $groupPath, null, $propertyAccessor);
-
-        trigger_error('The '.__CLASS__.' class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader instead.', E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -21,27 +21,6 @@ use Symfony\Component\Form\Extension\Core\View\ChoiceView as LegacyChoiceView;
 class ChoiceView extends LegacyChoiceView
 {
     /**
-     * The label displayed to humans.
-     *
-     * @var string
-     */
-    public $label;
-
-    /**
-     * The view representation of the choice.
-     *
-     * @var string
-     */
-    public $value;
-
-    /**
-     * The original choice value.
-     *
-     * @var mixed
-     */
-    public $data;
-
-    /**
      * Additional attributes for the HTML tag.
      *
      * @var array
@@ -58,9 +37,8 @@ class ChoiceView extends LegacyChoiceView
      */
     public function __construct($label, $value, $data, array $attr = array())
     {
-        $this->label = $label;
-        $this->value = $value;
-        $this->data = $data;
+        parent::__construct($data, $value, $label);
+
         $this->attr = $attr;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
+trigger_error('The '.__NAMESPACE__.'\ChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Exception\InvalidConfigurationException;
@@ -92,8 +94,6 @@ class ChoiceList implements ChoiceListInterface
         }
 
         $this->initialize($choices, $labels, $preferredChoices);
-
-        trigger_error('The '.__CLASS__.' class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceListInterface.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceListInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
+trigger_error('The '.__NAMESPACE__.'\ChoiceListInterface interface is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ChoiceListInterface instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface as BaseChoiceListInterface;
 
 /**

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
+trigger_error('The '.__NAMESPACE__.'\LazyChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 
 /**
@@ -34,11 +36,6 @@ abstract class LazyChoiceList implements ChoiceListInterface
      * @var ChoiceListInterface
      */
     private $choiceList;
-
-    public function __construct()
-    {
-        trigger_error('The '.__CLASS__.' class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\LazyChoiceList instead.', E_USER_DEPRECATED);
-    }
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
+trigger_error('The '.__NAMESPACE__.'\ObjectChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Form\Exception\StringCastException;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\PropertyPath;
@@ -97,8 +99,6 @@ class ObjectChoiceList extends ChoiceList
         $this->valuePath = null !== $valuePath ? new PropertyPath($valuePath) : null;
 
         parent::__construct($choices, array(), $preferredChoices);
-
-        trigger_error('The '.__CLASS__.' class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
+trigger_error('The '.__NAMESPACE__.'\SimpleChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
+
 /**
  * A choice list for choices of type string or integer.
  *

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
+trigger_error('The class '.__NAMESPACE__.'\ChoiceToBooleanArrayTransformer is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -38,8 +40,6 @@ class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
     {
         $this->choiceList = $choiceList;
         $this->placeholderPresent = $placeholderPresent;
-
-        trigger_error('The class '.__CLASS__.' is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\LazyChoiceList instead.', E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
+trigger_error('The class '.__NAMESPACE__.'\ChoicesToBooleanArrayTransformer is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -29,8 +31,6 @@ class ChoicesToBooleanArrayTransformer implements DataTransformerInterface
     public function __construct(ChoiceListInterface $choiceList)
     {
         $this->choiceList = $choiceList;
-
-        trigger_error('The class '.__CLASS__.' is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\LazyChoiceList instead.', E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxInputListener.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
+trigger_error('The class '.__NAMESPACE__.'\FixCheckboxInputListener is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -39,8 +41,6 @@ class FixCheckboxInputListener implements EventSubscriberInterface
     public function __construct(ChoiceListInterface $choiceList)
     {
         $this->choiceList = $choiceList;
-
-        trigger_error('The class '.__CLASS__.' is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper instead.', E_USER_DEPRECATED);
     }
 
     public function preSubmit(FormEvent $event)

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
+trigger_error('The class '.__NAMESPACE__.'\FixRadioInputListener is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\FormEvent;
@@ -42,8 +44,6 @@ class FixRadioInputListener implements EventSubscriberInterface
     {
         $this->choiceList = $choiceList;
         $this->placeholderPresent = $placeholderPresent;
-
-        trigger_error('The class '.__CLASS__.' is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper instead.', E_USER_DEPRECATED);
     }
 
     public function preSubmit(FormEvent $event)

--- a/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
@@ -55,6 +55,9 @@ class ChoiceView
         $this->value = $value;
         $this->label = $label;
 
-        trigger_error('The '.__CLASS__.' class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\View\ChoiceView instead.', E_USER_DEPRECATED);
+        // Trigger deprecation notice unless this is the new ChoiceView class
+        if ('Symfony\Component\Form\ChoiceList\View\ChoiceView' !== get_class($this)) {
+            trigger_error('The '.__NAMESPACE__.'\ChoiceView class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\View\ChoiceView instead.', E_USER_DEPRECATED);
+        }
     }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -730,6 +730,9 @@ class DefaultChoiceListFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertFlatViewWithAttr($view);
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateViewForLegacyChoiceList()
     {
         $preferred = array(new ChoiceView('Preferred', 'x', 'x'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/Fixtures/LazyChoiceListImpl.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/Fixtures/LazyChoiceListImpl.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\ChoiceList\Fixtures;
+
+use Symfony\Component\Form\Extension\Core\ChoiceList\LazyChoiceList;
+
+class LazyChoiceListImpl extends LazyChoiceList
+{
+    private $choiceList;
+
+    public function __construct($choiceList)
+    {
+        $this->choiceList = $choiceList;
+    }
+
+    protected function loadChoiceList()
+    {
+        return $this->choiceList;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/Fixtures/LazyChoiceListInvalidImpl.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/Fixtures/LazyChoiceListInvalidImpl.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\ChoiceList\Fixtures;
+
+use Symfony\Component\Form\Extension\Core\ChoiceList\LazyChoiceList;
+
+class LazyChoiceListInvalidImpl extends LazyChoiceList
+{
+    protected function loadChoiceList()
+    {
+        return new \stdClass();
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/LazyChoiceListTest.php
@@ -12,8 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\ChoiceList;
 
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
-use Symfony\Component\Form\Extension\Core\ChoiceList\LazyChoiceList;
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+use Symfony\Component\Form\Tests\Extension\Core\ChoiceList\Fixtures\LazyChoiceListImpl;
+use Symfony\Component\Form\Tests\Extension\Core\ChoiceList\Fixtures\LazyChoiceListInvalidImpl;
 
 /**
  * @group legacy
@@ -21,7 +22,7 @@ use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 class LazyChoiceListTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var LazyChoiceListTest_Impl
+     * @var LazyChoiceListImpl
      */
     private $list;
 
@@ -29,7 +30,7 @@ class LazyChoiceListTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->list = new LazyChoiceListTest_Impl(new SimpleChoiceList(array(
+        $this->list = new LazyChoiceListImpl(new SimpleChoiceList(array(
             'a' => 'A',
             'b' => 'B',
             'c' => 'C',
@@ -92,31 +93,8 @@ class LazyChoiceListTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadChoiceListShouldReturnChoiceList()
     {
-        $list = new LazyChoiceListTest_InvalidImpl();
+        $list = new LazyChoiceListInvalidImpl();
 
         $list->getChoices();
-    }
-}
-
-class LazyChoiceListTest_Impl extends LazyChoiceList
-{
-    private $choiceList;
-
-    public function __construct($choiceList)
-    {
-        $this->choiceList = $choiceList;
-    }
-
-    protected function loadChoiceList()
-    {
-        return $this->choiceList;
-    }
-}
-
-class LazyChoiceListTest_InvalidImpl extends LazyChoiceList
-{
-    protected function loadChoiceList()
-    {
-        return new \stdClass();
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR moves the deprecation notice triggers introduced in #14050 to file level, as [suggested](https://github.com/symfony/symfony/pull/14050#discussion_r27568751) by @stof.
