### PR TITLE
[Translation] added an --all option to the debug:translation command #14237

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
-use Symfony\Component\Translation\Catalogue\MergeOperation;
+use Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Translation\Catalogue\MergeOperation;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Translator;
 
@@ -48,6 +50,7 @@ class TranslationDebugCommand extends ContainerAwareCommand
                 new InputOption('domain', null, InputOption::VALUE_OPTIONAL, 'The messages domain'),
                 new InputOption('only-missing', null, InputOption::VALUE_NONE, 'Displays only missing messages'),
                 new InputOption('only-unused', null, InputOption::VALUE_NONE, 'Displays only unused messages'),
+                new InputOption('all', null, InputOption::VALUE_NONE, 'Load messages from all registered bundles'),
             ))
             ->setDescription('Displays translation messages information')
             ->setHelp(<<<EOF
@@ -75,6 +78,10 @@ You can display information about app translations in a specific locale:
 
   <info>php %command.full_name% en</info>
 
+You can display information about translations in all registered bundles in a specific locale:
+
+  <info>php %command.full_name% --all en</info>
+
 EOF
             )
         ;
@@ -91,129 +98,123 @@ EOF
 
         $locale = $input->getArgument('locale');
         $domain = $input->getOption('domain');
+        /** @var TranslationLoader $loader */
         $loader = $this->getContainer()->get('translation.loader');
+        /** @var Kernel $kernel */
         $kernel = $this->getContainer()->get('kernel');
 
         // Define Root Path to App folder
-        $rootPath = $kernel->getRootDir();
+        $rootPaths = array($kernel->getRootDir());
 
         // Override with provided Bundle info
         if (null !== $input->getArgument('bundle')) {
             try {
-                $rootPath = $kernel->getBundle($input->getArgument('bundle'))->getPath();
+                $rootPaths = array($kernel->getBundle($input->getArgument('bundle'))->getPath());
             } catch (\InvalidArgumentException $e) {
                 // such a bundle does not exist, so treat the argument as path
-                $rootPath = $input->getArgument('bundle');
+                $rootPaths = array($input->getArgument('bundle'));
 
-                if (!is_dir($rootPath)) {
-                    throw new \InvalidArgumentException(sprintf('<error>"%s" is neither an enabled bundle nor a directory.</error>', $rootPath));
+                if (!is_dir($rootPaths[0])) {
+                    throw new \InvalidArgumentException(
+                        sprintf('<error>"%s" is neither an enabled bundle nor a directory.</error>', $rootPaths[0])
+                    );
                 }
+            }
+        } elseif ($input->getOption('all')) {
+            foreach ($kernel->getBundles() as $bundle) {
+                $rootPaths[] = $bundle->getPath();
             }
         }
 
-        // get bundle directory
-        $translationsPath = $rootPath.'/Resources/translations';
+        foreach ($rootPaths as $rootPath) {
+            // get bundle directory
+            $translationsPath = $rootPath.'/Resources/translations';
 
-        // Extract used messages
-        $extractedCatalogue = new MessageCatalogue($locale);
-        if (is_dir($rootPath.'/Resources/views')) {
-            $this->getContainer()->get('translation.extractor')->extract($rootPath.'/Resources/views', $extractedCatalogue);
-        }
+            $output->writeln(sprintf('Translations in <info>%s</info>', $translationsPath));
 
-        // Load defined messages
-        $currentCatalogue = new MessageCatalogue($locale);
-        if (is_dir($translationsPath)) {
-            $loader->loadMessages($translationsPath, $currentCatalogue);
-        }
+            // Extract used messages
+            $extractedCatalogue = $this->extractMessages($locale, $rootPath);
 
-        // Merge defined and extracted messages to get all message ids
-        $mergeOperation = new MergeOperation($extractedCatalogue, $currentCatalogue);
-        $allMessages = $mergeOperation->getResult()->all($domain);
-        if (null !== $domain) {
-            $allMessages = array($domain => $allMessages);
-        }
+            // Load defined messages
+            $currentCatalogue = $this->loadCurrentMessages($locale, $translationsPath, $loader);
 
-        // No defined or extracted messages
-        if (empty($allMessages) || null !== $domain && empty($allMessages[$domain])) {
-            $outputMessage = sprintf('<info>No defined or extracted messages for locale "%s"</info>', $locale);
-
+            // Merge defined and extracted messages to get all message ids
+            $mergeOperation = new MergeOperation($extractedCatalogue, $currentCatalogue);
+            $allMessages    = $mergeOperation->getResult()->all($domain);
             if (null !== $domain) {
-                $outputMessage .= sprintf(' <info>and domain "%s"</info>', $domain);
+                $allMessages = array($domain => $allMessages);
             }
 
-            $output->writeln($outputMessage);
+            // No defined or extracted messages
+            if (empty($allMessages) || null !== $domain && empty($allMessages[$domain])) {
+                $outputMessage = sprintf('<info>No defined or extracted messages for locale "%s"</info>', $locale);
 
-            return;
-        }
-
-        // Load the fallback catalogues
-        $fallbackCatalogues = array();
-        $translator = $this->getContainer()->get('translator');
-        if ($translator instanceof Translator) {
-            foreach ($translator->getFallbackLocales() as $fallbackLocale) {
-                if ($fallbackLocale === $locale) {
-                    continue;
+                if (null !== $domain) {
+                    $outputMessage .= sprintf(' <info>and domain "%s"</info>', $domain);
                 }
 
-                $fallbackCatalogue = new MessageCatalogue($fallbackLocale);
-                $loader->loadMessages($translationsPath, $fallbackCatalogue);
-                $fallbackCatalogues[] = $fallbackCatalogue;
+                $output->writeln($outputMessage);
+
+                continue;
             }
-        }
 
-        if (class_exists('Symfony\Component\Console\Helper\Table')) {
-            $table = new Table($output);
-        } else {
-            $table = $this->getHelperSet()->get('table');
-        }
+            // Load the fallback catalogues
+            $fallbackCatalogues = $this->loadFallbackCatalogues($locale, $translationsPath, $loader);
+            if (class_exists('Symfony\Component\Console\Helper\Table')) {
+                $table = new Table($output);
+            } else {
+                $table = $this->getHelperSet()->get('table');
+            }
 
-        // Display header line
-        $headers = array('State', 'Domain', 'Id', sprintf('Message Preview (%s)', $locale));
-        foreach ($fallbackCatalogues as $fallbackCatalogue) {
-            $headers[] = sprintf('Fallback Message Preview (%s)', $fallbackCatalogue->getLocale());
-        }
-        $table->setHeaders($headers);
+            // Display header line
+            $headers = array('State', 'Domain', 'Id', sprintf('Message Preview (%s)', $locale));
+            foreach ($fallbackCatalogues as $fallbackCatalogue) {
+                $headers[] = sprintf('Fallback Message Preview (%s)', $fallbackCatalogue->getLocale());
+            }
+            $table->setHeaders($headers);
 
-        // Iterate all message ids and determine their state
-        foreach ($allMessages as $domain => $messages) {
-            foreach (array_keys($messages) as $messageId) {
-                $value = $currentCatalogue->get($messageId, $domain);
-                $states = array();
+            // Iterate all message ids and determine their state
+            foreach ($allMessages as $domain => $messages) {
+                foreach (array_keys($messages) as $messageId) {
+                    $value  = $currentCatalogue->get($messageId, $domain);
+                    $states = array();
 
-                if ($extractedCatalogue->defines($messageId, $domain)) {
-                    if (!$currentCatalogue->defines($messageId, $domain)) {
-                        $states[] = self::MESSAGE_MISSING;
+                    if ($extractedCatalogue->defines($messageId, $domain)) {
+                        if (!$currentCatalogue->defines($messageId, $domain)) {
+                            $states[] = self::MESSAGE_MISSING;
+                        }
+                    } elseif ($currentCatalogue->defines($messageId, $domain)) {
+                        $states[] = self::MESSAGE_UNUSED;
                     }
-                } elseif ($currentCatalogue->defines($messageId, $domain)) {
-                    $states[] = self::MESSAGE_UNUSED;
-                }
 
-                if (!in_array(self::MESSAGE_UNUSED, $states) && true === $input->getOption('only-unused')
-                    || !in_array(self::MESSAGE_MISSING, $states) && true === $input->getOption('only-missing')) {
-                    continue;
-                }
-
-                foreach ($fallbackCatalogues as $fallbackCatalogue) {
-                    if ($fallbackCatalogue->defines($messageId, $domain) && $value === $fallbackCatalogue->get($messageId, $domain)) {
-                        $states[] = self::MESSAGE_EQUALS_FALLBACK;
-
-                        break;
+                    if (!in_array(self::MESSAGE_UNUSED, $states) && true === $input->getOption('only-unused')
+                        || !in_array(self::MESSAGE_MISSING, $states) && true === $input->getOption('only-missing')) {
+                        continue;
                     }
-                }
 
-                $row = array($this->formatStates($states), $domain, $this->formatId($messageId), $this->sanitizeString($value));
-                foreach ($fallbackCatalogues as $fallbackCatalogue) {
-                    $row[] = $this->sanitizeString($fallbackCatalogue->get($messageId, $domain));
-                }
+                    foreach ($fallbackCatalogues as $fallbackCatalogue) {
+                        if ($fallbackCatalogue->defines($messageId, $domain) && $value === $fallbackCatalogue->get($messageId, $domain)) {
+                            $states[] = self::MESSAGE_EQUALS_FALLBACK;
 
-                $table->addRow($row);
+                            break;
+                        }
+                    }
+
+                    $row = array($this->formatStates($states), $domain, $this->formatId($messageId), $this->sanitizeString($value));
+                    foreach ($fallbackCatalogues as $fallbackCatalogue) {
+                        $row[] = $this->sanitizeString($fallbackCatalogue->get($messageId, $domain));
+                    }
+
+                    $table->addRow($row);
+                }
             }
-        }
 
-        if (class_exists('Symfony\Component\Console\Helper\Table')) {
-            $table->render();
-        } else {
-            $table->render($output);
+            if (class_exists('Symfony\Component\Console\Helper\Table')) {
+                $table->render();
+            } else {
+                $table->render($output);
+            }
+            $output->writeln('');
         }
     }
 
@@ -262,5 +263,64 @@ EOF
         }
 
         return $string;
+    }
+
+    /**
+     * @param string $locale
+     * @param string $rootPath
+     *
+     * @return MessageCatalogue
+     */
+    private function extractMessages($locale, $rootPath)
+    {
+        $extractedCatalogue = new MessageCatalogue($locale);
+        if (is_dir($rootPath.'/Resources/views')) {
+            $this->getContainer()->get('translation.extractor')->extract($rootPath.'/Resources/views', $extractedCatalogue);
+        }
+
+        return $extractedCatalogue;
+    }
+
+    /**
+     * @param string            $locale
+     * @param string            $translationsPath
+     * @param TranslationLoader $loader
+     *
+     * @return MessageCatalogue
+     */
+    private function loadCurrentMessages($locale, $translationsPath, TranslationLoader $loader)
+    {
+        $currentCatalogue = new MessageCatalogue($locale);
+        if (is_dir($translationsPath)) {
+            $loader->loadMessages($translationsPath, $currentCatalogue);
+        }
+
+        return $currentCatalogue;
+    }
+
+    /**
+     * @param string            $locale
+     * @param string            $translationsPath
+     * @param TranslationLoader $loader
+     *
+     * @return MessageCatalogue[]
+     */
+    private function loadFallbackCatalogues($locale, $translationsPath, TranslationLoader $loader)
+    {
+        $fallbackCatalogues = array();
+        $translator = $this->getContainer()->get('translator');
+        if ($translator instanceof Translator) {
+            foreach ($translator->getFallbackLocales() as $fallbackLocale) {
+                if ($fallbackLocale === $locale) {
+                    continue;
+                }
+
+                $fallbackCatalogue = new MessageCatalogue($fallbackLocale);
+                $loader->loadMessages($translationsPath, $fallbackCatalogue);
+                $fallbackCatalogues[] = $fallbackCatalogue;
+            }
+        }
+
+        return $fallbackCatalogues;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14237 |
| License | MIT |
| Doc PR | - |
- [ ] submit changes to the documentation

This PR adds an `--all` option the `debug:translation` command to enable debugging translations in all registered bundles _AND_ the app directory.
