### PR TITLE
[config] added remove option to ignoreExtraKeys

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -29,6 +29,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     protected $addIfNotSet = false;
     protected $performDeepMerging = true;
     protected $ignoreExtraKeys = false;
+    protected $removeExtraKeys = true;
     protected $normalizeKeys = true;
 
     public function setNormalizeKeys($normalizeKeys)
@@ -140,10 +141,12 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      * Whether extra keys should just be ignore without an exception.
      *
      * @param bool $boolean To allow extra keys
+     * @param bool $remove To remove extra keys
      */
-    public function setIgnoreExtraKeys($boolean)
+    public function setIgnoreExtraKeys($boolean, $remove = true)
     {
         $this->ignoreExtraKeys = (bool) $boolean;
+        $this->removeExtraKeys = $this->ignoreExtraKeys && $remove;
     }
 
     /**
@@ -299,6 +302,9 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         foreach ($value as $name => $val) {
             if (isset($this->children[$name])) {
                 $normalized[$name] = $this->children[$name]->normalize($val);
+                unset($value[$name]);
+            } elseif (false === $this->removeExtraKeys) {
+                $normalized[$name] = $val;
                 unset($value[$name]);
             }
         }

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -24,6 +24,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
 {
     protected $performDeepMerging = true;
     protected $ignoreExtraKeys = false;
+    protected $removeExtraKeys = true;
     protected $children = array();
     protected $prototype;
     protected $atLeastOne = false;
@@ -284,11 +285,14 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      * you want to send an entire configuration array through a special
      * tree that processes only part of the array.
      *
+     * @param bool $remove Whether to remove the extra keys
+     *
      * @return ArrayNodeDefinition
      */
-    public function ignoreExtraKeys()
+    public function ignoreExtraKeys($remove = true)
     {
         $this->ignoreExtraKeys = true;
+        $this->removeExtraKeys = $remove;
 
         return $this;
     }
@@ -393,7 +397,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
         $node->addEquivalentValue(false, $this->falseEquivalent);
         $node->setPerformDeepMerging($this->performDeepMerging);
         $node->setRequired($this->required);
-        $node->setIgnoreExtraKeys($this->ignoreExtraKeys);
+        $node->setIgnoreExtraKeys($this->ignoreExtraKeys, $this->removeExtraKeys);
         $node->setNormalizeKeys($this->normalizeKeys);
 
         if (null !== $this->normalization) {

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -51,6 +51,21 @@ class ArrayNodeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests that extra keys are not removed when
+     * ignoreExtraKeys second option is set to false.
+     *
+     * Related to testExceptionThrownOnUnrecognizedChild
+     */
+    public function testIgnoreExtraKeysNotRemoved()
+    {
+        $node = new ArrayNode('roo');
+        $node->setIgnoreExtraKeys(true, false);
+
+        $data = array('foo' => 'bar');
+        $this->assertSame($data, $node->normalize($data));
+    }
+
+    /**
      * @dataProvider getPreNormalizationTests
      */
     public function testPreNormalize($denormalized, $normalized)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I have added a remove option to the `ignoreExtraKeys()` method of `Config/Definition/Builder/ArrayNodeDefinition`. The current implementation removes all such keys from the resulting array. This can at times be an inconvenience as we have to write extra methods to remove them before the validation then add them back again when done. Passing a boolean to the method now leaves them in place.
