### PR TITLE
Fix symfony/form dependend components

### DIFF
--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -31,6 +31,10 @@
         "symfony/security-csrf": "~2.4|~3.0.0",
         "symfony/translation": "~2.0,>=2.0.5|~3.0.0"
     },
+    "conflict": {
+        "symfony/doctrine-bridge": "<2.7",
+        "symfony/framework-bundle": "<2.7"
+    },
     "suggest": {
         "symfony/validator": "For form validation.",
         "symfony/security-csrf": "For protecting forms against CSRF attacks.",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Because both the FrameworkBundle and the Doctrine bridge use the new choice list feature of 2.7, they are incompatible with Form below 2.7
