### PR TITLE
Add PHP7 compatible versions for the Null/True/False constraints as they are reserved words in PHP7

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -157,6 +157,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
 
             case 'Symfony\Component\Validator\Constraints\True':
             case 'Symfony\Component\Validator\Constraints\False':
+            case 'Symfony\Component\Validator\Constraints\IsTrue':
+            case 'Symfony\Component\Validator\Constraints\IsFalse':
                 return new TypeGuess('checkbox', array(), Guess::MEDIUM_CONFIDENCE);
         }
     }
@@ -174,6 +176,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\NotNull':
             case 'Symfony\Component\Validator\Constraints\NotBlank':
             case 'Symfony\Component\Validator\Constraints\True':
+            case 'Symfony\Component\Validator\Constraints\IsTrue':
                 return new ValueGuess(true, Guess::HIGH_CONFIDENCE);
         }
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
-use Symfony\Component\Validator\Constraints\True;
+use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -64,7 +64,7 @@ class ValidatorTypeGuesserTest extends \PHPUnit_Framework_TestCase
         return array(
             array(new NotNull(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)),
             array(new NotBlank(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)),
-            array(new True(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)),
+            array(new IsTrue(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)),
             array(new Length(10), new ValueGuess(false, Guess::LOW_CONFIDENCE)),
             array(new Range(array('min' => 1, 'max' => 20)), new ValueGuess(false, Guess::LOW_CONFIDENCE)),
         );
@@ -82,6 +82,18 @@ class ValidatorTypeGuesserTest extends \PHPUnit_Framework_TestCase
         $this->metadata->addPropertyConstraint(self::TEST_PROPERTY, $constraint);
 
         $this->assertEquals($guess, $this->guesser->guessRequired(self::TEST_CLASS, self::TEST_PROPERTY));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyGuessRequired()
+    {
+        if (PHP_VERSION_ID >= 70000) {
+            $this->markTestSkipped('Cannot use a class called True on PHP 7 or higher.');
+        }
+        $true = 'Symfony\Component\Validator\Constraints\True';
+        $this->testGuessRequired(new $true(), new ValueGuess(true, Guess::HIGH_CONFIDENCE));
     }
 
     public function testGuessRequiredReturnsFalseForUnmappedProperties()

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7",
         "doctrine/collections": "~1.0",
-        "symfony/validator": "~2.3.0,>=2.3.20",
+        "symfony/validator": "~2.3.29",
         "symfony/translation": "~2.0,>=2.0.5",
         "symfony/http-foundation": "~2.2"
     },

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.3.29
+------
+
+ * fixed compatibility with PHP7 and up by introducing new constraints (IsNull, IsTrue, IsFalse) and related validators (IsNullValidator, IsTrueValidator, IsFalseValidator)
+
 2.3.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/False.php
+++ b/src/Symfony/Component/Validator/Constraints/False.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
-
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
@@ -21,7 +19,4 @@ use Symfony\Component\Validator\Constraint;
  *
  * @api
  */
-class False extends Constraint
-{
-    public $message = 'This value should be false.';
-}
+class False extends IsFalse {}

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -11,27 +11,9 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\ConstraintValidator;
-
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
-class FalseValidator extends ConstraintValidator
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function validate($value, Constraint $constraint)
-    {
-        if (null === $value || false === $value || 0 === $value || '0' === $value) {
-            return;
-        }
-
-        $this->context->addViolation($constraint->message, array(
-            '{{ value }}' => $this->formatValue($value),
-        ));
-    }
-}
+class FalseValidator extends IsFalseValidator {}

--- a/src/Symfony/Component/Validator/Constraints/IsFalse.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalse.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Constraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
@@ -19,4 +21,7 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @api
  */
-class Null extends IsNull {}
+class IsFalse extends Constraint
+{
+    public $message = 'This value should be false.';
+}

--- a/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @api
+ */
+class IsFalseValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value || false === $value || 0 === $value || '0' === $value) {
+            return;
+        }
+
+        $this->context->addViolation($constraint->message, array(
+            '{{ value }}' => $this->formatValue($value),
+        ));
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/IsNull.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNull.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Constraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
@@ -19,4 +21,7 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @api
  */
-class Null extends IsNull {}
+class IsNull extends Constraint
+{
+    public $message = 'This value should be null.';
+}

--- a/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @api
+ */
+class IsNullValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null !== $value) {
+            $this->context->addViolation($constraint->message, array(
+                '{{ value }}' => $this->formatValue($value),
+            ));
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/IsTrue.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrue.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Constraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
@@ -19,4 +21,7 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @api
  */
-class Null extends IsNull {}
+class IsTrue extends Constraint
+{
+    public $message = 'This value should be true.';
+}

--- a/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @api
+ */
+class IsTrueValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        if (true !== $value && 1 !== $value && '1' !== $value) {
+            $this->context->addViolation($constraint->message, array(
+                '{{ value }}' => $this->formatValue($value),
+            ));
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/NullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NullValidator.php
@@ -11,25 +11,9 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\ConstraintValidator;
-
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
-class NullValidator extends ConstraintValidator
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function validate($value, Constraint $constraint)
-    {
-        if (null !== $value) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
-        }
-    }
-}
+class NullValidator extends IsNullValidator {}

--- a/src/Symfony/Component/Validator/Constraints/True.php
+++ b/src/Symfony/Component/Validator/Constraints/True.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
-
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
@@ -21,7 +19,4 @@ use Symfony\Component\Validator\Constraint;
  *
  * @api
  */
-class True extends Constraint
-{
-    public $message = 'This value should be true.';
-}
+class True extends IsTrue {}

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -11,29 +11,9 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\ConstraintValidator;
-
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
-class TrueValidator extends ConstraintValidator
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function validate($value, Constraint $constraint)
-    {
-        if (null === $value) {
-            return;
-        }
-
-        if (true !== $value && 1 !== $value && '1' !== $value) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $this->formatValue($value),
-            ));
-        }
-    }
-}
+class TrueValidator extends IsTrueValidator {}

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
@@ -11,40 +11,40 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-use Symfony\Component\Validator\Constraints\True;
-use Symfony\Component\Validator\Constraints\TrueValidator;
+use Symfony\Component\Validator\Constraints\IsFalse;
+use Symfony\Component\Validator\Constraints\IsFalseValidator;
 
-class TrueValidatorTest extends AbstractConstraintValidatorTest
+class IsFalseValidatorTest extends AbstractConstraintValidatorTest
 {
     protected function createValidator()
     {
-        return new TrueValidator();
+        return new IsFalseValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new True());
+        $this->validator->validate(null, new IsFalse());
 
         $this->assertNoViolation();
     }
 
-    public function testTrueIsValid()
+    public function testFalseIsValid()
     {
-        $this->validator->validate(true, new True());
+        $this->validator->validate(false, new IsFalse());
 
         $this->assertNoViolation();
     }
 
-    public function testFalseIsInvalid()
+    public function testTrueIsInvalid()
     {
-        $constraint = new True(array(
+        $constraint = new IsFalse(array(
             'message' => 'myMessage',
         ));
 
-        $this->validator->validate(false, $constraint);
+        $this->validator->validate(true, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', 'false')
+            ->setParameter('{{ value }}', 'true')
             ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
@@ -11,19 +11,19 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-use Symfony\Component\Validator\Constraints\Null;
-use Symfony\Component\Validator\Constraints\NullValidator;
+use Symfony\Component\Validator\Constraints\IsNull;
+use Symfony\Component\Validator\Constraints\IsNullValidator;
 
-class NullValidatorTest extends AbstractConstraintValidatorTest
+class IsNullValidatorTest extends AbstractConstraintValidatorTest
 {
     protected function createValidator()
     {
-        return new NullValidator();
+        return new IsNullValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Null());
+        $this->validator->validate(null, new IsNull());
 
         $this->assertNoViolation();
     }
@@ -33,7 +33,7 @@ class NullValidatorTest extends AbstractConstraintValidatorTest
      */
     public function testInvalidValues($value, $valueAsString)
     {
-        $constraint = new Null(array(
+        $constraint = new IsNull(array(
             'message' => 'myMessage',
         ));
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
@@ -11,40 +11,40 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-use Symfony\Component\Validator\Constraints\False;
-use Symfony\Component\Validator\Constraints\FalseValidator;
+use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Constraints\IsTrueValidator;
 
-class FalseValidatorTest extends AbstractConstraintValidatorTest
+class IsTrueValidatorTest extends AbstractConstraintValidatorTest
 {
     protected function createValidator()
     {
-        return new FalseValidator();
+        return new IsTrueValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new False());
+        $this->validator->validate(null, new IsTrue());
 
         $this->assertNoViolation();
     }
 
-    public function testFalseIsValid()
+    public function testTrueIsValid()
     {
-        $this->validator->validate(false, new False());
+        $this->validator->validate(true, new IsTrue());
 
         $this->assertNoViolation();
     }
 
-    public function testTrueIsInvalid()
+    public function testFalseIsInvalid()
     {
-        $constraint = new False(array(
+        $constraint = new IsTrue(array(
             'message' => 'myMessage',
         ));
 
-        $this->validator->validate(true, $constraint);
+        $this->validator->validate(false, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', 'true')
+            ->setParameter('{{ value }}', 'false')
             ->assertRaised();
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | PHP7 compatibility |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | N/A |
| Fixed tickets | N/A - helps towards https://github.com/symfony/symfony/issues/14086 |
| License | MIT |

Null, True and False are reserved words in PHP7:

https://wiki.php.net/rfc/reserve_more_types_in_php_7
