### PR TITLE
Bump component deps to make deps=low tests pass

### DIFF
--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -32,7 +32,7 @@
         "symfony/yaml": "~2.0,>=2.0.5|~3.0.0",
         "symfony/security": "~2.6|~3.0.0",
         "symfony/stopwatch": "~2.2|~3.0.0",
-        "symfony/console": "~2.6|~3.0.0",
+        "symfony/console": "~2.6,>2.6.6|~3.0.0",
         "symfony/var-dumper": "~2.6|~3.0.0",
         "symfony/expression-language": "~2.4|~3.0.0"
     },

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -32,7 +32,7 @@
         "symfony/yaml": "~2.0,>=2.0.5|~3.0.0",
         "symfony/security": "~2.6|~3.0.0",
         "symfony/stopwatch": "~2.2|~3.0.0",
-        "symfony/console": "~2.4|~3.0.0",
+        "symfony/console": "~2.6|~3.0.0",
         "symfony/var-dumper": "~2.6|~3.0.0",
         "symfony/expression-language": "~2.4|~3.0.0"
     },

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7|~3.0.0",
         "symfony/stopwatch": "~2.2|~3.0.0",
-        "symfony/dependency-injection": "~2.2|~3.0.0",
+        "symfony/dependency-injection": "~2.6,>=2.6.5|~3.0.0",
         "symfony/expression-language": "~2.4|~3.0.0",
         "symfony/config": "~2.2|~3.0.0",
         "symfony/routing": "~2.1|~3.0.0",


### PR DESCRIPTION
In #14205 / c29f779eded4c36152d2d1fbd1e3398281c458ba, CommandTester from symfony/console was fixed on the 2.6 branch.
