### PR TITLE
[Form] Added ability to clear form errors

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -110,6 +110,8 @@ UPGRADE FROM 2.x to 3.0
 
 ### Form
 
+ * The method `clearErrors()` was added to `FormInterface`.
+
  * The option "precision" was renamed to "scale".
 
    Before:

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -190,6 +190,14 @@ class Button implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function clearErrors($deep = false)
+    {
+        return $this;
+    }
+
+    /**
      * Unsupported method.
      *
      * This method should not be invoked.

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * removed `AbstractTypeExtension::setDefaultOptions()` method
  * added `FormTypeInterface::configureOptions()` method
  * added `FormTypeExtensionInterface::configureOptions()` method
+ * added `FormInterface::clearErrors()` method
 
 2.7.0
 -----

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -835,6 +835,23 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function clearErrors($deep = false)
+    {
+        $this->errors = array();
+
+        // Copy the errors of nested forms to the $errors array
+        if ($deep) {
+            foreach ($this as $child) {
+                $child->clearErrors(true);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Returns a string representation of all form errors (including children errors).
      *
      * This method should only be used to help debug a form.

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -109,6 +109,15 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function getErrors($deep = false, $flatten = true);
 
     /**
+     * Removes all the errors of this form.
+     *
+     * @param bool $deep Whether to remove errors of child forms as well
+     *
+     * @return FormInterface The form instance
+     */
+    public function clearErrors($deep = false);
+
+    /**
      * Updates the form with default data.
      *
      * @param mixed $modelData The data formatted as expected for the underlying object

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -918,6 +918,46 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertSame($nestedError, $nestedErrorsAsArray[0]);
     }
 
+    public function testClearErrors()
+    {
+        $this->form->addError(new FormError('Error 1'));
+        $this->form->addError(new FormError('Error 2'));
+
+        $this->form->clearErrors();
+
+        $this->assertCount(0, $this->form->getErrors());
+    }
+
+    public function testClearErrorsShallow()
+    {
+        $this->form->addError($error1 = new FormError('Error 1'));
+        $this->form->addError($error2 = new FormError('Error 2'));
+
+        $childForm = $this->getBuilder('Child')->getForm();
+        $childForm->addError(new FormError('Nested Error'));
+        $this->form->add($childForm);
+
+        $this->form->clearErrors(false);
+
+        $this->assertCount(0, $this->form->getErrors(false));
+        $this->assertCount(1, $this->form->getErrors(true));
+    }
+
+    public function testClearErrorsDeep()
+    {
+        $this->form->addError($error1 = new FormError('Error 1'));
+        $this->form->addError($error2 = new FormError('Error 2'));
+
+        $childForm = $this->getBuilder('Child')->getForm();
+        $childForm->addError($nestedError = new FormError('Nested Error'));
+        $this->form->add($childForm);
+
+        $this->form->clearErrors(true);
+
+        $this->assertCount(0, $this->form->getErrors(false));
+        $this->assertCount(0, $this->form->getErrors(true));
+    }
+
     // Basic cases are covered in SimpleFormTest
     public function testCreateViewWithChildren()
     {

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -339,6 +339,14 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertCount(0, $this->form->getErrors());
     }
 
+    public function testClearErrors()
+    {
+        $this->form->addError(new FormError('Error!'));
+        $this->form->clearErrors();
+
+        $this->assertCount(0, $this->form->getErrors());
+    }
+
     /**
      * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14060 |
| License | MIT |
| Doc PR | symfony/symfony-docs#5152 |

\* Travis seems to be failing some builds for an unrelated reason

**TODO:**
- [x] Ensure Travis tests pass
- [x] Add/update relevant documentation

**Summary:**

This PR adds the ability to manually clear form errors, thus improving the DX issue reported in #14060.
