### PR TITLE
[Translation] Revert inlining fallback catalogues as it might cause inconsistent results when a cache is used

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -196,6 +196,45 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $translator->trans('bar'));
     }
 
+    public function testGetCatalogueBehavesConsistently()
+    {
+        /*
+         * Create a translator that loads two catalogues for two different locales.
+         * The catalogues contain distinct sets of messages.
+         */
+        $translator = new Translator('a', null, $this->tmpDir);
+        $translator->setFallbackLocales(array('b'));
+
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', array('foo' => 'foo (a)'), 'a');
+        $translator->addResource('array', array('foo' => 'foo (b)'), 'b');
+        $translator->addResource('array', array('bar' => 'bar (b)'), 'b');
+
+        $catalogue = $translator->getCatalogue('a');
+        $this->assertFalse($catalogue->defines('bar')); // Sure, the "a" catalogue does not contain that message.
+
+        $fallback = $catalogue->getFallbackCatalogue();
+        $this->assertTrue($fallback->defines('foo')); // "foo" is present in "a" and "b"
+
+        /*
+         * Now, repeat the same test.
+         * Behind the scenes, the cache is used. But that should not matter, right?
+         */
+        $translator = new Translator('a', null, $this->tmpDir);
+        $translator->setFallbackLocales(array('b'));
+
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', array('foo' => 'foo (a)'), 'a');
+        $translator->addResource('array', array('foo' => 'foo (b)'), 'b');
+        $translator->addResource('array', array('bar' => 'bar (b)'), 'b');
+
+        $catalogue = $translator->getCatalogue('a');
+        $this->assertFalse($catalogue->defines('bar'));
+
+        $fallback = $catalogue->getFallbackCatalogue();
+        $this->assertTrue($fallback->defines('foo'));
+    }
+
     protected function getCatalogue($locale, $messages)
     {
         $catalogue = new MessageCatalogue($locale);

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -420,21 +420,6 @@ EOF
 
     private function getFallbackContent(MessageCatalogue $catalogue)
     {
-        if (!$this->debug) {
-            // merge all fallback catalogues messages into $catalogue
-            $fallbackCatalogue = $catalogue->getFallbackCatalogue();
-            $messages = $catalogue->all();
-            while ($fallbackCatalogue) {
-                $messages = array_replace_recursive($fallbackCatalogue->all(), $messages);
-                $fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue();
-            }
-            foreach ($messages as $domain => $domainMessages) {
-                $catalogue->add($domainMessages, $domain);
-            }
-
-            return '';
-        }
-
         $fallbackContent = '';
         $current = '';
         $replacementPattern = '/[^a-z0-9_]/i';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14315 |
| License | MIT |
| Doc PR | n/a |

The results from `getCatalogue()` are inconsistent when we're in production _and_ a cache comes into play.

This is due to the changes in 6eb5e7395cfb631240804319645b4592cf4fff8f, where the fallback catalogues will be _merged_ into the primary catalogue when it is written to the cache.

Strictly speaking, this is a BC break because it behaved differently before.

I am not sure what the relevance of this might be in practice.

However, it may cause headaches because 
- The result changes only in the second+ try (when the cache is warm); a priori you cannot tell whether you're going to see this
- The catalogue is clearly not what the loader provided
- You have no chance of telling whether the message was originally available in the catalogue or not
- Generally, for every message you retrieve from the catalogue, you have no way of telling which locale it actually comes from (it need not be from the catalogue's locale, and the catalogue does not provide fallback catalogues either)

Regarding the last point, you usually don't care when using the `Translator`. Its purpose is to get the "best" translation available. However, when you bother to explicitly retrieve the catalogue, chances are your intentions are different.
