### PR TITLE
Use baseHref also for forms

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -766,7 +766,7 @@ class Crawler extends \SplObjectStorage
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        $form = new Form($this->getNode(0), $this->uri, $method);
+        $form = new Form($this->getNode(0), $this->baseHref, $method);
 
         if (null !== $values) {
             $form->setValues($values);


### PR DESCRIPTION
The baseHref should also be used for forms. It should be the same behaviour as for normal links.
