### PR TITLE
[DX] Added CurrentUserProvider service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -120,6 +120,7 @@ class Controller extends ContainerAware
      * @param mixed $object     The object
      *
      * @throws \LogicException
+     *
      * @return bool
      */
     protected function isGranted($attributes, $object = null)
@@ -305,20 +306,11 @@ class Controller extends ContainerAware
      */
     public function getUser()
     {
-        if (!$this->container->has('security.token_storage')) {
+        if (!$this->container->has('security.current_user_provider')) {
             throw new \LogicException('The SecurityBundle is not registered in your application.');
         }
 
-        if (null === $token = $this->container->get('security.token_storage')->getToken()) {
-            return;
-        }
-
-        if (!is_object($user = $token->getUser())) {
-            // e.g. anonymous authentication
-            return;
-        }
-
-        return $user;
+        return $this->container->get('security.current_user_provider')->getUser();
     }
 
     /**
@@ -362,7 +354,7 @@ class Controller extends ContainerAware
     }
 
     /**
-     * Checks the validity of a CSRF token
+     * Checks the validity of a CSRF token.
      *
      * @param string $id    The id used when generating the token
      * @param string $token The actual token sent with the request that should be validated

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -13,13 +13,9 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\User\User;
 
 class ControllerTest extends TestCase
 {
@@ -50,31 +46,30 @@ class ControllerTest extends TestCase
 
     public function testGetUser()
     {
-        $user = new User('user', 'pass');
-        $token = new UsernamePasswordToken($user, 'pass', 'default', array('ROLE_USER'));
+        $currentUserProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\CurrentUserProvider')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $currentUserProvider
+            ->expects($this->once())
+            ->method('getUser');
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('security.current_user_provider')
+            ->will($this->returnValue(true));
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with('security.current_user_provider')
+            ->will($this->returnValue($currentUserProvider));
 
         $controller = new TestController();
-        $controller->setContainer($this->getContainerWithTokenStorage($token));
+        $controller->setContainer($container);
 
-        $this->assertSame($controller->getUser(), $user);
-    }
-
-    public function testGetUserAnonymousUserConvertedToNull()
-    {
-        $token = new AnonymousToken('default', 'anon.');
-
-        $controller = new TestController();
-        $controller->setContainer($this->getContainerWithTokenStorage($token));
-
-        $this->assertNull($controller->getUser());
-    }
-
-    public function testGetUserWithEmptyTokenStorage()
-    {
-        $controller = new TestController();
-        $controller->setContainer($this->getContainerWithTokenStorage(null));
-
-        $this->assertNull($controller->getUser());
+        $controller->getUser();
     }
 
     /**
@@ -87,41 +82,13 @@ class ControllerTest extends TestCase
         $container
             ->expects($this->once())
             ->method('has')
-            ->with('security.token_storage')
+            ->with('security.current_user_provider')
             ->will($this->returnValue(false));
 
         $controller = new TestController();
         $controller->setContainer($container);
 
         $controller->getUser();
-    }
-
-    /**
-     * @param $token
-     * @return ContainerInterface
-     */
-    private function getContainerWithTokenStorage($token = null)
-    {
-        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage');
-        $tokenStorage
-            ->expects($this->once())
-            ->method('getToken')
-            ->will($this->returnValue($token));
-
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container
-            ->expects($this->once())
-            ->method('has')
-            ->with('security.token_storage')
-            ->will($this->returnValue(true));
-
-        $container
-            ->expects($this->once())
-            ->method('get')
-            ->with('security.token_storage')
-            ->will($this->returnValue($tokenStorage));
-
-        return $container;
     }
 }
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -102,6 +102,10 @@
             <argument type="service" id="request_stack" />
         </service>
 
+        <service id="security.current_user_provider" class="Symfony\Component\Security\Core\User\CurrentUserProvider">
+            <argument type="service" id="security.token_storage" />
+        </service>
+
         <!-- Authorization related services -->
         <service id="security.access.decision_manager" class="%security.access.decision_manager.class%" public="false">
             <argument type="collection" />

--- a/src/Symfony/Component/Security/Core/Tests/User/CurrentUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/CurrentUserProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\User;
+
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\CurrentUserProvider;
+use Symfony\Component\Security\Core\User\User;
+
+class CurrentUserProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetUser()
+    {
+        $user = new User('user', 'pass');
+        $token = new UsernamePasswordToken($user, 'pass', 'default', array('ROLE_USER'));
+
+        $service = new CurrentUserProvider($this->getTokenStorage($token));
+
+        $this->assertSame($service->getUser(), $user);
+    }
+
+    public function testGetUserAnonymousUserConvertedToNull()
+    {
+        $token = new AnonymousToken('default', 'anon.');
+
+        $service = new CurrentUserProvider($this->getTokenStorage($token));
+
+        $this->assertNull($service->getUser());
+    }
+
+    public function testGetUserWithEmptyTokenStorage()
+    {
+        $service = new CurrentUserProvider($this->getTokenStorage(null));
+
+        $this->assertNull($service->getUser());
+    }
+
+    /**
+     * @param $token
+     *
+     * @return TokenStorageInterface
+     */
+    private function getTokenStorage($token = null)
+    {
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage');
+        $tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->will($this->returnValue($token));
+
+        return $tokenStorage;
+    }
+}

--- a/src/Symfony/Component/Security/Core/User/CurrentUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/CurrentUserProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Symfony\Component\Security\Core\User;
+
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Current User Provider.
+ *
+ * This provider gives you the current logged in user.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class CurrentUserProvider
+{
+    /**
+     * @var TokenStorageInterface tokenStorage
+     */
+    private $tokenStorage;
+
+    /**
+     * @param TokenStorageInterface $tokenStorage
+     */
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * Get a user from the Security Token Storage.
+     *
+     * @return mixed
+     *
+     * @see TokenInterface::getUser()
+     */
+    public function getUser()
+    {
+        if (null === $token = $this->tokenStorage->getToken()) {
+            return;
+        }
+
+        if (!is_object($user = $token->getUser())) {
+            // e.g. anonymous authentication
+            return;
+        }
+
+        return $user;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/5192 |

I believe it would be nice to make it little easier to retrieve the current user. This provider will hide the complexity with the token and check if the `$token->getUser()` is an object or a string. 
