### PR TITLE
[Form] deprecate read_only option

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -314,7 +314,6 @@
 
 {%- block widget_attributes -%}
     id="{{ id }}" name="{{ full_name }}"
-    {%- if read_only %} readonly="readonly"{% endif -%}
     {%- if disabled %} disabled="disabled"{% endif -%}
     {%- if required %} required="required"{% endif -%}
     {%- for attrname, attrvalue in attr -%}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/phpunit-bridge": "~2.7|~3.0.0",
         "symfony/asset": "~2.7|~3.0.0",
         "symfony/finder": "~2.3|~3.0.0",
-        "symfony/form": "~2.7|~3.0.0",
+        "symfony/form": "~2.8|~3.0.0",
         "symfony/http-kernel": "~2.3|~3.0.0",
         "symfony/intl": "~2.3|~3.0.0",
         "symfony/routing": "~2.2|~3.0.0",

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -1,5 +1,4 @@
-id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>"
-<?php if ($disabled): ?> disabled="disabled"<?php endif ?>
+id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>"<?php if ($disabled): ?> disabled="disabled"<?php endif ?>
 <?php if ($required): ?> required="required"<?php endif ?>
 <?php foreach ($attr as $k => $v): ?>
 <?php if (in_array($k, array('placeholder', 'title'), true)): ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -1,12 +1,12 @@
-id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($read_only): ?>readonly="readonly" <?php endif ?>
-<?php if ($disabled): ?>disabled="disabled" <?php endif ?>
-<?php if ($required): ?>required="required" <?php endif ?>
+id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>"
+<?php if ($disabled): ?> disabled="disabled"<?php endif ?>
+<?php if ($required): ?> required="required"<?php endif ?>
 <?php foreach ($attr as $k => $v): ?>
 <?php if (in_array($k, array('placeholder', 'title'), true)): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape($view['translator']->trans($v, array(), $translation_domain))) ?>
+<?php printf(' %s="%s"', $view->escape($k), $view->escape($view['translator']->trans($v, array(), $translation_domain))) ?>
 <?php elseif ($v === true): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape($k)) ?>
+<?php printf(' %s="%s"', $view->escape($k), $view->escape($k)) ?>
 <?php elseif ($v !== false): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape($v)) ?>
+<?php printf(' %s="%s"', $view->escape($k), $view->escape($v)) ?>
 <?php endif ?>
 <?php endforeach ?>

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -41,7 +41,7 @@
         "symfony/finder": "~2.0,>=2.0.5|~3.0.0",
         "symfony/intl": "~2.3|~3.0.0",
         "symfony/security": "~2.6|~3.0.0",
-        "symfony/form": "~2.7|~3.0.0",
+        "symfony/form": "~2.8|~3.0.0",
         "symfony/class-loader": "~2.1|~3.0.0",
         "symfony/expression-language": "~2.6|~3.0.0",
         "symfony/process": "~2.0,>=2.0.5|~3.0.0",

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * deprecated option "read_only" in favor of "attr['readonly']"
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -78,7 +78,7 @@ class FormType extends BaseType
             }
 
             // Complex fields are read-only if they themselves or their parents are.
-            if (!isset($view->vars['attr']['readonly']) && isset($view->parent->vars['attr']['readonly']) && false !== $view->parent->vars['attr']['readonly'])) {
+            if (!isset($view->vars['attr']['readonly']) && isset($view->parent->vars['attr']['readonly']) && false !== $view->parent->vars['attr']['readonly']) {
                 $view->vars['attr']['readonly'] = true;
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -195,7 +195,7 @@ class FormType extends BaseType
 
         $readOnlyNormalizer = function (Options $options, $readOnly) {
             if (null !== $readOnly) {
-                trigger_error('The form option "read_only" is deprecated since version 2.7 and will be removed in 3.0. Use "attr[\'readonly\']" instead.', E_USER_DEPRECATED);
+                trigger_error('The form option "read_only" is deprecated since version 2.8 and will be removed in 3.0. Use "attr[\'readonly\']" instead.', E_USER_DEPRECATED);
 
                 return $readOnly;
             }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -185,12 +185,22 @@ class FormType extends BaseType
             return $attributes;
         };
 
+        $readOnlyNormalizer = function (Options $options, $readOnly) {
+            if (null !== $readOnly) {
+                trigger_error('The form option "read_only" is deprecated since version 2.7 and will be removed in 3.0. Use "attr[\'readonly\']" instead.', E_USER_DEPRECATED);
+
+                return $readOnly;
+            }
+
+            return false;
+        };
+
         $resolver->setDefaults(array(
             'data_class' => $dataClass,
             'empty_data' => $emptyData,
             'trim' => true,
             'required' => true,
-            'read_only' => false,
+            'read_only' => null,
             'max_length' => null,
             'pattern' => null,
             'property_path' => null,
@@ -208,6 +218,8 @@ class FormType extends BaseType
             'attr' => $defaultAttr,
             'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
         ));
+
+        $resolver->setNormalizer('read_only', $readOnlyNormalizer);
 
         $resolver->setAllowedTypes('label_attr', 'array');
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -71,7 +71,6 @@ class FormType extends BaseType
         parent::buildView($view, $form, $options);
 
         $name = $form->getName();
-        $readOnly = $options['read_only'];
 
         if ($view->parent) {
             if ('' === $name) {
@@ -79,13 +78,13 @@ class FormType extends BaseType
             }
 
             // Complex fields are read-only if they themselves or their parents are.
-            if (!$readOnly) {
-                $readOnly = $view->parent->vars['read_only'];
+            if (!isset($view->vars['attr']['readonly']) && isset($view->parent->vars['attr']['readonly']) && false !== $view->parent->vars['attr']['readonly'])) {
+                $view->vars['attr']['readonly'] = true;
             }
         }
 
         $view->vars = array_replace($view->vars, array(
-            'read_only' => $readOnly,
+            'read_only' => isset($view->vars['attr']['readonly']) && false !== $view->vars['attr']['readonly'], // deprecated
             'errors' => $form->getErrors(),
             'valid' => $form->isSubmitted() ? $form->isValid() : true,
             'value' => $form->getViewData(),
@@ -185,6 +184,15 @@ class FormType extends BaseType
             return $attributes;
         };
 
+        // BC for "read_only" option
+        $attrNormalizer = function (Options $options, array $attr) {
+            if (!isset($attr['readonly']) && $options['read_only']) {
+                $attr['readonly'] = true;
+            }
+
+            return $attr;
+        };
+
         $readOnlyNormalizer = function (Options $options, $readOnly) {
             if (null !== $readOnly) {
                 trigger_error('The form option "read_only" is deprecated since version 2.7 and will be removed in 3.0. Use "attr[\'readonly\']" instead.', E_USER_DEPRECATED);
@@ -200,7 +208,7 @@ class FormType extends BaseType
             'empty_data' => $emptyData,
             'trim' => true,
             'required' => true,
-            'read_only' => null,
+            'read_only' => null, // deprecated
             'max_length' => null,
             'pattern' => null,
             'property_path' => null,
@@ -219,6 +227,7 @@ class FormType extends BaseType
             'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
         ));
 
+        $resolver->setNormalizer('attr', $attrNormalizer);
         $resolver->setNormalizer('read_only', $readOnlyNormalizer);
 
         $resolver->setAllowedTypes('label_attr', 'array');

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -1342,7 +1342,10 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
-    public function testReadOnly()
+    /**
+     * @group legacy
+     */
+    public function testLegacyReadOnly()
     {
         $form = $this->factory->createNamed('name', 'text', null, array(
             'read_only' => true,
@@ -1907,14 +1910,13 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         $form = $this->factory->createNamed('text', 'text', 'value', array(
             'required' => true,
             'disabled' => true,
-            'read_only' => true,
-            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
+            'attr' => array('readonly' => true, 'maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
         ));
 
         $html = $this->renderWidget($form->createView());
 
         // compare plain HTML to check the whitespace
-        $this->assertSame('<input type="text" id="text" name="text" readonly="readonly" disabled="disabled" required="required" maxlength="10" pattern="\d+" class="foobar form-control" data-foo="bar" value="value" />', $html);
+        $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar form-control" data-foo="bar" value="value" />', $html);
     }
 
     public function testWidgetAttributeNameRepeatedIfTrue()

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1512,7 +1512,10 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testReadOnly()
+    /**
+     * @group legacy
+     */
+    public function testLegacyReadOnly()
     {
         $form = $this->factory->createNamed('name', 'text', null, array(
             'read_only' => true,
@@ -2119,14 +2122,13 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $form = $this->factory->createNamed('text', 'text', 'value', array(
             'required' => true,
             'disabled' => true,
-            'read_only' => true,
-            'attr' => array('maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
+            'attr' => array('readonly' => true, 'maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
         ));
 
         $html = $this->renderWidget($form->createView());
 
         // compare plain HTML to check the whitespace
-        $this->assertSame('<input type="text" id="text" name="text" readonly="readonly" disabled="disabled" required="required" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value" />', $html);
+        $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value" />', $html);
     }
 
     public function testWidgetAttributeNameRepeatedIfTrue()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -99,7 +99,10 @@ class FormTypeTest extends BaseTypeTest
         $this->assertEquals('reverse[ a ]', $form->getData());
     }
 
-    public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
+    /**
+     * @group legacy
+     */
+    public function testLegacyNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
         $view = $this->factory->createNamedBuilder('parent', 'form', null, array('read_only' => true))
             ->add('child', 'form')
@@ -109,7 +112,20 @@ class FormTypeTest extends BaseTypeTest
         $this->assertTrue($view['child']->vars['read_only']);
     }
 
-    public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
+    public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
+    {
+        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('attr' => array('readonly' => true)))
+            ->add('child', 'form')
+            ->getForm()
+            ->createView();
+
+        $this->assertTrue($view['child']->vars['attr']['readonly']);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
         $view = $this->factory->createNamedBuilder('parent', 'form')
             ->add('child', 'form', array('read_only' => true))
@@ -119,7 +135,20 @@ class FormTypeTest extends BaseTypeTest
         $this->assertTrue($view['child']->vars['read_only']);
     }
 
-    public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
+    public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
+    {
+        $view = $this->factory->createNamedBuilder('parent', 'form')
+            ->add('child', 'form', array('attr' => array('readonly' => true)))
+            ->getForm()
+            ->createView();
+
+        $this->assertTrue($view['child']->vars['attr']['readonly']);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
     {
         $view = $this->factory->createNamedBuilder('parent', 'form')
                 ->add('child', 'form')
@@ -127,6 +156,16 @@ class FormTypeTest extends BaseTypeTest
                 ->createView();
 
         $this->assertFalse($view['child']->vars['read_only']);
+    }
+
+    public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
+    {
+        $view = $this->factory->createNamedBuilder('parent', 'form')
+            ->add('child', 'form')
+            ->getForm()
+            ->createView();
+
+        $this->assertArrayNotHasKey('readonly', $view['child']->vars['attr']);
     }
 
     public function testPassMaxLengthToView()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #10658 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3782 |

Replaces #10676 with a slightly different implementation.
- fixes BC break when 'read_only' => true option and at the same time custom attributes are used by using a normalizer
- adds deprecation notice
- keeps legacy tests
