### PR TITLE
 [WebProfilerBundle] Fix resiliency to exceptions thrown by the url generator

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -61,10 +61,14 @@ class WebDebugToolbarListener implements EventSubscriberInterface
         $request = $event->getRequest();
 
         if ($response->headers->has('X-Debug-Token') && null !== $this->urlGenerator) {
-            $response->headers->set(
-                'X-Debug-Token-Link',
-                $this->urlGenerator->generate('_profiler', array('token' => $response->headers->get('X-Debug-Token')))
-            );
+            try {
+                $response->headers->set(
+                    'X-Debug-Token-Link',
+                    $this->urlGenerator->generate('_profiler', array('token' => $response->headers->get('X-Debug-Token')))
+                );
+            } catch (\Exception $e) {
+                $response->headers->set('X-Debug-Error', get_class($e).': '.$e->getMessage());
+            }
         }
 
         if (!$event->isMasterRequest()) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14111, #14337, #14342 in conjunction with #14345 |
| License | MIT |
| Doc PR | - |
