### PR TITLE
[Form] Fixed DateType/TimeType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -57,8 +57,8 @@ class DateType extends AbstractType
 
         if ('single_text' === $options['widget']) {
             $builder->addViewTransformer(new DateTimeToLocalizedStringTransformer(
-                null,
-                null,
+                $options['model_timezone'],
+                $options['view_timezone'],
                 $dateFormat,
                 $timeFormat,
                 $calendar,
@@ -105,7 +105,7 @@ class DateType extends AbstractType
                 ->add('month', $options['widget'], $monthOptions)
                 ->add('day', $options['widget'], $dayOptions)
                 ->addViewTransformer(new DateTimeToArrayTransformer(
-                    null, null, array('year', 'month', 'day')
+                    $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day')
                 ))
                 ->setAttribute('formatter', $formatter)
             ;
@@ -113,15 +113,15 @@ class DateType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer(null, null, 'Y-m-d')
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'Y-m-d')
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer(null, null)
+                new DateTimeToTimestampTransformer($options['model_timezone'], $options['model_timezone'])
             ));
         } elseif ('array' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer(null, null, array('year', 'month', 'day'))
+                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], array('year', 'month', 'day'))
             ));
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -48,7 +48,7 @@ class TimeType extends AbstractType
         }
 
         if ('single_text' === $options['widget']) {
-            $builder->addViewTransformer(new DateTimeToStringTransformer(null, null, $format));
+            $builder->addViewTransformer(new DateTimeToStringTransformer($options['model_timezone'], $options['view_timezone'], $format));
         } else {
             $hourOptions = $minuteOptions = $secondOptions = array(
                 'error_bubbling' => true,
@@ -109,20 +109,20 @@ class TimeType extends AbstractType
                 $builder->add('second', $options['widget'], $secondOptions);
             }
 
-            $builder->addViewTransformer(new DateTimeToArrayTransformer(null, null, $parts, 'text' === $options['widget']));
+            $builder->addViewTransformer(new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts, 'text' === $options['widget']));
         }
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer(null, null, 'H:i:s')
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'H:i:s')
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer(null, null)
+                new DateTimeToTimestampTransformer($options['model_timezone'], $options['model_timezone'])
             ));
         } elseif ('array' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer(null, null, $parts)
+                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], $parts)
             ));
         }
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -380,91 +380,41 @@ class DateTypeTest extends TestCase
         ));
     }
 
-    public function testSetDataWithDifferentNegativeUTCTimezoneDateTime()
+    public function testSetDataWithNegativeTimezoneOffsetStringInput()
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'model_timezone' => 'America/New_York',
-            'view_timezone' => 'Pacific/Tahiti',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'America/New_York',
             'input' => 'string',
             'widget' => 'single_text',
         ));
 
         $form->setData('2010-06-02');
 
+        // 2010-06-02 00:00:00 UTC
+        // 2010-06-01 20:00:00 UTC-4
         $this->assertEquals('01.06.2010', $form->getViewData());
     }
 
-    public function testSetDataWithDifferentTimezonesDateTime()
+    public function testSetDataWithNegativeTimezoneOffsetDateTimeInput()
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'model_timezone' => 'America/New_York',
-            'view_timezone' => 'Pacific/Tahiti',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'America/New_York',
             'input' => 'datetime',
             'widget' => 'single_text',
         ));
 
-        $dateTime = new \DateTime('2010-06-02 America/New_York');
+        $dateTime = new \DateTime('2010-06-02 UTC');
 
         $form->setData($dateTime);
 
+        // 2010-06-02 00:00:00 UTC
+        // 2010-06-01 20:00:00 UTC-4
         $this->assertDateTimeEquals($dateTime, $form->getData());
         $this->assertEquals('01.06.2010', $form->getViewData());
-    }
-
-    public function testSetDataWithDifferentPositiveUTCTimezoneDateTime()
-    {
-        date_default_timezone_set('Pacific/Tahiti');
-
-        $form = $this->factory->create('date', null, array(
-            'format' => \IntlDateFormatter::MEDIUM,
-            'input' => 'datetime',
-            'widget' => 'single_text',
-        ));
-
-        $dateTime = new \DateTime('2010-06-02 Australia/Melbourne');
-
-        $form->setData($dateTime);
-
-        $this->assertDateTimeEquals($dateTime, $form->getData());
-        $this->assertEquals('02.06.2010', $form->getViewData());
-    }
-
-    public function testSetDataWithSamePositiveUTCTimezoneDateTime()
-    {
-        date_default_timezone_set('Australia/Melbourne');
-
-        $form = $this->factory->create('date', null, array(
-            'format' => \IntlDateFormatter::MEDIUM,
-            'input' => 'datetime',
-            'widget' => 'single_text',
-        ));
-
-        $dateTime = new \DateTime('2010-06-02 Australia/Melbourne');
-
-        $form->setData($dateTime);
-
-        $this->assertDateTimeEquals($dateTime, $form->getData());
-        $this->assertEquals('02.06.2010', $form->getViewData());
-    }
-
-    public function testSetDataWithSameNegativeUTCTimezoneDateTime()
-    {
-        date_default_timezone_set('America/New_York');
-
-        $form = $this->factory->create('date', null, array(
-            'format' => \IntlDateFormatter::MEDIUM,
-            'input' => 'datetime',
-            'widget' => 'single_text',
-        ));
-
-        $dateTime = new \DateTime('2010-06-02 America/New_York');
-
-        $form->setData($dateTime);
-
-        $this->assertDateTimeEquals($dateTime, $form->getData());
-        $this->assertEquals('02.06.2010', $form->getViewData());
     }
 
     public function testYearsOption()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12808 |
| License | MIT |
| Doc PR | - |

In 849fb2998485639d253e2438ecf78f62cc833a53, support for the "model_timezone" and "view_timezone" options was removed from DateType and TimeType. In 1c4a75a00a86df3e17979be86bddaafc108daf98, this change was reverted, but only partially, leaving the tests in a broken state and leading to bugs such as described in #12808 (I have no idea why this bug report is closed, when the bug still seems to be present to me).

This PR fixes both types.
