### PR TITLE
[WebProfilerBundle] [HttpKernel] A static approach to version feedback

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -83,7 +83,7 @@ class ConfigDataCollector extends DataCollector
                 $this->data['bundles'][$name] = $bundle->getPath();
             }
 
-            $this->data['symfony_state'] = $this->calculateSymfonyState();
+            $this->data['symfony_state'] = $this->determineSymfonyState();
         }
     }
 
@@ -268,9 +268,9 @@ class ConfigDataCollector extends DataCollector
     /**
      * Tries to retrieve information about the current Symfony version.
      *
-     * @return string One of: unknown, dev, stable, eom, eol
+     * @return string One of: dev, stable, eom, eol
      */
-    private function calculateSymfonyState()
+    private function determineSymfonyState()
     {
         $now = new \DateTime();
         $eom = \DateTime::createFromFormat('m/Y', Kernel::END_OF_MAINTENANCE)->modify('last day of this month');
@@ -280,7 +280,7 @@ class ConfigDataCollector extends DataCollector
             $versionState = 'eol';
         } elseif ($now > $eom) {
             $versionState = 'eom';
-        } elseif ('DEV' === Kernel::EXTRA_VERSION) {
+        } elseif ('' !== Kernel::EXTRA_VERSION) {
             $versionState = 'dev';
         } else {
             $versionState = 'stable';

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -83,7 +83,7 @@ class ConfigDataCollector extends DataCollector
                 $this->data['bundles'][$name] = $bundle->getPath();
             }
 
-            $this->data['symfony_state'] = $this->caculateSymfonyState();
+            $this->data['symfony_state'] = $this->calculateSymfonyState();
         }
     }
 
@@ -270,7 +270,7 @@ class ConfigDataCollector extends DataCollector
      *
      * @return string One of: unknown, dev, stable, eom, eol
      */
-    private function caculateSymfonyState()
+    private function calculateSymfonyState()
     {
         $now = new \DateTime();
         $eom = \DateTime::createFromFormat('m/Y', Kernel::END_OF_MAINTENANCE)->modify('last day of this month');

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -67,6 +67,9 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     const RELEASE_VERSION = '0';
     const EXTRA_VERSION = 'DEV';
 
+    const END_OF_MAINTENANCE = '05/2018';
+    const END_OF_LIFE = '05/2019';
+
     /**
      * Constructor.
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14349, #13626 |
| License | MIT |
| Doc PR | N/A |

This is an alternative approach for the version feedback feature of PR #13626. The original PR performed a server-side HTTP request to symfony.com, which might be problematic in certain environments, see #14349.

This PR makes the following assumptions:
- Symfony's release roadmap is rarely changed
- After the first release of a branch, the Symfony development team is committed to the announced support dates.
- The support period of a stable  branch might be extended, but it's usually not reduced.

Given those assumptions, the EOM and EOL dates may be shipped with the Symfony release and may be updated with a later bugfix release. The information would be available offline without any need to query Symfony's servers.

If the user is running the latest bugfix release of a branch, the EOM/EOL dates should be accurate. If he's running an earlier version, he might get a false positive warning about reaching EOM or EOL if the support period has been extended in the meantime. But since he's running an outdated version anyway, would this really be a problem?
