### PR TITLE
[DomCrawler] Callable type hint

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.0.0
 -----
 
- * The first argument of `Crawler::each()` and `Crawler::reduce()` are type hinted with `callback` instead of `Closure`.
+ * The first argument of `Crawler::each()` and `Crawler::reduce()` are type hinted with `callable` instead of `Closure`.
 
 2.5.0
 -----

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.0.0
+-----
+
+ * The first argument of `Crawler::each()` and `Crawler::reduce()` are type hinted with `callback` instead of `Closure`.
+
 2.5.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -323,9 +323,9 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
-     * Calls an anonymous function on each node of the list.
+     * Execute a callback on each node of the list.
      *
-     * The anonymous function receives the position and the node wrapped
+     * The callback receives the position and the node wrapped
      * in a Crawler instance as arguments.
      *
      * Example:
@@ -334,17 +334,17 @@ class Crawler extends \SplObjectStorage
      *         return $node->text();
      *     });
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $fn A callback
      *
-     * @return array An array of values returned by the anonymous function
+     * @return array An array of values returned by the callback
      *
      * @api
      */
-    public function each(\Closure $closure)
+    public function each(callable $fn)
     {
         $data = array();
         foreach ($this as $i => $node) {
-            $data[] = $closure(new static($node, $this->uri, $this->baseHref), $i);
+            $data[] = $fn(new static($node, $this->uri, $this->baseHref), $i);
         }
 
         return $data;
@@ -364,21 +364,21 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
-     * Reduces the list of nodes by calling an anonymous function.
+     * Reduces the list of nodes by calling a callback.
      *
-     * To remove a node from the list, the anonymous function must return false.
+     * To remove a node from the list, the callback must return false.
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $fn A callback
      *
      * @return Crawler A Crawler instance with the selected nodes.
      *
      * @api
      */
-    public function reduce(\Closure $closure)
+    public function reduce(callable $fn)
     {
         $nodes = array();
         foreach ($this as $i => $node) {
-            if (false !== $closure(new static($node, $this->uri, $this->baseHref), $i)) {
+            if (false !== $fn(new static($node, $this->uri, $this->baseHref), $i)) {
                 $nodes[] = $node;
             }
         }

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -310,7 +310,7 @@ EOF
             return $i.'-'.$node->text();
         });
 
-        $this->assertEquals(array('0-One', '1-Two', '2-Three'), $data, '->each() executes an anonymous function on each node of the list');
+        $this->assertEquals(array('0-One', '1-Two', '2-Three'), $data, '->each() executes a callback on each node of the list');
     }
 
     public function testSlice()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

As of PHP 5.4 exists the `callable` type hint. Example:

``` php
// With the Closure type hint we can only create callbacks in this way...
$crawler->each(function ($node, $i) {});

// With the callable type hint this works too
$obj = new MyClass();
$crawler->each(array($obj, 'myCallbackMethod'));
```
