### PR TITLE
[Bridge\PhpUnit] Relax silencing rule and fix phpunit runtime detection

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/README.md
+++ b/src/Symfony/Bridge/PhpUnit/README.md
@@ -9,19 +9,13 @@ It comes with the following features:
  * auto-register `class_exists` to load Doctrine annotations;
  * print a user deprecation notices summary at the end of the test suite.
 
-Handling user deprecation notices is sensitive to the SYMFONY_DEPRECATIONS_HELPER
-environment variable. This env var configures 3 behaviors depending on its value:
+By default any non-legacy-tagged deprecation notice will make tests fail.
+This can be changed by setting the SYMFONY_DEPRECATIONS_HELPER environment
+variable to `weak`. This will make the bridge ignore deprecation notices and
+is useful to projects that must use deprecated interfaces for backward
+compatibility reasons.
 
- * when set to `strict`, all but silenced-legacy-tagged deprecation notices will
-   make tests fail. This is the recommended mode for best forward compatibility
- * `weak` on the contrary will make tests ignore all deprecation notices.
-   This is the recommended mode for legacy projects that must use deprecated
-   interfaces for backward compatibility reasons.
- * with any other value, all but silenced-or-not-legacy-tagged deprecation
-   notices will make tests fail.
-
-All three modes will display a summary of deprecation notices at the end of the
-test suite, split in two groups:
+A summary of deprecation notices is displayed at the end of the test suite:
 
  * **Legacy** deprecation notices denote tests that explicitly test some legacy
    interfaces. There are four ways to mark a test as legacy:
@@ -36,8 +30,7 @@ Usage
 -----
 
 Add this bridge to the `require-dev` section of your composer.json file
-(not in `require`) with e.g.
-`composer require --dev "symfony/phpunit-bridge"`.
+(not in `require`) with e.g. `composer require --dev "symfony/phpunit-bridge"`.
 
 When running `phpunit`, you will see a summary of deprecation notices at the end
 of the test suite.
@@ -48,15 +41,3 @@ You have to decide either to:
  * update your code to not use deprecated interfaces anymore, thus gaining better
    forward compatibility;
  * or move them to the **Legacy** section (by using one of the above way).
-
-After reviewing them, you should silence deprecations in the **Legacy** section
-if you think they are triggered by tests dedicated to testing deprecated
-interfaces. To do so, add the following line at the beginning of your legacy
-test case or in the `setUp()` method of your legacy test class:
-`$this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);`
-
-Last but not least, you should then configure your C.I. to the reporting mode
-that is appropriated to your project by setting SYMFONY_DEPRECATIONS_HELPER to
-`strict`, `weak` or empty. It is recommended to start with `weak` mode, upgrade
-your code as described above, then when the *Remaining/Other* sections are empty,
-move to `strict` to keep forward compatibility on the long run.

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -3,7 +3,8 @@
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
-if (!class_exists('PHPUnit_Util_ErrorHandler')) {
+// Detect if we're loaded by an actual run of phpunit
+if (!class_exists('PHPUnit_TextUI_Command', false)) {
     return;
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR removes the need to call `$this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);` in tests that are already tagged as legacy. We needed them while drafting our deprecation policy, but that's only burden to me now.

This PR also fixes the way we detect if phpunit is running the test suite for projects that have phpunit in their composer.json's require-dev
