### PR TITLE
[2.7][Form] Patch label_attr in choice_attr. Fix #14404, #14165, #14393

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package*.tar
 packages.json
 phpunit.xml
 /vendor/
+/.idea

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -247,7 +247,7 @@ class ChoiceType extends AbstractType
         };
 
         $emptyValue = function (Options $options) {
-            return $options['required'] ? null : '';
+            return $options['required'] ? '' : null;
         };
 
         // for BC with the "empty_value" option

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -418,6 +418,20 @@ class ChoiceType extends AbstractType
             'block_name' => 'entry',
         );
 
+        // Start fix
+        /*
+         * patch label_attr as passing it as an array to choiceOpts throw an exception in twig rendering
+         * need it for labels of <input type="radio|checkbox"> tags
+         * if expanded is true only, no need to pass array for html attributes in <option> tags
+         * addSubForm is called only is expanded is set to true so no need to catch the exception elsewhere
+         * as label_attr seems to be the only use case to me
+         */
+        if (isset($choiceOpts['attr']['label_attr'])) {
+            $choiceOpts['label_attr'] = $choiceOpts['attr']['label_attr']; // pass label_attr to the right level
+            unset($choiceOpts['attr']['label_attr']);                      // unset wrong level
+        }
+        // End fix
+
         if ($options['multiple']) {
             $choiceType = 'checkbox';
             // The user can check 0 or more checkboxes. If required

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator;
-use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Factory\DefaultChoiceListFactory;
@@ -418,19 +417,11 @@ class ChoiceType extends AbstractType
             'block_name' => 'entry',
         );
 
-        // Start fix
-        /*
-         * patch label_attr as passing it as an array to choiceOpts throw an exception in twig rendering
-         * need it for labels of <input type="radio|checkbox"> tags
-         * if expanded is true only, no need to pass array for html attributes in <option> tags
-         * addSubForm is called only is expanded is set to true so no need to catch the exception elsewhere
-         * as label_attr seems to be the only use case to me
-         */
+        // Resolve label_attr to the right level
         if (isset($choiceOpts['attr']['label_attr'])) {
-            $choiceOpts['label_attr'] = $choiceOpts['attr']['label_attr']; // pass label_attr to the right level
-            unset($choiceOpts['attr']['label_attr']);                      // unset wrong level
+            $choiceOpts['label_attr'] = $choiceOpts['attr']['label_attr'];
+            unset($choiceOpts['attr']['label_attr']);
         }
-        // End fix
 
         if ($options['multiple']) {
             $choiceType = 'checkbox';

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -247,7 +247,7 @@ class ChoiceType extends AbstractType
         };
 
         $emptyValue = function (Options $options) {
-            return $options['required'] ? '' : null;
+            return $options['required'] && empty($options['choices']) ? '' : null;
         };
 
         // for BC with the "empty_value" option

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -359,11 +359,10 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     [@class="my&class form-control"]
     [not(@required)]
     [
-        ./option[@value=""][.="[trans][/trans]"]
-        /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
+        ./option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
-    [count(./option)=3]
+    [count(./option)=2]
 '
         );
     }
@@ -383,11 +382,10 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     [@class="my&class form-control"]
     [not(@required)]
     [
-        ./option[@value=""][.="[trans][/trans]"]
-        /following-sibling::option[@value="&a"][not(@selected)][.="[trans]Choice&A[/trans]"]
+        ./option[@value="&a"][not(@selected)][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
-    [count(./option)=3]
+    [count(./option)=2]
 '
         );
     }

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -806,7 +806,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
                     return array(
                         'class' => 'option_input_class', // expected
                         'label_attr' => array(
-                            'class' => 'option_label_class', // error
+                            'class' => 'option_label_class', // expected
                         ),
                     );
                 },
@@ -816,21 +816,21 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
         $html = $this->renderRow($view['choice']);
 
-        // __OK__   @Field div     --expected class="choice_field_class" | attr
+        // __OK__ @Field div     --expected class="choice_field_class" | attr
         $this->assertContains('<div id="name_choice" class="choice_field_class">',                                                           $html);
 
-        // __OK__   @Field_label   --expected class="choice_label_class" | label_attr
+        // __OK__ @Field_label   --expected class="choice_label_class" | label_attr
         $this->assertContains('<label class="choice_label_class">[trans]Choice[/trans]</label>',                                             $html);
 
-        // Before Patch tests fails
-        // __FAIL__ @Options  x2   --error label_attr=_ARRAY_            | choice_attr                 ERRORS   1 & 2
+        // All green
+        // __OK__ @Options  x2   --error label_attr=_ARRAY_            | choice_attr
         if (!$multiple) {
             $this->assertContains('<input type="radio" id="name_choice_0" name="name[choice]" class="option_input_class" value="0" />',      $html);
         } else {
             $this->assertContains('<input type="checkbox" id="name_choice_0" name="name[choice][]" class="option_input_class" value="0" />', $html);
         }
 
-        // __FAIL__ @Options_label --missing class="option_label_class"  | choice_attr [ label_attr ]  FAILURES 1 & 2
+        // __OK__ @Options_label --expected class="option_label_class" | choice_attr [ label_attr ]
         $this->assertContains('<label class="option_label_class" for="name_choice_0">[trans]Bernhard[/trans]</label>',                                 $html);
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -635,11 +635,10 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     [@name="name"]
     [not(@required)]
     [
-        ./option[@value=""][.="[trans][/trans]"]
-        /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
+        ./option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
-    [count(./option)=3]
+    [count(./option)=2]
 '
         );
     }
@@ -658,11 +657,10 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     [@name="name"]
     [not(@required)]
     [
-        ./option[@value=""][.="[trans][/trans]"]
-        /following-sibling::option[@value="&a"][not(@selected)][.="[trans]Choice&A[/trans]"]
+        ./option[@value="&a"][not(@selected)][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
-    [count(./option)=3]
+    [count(./option)=2]
 '
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no (yes in BridgeTwig/Tests) |
| Fixed tickets | #14404, #14165 , #14393 |
| License | MIT |
| Doc PR | - |
- add possibility to pass `label_attr` to `choice_attr` when choice field is expanded for radio buttons and checkboxes labels, #14404
- fix default `placeholder` option in `ChoiceType`, when required set to false causes validation error, #14165, #14393 
