### PR TITLE
[2.7][Console] Make lineLength protected insted of private

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -32,10 +32,11 @@ class SymfonyStyle extends OutputStyle
 {
     const MAX_LINE_LENGTH = 120;
 
+    protected $lineLength;
+
     private $input;
     private $questionHelper;
     private $progressBar;
-    private $lineLength;
 
     /**
      * @param InputInterface  $input


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

This way, it can be more easily extended.

For example, I want to extend the SymfonyStyle (see https://github.com/laravel/framework/pull/8338) with just some tweaks to the Symfony style. But because of the private methods, this isn't as easy to use as I would like. I'd need to access the lineLength to use a different block function.

But perhaps there is a better way?
