### PR TITLE
[DoctrineBridge][Form] fix EntityChoiceList when indexing by primary foreign key

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleAssociationToIntIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleAssociationToIntIdEntity.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\OneToOne;
+
+/** @Entity */
+class SingleAssociationToIntIdEntity
+{
+    /** @Id @OneToOne(targetEntity="SingleIntIdNoToStringEntity", cascade={"ALL"}) */
+    protected $entity;
+
+    /** @Column(type="string", nullable=true) */
+    public $name;
+
+    public function __construct(SingleIntIdNoToStringEntity $entity, $name)
+    {
+        $this->entity = $entity;
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/AbstractEntityChoiceListSingleAssociationToIntIdTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/AbstractEntityChoiceListSingleAssociationToIntIdTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Form\ChoiceList;
+
+use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleAssociationToIntIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity;
+use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
+
+/**
+ * Test choices generated from an entity with a primary foreign key.
+ *
+ * @author Premi Giorgio <giosh94mhz@gmail.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+abstract class AbstractEntityChoiceListSingleAssociationToIntIdTest extends AbstractEntityChoiceListTest
+{
+    protected function getEntityClass()
+    {
+        return 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleAssociationToIntIdEntity';
+    }
+
+    protected function getClassesMetadata()
+    {
+        return array(
+            $this->em->getClassMetadata($this->getEntityClass()),
+            $this->em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity'),
+        );
+    }
+
+    protected function createChoiceList()
+    {
+        return new EntityChoiceList($this->em, $this->getEntityClass(), 'name');
+    }
+
+    /**
+     * @return \Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface
+     */
+    protected function createObjects()
+    {
+        $innerA = new SingleIntIdNoToStringEntity(-10, 'inner_A');
+        $innerB = new SingleIntIdNoToStringEntity(10, 'inner_B');
+        $innerC = new SingleIntIdNoToStringEntity(20, 'inner_C');
+        $innerD = new SingleIntIdNoToStringEntity(30, 'inner_D');
+
+        $this->em->persist($innerA);
+        $this->em->persist($innerB);
+        $this->em->persist($innerC);
+        $this->em->persist($innerD);
+
+        return array(
+            new SingleAssociationToIntIdEntity($innerA, 'A'),
+            new SingleAssociationToIntIdEntity($innerB, 'B'),
+            new SingleAssociationToIntIdEntity($innerC, 'C'),
+            new SingleAssociationToIntIdEntity($innerD, 'D'),
+        );
+    }
+
+    protected function getChoices()
+    {
+        return array('_10' => $this->obj1, 10 => $this->obj2, 20 => $this->obj3, 30 => $this->obj4);
+    }
+
+    protected function getLabels()
+    {
+        return array('_10' => 'A', 10 => 'B', 20 => 'C', 30 => 'D');
+    }
+
+    protected function getValues()
+    {
+        return array('_10' => '-10', 10 => '10', 20 => '20', 30 => '30');
+    }
+
+    protected function getIndices()
+    {
+        return array('_10', 10, 20, 30);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/AbstractEntityChoiceListTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/AbstractEntityChoiceListTest.php
@@ -39,7 +39,7 @@ abstract class AbstractEntityChoiceListTest extends AbstractChoiceListTest
         $this->em = DoctrineTestHelper::createTestEntityManager();
 
         $schemaTool = new SchemaTool($this->em);
-        $classes = array($this->em->getClassMetadata($this->getEntityClass()));
+        $classes = $this->getClassesMetadata();
 
         try {
             $schemaTool->dropSchema($classes);
@@ -72,6 +72,11 @@ abstract class AbstractEntityChoiceListTest extends AbstractChoiceListTest
     abstract protected function getEntityClass();
 
     abstract protected function createObjects();
+
+    protected function getClassesMetadata()
+    {
+        return array($this->em->getClassMetadata($this->getEntityClass()));
+    }
 
     /**
      * @return \Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/LoadedEntityChoiceListSingleAssociationToIntIdTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/LoadedEntityChoiceListSingleAssociationToIntIdTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Form\ChoiceList;
+
+/**
+ * @author Premi Giorgio <giosh94mhz@gmail.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class LoadedEntityChoiceListSingleAssociationToIntIdTest extends AbstractEntityChoiceListSingleAssociationToIntIdTest
+{
+    /**
+     * @return \Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface
+     */
+    protected function createChoiceList()
+    {
+        $list = parent::createChoiceList();
+
+        // load list
+        $list->getChoices();
+
+        return $list;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/UnloadedEntityChoiceListSingleAssociationToIntIdTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/UnloadedEntityChoiceListSingleAssociationToIntIdTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Form\ChoiceList;
+
+/**
+ * @author Premi Giorgio <giosh94mhz@gmail.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class UnloadedEntityChoiceListSingleAssociationToIntIdTest extends AbstractEntityChoiceListSingleAssociationToIntIdTest
+{
+    public function testGetIndicesForValuesIgnoresNonExistingValues()
+    {
+        $this->markTestSkipped('Non-existing values are not detected for unloaded choice lists.');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyGetIndicesForValuesIgnoresNonExistingValues()
+    {
+        $this->markTestSkipped('Non-existing values are not detected for unloaded choice lists.');
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/UnloadedEntityChoiceListSingleAssociationToIntIdWithQueryBuilderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/UnloadedEntityChoiceListSingleAssociationToIntIdWithQueryBuilderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Form\ChoiceList;
+
+use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
+use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
+
+/**
+ * @author Premi Giorgio <giosh94mhz@gmail.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class UnloadedEntityChoiceListSingleAssociationToIntIdWithQueryBuilderTest extends UnloadedEntityChoiceListSingleAssociationToIntIdTest
+{
+    /**
+     * @return \Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface
+     */
+    protected function createChoiceList()
+    {
+        $qb = $this->em->createQueryBuilder()->select('s')->from($this->getEntityClass(), 's');
+        $loader = new ORMQueryBuilderLoader($qb);
+
+        return new EntityChoiceList($this->em, $this->getEntityClass(), null, $loader);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I've found a bug while using the 'entity' FormType.

Doctrine allow the definition of primary keys which are foreign key of other entities. In this scenario, the `EntityChoiceList` instance check if:
- the entity has a id composed by a single column and
- eventually, the column is an integer

When this happens, it use the primary key as "choices indices", but since is an entity it fails in many places, where it expects integer.

The easy solution is to check whether the single-column id is not an association. Anyway, I've fixed it the RightWay™ :), and now it resolve the entity reference to the actual column type, and restart the logic. Code speaks better then words.
