### PR TITLE
[Debug] Map PHP errors to LogLevel::CRITICAL

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -78,12 +78,12 @@ class ErrorHandler
         E_USER_WARNING => array(null, LogLevel::WARNING),
         E_COMPILE_WARNING => array(null, LogLevel::WARNING),
         E_CORE_WARNING => array(null, LogLevel::WARNING),
-        E_USER_ERROR => array(null, LogLevel::ERROR),
-        E_RECOVERABLE_ERROR => array(null, LogLevel::ERROR),
-        E_COMPILE_ERROR => array(null, LogLevel::EMERGENCY),
-        E_PARSE => array(null, LogLevel::EMERGENCY),
-        E_ERROR => array(null, LogLevel::EMERGENCY),
-        E_CORE_ERROR => array(null, LogLevel::EMERGENCY),
+        E_USER_ERROR => array(null, LogLevel::CRITICAL),
+        E_RECOVERABLE_ERROR => array(null, LogLevel::CRITICAL),
+        E_COMPILE_ERROR => array(null, LogLevel::CRITICAL),
+        E_PARSE => array(null, LogLevel::CRITICAL),
+        E_ERROR => array(null, LogLevel::CRITICAL),
+        E_CORE_ERROR => array(null, LogLevel::CRITICAL),
     );
 
     private $thrownErrors = 0x1FFF; // E_ALL - E_DEPRECATED - E_USER_DEPRECATED

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -148,12 +148,12 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                 E_USER_WARNING => array(null, LogLevel::WARNING),
                 E_COMPILE_WARNING => array(null, LogLevel::WARNING),
                 E_CORE_WARNING => array(null, LogLevel::WARNING),
-                E_USER_ERROR => array(null, LogLevel::ERROR),
-                E_RECOVERABLE_ERROR => array(null, LogLevel::ERROR),
-                E_COMPILE_ERROR => array(null, LogLevel::EMERGENCY),
-                E_PARSE => array(null, LogLevel::EMERGENCY),
-                E_ERROR => array(null, LogLevel::EMERGENCY),
-                E_CORE_ERROR => array(null, LogLevel::EMERGENCY),
+                E_USER_ERROR => array(null, LogLevel::CRITICAL),
+                E_RECOVERABLE_ERROR => array(null, LogLevel::CRITICAL),
+                E_COMPILE_ERROR => array(null, LogLevel::CRITICAL),
+                E_PARSE => array(null, LogLevel::CRITICAL),
+                E_ERROR => array(null, LogLevel::CRITICAL),
+                E_CORE_ERROR => array(null, LogLevel::CRITICAL),
             );
             $this->assertSame($loggers, $handler->setLoggers(array()));
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

See https://github.com/Seldaek/monolog#log-levels for reference.
This is #14294 on 2.7 (not 2.6)
