### PR TITLE
[FrameworkBundle][Translation] Check for 'xlf' instead of 'xliff'

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -125,7 +125,7 @@ EOF
                 }
             }
 
-            if ($input->getOption('output-format') == 'xliff') {
+            if ($input->getOption('output-format') == 'xlf') {
                 $output->writeln('Xliff output version is <info>1.2</info>');
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

There is no translation writer format named 'xliff', but 'xlf' only. So the TranslationUpdateCommand can't be called with 'output-format' == 'xliff' and the version info will never be shown.

The change from 'xliff' to 'xlf' was introduced in https://github.com/symfony/symfony/commit/2cb6260. The translation dumper alias was just renamed while the translation loader supports both 'xliff' and 'xlf'.
