### PR TITLE
[Translator] Cache does not take fallback locales into consideration (sf2.3)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -95,7 +95,7 @@ class Translator extends BaseTranslator
 
         $this->assertValidLocale($locale);
 
-        $cache = new ConfigCache($this->options['cache_dir'].'/catalogue.'.$locale.'.php', $this->options['debug']);
+        $cache = new ConfigCache($this->getCatalogueCachePath($locale), $this->options['debug']);
         if (!$cache->isFresh()) {
             $this->initialize();
 
@@ -156,5 +156,10 @@ EOF
                 $this->addLoader($alias, $this->container->get($id));
             }
         }
+    }
+
+    private function getCatalogueCachePath($locale)
+    {
+        return $this->options['cache_dir'].'/catalogue.'.$locale.'.'.sha1(serialize($this->getFallbackLocales())).'.php';
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14268 |
| License | MIT |
| Doc PR | n/a |

This is the Symfony 2.3 variant of #14267.
