### PR TITLE
[FrameworkBundle] Dumped container files not being renamed correctly on cache:clear

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -146,7 +146,7 @@ EOF
         // fix references to kernel/container related classes
         $search = $tempKernel->getName().ucfirst($tempKernel->getEnvironment());
         $replace = $realKernel->getName().ucfirst($realKernel->getEnvironment());
-        foreach (Finder::create()->files()->name($search.'*')->in($warmupDir) as $file) {
+        foreach (Finder::create()->files()->name('*'.$search.'*')->in($warmupDir) as $file) {
             $content = str_replace($search, $replace, file_get_contents($file));
             file_put_contents(str_replace($search, $replace, $file), $content);
             unlink($file);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |
# Abstract

When you override the `AppKernel::getContainerClass()`, `cache:clear` fails to correctly rename `XX_DevDebugProjectContainer.php` to `XXXDevDebugProjectContainer` when it moves the newly generated cache file, to replace the soon-to-be-deleted ones.

Aside from the confusion introduced when looking at the generated code/files, this also means the cache is not correctly warmed up, and can potentially cause concurrency issues when the service container gets lazily dumped upon the first HTTP requests.
# Fix

So far, the fix I'm suggesting looks more like a workaround. I broadened the `Finder` selector, so that it detects and rename the `XX_DevDebugProjectContainer.php`, along with the other `appDevUrlGenerator` or `appDevUrlMatcher` files. I am however a little concerned by the possible side-effects on this.
# Reproducing steps

```
$ symfony new symfony-cache-rename 2.3
$ cd symfony-cache-rename/
```

Add the following method to `app/AppKernel.php`

``` php
    protected function getContainerClass()
    {
        return sprintf('Foo' . parent::getContainerClass());
    }
```

```
$ app/console cache:clear
```
## Expected

```
app/cache/dev
|-- FooappDevDebugProjectContainer.php
|-- FooappDevDebugProjectContainer.php.meta
|-- FooappDevDebugProjectContainer.xml
|-- FooappDevDebugProjectContainerCompiler.log
|-- annotations
|-- appDevUrlGenerator.php
|-- appDevUrlGenerator.php.meta
|-- appDevUrlMatcher.php
|-- appDevUrlMatcher.php.meta
|-- assetic
|-- classes.map
|-- doctrine
|-- profiler
|-- sessions
|-- templates.php
`-- twig

6 directories, 10 files
```
## Got

```
app/cache/dev
|-- Fooap_DevDebugProjectContainer.php
|-- Fooap_DevDebugProjectContainer.php.meta
|-- Fooap_DevDebugProjectContainer.xml
|-- Fooap_DevDebugProjectContainerCompiler.log
|-- annotations
|-- appDevUrlGenerator.php
|-- appDevUrlGenerator.php.meta
|-- appDevUrlMatcher.php
|-- appDevUrlMatcher.php.meta
|-- assetic
|-- classes.map
|-- doctrine
|-- profiler
|-- sessions
|-- templates.php
`-- twig

6 directories, 10 files
```
# Got after the first HTTP request

```
app/cache/dev
|-- Fooap_DevDebugProjectContainer.php
|-- Fooap_DevDebugProjectContainer.php.meta
|-- Fooap_DevDebugProjectContainer.xml
|-- Fooap_DevDebugProjectContainerCompiler.log
|-- FooappDevDebugProjectContainer.php
|-- FooappDevDebugProjectContainer.php.meta
|-- FooappDevDebugProjectContainer.xml
|-- FooappDevDebugProjectContainerCompiler.log
|-- annotations
|-- appDevUrlGenerator.php
|-- appDevUrlGenerator.php.meta
|-- appDevUrlMatcher.php
|-- appDevUrlMatcher.php.meta
|-- assetic
|-- classes.map
|-- doctrine
|-- profiler
|-- sessions
|-- templates.php
`-- twig

6 directories, 14 files
```
