### PR TITLE
[WebProfiler] Added deprecation message and original color back

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -93,7 +93,7 @@
                 {% set is_deprecation = log.context.level is defined and log.context.type is defined and (constant('E_DEPRECATED') == log.context.type or constant('E_USER_DEPRECATED') == log.context.type) %}
                 {% if priority == '-100' ? is_deprecation : log.priority >= priority %}
                     {% set log_loop_index = log_loop_index + 1 %}
-                    <li class="{{ cycle(['odd', 'even'], log_loop_index) }}{% if log.context.scream is defined %} scream{% elseif log.priority >= 400 %} error{% elseif log.priority >= 300 %} warning{% endif %}">
+                    <li class="{{ cycle(['odd', 'even'], log_loop_index) }}{% if log.context.scream is defined %} scream{% elseif log.priority >= 400 %} error{% elseif log.priority >= 300 or is_deprecation %} warning{% endif %}">
                         {{ logger.display_message(loop.index, log, is_deprecation) }}
                     </li>
                 {% endif %}
@@ -113,6 +113,8 @@
     {% if is_deprecation %}
         {% set stack = log.context.stack|default([]) %}
         {% set id = 'sf-call-stack-' ~ log_index %}
+
+        DEPRECATED - {{ log.message }}
 
         {% if stack %}
             <a href="#" onclick="Sfjs.toggle('{{ id }}', document.getElementById('{{ id }}-on'), document.getElementById('{{ id }}-off')); return false;">


### PR DESCRIPTION
For some reason, the deprecation message and its original yellow color were removed. This means that you don't know the error (without a stack, you would just see an empty bar) and they aren't easy to find anymore in a long list of logs (yeah, the filter can be used...).

**Before**
![sf-logger-deprecation-before](https://cloud.githubusercontent.com/assets/749025/7062927/4094d5d4-dea2-11e4-80e2-c13a02d6d748.png)

**After**
![sf-logger-deprecation-after](https://cloud.githubusercontent.com/assets/749025/7062930/475fc2b6-dea2-11e4-978f-0f18262f283c.png)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
