### PR TITLE
[HttpKernel] fixed a regression when no exception listeners are registered

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -229,7 +229,11 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         if (!$event->hasResponse()) {
             $this->finishRequest($request, $type);
 
-            throw new \LogicException('No listeners of the "kernel.exception" event set a Response', 0, $e);
+            if ($this->dispatcher->hasListeners(KernelEvents::EXCEPTION)) {
+                throw new \LogicException('No listeners of the "kernel.exception" event set a Response', 0, $e);
+            }
+
+            throw $e;
         }
 
         $response = $event->getResponse();

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -102,8 +102,8 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
             $this->fail('->handle() suppresses the controller exception');
         } catch (\PHPUnit_Framework_Exception $exception) {
             throw $exception;
-        } catch (\LogicException $actual) {
-            $this->assertSame($expected, $actual->getPrevious(), '->handle() throws the controller exception, wrapped when no listener');
+        } catch (\Exception $actual) {
+            $this->assertSame($expected, $actual, '->handle() throws the controller exception');
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -23,17 +23,14 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class HttpKernelTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedException \RuntimeException
+     */
     public function testHandleWhenControllerThrowsAnExceptionAndCatchIsTrue()
     {
-        $exception = new \RuntimeException();
-        $kernel = new HttpKernel(new EventDispatcher(), $this->getResolver(function () use ($exception) { throw $exception; }));
+        $kernel = new HttpKernel(new EventDispatcher(), $this->getResolver(function () { throw new \RuntimeException(); }));
 
-        try {
-            $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
-            $this->fail('LogicException expected');
-        } catch (\LogicException $e) {
-            $this->assertSame($exception, $e->getPrevious());
-        }
+        $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This fixes a regression in 2.7. When no exception listeners are registered, the original exception should not be wrapped by the exception management layer of HttpKernel.
