### PR TITLE
[3.0][Console][OutputStyle] Implements verbosity levels methods

### DIFF
--- a/src/Symfony/Component/Console/Style/OutputStyle.php
+++ b/src/Symfony/Component/Console/Style/OutputStyle.php
@@ -113,4 +113,36 @@ abstract class OutputStyle implements OutputInterface, StyleInterface
     {
         return $this->output->getFormatter();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isQuiet()
+    {
+        return $this->output->isQuiet();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isVerbose()
+    {
+        return $this->output->isVerbose();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isVeryVerbose()
+    {
+        return $this->output->isVeryVerbose();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDebug()
+    {
+        return $this->output->isDebug();
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A - Travis build for #14032 |
| License | MIT |

Implements the verbosity level methods from `OutputInterface` for the new `OutputStyle` abstract class in 3.0 branch.
Fixes Travis builds with `deps=high` env var for #14032 PR and future console style updates.
# 

Related to: #14032, #14057, #14138, #14132, #14172, ...
