### PR TITLE
[WebProfilerBundle] Add link to show profile of latest request

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -91,6 +91,10 @@ class ProfilerController
         $panel = $request->query->get('panel', 'request');
         $page = $request->query->get('page', 'home');
 
+        if ('latest' === $token && $latest = current($this->profiler->find(null, null, 1, null, null, null))) {
+            $token = $latest['token'];
+        }
+
         if (!$profile = $this->profiler->loadProfile($token)) {
             return new Response($this->twig->render('@WebProfiler/Profiler/info.html.twig', array('about' => 'no_token', 'token' => $token)), 200, array('Content-Type' => 'text/html'));
         }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/info.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/info.html.twig
@@ -25,10 +25,17 @@
                                     <em>The token already exists in the database.</em>
                                 </p>
                             {% elseif about == 'no_token' %}
-                                <h2>Token not found</h2>
-                                <p>
-                                    <em>Token "{{ token }}" was not found in the database.</em>
-                                </p>
+                                {% if token == 'latest' %}
+                                    <h2>No profiles</h2>
+                                    <p>
+                                        <em>No profiles found in the database.</em>
+                                    </p>
+                                {% else %}
+                                    <h2>Token not found</h2>
+                                    <p>
+                                        <em>Token "{{ token }}" was not found in the database.</em>
+                                    </p>
+                                {% endif %}
                             {% endif %}
                         {% endblock %}
                     </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -14,6 +14,7 @@
                     {% if profile %}
                         <div id="resume">
                             <a id="resume-view-all" href="{{ path('_profiler_search', {limit: 10}) }}">View last 10</a>
+                            <a id="resume-view-latest" href="{{ path('_profiler', {token: 'latest', 'panel': panel}) }}">View latest</a>
                             <strong>Profile for:</strong>
                             {{ profile.method|upper }}
                             {% if profile.method|upper in ['GET', 'HEAD'] %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -217,7 +217,7 @@ li {
     border-top-right-radius: 16px;
     line-height: 18px;
 }
-a#resume-view-all {
+a#resume-view-all, a#resume-view-latest {
     display: inline-block;
     padding: 0.2em 0.7em;
     margin-right: 0.5em;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR adds a "View latest" link next to "View last 10" to enable quick access to the profile of the latest request. This is useful especially when using the profiler along with a REST client. After sending a new request it is now possible to view the latest profile with just one click.
