### PR TITLE
[DependencyInjection] Show better error when the Yaml component is not installed

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * YamlDumper dumps a service container as a YAML string.

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -32,24 +32,6 @@ class YamlDumper extends Dumper
     private $dumper;
 
     /**
-     * Constructor.
-     *
-     * @param ContainerBuilder $container The service container to dump
-     *
-     * @api
-     */
-    public function __construct(ContainerBuilder $container)
-    {
-        parent::__construct($container);
-
-        if (!class_exists('Symfony\Component\Yaml\Dumper')) {
-            throw new RuntimeException('Unable to dump the container as the Symfony Yaml Component is not installed.');
-        }
-
-        $this->dumper = new YmlDumper();
-    }
-
-    /**
      * Dumps the service container as an YAML string.
      *
      * @param array $options An array of options
@@ -60,6 +42,14 @@ class YamlDumper extends Dumper
      */
     public function dump(array $options = array())
     {
+        if (!class_exists('Symfony\Component\Yaml\Dumper')) {
+            throw new RuntimeException('Unable to dump the container as the Symfony Yaml Component is not installed.');
+        }
+
+        if (null === $this->dumper) {
+            $this->dumper = new YmlDumper();
+        }
+
         return $this->addParameters()."\n".$this->addServices();
     }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -42,6 +42,10 @@ class YamlDumper extends Dumper
     {
         parent::__construct($container);
 
+        if (!class_exists('Symfony\Component\Yaml\Dumper')) {
+            throw new RuntimeException('Unable to dump the container as the Symfony Yaml Component is not installed.');
+        }
+
         $this->dumper = new YmlDumper();
     }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -13,13 +13,11 @@ namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Alias;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
-use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Yaml\Parser as YamlParser;
 
@@ -33,15 +31,6 @@ use Symfony\Component\Yaml\Parser as YamlParser;
 class YamlFileLoader extends FileLoader
 {
     private $yamlParser;
-
-    public function __construct(ContainerBuilder $container, FileLocatorInterface $locator)
-    {
-        if (!class_exists('Symfony\Component\Yaml\Parser')) {
-            throw new RuntimeException('Unable to load YAML files service definitions as the Symfony Yaml Component is not installed.');
-        }
-
-        parent::__construct($container, $locator);
-    }
 
     /**
      * {@inheritdoc}
@@ -281,6 +270,10 @@ class YamlFileLoader extends FileLoader
      */
     protected function loadFile($file)
     {
+        if (!class_exists('Symfony\Component\Yaml\Parser')) {
+            throw new RuntimeException('Unable to load YAML files service definitions as the Symfony Yaml Component is not installed.');
+        }
+
         if (!stream_is_local($file)) {
             throw new InvalidArgumentException(sprintf('This is not a local file "%s".', $file));
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -271,7 +271,7 @@ class YamlFileLoader extends FileLoader
     protected function loadFile($file)
     {
         if (!class_exists('Symfony\Component\Yaml\Parser')) {
-            throw new RuntimeException('Unable to load YAML files service definitions as the Symfony Yaml Component is not installed.');
+            throw new RuntimeException('Unable to load YAML config files as the Symfony Yaml Component is not installed.');
         }
 
         if (!stream_is_local($file)) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -13,10 +13,13 @@ namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Yaml\Parser as YamlParser;
 
@@ -30,6 +33,15 @@ use Symfony\Component\Yaml\Parser as YamlParser;
 class YamlFileLoader extends FileLoader
 {
     private $yamlParser;
+
+    public function __construct(ContainerBuilder $container, FileLocatorInterface $locator)
+    {
+        if (!class_exists('Symfony\Component\Yaml\Parser')) {
+            throw new RuntimeException('Unable to load YAML files service definitions as the Symfony Yaml Component is not installed.');
+        }
+
+        parent::__construct($container, $locator);
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

As the Yaml component is a suggested dependency, if someone try to use the `YamlFileLoader` or the `YamlDumper` without the component will get an ugly message:

```
PHP Fatal error:  Class 'Symfony\Component\Yaml\Dumper' not found in xxxx
```

With this PR the error will be an exception with the message: `Unable to dump the container as the Symfony Yaml Component is not installed.` for `YamlDumper` and `Unable to load YAML files service definitions as the Symfony Yaml Component is not installed.'` for `YamlFileLoader`
