### PR TITLE
[Config] Renamings to allow all callback types

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -1,4 +1,4 @@
-﻿UPGRADE FROM 2.7 to 2.8
+UPGRADE FROM 2.7 to 2.8
 =======================
 
 Form
@@ -136,3 +136,13 @@ DependencyInjection
        <service id="foo" class="stdClass" shared="false" />
    </services>
    ```
+
+Config
+------
+
+ * The methods `setNormalizationClosures()` and `setFinalValidationClosures()` in
+   `BaseNode` were deprecated, `setNormalizationCallbacks()` and
+   `setFinalValidationCallbacks()` should be used instead.
+
+ * The protected properties `normalizationClosures` and `finalValidationClosures` in
+   `BaseNode` were renamed to `normalizationCallbacks` and `finalValidationCallbacks`.

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * [DEPRECATION] The protected properties `normalizationClosures` and `finalValidationClosures` in
+   `BaseNode` were renamed to `normalizationCallbacks` and `finalValidationCallbacks`.
+ * [DEPRECATION] The methods `setNormalizationClosures()` and `setFinalValidationClosures()` in
+   `BaseNode` were deprecated, `setNormalizationCallbacks()` and `setFinalValidationCallbacks()`
+   should be used instead.
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -401,7 +401,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
         $node->setNormalizeKeys($this->normalizeKeys);
 
         if (null !== $this->normalization) {
-            $node->setNormalizationClosures($this->normalization->before);
+            $node->setNormalizationCallbacks($this->normalization->before);
             $node->setXmlRemappings($this->normalization->remappings);
         }
 
@@ -411,7 +411,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
         }
 
         if (null !== $this->validation) {
-            $node->setFinalValidationClosures($this->validation->rules);
+            $node->setFinalValidationCallbacks($this->validation->rules);
         }
 
         return $node;

--- a/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
@@ -38,7 +38,7 @@ class VariableNodeDefinition extends NodeDefinition
         $node = $this->instantiateNode();
 
         if (null !== $this->normalization) {
-            $node->setNormalizationClosures($this->normalization->before);
+            $node->setNormalizationCallbacks($this->normalization->before);
         }
 
         if (null !== $this->merge) {
@@ -56,7 +56,7 @@ class VariableNodeDefinition extends NodeDefinition
         $node->setRequired($this->required);
 
         if (null !== $this->validation) {
-            $node->setFinalValidationClosures($this->validation->rules);
+            $node->setFinalValidationCallbacks($this->validation->rules);
         }
 
         return $node;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The function and property name changes in preparation of #14330 to allow using any callable with config builders.
