### PR TITLE
[FrameworkBundle] Workaround php -S ignoring auto_prepend_file

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php
@@ -21,6 +21,11 @@
  * @author: Albert Jessurum <ajessu@gmail.com>
  */
 
+// Workaround https://bugs.php.net/64566
+if (ini_get('auto_prepend_file') && !in_array(realpath(ini_get('auto_prepend_file')), get_included_files(), true)) {
+    require ini_get('auto_prepend_file');
+}
+
 if (is_file($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$_SERVER['SCRIPT_NAME'])) {
     return false;
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_prod.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_prod.php
@@ -21,6 +21,11 @@
  * @author: Albert Jessurum <ajessu@gmail.com>
  */
 
+// Workaround https://bugs.php.net/64566
+if (ini_get('auto_prepend_file') && !in_array(realpath(ini_get('auto_prepend_file')), get_included_files(), true)) {
+    require ini_get('auto_prepend_file');
+}
+
 if (is_file($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$_SERVER['SCRIPT_NAME'])) {
     return false;
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

`php -S front_controller.php` (thus `php app/console server:run`) ignores auto_prepend_file for no reason.
