### PR TITLE
[Finder] Removed duplicated toRegex() code

### DIFF
--- a/src/Symfony/Component/Finder/Expression/Glob.php
+++ b/src/Symfony/Component/Finder/Expression/Glob.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Finder\Expression;
 
+use Symfony\Component\Finder\Glob as FinderGlob;
+
 /**
  * @author Jean-François Simon <contact@jfsimon.fr>
  */
@@ -100,58 +102,8 @@ class Glob implements ValueInterface
      */
     public function toRegex($strictLeadingDot = true, $strictWildcardSlash = true)
     {
-        $firstByte = true;
-        $escaping = false;
-        $inCurlies = 0;
-        $regex = '';
-        $sizeGlob = strlen($this->pattern);
-        for ($i = 0; $i < $sizeGlob; $i++) {
-            $car = $this->pattern[$i];
-            if ($firstByte) {
-                if ($strictLeadingDot && '.' !== $car) {
-                    $regex .= '(?=[^\.])';
-                }
+        $regex = FinderGlob::toRegex($this->pattern, $strictLeadingDot, $strictWildcardSlash, '');
 
-                $firstByte = false;
-            }
-
-            if ('/' === $car) {
-                $firstByte = true;
-            }
-
-            if ('.' === $car || '(' === $car || ')' === $car || '|' === $car || '+' === $car || '^' === $car || '$' === $car) {
-                $regex .= "\\$car";
-            } elseif ('*' === $car) {
-                $regex .= $escaping ? '\\*' : ($strictWildcardSlash ? '[^/]*' : '.*');
-            } elseif ('?' === $car) {
-                $regex .= $escaping ? '\\?' : ($strictWildcardSlash ? '[^/]' : '.');
-            } elseif ('{' === $car) {
-                $regex .= $escaping ? '\\{' : '(';
-                if (!$escaping) {
-                    ++$inCurlies;
-                }
-            } elseif ('}' === $car && $inCurlies) {
-                $regex .= $escaping ? '}' : ')';
-                if (!$escaping) {
-                    --$inCurlies;
-                }
-            } elseif (',' === $car && $inCurlies) {
-                $regex .= $escaping ? ',' : '|';
-            } elseif ('\\' === $car) {
-                if ($escaping) {
-                    $regex .= '\\\\';
-                    $escaping = false;
-                } else {
-                    $escaping = true;
-                }
-
-                continue;
-            } else {
-                $regex .= $car;
-            }
-            $escaping = false;
-        }
-
-        return new Regex('^'.$regex.'$');
+        return new Regex($regex);
     }
 }

--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -41,10 +41,11 @@ class Glob
      * @param string $glob                The glob pattern
      * @param bool   $strictLeadingDot
      * @param bool   $strictWildcardSlash
+     * @param string $delimiter           Optional delimiter
      *
      * @return string regex The regexp
      */
-    public static function toRegex($glob, $strictLeadingDot = true, $strictWildcardSlash = true)
+    public static function toRegex($glob, $strictLeadingDot = true, $strictWildcardSlash = true, $delimiter = '#')
     {
         $firstByte = true;
         $escaping = false;
@@ -98,6 +99,6 @@ class Glob
             $escaping = false;
         }
 
-        return '#^'.$regex.'$#';
+        return $delimiter.'^'.$regex.'$'.$delimiter;
     }
 }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -308,7 +308,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder = $this->buildFinder($adapter);
         $iterator = $finder->files()->name('*.php')->depth('< 1')->in(array(self::$tmpDir, __DIR__))->getIterator();
 
-        $this->assertIterator(array(self::$tmpDir.DIRECTORY_SEPARATOR.'test.php', __DIR__.DIRECTORY_SEPARATOR.'FinderTest.php'), $iterator);
+        $this->assertIterator(array(self::$tmpDir.DIRECTORY_SEPARATOR.'test.php', __DIR__.DIRECTORY_SEPARATOR.'FinderTest.php', __DIR__.DIRECTORY_SEPARATOR.'GlobTest.php'), $iterator);
     }
 
     /**

--- a/src/Symfony/Component/Finder/Tests/GlobTest.php
+++ b/src/Symfony/Component/Finder/Tests/GlobTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests;
+
+use Symfony\Component\Finder\Glob;
+
+class GlobTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testGlobToRegexDelimiters()
+    {
+        $this->assertEquals(Glob::toRegex('.*'), '#^\.[^/]*$#');
+        $this->assertEquals(Glob::toRegex('.*', true, true, ''), '^\.[^/]*$');
+        $this->assertEquals(Glob::toRegex('.*', true, true, '/'), '/^\.[^/]*$/');
+    }
+
+}


### PR DESCRIPTION
This patch removes duplicated `toRegex()` code by using the already existing `Glob` class. As this class wasn't unit-tested to begin with, this duplication also makes sure this class is tested properly.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14075 |
| License | MIT |
