### PR TITLE
[HttpFoundation] remove getExtension method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -88,20 +88,6 @@ class File extends \SplFileInfo
     }
 
     /**
-     * Returns the extension of the file.
-     *
-     * \SplFileInfo::getExtension() is not available before PHP 5.3.6
-     *
-     * @return string The extension
-     *
-     * @api
-     */
-    public function getExtension()
-    {
-        return pathinfo($this->getBasename(), PATHINFO_EXTENSION);
-    }
-
-    /**
      * Moves the file to a new location.
      *
      * @param string $directory The destination folder

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -148,12 +148,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
         @rmdir($targetDir);
     }
 
-    public function testGetExtension()
-    {
-        $file = new File(__DIR__.'/Fixtures/test.gif');
-        $this->assertEquals('gif', $file->getExtension());
-    }
-
     protected function createMockGuesser($path, $mimeType)
     {
         $guesser = $this->getMock('Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Since the minimum PHP version in 2.7 is 5.3.9 we can delete the `getExtension` method and use the real `\SplFileInfo::getExtension()`
