### PR TITLE
[2.7][Form] Fix default placeholder resolution if choice option required is false

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -248,7 +248,7 @@ class ChoiceType extends AbstractType
         };
 
         $emptyValue = function (Options $options) {
-            return $options['required'] ? null : '';
+            return ($options['required'] && empty($options['choices'])) || !$options['required'] ? '' : null;
         };
 
         // for BC with the "empty_value" option


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14165, #14393 |
| License | MIT |
| Doc PR | - |

If a choice is required in a form and no choice is set, placeholder should be resolved to an empty string, and null if not.
