### PR TITLE
[TwigBundle] Enforce symfony/debug 2.x

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/twig-bridge": "~2.3,>=2.3.10",
-        "symfony/http-kernel": "~2.3.24|~2.5.9|~2.6,>=2.6.2"
+        "symfony/http-kernel": "~2.3.24|~2.5.9|~2.6,>=2.6.2",
+        "symfony/debug": "~2.3"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Required to prevent installing symfony/debug 3.0 that is incompatible. Should make tests green again on 2.3
