### PR TITLE
[Debug] Fix fatal error in test on PHP7

### DIFF
--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -61,18 +61,21 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testUnsilencing()
     {
-        ob_start();
-
         $this->iniSet('log_errors', 0);
         $this->iniSet('display_errors', 1);
 
         // See below: this will fail with parse error
         // but this should not be @-silenced.
-        @class_exists(__NAMESPACE__.'\TestingUnsilencing', true);
+        try {
+            ob_start();
+            @class_exists(__NAMESPACE__.'\TestingUnsilencing', true);
 
-        $output = ob_get_clean();
-
-        $this->assertStringMatchesFormat('%aParse error%a', $output);
+            $output = ob_get_clean();
+            $this->assertStringMatchesFormat('%aParse error%a', $output);
+        } catch (\ParseException $e) {
+            $this->assertContains('syntax error', $e->getMessage());
+            ob_end_clean();
+        }
     }
 
     public function testStacking()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Fix to check for ParseException in test on PHP7. Previously PHP would throw a parse error rather than an exception.
