### PR TITLE
[HttpKernel] Require symfony/debug < 3.0

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.9",
         "symfony/event-dispatcher": "~2.5.9|~2.6,>=2.6.2|~3.0.0",
         "symfony/http-foundation": "~2.5,>=2.5.4|~3.0.0",
-        "symfony/debug": "~2.6,>=2.6.2|~3.0.0",
+        "symfony/debug": "~2.6,>=2.6.2",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The deprecated Exception\FlattenException relies on symfony/debug < 3.0
