### PR TITLE
Make it possible to subclass CompiledRoute

### DIFF
--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -18,14 +18,14 @@ namespace Symfony\Component\Routing;
  */
 class CompiledRoute implements \Serializable
 {
-    private $variables;
-    private $tokens;
-    private $staticPrefix;
-    private $regex;
-    private $pathVariables;
-    private $hostVariables;
-    private $hostRegex;
-    private $hostTokens;
+    protected $variables;
+    protected $tokens;
+    protected $staticPrefix;
+    protected $regex;
+    protected $pathVariables;
+    protected $hostVariables;
+    protected $hostRegex;
+    protected $hostTokens;
 
     /**
      * Constructor.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Drupal subclasses CompiledRoute to add additional information. As we store those
bits in the database, we need to serialize the information.

Due to some bugs in the language though, see https://bugs.php.net/bug.php?id=65591, its not always true, that you can rely on the parent
class to serialize/unserialize so having a good way to set this variables back, would be great.

For now this PR just marks the vars as protected, so you can set them.
It would be great to not require setter methods, as we need to serialize quite a lot of those routes potentially.
