### PR TITLE
add frameworkbundle break on configuration note

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -1,6 +1,30 @@
 UPGRADE FROM 2.6 to 2.7
 =======================
 
+FrameworkBundle
+---------------
+
+ * The decoupling of Twig and the Symfony Templating system made the inclusion
+   of the service ```templating.helper.router``` only available when the configuration
+   specified also the PHP engine. Because some bundles use this related service the
+   following update is required:
+
+   Before:
+
+   ```yaml
+   framework:
+       templating:
+           engines: ['twig']
+   ```
+
+   After:
+
+   ```yaml
+   framework:
+       templating:
+           engines: ['twig', 'php']
+   ```
+
 Router
 ------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | yes but not reported yet |
| New Feature? | no |
| BC Breaks? | no |
| Deprecations? | no |
| Tests Pass? | yes |
| Fixed Tickets | not one reported |
| License | MIT |
| Doc PR | no |

This fixes an exception when using bundles like knppaginator or others that use the template.helper.route service which is only defined when using php engine type on twig configuration.
