### PR TITLE
[WIP] Use callable typehints

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -20,6 +20,36 @@ UPGRADE FROM 2.x to 3.0
    `DebugClassLoader`. The difference is that the constructor now takes a
    loader to wrap.
 
+### Config
+
+ * Any `callable` can now be used as an argument with the builder methods that
+   previously only accepted closures. The signatures of these methods need to
+   be changed in any overriding custom builder class.
+
+   Before:
+
+   ```php
+   use Symfony\Component\Config\Definition\Builder;
+
+   Builder\ExprBuilder::always(\Closure $closure)
+   Builder\ExprBuilder::ifTrue(\Closure $closure)
+   Builder\ExprBuilder::then(\Closure $closure)
+   Builder\NormalizationBuilder::before(\Closure $closure)
+   Builder\ValidationBuilder::rule(\Closure $closure)
+   ```
+
+   After:
+
+   ```php
+   use Symfony\Component\Config\Definition\Builder;
+
+   Builder\ExprBuilder::always(callable $callback)
+   Builder\ExprBuilder::ifTrue(callable $callback)
+   Builder\ExprBuilder::then(callable $callback)
+   Builder\NormalizationBuilder::before(callable $callback)
+   Builder\ValidationBuilder::rule(callable $callback)
+   ```
+
 ### Console
 
  * The `dialog` helper has been removed in favor of the `question` helper.

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -5,6 +5,11 @@ CHANGELOG
 -----
 
  * removed `ReferenceDumper` class
+ * [BC BREAK] Any `callable` is now an allowed argument for methods `ExprBuilder::always()`,
+   `ExprBuilder::ifTrue()`, `ExprBuilder::then()`, `NormalizationBuilder::before()` and
+   `ValidationBuilder::rule()` instead of just closures. The BC break only affects custom
+   implementations of these methods in extended builders, where the method argument type hint
+   needs to be changed from `\Closure` to `callable`.
 
 2.7.0
 -----

--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -38,11 +38,11 @@ class ExprBuilder
     /**
      * Marks the expression as being always used.
      *
-     * @param \Closure $then
+     * @param callable $then
      *
      * @return ExprBuilder
      */
-    public function always(\Closure $then = null)
+    public function always(callable $then = null)
     {
         $this->ifPart = function ($v) { return true; };
 
@@ -54,21 +54,21 @@ class ExprBuilder
     }
 
     /**
-     * Sets a closure to use as tests.
+     * Sets a callback to use as tests.
      *
      * The default one tests if the value is true.
      *
-     * @param \Closure $closure
+     * @param callable $callback
      *
      * @return ExprBuilder
      */
-    public function ifTrue(\Closure $closure = null)
+    public function ifTrue(callable $callback = null)
     {
-        if (null === $closure) {
-            $closure = function ($v) { return true === $v; };
+        if (null === $callback) {
+            $callback = function ($v) { return true === $v; };
         }
 
-        $this->ifPart = $closure;
+        $this->ifPart = $callback;
 
         return $this;
     }
@@ -138,15 +138,15 @@ class ExprBuilder
     }
 
     /**
-     * Sets the closure to run if the test pass.
+     * Sets the callback to run if the test pass.
      *
-     * @param \Closure $closure
+     * @param callable $callback
      *
      * @return ExprBuilder
      */
-    public function then(\Closure $closure)
+    public function then(callable $callback)
     {
-        $this->thenPart = $closure;
+        $this->thenPart = $callback;
 
         return $this;
     }
@@ -228,7 +228,7 @@ class ExprBuilder
                 $if = $expr->ifPart;
                 $then = $expr->thenPart;
                 $expressions[$k] = function ($v) use ($if, $then) {
-                    return $if($v) ? $then($v) : $v;
+                    return call_user_func($if, $v) ? call_user_func($then, $v) : $v;
                 };
             }
         }

--- a/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
@@ -48,16 +48,16 @@ class NormalizationBuilder
     }
 
     /**
-     * Registers a closure to run before the normalization or an expression builder to build it if null is provided.
+     * Registers a callback to run before the normalization or an expression builder to build it if null is provided.
      *
-     * @param \Closure $closure
+     * @param callable $callback
      *
      * @return ExprBuilder|NormalizationBuilder
      */
-    public function before(\Closure $closure = null)
+    public function before(callable $callback = null)
     {
-        if (null !== $closure) {
-            $this->before[] = $closure;
+        if (null !== $callback) {
+            $this->before[] = $callback;
 
             return $this;
         }

--- a/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
@@ -32,16 +32,16 @@ class ValidationBuilder
     }
 
     /**
-     * Registers a closure to run as normalization or an expression builder to build it if null is provided.
+     * Registers a callback to run as normalization or an expression builder to build it if null is provided.
      *
-     * @param \Closure $closure
+     * @param callable $callback
      *
      * @return ExprBuilder|ValidationBuilder
      */
-    public function rule(\Closure $closure = null)
+    public function rule(callable $callback = null)
     {
-        if (null !== $closure) {
-            $this->rules[] = $closure;
+        if (null !== $callback) {
+            $this->rules[] = $callback;
 
             return $this;
         }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -275,12 +275,8 @@ class Command
      *
      * @api
      */
-    public function setCode($code)
+    public function setCode(callable $code)
     {
-        if (!is_callable($code)) {
-            throw new \InvalidArgumentException('Invalid callable provided to Command::setCode.');
-        }
-
         $this->code = $code;
 
         return $this;

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -303,16 +303,6 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('interact called'.PHP_EOL.'from the code...'.PHP_EOL, $tester->getDisplay());
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage Invalid callable provided to Command::setCode.
-     */
-    public function testSetCodeWithNonCallable()
-    {
-        $command = new \TestCommand();
-        $command->setCode(array($this, 'nonExistentMethod'));
-    }
-
     public function callableMethodCommand(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('from the code...');

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -208,14 +208,9 @@ class ErrorHandler
      * @param callable $handler A handler that will be called on Exception
      *
      * @return callable|null The previous exception handler
-     *
-     * @throws \InvalidArgumentException
      */
-    public function setExceptionHandler($handler)
+    public function setExceptionHandler(callable $handler = null)
     {
-        if (null !== $handler && !is_callable($handler)) {
-            throw new \LogicException('The exception handler must be a valid PHP callable.');
-        }
         $prev = $this->exceptionHandler;
         $this->exceptionHandler = $handler;
 

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -78,11 +78,8 @@ class ExceptionHandler
      *
      * @return callable|null The previous exception handler if any
      */
-    public function setHandler($handler)
+    public function setHandler(callable $handler = null)
     {
-        if (null !== $handler && !is_callable($handler)) {
-            throw new \LogicException('The exception handler must be a valid PHP callable.');
-        }
         $old = $this->handler;
         $this->handler = $handler;
 

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.0.0
+-----
+
+ * The first argument of `Crawler::each()` and `Crawler::reduce()` are type hinted with `callable` instead of `Closure`.
+
 2.5.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -323,9 +323,9 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
-     * Calls an anonymous function on each node of the list.
+     * Execute a callback on each node of the list.
      *
-     * The anonymous function receives the position and the node wrapped
+     * The callback receives the position and the node wrapped
      * in a Crawler instance as arguments.
      *
      * Example:
@@ -334,17 +334,17 @@ class Crawler extends \SplObjectStorage
      *         return $node->text();
      *     });
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $callback A callback
      *
-     * @return array An array of values returned by the anonymous function
+     * @return array An array of values returned by the callback
      *
      * @api
      */
-    public function each(\Closure $closure)
+    public function each(callable $callback)
     {
         $data = array();
         foreach ($this as $i => $node) {
-            $data[] = $closure(new static($node, $this->uri, $this->baseHref), $i);
+            $data[] = $callback(new static($node, $this->uri, $this->baseHref), $i);
         }
 
         return $data;
@@ -364,21 +364,21 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
-     * Reduces the list of nodes by calling an anonymous function.
+     * Reduces the list of nodes by calling a callback.
      *
-     * To remove a node from the list, the anonymous function must return false.
+     * To remove a node from the list, the callback must return false.
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $callback A callback
      *
      * @return Crawler A Crawler instance with the selected nodes.
      *
      * @api
      */
-    public function reduce(\Closure $closure)
+    public function reduce(callable $callback)
     {
         $nodes = array();
         foreach ($this as $i => $node) {
-            if (false !== $closure(new static($node, $this->uri, $this->baseHref), $i)) {
+            if (false !== $callback(new static($node, $this->uri, $this->baseHref), $i)) {
                 $nodes[] = $node;
             }
         }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -344,7 +344,7 @@ class Crawler extends \SplObjectStorage
     {
         $data = array();
         foreach ($this as $i => $node) {
-            $data[] = $callback(new static($node, $this->uri, $this->baseHref), $i);
+            $data[] = call_user_func($callback, new static($node, $this->uri, $this->baseHref), $i);
         }
 
         return $data;
@@ -378,7 +378,7 @@ class Crawler extends \SplObjectStorage
     {
         $nodes = array();
         foreach ($this as $i => $node) {
-            if (false !== $callback(new static($node, $this->uri, $this->baseHref), $i)) {
+            if (false !== call_user_func($callback, new static($node, $this->uri, $this->baseHref), $i)) {
                 $nodes[] = $node;
             }
         }

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -483,13 +483,13 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Sorts files and directories by an anonymous function.
+     * Sorts files and directories by a callback function.
      *
-     * The anonymous function receives two \SplFileInfo instances to compare.
+     * The callback function receives two \SplFileInfo instances to compare.
      *
      * This can be slow as all the matching files and directories must be retrieved for comparison.
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $callback A callback function
      *
      * @return Finder The current Finder instance
      *
@@ -497,9 +497,9 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * @api
      */
-    public function sort(\Closure $closure)
+    public function sort(callable $callback)
     {
-        $this->sort = $closure;
+        $this->sort = $callback;
 
         return $this;
     }
@@ -603,12 +603,12 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Filters the iterator with an anonymous function.
+     * Filters the iterator with a callback function.
      *
-     * The anonymous function receives a \SplFileInfo and must return false
+     * The callback function receives a \SplFileInfo and must return false
      * to remove files.
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $callback A callback function
      *
      * @return Finder The current Finder instance
      *
@@ -616,9 +616,9 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * @api
      */
-    public function filter(\Closure $closure)
+    public function filter(callable $callback)
     {
-        $this->filters[] = $closure;
+        $this->filters[] = $callback;
 
         return $this;
     }

--- a/src/Symfony/Component/Finder/Shell/Command.php
+++ b/src/Symfony/Component/Finder/Shell/Command.php
@@ -32,7 +32,7 @@ class Command
     private $labels = array();
 
     /**
-     * @var \Closure|null
+     * @var callable|null
      */
     private $errorHandler;
 
@@ -218,11 +218,11 @@ class Command
     }
 
     /**
-     * @param \Closure $errorHandler
+     * @param callable $errorHandler
      *
      * @return Command
      */
-    public function setErrorHandler(\Closure $errorHandler)
+    public function setErrorHandler(callable $errorHandler)
     {
         $this->errorHandler = $errorHandler;
 
@@ -230,7 +230,7 @@ class Command
     }
 
     /**
-     * @return \Closure|null
+     * @return callable|null
      */
     public function getErrorHandler()
     {
@@ -253,7 +253,7 @@ class Command
             $output = preg_split('~(\r\n|\r|\n)~', stream_get_contents($pipes[1]), -1, PREG_SPLIT_NO_EMPTY);
 
             if ($error = stream_get_contents($pipes[2])) {
-                $errorHandler($error);
+                call_user_func($errorHandler, $error);
             }
 
             proc_close($process);

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -35,18 +35,9 @@ class CallbackTransformer implements DataTransformerInterface
      *
      * @param callable $transform        The forward transform callback
      * @param callable $reverseTransform The reverse transform callback
-     *
-     * @throws \InvalidArgumentException when the given callbacks is invalid
      */
-    public function __construct($transform, $reverseTransform)
+    public function __construct(callable $transform, callable $reverseTransform)
     {
-        if (!is_callable($transform)) {
-            throw new \InvalidArgumentException('Argument 1 should be a callable');
-        }
-        if (!is_callable($reverseTransform)) {
-            throw new \InvalidArgumentException('Argument 2 should be a callable');
-        }
-
         $this->transform = $transform;
         $this->reverseTransform = $reverseTransform;
     }

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Form\ChoiceList;
 
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
-
 /**
  * A list of choices with arbitrary data types.
  *
@@ -56,12 +54,8 @@ class ArrayChoiceList implements ChoiceListInterface
      *                               choice. If `null` is passed, incrementing
      *                               integers are used as values
      */
-    public function __construct(array $choices, $value = null)
+    public function __construct(array $choices, callable $value = null)
     {
-        if (null !== $value && !is_callable($value)) {
-            throw new UnexpectedTypeException($value, 'null or callable');
-        }
-
         $this->choices = $choices;
         $this->values = array();
         $this->valueCallback = $value;

--- a/src/Symfony/Component/Form/Tests/CallbackTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/CallbackTransformerTest.php
@@ -25,22 +25,4 @@ class CallbackTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo has been transformed', $transformer->transform('foo'));
         $this->assertEquals('bar has reversely been transformed', $transformer->reverseTransform('bar'));
     }
-
-    /**
-     * @dataProvider invalidCallbacksProvider
-     *
-     * @expectedException \InvalidArgumentException
-     */
-    public function testConstructorWithInvalidCallbacks($transformCallback, $reverseTransformCallback)
-    {
-        new CallbackTransformer($transformCallback, $reverseTransformCallback);
-    }
-
-    public function invalidCallbacksProvider()
-    {
-        return array(
-            array(null, function () {}),
-            array(function () {}, null),
-        );
-    }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -44,14 +44,6 @@ class ArrayChoiceListTest extends AbstractChoiceListTest
         return array('0', '1', '2', '3', '4', '5', '6');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
-    public function testFailIfKeyMismatch()
-    {
-        new ArrayChoiceList(array(0 => 'a', 1 => 'b'), array(1 => 'a', 2 => 'b'));
-    }
-
     public function testCreateChoiceListWithValueCallback()
     {
         $callback = function ($choice) {

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -68,14 +68,9 @@ class StreamedResponse extends Response
      * Sets the PHP callback associated with this Response.
      *
      * @param callable $callback A valid PHP callback
-     *
-     * @throws \LogicException
      */
-    public function setCallback($callback)
+    public function setCallback(callable $callback)
     {
-        if (!is_callable($callback)) {
-            throw new \LogicException('The Response callback must be a valid PHP callable.');
-        }
         $this->callback = $callback;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -90,15 +90,6 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \LogicException
      */
-    public function testSetCallbackNonCallable()
-    {
-        $response = new StreamedResponse(null);
-        $response->setCallback(null);
-    }
-
-    /**
-     * @expectedException \LogicException
-     */
     public function testSetContent()
     {
         $response = new StreamedResponse(function () { echo 'foo'; });

--- a/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
@@ -64,47 +64,8 @@ class FilterControllerEvent extends KernelEvent
      *
      * @api
      */
-    public function setController($controller)
+    public function setController(callable $controller)
     {
-        // controller must be a callable
-        if (!is_callable($controller)) {
-            throw new \LogicException(sprintf('The controller must be a callable (%s given).', $this->varToString($controller)));
-        }
-
         $this->controller = $controller;
-    }
-
-    private function varToString($var)
-    {
-        if (is_object($var)) {
-            return sprintf('Object(%s)', get_class($var));
-        }
-
-        if (is_array($var)) {
-            $a = array();
-            foreach ($var as $k => $v) {
-                $a[] = sprintf('%s => %s', $k, $this->varToString($v));
-            }
-
-            return sprintf('Array(%s)', implode(', ', $a));
-        }
-
-        if (is_resource($var)) {
-            return sprintf('Resource(%s)', get_resource_type($var));
-        }
-
-        if (null === $var) {
-            return 'null';
-        }
-
-        if (false === $var) {
-            return 'false';
-        }
-
-        if (true === $var) {
-            return 'true';
-        }
-
-        return (string) $var;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -88,15 +88,9 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      * @param callable $circularReferenceHandler
      *
      * @return self
-     *
-     * @throws InvalidArgumentException
      */
-    public function setCircularReferenceHandler($circularReferenceHandler)
+    public function setCircularReferenceHandler(callable $circularReferenceHandler)
     {
-        if (!is_callable($circularReferenceHandler)) {
-            throw new InvalidArgumentException('The given circular reference handler is not callable.');
-        }
-
         $this->circularReferenceHandler = $circularReferenceHandler;
 
         return $this;

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -189,12 +189,10 @@ class PluralizationRules
     /**
      * Overrides the default plural rule for a given locale.
      *
-     * @param string $rule   A PHP callable
-     * @param string $locale The locale
-     *
-     * @throws \LogicException
+     * @param callable $rule   A PHP callable
+     * @param string   $locale The locale
      */
-    public static function set($rule, $locale)
+    public static function set(callable $rule, $locale)
     {
         if ('pt_BR' === $locale) {
             // temporary set a locale for brazilian
@@ -203,10 +201,6 @@ class PluralizationRules
 
         if (strlen($locale) > 3) {
             $locale = substr($locale, 0, -strlen(strrchr($locale, '_')));
-        }
-
-        if (!is_callable($rule)) {
-            throw new \LogicException('The given rule can not be called');
         }
 
         self::$rules[$locale] = $rule;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Initially discussed in #14293, now includes those changes as well.

The `callable` typehint is used where applicable. Two types of changes are included:
- Replace `\Closure` typehints
- Replace `is_callable()` checks

The PHP bug in the handling of callables of the `'Foo::bar'` type (https://bugs.php.net/bug.php?id=68475) causes some issues. To support every possible callable, `call_user_func($func, ...)` needs to be used instead of using `$func(...)` directly. Besides the more verbose syntax, `call_user_func` is also slower. There are a few options on how to deal with this:
1. Use `call_user_func`.
2. Don't support callables of the static string type. Possibly add an extra check and throw an exception when such a callback is passed.
3. Don't change typehints where this is an issue, but continue to use `\Closure`.

Even option 2 doesn't sound entirely unworkable to me, static callback strings are very unwieldy -- especially with namespaces. That the error is thrown at call time is less than ideal of course.

In these cases using `call_user_func` doesn't look like a too bad option either. But in other places noticeable performance improvements could be possible if existing code could be converted to use direct calls. So the decision may have implications beyond just this PR.

In addition to handling the static strings, I still want to make sure that none of the `\Closure` typehints that were replaced were intentionally strict. The one typehint in `OptionsResolver` mentioned by @stof in #14293 was already skipped.
- [x] Implement support for callables of `'Foo::bar'` type.
- [x] Make sure all `\Closure` to `callable` changes are valid.
- [ ] Resolve #14364 
- [ ] Add method signature changes to CHANGELOG / UPGRADE files.
