### PR TITLE
WIP [DebugBundle] Allow configuring a dumper while collecting dumps, add a default one writing to stderr when the cli-server is in use

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DebugBundle.php
+++ b/src/Symfony/Bundle/DebugBundle/DebugBundle.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\DebugBundle;
 use Symfony\Bundle\DebugBundle\DependencyInjection\Compiler\DumpDataCollectorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\VarDumper;
 
 /**
@@ -31,7 +30,7 @@ class DebugBundle extends Bundle
             // configuration for CLI mode is overridden in HTTP mode on
             // 'kernel.request' event
             VarDumper::setHandler(function ($var) use ($container) {
-                $dumper = new CliDumper();
+                $dumper = $container->get('var_dumper.cli_dumper');
                 $cloner = $container->get('var_dumper.cloner');
                 $handler = function ($var) use ($dumper, $cloner) {
                     $dumper->dump($cloner->cloneVar($var));

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -16,6 +16,7 @@
             <argument>null</argument><!-- %templating.helper.code.file_link_format% -->
             <argument>%kernel.charset%</argument>
             <argument type="service" id="request_stack" />
+            <argument type="service" id="var_dumper.cli_dumper" />
         </service>
 
         <service id="debug.dump_listener" class="Symfony\Component\HttpKernel\EventListener\DumpListener">
@@ -25,6 +26,10 @@
         </service>
 
         <service id="var_dumper.cloner" class="Symfony\Component\VarDumper\Cloner\VarCloner" />
+        <service id="var_dumper.cli_dumper" class="Symfony\Component\VarDumper\Dumper\CliDumper">
+            <argument>null</argument>
+            <argument>%kernel.charset%</argument>
+        </service>
     </services>
 
 </container>

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -123,10 +123,10 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
         if ($this->dumper) {
             $this->doDump($data, $name, $file, $line);
-        } else {
-            $this->data[] = compact('data', 'name', 'file', 'line', 'fileExcerpt');
-            ++$this->dataCount;
         }
+
+        $this->data[] = compact('data', 'name', 'file', 'line', 'fileExcerpt');
+        ++$this->dataCount;
 
         if ($this->stopwatch) {
             $this->stopwatch->stop('dump');
@@ -136,7 +136,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         // Sub-requests and programmatic calls stay in the collected profile.
-        if (($this->requestStack && $this->requestStack->getMasterRequest() !== $request) || $request->isXmlHttpRequest() || $request->headers->has('Origin')) {
+        if ($this->dumper || ($this->requestStack && $this->requestStack->getMasterRequest() !== $request) || $request->isXmlHttpRequest() || $request->headers->has('Origin')) {
             return;
         }
 
@@ -154,13 +154,9 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                 $this->dumper = new CliDumper('php://output', $this->charset);
             }
 
-            foreach ($this->data as $i => $dump) {
-                $this->data[$i] = null;
+            foreach ($this->data as $dump) {
                 $this->doDump($dump['data'], $dump['name'], $dump['file'], $dump['line']);
             }
-
-            $this->data = array();
-            $this->dataCount = 0;
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -251,20 +251,33 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
     private function doDump($data, $name, $file, $line)
     {
-        if ($this->dumper instanceof HtmlDumper) {
-            $name = $this->htmlEncode($name);
-            $file = $this->htmlEncode($file);
-            if ('' !== $file) {
-                if ($this->fileLinkFormat) {
-                    $link = strtr($this->fileLinkFormat, array('%f' => $file, '%l' => $line));
-                    $name = sprintf('<a href="%s" title="%s">%s</a>', $link, $file, $name);
+        if (PHP_VERSION_ID >= 50400 && $this->dumper instanceof CliDumper) {
+            $contextDumper = function ($name, $file, $line, $fileLinkFormat) {
+                if ($this instanceof HtmlDumper) {
+                    if ('' !== $file) {
+                        $s = $this->style('meta', '%s');
+                        $name = strip_tags($this->style('', $name));
+                        $file = strip_tags($this->style('', $file));
+                        if ($fileLinkFormat) {
+                            $link = strtr($fileLinkFormat, array('%f' => $file, '%l' => (int) $line));
+                            $name = sprintf('<a href="%s" title="%s">'.$s.'</a>', $link, $file, $name);
+                        } else {
+                            $name = sprintf('<abbr title="%s">'.$s.'</abbr>', $file, $name);
+                        }
+                    } else {
+                        $name = $this->style('meta', $name);
+                    }
+                    $this->line = $name.' on line '.$this->style('meta', $line).':';
                 } else {
-                    $name = sprintf('<abbr title="%s">%s</abbr>', $file, $name);
+                    $this->line = $this->style('meta', $name).' on line '.$this->style('meta', $line).':';
                 }
-            }
-            echo "\n<span class=\"sf-dump-meta\">{$name} on line {$line}:</span>";
+                $this->dumpLine(0);
+            };
+            $contextDumper = $contextDumper->bindTo($this->dumper, $this->dumper);
+            $contextDumper($name, $file, $line, $this->fileLinkFormat);
         } else {
-            echo "{$name} on line {$line}:\n";
+            $cloner = new VarCloner();
+            $this->dumper->dump($cloner->cloneVar($name.' on line '.$line.':'));
         }
         $this->dumper->dump($data);
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -41,9 +41,10 @@ class DumpListener implements EventSubscriberInterface
     {
         $cloner = $this->cloner;
         $dumper = $this->dumper;
+        $output = 'php://stderr';
 
-        VarDumper::setHandler(function ($var) use ($cloner, $dumper) {
-            $dumper->dump($cloner->cloneVar($var));
+        VarDumper::setHandler(function ($var) use ($cloner, $dumper, $output) {
+            $dumper->dump($cloner->cloneVar($var), $output);
         });
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -71,7 +71,11 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $collector->collect(new Request(), new Response());
         $output = ob_get_clean();
 
-        $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n123\n", $output);
+        if (PHP_VERSION_ID >= 50400) {
+            $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n123\n", $output);
+        } else {
+            $this->assertSame("\"DumpDataCollectorTest.php on line {$line}:\"\n123\n", $output);
+        }
         $this->assertSame(1, $collector->getDumpsCount());
     }
 
@@ -85,8 +89,8 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $line = __LINE__ - 1;
         $file = __FILE__;
         $xOutput = <<<EOTXT
-
-<span class="sf-dump-meta"><a href="test://{$file}:{$line}" title="{$file}">DumpDataCollectorTest.php</a> on line {$line}:</span> <pre class=sf-dump id=sf-dump data-indent-pad="  "><span class=sf-dump-num>123</span>
+ <pre class=sf-dump id=sf-dump data-indent-pad="  "><a href="test://{$file}:{$line}" title="{$file}"><span class=sf-dump-meta>DumpDataCollectorTest.php</span></a> on line <span class=sf-dump-meta>{$line}</span>:
+<span class=sf-dump-num>123</span>
 </pre>
 
 EOTXT;
@@ -112,6 +116,10 @@ EOTXT;
 
         ob_start();
         $collector = null;
-        $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n456\n", ob_get_clean());
+        if (PHP_VERSION_ID >= 50400) {
+            $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n456\n", ob_get_clean());
+        } else {
+            $this->assertSame("\"DumpDataCollectorTest.php on line {$line}:\"\n456\n", ob_get_clean());
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -72,6 +72,7 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $output = ob_get_clean();
 
         $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n123\n", $output);
+        $this->assertSame(1, $collector->getDumpsCount());
     }
 
     public function testCollectHtml()
@@ -99,6 +100,7 @@ EOTXT;
         $output = preg_replace('/sf-dump-\d+/', 'sf-dump', $output);
 
         $this->assertSame($xOutput, $output);
+        $this->assertSame(1, $collector->getDumpsCount());
     }
 
     public function testFlush()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14608 |
| License | MIT |
| Doc PR | - |

When `dump()` is called, you all know this happens:
![dump1](https://cloud.githubusercontent.com/assets/243674/7179984/77921718-e43d-11e4-9a58-02e27a89f376.png)

With this PR, dumps are duplicated in the console output of a `php -S` process:
![dump2](https://cloud.githubusercontent.com/assets/243674/7179954/420a8c60-e43d-11e4-9d34-ddaf1d05e01c.png)

This does not work with php app/console server:run but that is for an other PR.
