### PR TITLE
propel/propel1 is now useless

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,6 @@
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
         "monolog/monolog": "~1.11",
-        "propel/propel1": "~1.6",
         "ircmaxell/password-compat": "~1.0",
         "ocramius/proxy-manager": "~0.4|~1.0",
         "egulias/email-validator": "~1.2"


### PR DESCRIPTION
Since Propel bridge has been removed, no need to require it anymore for
development.
