### PR TITLE
[DX] Added a logout link in the security panel of the web debug toolbar

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -50,6 +50,7 @@ class SecurityDataCollector extends DataCollector
                 'enabled' => false,
                 'authenticated' => false,
                 'token_class' => null,
+                'provider_key' => null,
                 'user' => '',
                 'roles' => array(),
                 'inherited_roles' => array(),
@@ -60,6 +61,7 @@ class SecurityDataCollector extends DataCollector
                 'enabled' => true,
                 'authenticated' => false,
                 'token_class' => null,
+                'provider_key' => null,
                 'user' => '',
                 'roles' => array(),
                 'inherited_roles' => array(),
@@ -80,6 +82,7 @@ class SecurityDataCollector extends DataCollector
                 'enabled' => true,
                 'authenticated' => $token->isAuthenticated(),
                 'token_class' => get_class($token),
+                'provider_key' => method_exists($token, 'getProviderKey') ? $token->getProviderKey() : null,
                 'user' => $token->getUsername(),
                 'roles' => array_map(function (RoleInterface $role) { return $role->getRole();}, $assignedRoles),
                 'inherited_roles' => array_map(function (RoleInterface $role) { return $role->getRole(); }, $inheritedRoles),
@@ -157,6 +160,16 @@ class SecurityDataCollector extends DataCollector
     public function getTokenClass()
     {
         return $this->data['token_class'];
+    }
+
+    /**
+     * Get the provider key (i.e. the name of the active firewall).
+     *
+     * @return string The provider key
+     */
+    public function getProviderKey()
+    {
+        return $this->data['provider_key'];
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -33,7 +33,8 @@
             {% endif %}
             {% if collector.providerKey %}
             <div class="sf-toolbar-info-piece">
-                <a class="sf-btn" title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}"><span class="sf-icon sf-danger">&times;</span> Logout</a>
+                <b>Actions</b>
+                <a class="sf-btn" title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}">Logout</a>
             </div>
             {% endif %}
         {% elseif collector.enabled %}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -33,7 +33,7 @@
             {% endif %}
             {% if collector.providerKey != null %}
             <div class="sf-toolbar-info-piece">
-            <a title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}">Logout</a>
+                <a title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}">Logout</a>
             </div>
             {% endif %}
         {% elseif collector.enabled %}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -34,7 +34,7 @@
             {% if collector.providerKey %}
             <div class="sf-toolbar-info-piece">
                 <b>Actions</b>
-                <a class="sf-btn" title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}">Logout</a>
+                <span><a href="{{ logout_path(collector.providerKey) }}">Logout</a></span>
             </div>
             {% endif %}
         {% elseif collector.enabled %}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -31,6 +31,11 @@
                 <span>{{ collector.tokenClass|abbr_class }}</span>
             </div>
             {% endif %}
+            {% if collector.providerKey != null %}
+            <div class="sf-toolbar-info-piece">
+                <a title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}">Logout</a>
+            </div>
+            {% endif %}
         {% elseif collector.enabled %}
             <div class="sf-toolbar-info-piece">
                 <span>You are not authenticated.</span>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -33,7 +33,7 @@
             {% endif %}
             {% if collector.providerKey != null %}
             <div class="sf-toolbar-info-piece">
-                <a title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}">Logout</a>
+            <a title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}">Logout</a>
             </div>
             {% endif %}
         {% elseif collector.enabled %}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -31,9 +31,9 @@
                 <span>{{ collector.tokenClass|abbr_class }}</span>
             </div>
             {% endif %}
-            {% if collector.providerKey != null %}
+            {% if collector.providerKey %}
             <div class="sf-toolbar-info-piece">
-                <a title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}">Logout</a>
+                <a class="sf-btn" title="Logout from the {{ collector.providerKey }} firewall" href="{{ logout_path(collector.providerKey) }}"><span class="sf-icon sf-danger">&times;</span> Logout</a>
             </div>
             {% endif %}
         {% elseif collector.enabled %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

While developing applications, it's common to login/logout users continuously to test security features. I usually type `/logout` in the URL, but this is boring and, depending on the application, not always works.

This PR adds a small _Logout_ link in the security panel when you are logged in the application:

![logged](https://cloud.githubusercontent.com/assets/73419/7184976/6c66831a-e460-11e4-86a9-eb5a48c9aa4c.png)

Anonymous users won't see anything:

![anonymous](https://cloud.githubusercontent.com/assets/73419/7184982/74a95b60-e460-11e4-8b35-72d8336355fb.png)
