### PR TITLE
Removed error occurs when the value of mbstring.func_overload == 2

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -155,7 +155,7 @@ class OutputFormatter implements OutputFormatterInterface
             }
 
             // add the text up to the next tag
-            $output .= $this->applyCurrentStyle(substr($message, $offset, $pos - $offset));
+            $output .= $this->applyCurrentStyle(mb_substr($message, $offset, $pos - $offset, '8bit'));
             $offset = $pos + strlen($text);
 
             // opening tag?
@@ -177,7 +177,7 @@ class OutputFormatter implements OutputFormatterInterface
             }
         }
 
-        $output .= $this->applyCurrentStyle(substr($message, $offset));
+        $output .= $this->applyCurrentStyle(mb_substr($message, $offset, null, '8bit'));
 
         return str_replace('\\<', '<', $output);
     }


### PR DESCRIPTION
Fix for this issue:
https://github.com/symfony/symfony/issues/12530

code:

``` php
$formatter = new \Symfony\Component\Console\Formatter\OutputFormatter();

echo $formatter->format('<info>тест</info>');
```
### before

config:

```
mbstring.func_overload = 2
```

output:

```
тест</in
```

config:

```
mbstring.func_overload = 0
```

output:

```
тест
```
### after

config:

```
mbstring.func_overload = 2
```

output:

```
тест
```

config:

```
mbstring.func_overload = 0
```

output:

```
тест
```
