### PR TITLE
[Translator] Cache does not take fallback locales into consideration

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -352,7 +352,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
         }
 
         $this->assertValidLocale($locale);
-        $cache = new ConfigCache($this->cacheDir.'/catalogue.'.$locale.'.php', $this->debug);
+        $cache = new ConfigCache($this->getCatalogueCachePath($locale), $this->debug);
         if (!$cache->isFresh()) {
             $this->initializeCatalogue($locale);
 
@@ -402,6 +402,11 @@ EOF
         }
 
         $this->catalogues[$locale] = include $cache;
+    }
+
+    private function getCatalogueCachePath($locale)
+    {
+        return $this->cacheDir.'/catalogue.'.$locale.'.'.sha1(serialize($this->fallbackLocales)).'.php';
     }
 
     private function doLoadCatalogue($locale)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14267 |
| License | MIT |
| Doc PR | n/a |

As we're dumping entire catalogues including their fallbacks (standalone or inlined in ~2.7), we need to use different cache files for different sets of fallback locales.

This glitch probably exists also prior to 2.6 but the caching part was still part of the FrameworkBundle then.

What's the best way of backporting it?
