### PR TITLE
[2.7][Console] Count the $messages array instead of $message

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -73,7 +73,7 @@ class SymfonyStyle extends OutputStyle
             $message = OutputFormatter::escape($message);
             $lines = array_merge($lines, explode("\n", wordwrap($message, $this->lineLength - Helper::strlen($prefix))));
 
-            if (count($messages) > 1 && $key < count($message)) {
+            if (count($messages) > 1 && $key < count($messages)) {
                 $lines[] = '';
             }
         }

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -73,7 +73,7 @@ class SymfonyStyle extends OutputStyle
             $message = OutputFormatter::escape($message);
             $lines = array_merge($lines, explode("\n", wordwrap($message, $this->lineLength - Helper::strlen($prefix))));
 
-            if (count($messages) > 1 && $key < count($messages)) {
+            if (count($messages) > 1 && $key < count($messages) - 1) {
                 $lines[] = '';
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | n/a |
| License | MIT |

I think you mean $messages instead of $message. With this patch, the number of messages is correctly counted.
