### PR TITLE
[HttpKernel] [Bug] Don't update context if none has bee provided

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -73,7 +73,7 @@ class RouterListener implements EventSubscriberInterface
      */
     public function setRequest(Request $request = null)
     {
-        if (null !== $request && $this->request !== $request) {
+        if (null !== $request && $this->request !== $request && null !== $this->context) {
             $this->context->fromRequest($request);
         }
         $this->request = $request;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Hi,

This code should be valid (stack provided but no context):

```
$request = Request::createFromGlobals();

$stack = new RequestStack();
$stack->push($request);

$matcher = new UrlMatcher();

$dispatcher = new EventDispatcher();
$dispatcher->addSubscriber(new RouterListener($matcher, null, null, $stack));

$resolver = new ControllerResolver();

$kernel = new HttpKernel($dispatcher, $resolver);
$response = $kernel->handle($request);

$response->send();
```

But an error is thrown : `Call to a member function fromRequest() on null`
