### PR TITLE
[Form] Cleanup deprecation notices

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -9,16 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Form\ChoiceList\View;
-
-use Symfony\Component\Form\Extension\Core\View\ChoiceView as LegacyChoiceView;
+namespace Symfony\Component\Form\Extension\Core\View;
 
 /**
  * Represents a choice in templates.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated since version 2.7, to be removed in 3.0.
+ *             Use {@link \Symfony\Component\Form\ChoiceList\View\ChoiceView} instead.
  */
-class ChoiceView extends LegacyChoiceView
+class ChoiceView
 {
     /**
      * The label displayed to humans.
@@ -42,6 +43,32 @@ class ChoiceView extends LegacyChoiceView
     public $data;
 
     /**
+     * Creates a new ChoiceView.
+     *
+     * @param mixed  $data  The original choice.
+     * @param string $value The view representation of the choice.
+     * @param string $label The label displayed to humans.
+     */
+    public function __construct($data, $value, $label)
+    {
+        $this->data = $data;
+        $this->value = $value;
+        $this->label = $label;
+    }
+}
+
+namespace Symfony\Component\Form\ChoiceList\View;
+
+use Symfony\Component\Form\Extension\Core\View\ChoiceView as LegacyChoiceView;
+
+/**
+ * Represents a choice in templates.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class ChoiceView extends LegacyChoiceView
+{
+    /**
      * Additional attributes for the HTML tag.
      *
      * @var array
@@ -58,9 +85,8 @@ class ChoiceView extends LegacyChoiceView
      */
     public function __construct($label, $value, $data, array $attr = array())
     {
-        $this->label = $label;
-        $this->value = $value;
-        $this->data = $data;
+        parent::__construct($data, $value, $label);
+
         $this->attr = $attr;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -34,7 +34,7 @@ use Symfony\Component\Form\Extension\Core\View\ChoiceView;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
+ * @deprecated since version 2.7, to be removed in 3.0.
  *             Use {@link \Symfony\Component\Form\ChoiceList\ArrayChoiceList} instead.
  */
 class ChoiceList implements ChoiceListInterface

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceListInterface.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceListInterface.php
@@ -28,7 +28,7 @@ use Symfony\Component\Form\ChoiceList\ChoiceListInterface as BaseChoiceListInter
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
+ * @deprecated since version 2.7, to be removed in 3.0.
  *             Use {@link BaseChoiceListInterface} instead.
  */
 interface ChoiceListInterface extends BaseChoiceListInterface

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
@@ -22,9 +22,8 @@ use Symfony\Component\Form\Exception\InvalidArgumentException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
- *             Use {@link \Symfony\Component\Form\ChoiceList\LazyChoiceList}
- *             instead.
+ * @deprecated since version 2.7, to be removed in 3.0.
+ *             Use {@link \Symfony\Component\Form\ChoiceList\LazyChoiceList} instead.
  */
 abstract class LazyChoiceList implements ChoiceListInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -33,9 +33,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
- *             Use {@link \Symfony\Component\Form\ChoiceList\ArrayChoiceList}
- *             instead.
+ * @deprecated since Symfony 2.7, to be removed in version 3.0.
+ *             Use {@link \Symfony\Component\Form\ChoiceList\ArrayChoiceList} instead.
  */
 class ObjectChoiceList extends ChoiceList
 {

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
@@ -29,9 +29,8 @@ namespace Symfony\Component\Form\Extension\Core\ChoiceList;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
- *             Use {@link \Symfony\Component\Form\ChoiceList\ArrayChoiceList}
- *             instead.
+ * @deprecated since version 2.7, to be removed in 3.0.
+ *             Use {@link \Symfony\Component\Form\ChoiceList\ArrayChoiceList} instead.
  */
 class SimpleChoiceList extends ChoiceList
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -18,9 +18,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
- *             Use {@link \Symfony\Component\Form\ChoiceList\LazyChoiceList}
- *             instead.
+ * @deprecated since version 2.7, to be removed in 3.0.
+ *             Use {@link \Symfony\Component\Form\ChoiceList\LazyChoiceList} instead.
  */
 class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
@@ -18,9 +18,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
- *             Use {@link \Symfony\Component\Form\ChoiceList\LazyChoiceList}
- *             instead.
+ * @deprecated since version 2.7, to be removed in 3.0.
+ *             Use {@link \Symfony\Component\Form\ChoiceList\LazyChoiceList} instead.
  */
 class ChoicesToBooleanArrayTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxInputListener.php
@@ -23,9 +23,8 @@ use Symfony\Component\Form\FormEvents;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
- *             Use {@link \Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper}
- *             instead.
+ * @deprecated since version 2.7, to be removed in 3.0.
+ *             Use {@link \Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper} instead.
  */
 class FixCheckboxInputListener implements EventSubscriberInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -22,9 +22,8 @@ use Symfony\Component\Form\FormEvents;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
- *             Use {@link \Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper}
- *             instead.
+ * @deprecated since version 2.7, to be removed in 3.0.
+ *             Use {@link \Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper} instead.
  */
 class FixRadioInputListener implements EventSubscriberInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
@@ -11,50 +11,14 @@
 
 namespace Symfony\Component\Form\Extension\Core\View;
 
+trigger_error('The '.__NAMESPACE__.'\ChoiceView class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\View\ChoiceView instead.', E_USER_DEPRECATED);
+
 /**
  * Represents a choice in templates.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
+ * @deprecated since version 2.7, to be removed in 3.0.
  *             Use {@link \Symfony\Component\Form\ChoiceList\View\ChoiceView} instead.
  */
-class ChoiceView
-{
-    /**
-     * The original choice value.
-     *
-     * @var mixed
-     */
-    public $data;
-
-    /**
-     * The view representation of the choice.
-     *
-     * @var string
-     */
-    public $value;
-
-    /**
-     * The label displayed to humans.
-     *
-     * @var string
-     */
-    public $label;
-
-    /**
-     * Creates a new ChoiceView.
-     *
-     * @param mixed  $data  The original choice.
-     * @param string $value The view representation of the choice.
-     * @param string $label The label displayed to humans.
-     */
-    public function __construct($data, $value, $label)
-    {
-        $this->data = $data;
-        $this->value = $value;
-        $this->label = $label;
-
-        trigger_error('The '.__CLASS__.' class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\View\ChoiceView instead.', E_USER_DEPRECATED);
-    }
-}
+class_exists('Symfony\Component\Form\ChoiceList\View\ChoiceView');

--- a/src/Symfony/Component/Form/FormTypeExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormTypeExtensionInterface.php
@@ -64,7 +64,7 @@ interface FormTypeExtensionInterface
      *
      * @param OptionsResolverInterface $resolver The resolver for the options.
      *
-     * @deprecated Deprecated since Symfony 2.7, to be removed in Symfony 3.0.
+     * @deprecated since version 2.7, to be removed in 3.0.
      *             Use the method configureOptions instead. This method will be
      *             added to the FormTypeExtensionInterface with Symfony 3.0
      */

--- a/src/Symfony/Component/Form/FormTypeInterface.php
+++ b/src/Symfony/Component/Form/FormTypeInterface.php
@@ -73,7 +73,7 @@ interface FormTypeInterface
      *
      * @param OptionsResolverInterface $resolver The resolver for the options.
      *
-     * @deprecated Deprecated since Symfony 2.7, to be renamed in Symfony 3.0.
+     * @deprecated since version 2.7, to be renamed in 3.0.
      *             Use the method configureOptions instead. This method will be
      *             added to the FormTypeInterface with Symfony 3.0.
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This uses the same technique used for FlattenException in HttpKernel that prevents repeated notices triggered by the constructor.
