### PR TITLE
[WIP] [Form] [Translator] add translation_params options for label

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -169,7 +169,7 @@
         {% endif %}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{- widget|raw -}}
-            {{- label is not sameas(false) ? label|trans({}, translation_domain) -}}
+            {{- label is not sameas(false) ? label|trans(translation_params, translation_domain) -}}
         </label>
     {% endif %}
 {% endblock checkbox_radio_label %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -187,7 +187,7 @@
             {% set label = name|humanize %}
         {%- endif -%}
     {%- endif -%}
-    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ label|trans({}, translation_domain) }}</button>
+    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ label|trans(translation_params, translation_domain) }}</button>
 {%- endblock button_widget -%}
 
 {%- block submit_widget -%}
@@ -220,7 +220,7 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans(translation_params, translation_domain) }}</label>
     {%- endif -%}
 {%- endblock form_label -%}
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/custom_widgets.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/custom_widgets.html.twig
@@ -11,7 +11,7 @@
     {% if label is empty %}
         {% set label = name|humanize %}
     {% endif %}
-    <label>Custom label: {{ label|trans({}, translation_domain) }}</label>
+    <label>Custom label: {{ label|trans(translation_params, translation_domain) }}</label>
 {% endspaceless %}
 {% endblock _names_entry_label %}
 
@@ -20,6 +20,6 @@
     {% if label is empty %}
         {% set label = name|humanize %}
     {% endif %}
-    <label>Custom name label: {{ label|trans({}, translation_domain) }}</label>
+    <label>Custom name label: {{ label|trans(translation_params, translation_domain) }}</label>
 {% endspaceless %}
 {% endblock _name_c_entry_label %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -4,5 +4,5 @@
 <?php if (!$label) { $label = isset($label_format)
     ? strtr($label_format, array('%name%' => $name, '%id%' => $id))
     : $view['form']->humanize($name); } ?>
-<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>
+<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label, $translation_params, $translation_domain)) ?></label>
 <?php endif ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -44,6 +44,7 @@ abstract class BaseType extends AbstractType
         $name = $form->getName();
         $blockName = $options['block_name'] ?: $form->getName();
         $translationDomain = $options['translation_domain'];
+        $translationParams = $options['translation_params'];
         $labelFormat = $options['label_format'];
 
         if ($view->parent) {
@@ -94,6 +95,7 @@ abstract class BaseType extends AbstractType
             'block_prefixes' => $blockPrefixes,
             'unique_block_prefix' => $uniqueBlockPrefix,
             'translation_domain' => $translationDomain,
+            'translation_params' => $translationParams,
             // Using the block name here speeds up performance in collection
             // forms, where each entry has the same full block name.
             // Including the type is important too, because if rows of a
@@ -116,6 +118,7 @@ abstract class BaseType extends AbstractType
             'label_format' => null,
             'attr' => array(),
             'translation_domain' => null,
+            'translation_params' => array(),
             'auto_initialize' => true,
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -115,6 +115,26 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($view['child']->vars['translation_domain']);
     }
 
+    public function testPassTranslationParamsToView()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, array(
+            'translation_params' => array('foo' => 'bar'),
+        ));
+        $view = $form->createView();
+
+        $this->assertSame(array('foo' => 'bar'), $view->vars['translation_params']);
+    }
+
+    public function testDefaultTranslationParams()
+    {
+        $view = $this->factory->createNamedBuilder('parent', 'form')
+            ->add('child', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertEmpty($view['child']->vars['translation_params']);
+    }
+
     public function testPassLabelToView()
     {
         $form = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array('label' => 'My label'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14112 |
| License | MIT |
| Doc PR | - |

**WIP**
For the moment only `labels` are translated with injected params
IDK how to test other things, feedback welcome :)

ping @aitboudad
