### PR TITLE
[FrameworkBundle][Server Command] add address port number option.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -33,7 +33,8 @@ class ServerStartCommand extends ServerCommand
     {
         $this
             ->setDefinition(array(
-                new InputArgument('address', InputArgument::OPTIONAL, 'Address:port', '127.0.0.1:8000'),
+                new InputArgument('address', InputArgument::OPTIONAL, 'Address:port', '127.0.0.1'),
+                new InputOption('port', 'p', InputOption::VALUE_REQUIRED, 'Address port number', '8000'),
                 new InputOption('docroot', 'd', InputOption::VALUE_REQUIRED, 'Document root', null),
                 new InputOption('router', 'r', InputOption::VALUE_REQUIRED, 'Path to custom router script'),
             ))
@@ -101,9 +102,7 @@ EOF
         $address = $input->getArgument('address');
 
         if (false === strpos($address, ':')) {
-            $output->writeln('The address has to be of the form <comment>bind-address:port</comment>.');
-
-            return 1;
+            $address = $address.':'.$input->getOption('port');
         }
 
         if ($this->isOtherServerProcessRunning($address)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStopCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStopCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Stops a background process running PHP's built-in web server.
@@ -29,7 +30,8 @@ class ServerStopCommand extends ServerCommand
     {
         $this
             ->setDefinition(array(
-                new InputArgument('address', InputArgument::OPTIONAL, 'Address:port', '127.0.0.1:8000'),
+                new InputArgument('address', InputArgument::OPTIONAL, 'Address:port', '127.0.0.1'),
+                new InputOption('port', 'p', InputOption::VALUE_REQUIRED, 'Address port number', '8000'),
             ))
             ->setName('server:stop')
             ->setDescription('Stops PHP\'s built-in web server that was started with the server:start command')
@@ -53,6 +55,10 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $address = $input->getArgument('address');
+        if (false === strpos($address, ':')) {
+            $address = $address.':'.$input->getOption('port');
+        }
+
         $lockFile = $this->getLockFile($address);
 
         if (!file_exists($lockFile)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This allow running server without repeating `127.0.0.1` each time, in the most of case we only change the port number.
- Before

```
app/console server:start 127.0.0.1:8080
```
- After

```
app/console server:start -p 8080
```
