### PR TITLE
[3.0]Closures support $this in PHP >= 5.4

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -75,7 +75,7 @@ class QuestionHelper extends Helper
     }
 
     /**
-     * Returns the helper's input stream
+     * Returns the helper's input stream.
      *
      * @return resource
      */
@@ -95,8 +95,6 @@ class QuestionHelper extends Helper
     /**
      * Asks the question to the user.
      *
-     * This method is public for PHP 5.3 compatibility, it should be private.
-     *
      * @param OutputInterface $output
      * @param Question        $question
      *
@@ -105,7 +103,7 @@ class QuestionHelper extends Helper
      * @throws \Exception
      * @throws \RuntimeException
      */
-    public function doAsk(OutputInterface $output, Question $question)
+    private function doAsk(OutputInterface $output, Question $question)
     {
         $this->writePrompt($output, $question);
 
@@ -148,7 +146,7 @@ class QuestionHelper extends Helper
      * Outputs the question prompt.
      *
      * @param OutputInterface $output
-     * @param Question $question
+     * @param Question        $question
      */
     protected function writePrompt(OutputInterface $output, Question $question)
     {

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -278,32 +278,27 @@ class Router implements RouterInterface, RequestMatcherInterface
             return $this->matcher;
         }
 
-        $class = $this->options['matcher_cache_class'];
-        $baseClass = $this->options['matcher_base_class'];
-        $expressionLanguageProviders = $this->expressionLanguageProviders;
-        $that = $this; // required for PHP 5.3 where "$this" cannot be use()d in anonymous functions. Change in Symfony 3.0.
-
-        $cache = $this->getConfigCacheFactory()->cache($this->options['cache_dir'].'/'.$class.'.php',
-            function (ConfigCacheInterface $cache) use ($that, $class, $baseClass, $expressionLanguageProviders) {
-                $dumper = $that->getMatcherDumperInstance();
+        $cache = $this->getConfigCacheFactory()->cache($this->options['cache_dir'].'/'.$this->options['matcher_cache_class'].'.php',
+            function (ConfigCacheInterface $cache) {
+                $dumper = $this->getMatcherDumperInstance();
                 if (method_exists($dumper, 'addExpressionLanguageProvider')) {
-                    foreach ($expressionLanguageProviders as $provider) {
+                    foreach ($this->expressionLanguageProviders as $provider) {
                         $dumper->addExpressionLanguageProvider($provider);
                     }
                 }
 
                 $options = array(
-                    'class' => $class,
-                    'base_class' => $baseClass,
+                    'class' => $this->options['matcher_cache_class'],
+                    'base_class' => $this->options['matcher_base_class'],
                 );
 
-                $cache->write($dumper->dump($options), $that->getRouteCollection()->getResources());
+                $cache->write($dumper->dump($options), $this->getRouteCollection()->getResources());
             }
         );
 
         require_once $cache->getPath();
 
-        return $this->matcher = new $class($this->context);
+        return $this->matcher = new $this->options['matcher_cache_class']($this->context);
     }
 
     /**
@@ -320,25 +315,22 @@ class Router implements RouterInterface, RequestMatcherInterface
         if (null === $this->options['cache_dir'] || null === $this->options['generator_cache_class']) {
             $this->generator = new $this->options['generator_class']($this->getRouteCollection(), $this->context, $this->logger);
         } else {
-            $class = $this->options['generator_cache_class'];
-            $baseClass = $this->options['generator_base_class'];
-            $that = $this; // required for PHP 5.3 where "$this" cannot be use()d in anonymous functions. Change in Symfony 3.0.
-            $cache = $this->getConfigCacheFactory()->cache($this->options['cache_dir'].'/'.$class.'.php',
-                function (ConfigCacheInterface $cache) use ($that, $class, $baseClass) {
-                    $dumper = $that->getGeneratorDumperInstance();
+            $cache = $this->getConfigCacheFactory()->cache($this->options['cache_dir'].'/'.$this->options['generator_cache_class'].'.php',
+                function (ConfigCacheInterface $cache) {
+                    $dumper = $this->getGeneratorDumperInstance();
 
                     $options = array(
-                        'class' => $class,
-                        'base_class' => $baseClass,
+                        'class' => $this->options['generator_cache_class'],
+                        'base_class' => $this->options['generator_base_class'],
                     );
 
-                    $cache->write($dumper->dump($options), $that->getRouteCollection()->getResources());
+                    $cache->write($dumper->dump($options), $this->getRouteCollection()->getResources());
                 }
             );
 
             require_once $cache->getPath();
 
-            $this->generator = new $class($this->context, $this->logger);
+            $this->generator = new $this->options['generator_cache_class']($this->context, $this->logger);
         }
 
         if ($this->generator instanceof ConfigurableRequirementsInterface) {
@@ -354,21 +346,17 @@ class Router implements RouterInterface, RequestMatcherInterface
     }
 
     /**
-     * This method is public because it needs to be callable from a closure in PHP 5.3. It should be converted back to protected in 3.0.
-     * @internal
      * @return GeneratorDumperInterface
      */
-    public function getGeneratorDumperInstance()
+    protected function getGeneratorDumperInstance()
     {
         return new $this->options['generator_dumper_class']($this->getRouteCollection());
     }
 
     /**
-     * This method is public because it needs to be callable from a closure in PHP 5.3. It should be converted back to protected in 3.0.
-     * @internal
      * @return MatcherDumperInterface
      */
-    public function getMatcherDumperInstance()
+    protected function getMatcherDumperInstance()
     {
         return new $this->options['matcher_dumper_class']($this->getRouteCollection());
     }

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -327,10 +327,9 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
         }
 
         $this->assertValidLocale($locale);
-        $self = $this; // required for PHP 5.3 where "$this" cannot be use()d in anonymous functions. Change in Symfony 3.0.
         $cache = $this->getConfigCacheFactory()->cache($this->getCatalogueCachePath($locale),
-            function (ConfigCacheInterface $cache) use ($self, $locale) {
-                $self->dumpCatalogue($locale, $cache);
+            function (ConfigCacheInterface $cache) use ($locale) {
+                $this->dumpCatalogue($locale, $cache);
             }
         );
 
@@ -343,12 +342,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
         $this->catalogues[$locale] = include $cache->getPath();
     }
 
-    /**
-     * This method is public because it needs to be callable from a closure in PHP 5.3. It should be made protected (or even private, if possible) in 3.0.
-     *
-     * @internal
-     */
-    public function dumpCatalogue($locale, ConfigCacheInterface $cache)
+    private function dumpCatalogue($locale, ConfigCacheInterface $cache)
     {
         $this->initializeCatalogue($locale);
         $fallbackContent = $this->getFallbackContent($this->catalogues[$locale]);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Closures support `$this` in PHP >= 5.4

ping @aitboudad 
