### PR TITLE
[FrameworkBundle] improve usage of Table helper

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
@@ -28,14 +29,23 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
     {
         $output->writeln('Available registered bundles with their extension alias if available:');
 
-        $table = $this->getHelperSet()->get('table');
+        if (class_exists('Symfony\Component\Console\Helper\Table')) {
+            $table = new Table($output);
+        } else {
+            $table = $this->getHelperSet()->get('table');
+        }
+
         $table->setHeaders(array('Bundle name', 'Extension alias'));
         foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
             $extension = $bundle->getContainerExtension();
             $table->addRow(array($bundle->getName(), $extension ? $extension->getAlias() : ''));
         }
 
-        $table->render($output);
+        if (class_exists('Symfony\Component\Console\Helper\Table')) {
+            $table->render();
+        } else {
+            $table->render($output);
+        }
     }
 
     protected function findExtension($name)

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -131,8 +131,11 @@ EOF
             }
         }
 
-        /** @var \Symfony\Component\Console\Helper\Table $table */
-        $table = new Table($output);
+        if (class_exists('Symfony\Component\Console\Helper\Table')) {
+            $table = new Table($output);
+        } else {
+            $table = $this->getHelperSet()->get('table');
+        }
 
         // Display header line
         $headers = array('State(s)', 'Id', sprintf('Message Preview (%s)', $locale));
@@ -177,7 +180,11 @@ EOF
             }
         }
 
-        $table->render();
+        if (class_exists('Symfony\Component\Console\Helper\Table')) {
+            $table->render();
+        } else {
+            $table->render($output);
+        }
 
         $output->writeln('');
         $output->writeln('<info>Legend:</info>');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Use the `Table` helper if present in favor of the deprecated
`TableHelper` class.
