### PR TITLE
[VarDumper] Added support for SplFileInfo

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -20,6 +20,13 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class SplCaster
 {
+    private static $splFileObjectFlags = array(
+        \SplFileObject::DROP_NEW_LINE => 'DROP_NEW_LINE',
+        \SplFileObject::READ_AHEAD => 'READ_AHEAD',
+        \SplFileObject::SKIP_EMPTY => 'SKIP_EMPTY',
+        \SplFileObject::READ_CSV => 'READ_CSV',
+    );
+
     public static function castArrayObject(\ArrayObject $c, array $a, Stub $stub, $isNested)
     {
         $prefix = Caster::PREFIX_VIRTUAL;
@@ -117,6 +124,54 @@ class SplCaster
             if (isset($a[$prefix.$key])) {
                 $a[$prefix.$key] = new ConstStub(date('Y-m-d H:i:s', $a[$prefix.$key]), $a[$prefix.$key]);
             }
+        }
+
+        return $a;
+    }
+
+    public static function castFileObject(\SplFileObject $c, array $a, Stub $stub, $isNested)
+    {
+        static $map = array(
+            'csvControl' => 'getCsvControl',
+            'flags' => 'getFlags',
+            'maxLineLen' => 'getMaxLineLen',
+            'fstat' => 'fstat',
+            'eof' => 'eof',
+            'key' => 'key',
+        );
+
+        $prefix = Caster::PREFIX_VIRTUAL;
+
+        foreach ($map as $key => $accessor) {
+            try {
+                $a[$prefix.$key] = $c->$accessor();
+            } catch (\Exception $e) {
+            }
+        }
+
+        if (isset($a[$prefix.'flags'])) {
+            $flagsArray = array();
+            foreach (self::$splFileObjectFlags as $value => $name) {
+                if ($a[$prefix.'flags'] & $value) {
+                    $flagsArray[] = $name;
+                }
+            }
+            $a[$prefix.'flags'] = new ConstStub(implode('|', $flagsArray), $a[$prefix.'flags']);
+        }
+
+        if (isset($a[$prefix.'fstat'])) {
+            $fstat = $a[$prefix.'fstat'];
+            $fstat = array(
+                'dev' => $fstat['dev'],
+                'ino' => $fstat['ino'],
+                'nlink' => $fstat['nlink'],
+                'rdev' => $fstat['rdev'],
+                'blksize' => $fstat['blksize'],
+                'blocks' => $fstat['blocks'],
+                '…' => '…'.(count($fstat) - 6),
+            );
+
+            $a[$prefix.'fstat'] = $fstat;
         }
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -72,6 +72,56 @@ class SplCaster
         return $a;
     }
 
+    public static function castFileInfo(\SplFileInfo $c, array $a, Stub $stub, $isNested)
+    {
+        static $map = array(
+            'path' => 'getPath',
+            'filename' => 'getFilename',
+            'basename' => 'getBasename',
+            'pathname' => 'getPathname',
+            'extension' => 'getExtension',
+            'realPath' => 'getRealPath',
+            'aTime' => 'getATime',
+            'mTime' => 'getMTime',
+            'cTime' => 'getCTime',
+            'inode' => 'getInode',
+            'size' => 'getSize',
+            'perms' => 'getPerms',
+            'owner' => 'getOwner',
+            'group' => 'getGroup',
+            'type' => 'getType',
+            'writable' => 'isWritable',
+            'readable' => 'isReadable',
+            'executable' => 'isExecutable',
+            'file' => 'isFile',
+            'dir' => 'isDir',
+            'link' => 'isLink',
+            'linkTarget' => 'getLinkTarget',
+        );
+
+        $prefix = Caster::PREFIX_VIRTUAL;
+
+        foreach ($map as $key => $accessor) {
+            try {
+                $a[$prefix.$key] = $c->$accessor();
+            } catch (\Exception $e) {
+            }
+        }
+
+        if (isset($a[$prefix.'perms'])) {
+            $a[$prefix.'perms'] = new ConstStub(sprintf('0%o', $a[$prefix.'perms']), $a[$prefix.'perms']);
+        }
+
+        static $mapDate = array('aTime', 'mTime', 'cTime');
+        foreach ($mapDate as $key) {
+            if (isset($a[$prefix.$key])) {
+                $a[$prefix.$key] = new ConstStub(date('Y-m-d H:i:s', $a[$prefix.$key]), $a[$prefix.$key]);
+            }
+        }
+
+        return $a;
+    }
+
     public static function castFixedArray(\SplFixedArray $c, array $a, Stub $stub, $isNested)
     {
         $a += array(

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -79,6 +79,7 @@ abstract class AbstractCloner implements ClonerInterface
         'ArrayObject' => 'Symfony\Component\VarDumper\Caster\SplCaster::castArrayObject',
         'SplDoublyLinkedList' => 'Symfony\Component\VarDumper\Caster\SplCaster::castDoublyLinkedList',
         'SplFileInfo' => 'Symfony\Component\VarDumper\Caster\SplCaster::castFileInfo',
+        'SplFileObject' => 'Symfony\Component\VarDumper\Caster\SplCaster::castFileObject',
         'SplFixedArray' => 'Symfony\Component\VarDumper\Caster\SplCaster::castFixedArray',
         'SplHeap' => 'Symfony\Component\VarDumper\Caster\SplCaster::castHeap',
         'SplObjectStorage' => 'Symfony\Component\VarDumper\Caster\SplCaster::castObjectStorage',

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -78,6 +78,7 @@ abstract class AbstractCloner implements ClonerInterface
 
         'ArrayObject' => 'Symfony\Component\VarDumper\Caster\SplCaster::castArrayObject',
         'SplDoublyLinkedList' => 'Symfony\Component\VarDumper\Caster\SplCaster::castDoublyLinkedList',
+        'SplFileInfo' => 'Symfony\Component\VarDumper\Caster\SplCaster::castFileInfo',
         'SplFixedArray' => 'Symfony\Component\VarDumper\Caster\SplCaster::castFixedArray',
         'SplHeap' => 'Symfony\Component\VarDumper\Caster\SplCaster::castHeap',
         'SplObjectStorage' => 'Symfony\Component\VarDumper\Caster\SplCaster::castObjectStorage',

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\VarDumper\Tests\Caster;
 
-use Symfony\Component\VarDumper\Cloner\VarCloner;
-use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Test\VarDumperTestCase;
 
 /**

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
@@ -23,20 +23,20 @@ class SplCasterTest extends VarDumperTestCase
         return array(
             array(__FILE__, <<<'EOTXT'
 SplFileInfo {
-  path: "%s/src/Symfony/Component/VarDumper/Tests/Caster"
+  path: "%s/Tests/Caster"
   filename: "SplCasterTest.php"
   basename: "SplCasterTest.php"
-  pathname: "%s/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php"
+  pathname: "%s/Tests/Caster/SplCasterTest.php"
   extension: "php"
-  realPath: "%s/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php"
+  realPath: "%s/Tests/Caster/SplCasterTest.php"
   aTime: %s-%s-%d %d:%d:%d
   mTime: %s-%s-%d %d:%d:%d
   cTime: %s-%s-%d %d:%d:%d
   inode: %d
   size: %d
-  perms: 0100644
-  owner: 1000
-  group: 1000
+  perms: 0%d
+  owner: %d
+  group: %d
   type: "file"
   writable: true
   readable: true
@@ -71,5 +71,54 @@ EOTXT
     public function testCastFileInfo($file, $dump)
     {
         $this->assertDumpMatchesFormat($dump, new \SplFileInfo($file));
+    }
+
+    public function testCastFileObject()
+    {
+        $var = new \SplFileObject(__FILE__);
+        $var->setFlags(\SplFileObject::DROP_NEW_LINE | \SplFileObject::SKIP_EMPTY);
+        $dump = <<<'EOTXT'
+SplFileObject {
+  path: "%s/Tests/Caster"
+  filename: "SplCasterTest.php"
+  basename: "SplCasterTest.php"
+  pathname: "%s/Tests/Caster/SplCasterTest.php"
+  extension: "php"
+  realPath: "%s/Tests/Caster/SplCasterTest.php"
+  aTime: %s-%s-%d %d:%d:%d
+  mTime: %s-%s-%d %d:%d:%d
+  cTime: %s-%s-%d %d:%d:%d
+  inode: %d
+  size: %d
+  perms: 0%d
+  owner: %d
+  group: %d
+  type: "file"
+  writable: true
+  readable: true
+  executable: false
+  file: true
+  dir: false
+  link: false
+  csvControl: array:2 [
+    0 => ","
+    1 => """
+  ]
+  flags: DROP_NEW_LINE|SKIP_EMPTY
+  maxLineLen: 0
+  fstat: array:7 [
+    "dev" => %d
+    "ino" => %d
+    "nlink" => %d
+    "rdev" => 0
+    "blksize" => %d
+    "blocks" => %d
+    "…" => "…20"
+  ]
+  eof: false
+  key: 0
+}
+EOTXT;
+        $this->assertDumpMatchesFormat($dump, $var);
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use Symfony\Component\VarDumper\Test\VarDumperTestCase;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class SplCasterTest extends VarDumperTestCase
+{
+    public function getCastFileInfoTests()
+    {
+        return array(
+            array(__FILE__, <<<'EOTXT'
+SplFileInfo {
+  path: "%s/src/Symfony/Component/VarDumper/Tests/Caster"
+  filename: "SplCasterTest.php"
+  basename: "SplCasterTest.php"
+  pathname: "%s/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php"
+  extension: "php"
+  realPath: "%s/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php"
+  aTime: %s-%s-%d %d:%d:%d
+  mTime: %s-%s-%d %d:%d:%d
+  cTime: %s-%s-%d %d:%d:%d
+  inode: %d
+  size: %d
+  perms: 0100644
+  owner: 1000
+  group: 1000
+  type: "file"
+  writable: true
+  readable: true
+  executable: false
+  file: true
+  dir: false
+  link: false
+}
+EOTXT
+            ),
+            array('https://google.com/about', <<<'EOTXT'
+SplFileInfo {
+  path: "https://google.com"
+  filename: "about"
+  basename: "about"
+  pathname: "https://google.com/about"
+  extension: ""
+  realPath: false
+  writable: false
+  readable: false
+  executable: false
+  file: false
+  dir: false
+  link: false
+}
+EOTXT
+            ),
+        );
+    }
+
+    /** @dataProvider getCastFileInfoTests */
+    public function testCastFileInfo($file, $dump)
+    {
+        $this->assertDumpMatchesFormat($dump, new \SplFileInfo($file));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Before:

```
SplFileInfo {#3}
```

After:

```
SplFileInfo {#3
  path: "/home/greg/dev/github.com/lyrixx/gaga-photo/fixtures"
  filename: "grisou.jpg"
  basename: "grisou.jpg"
  pathname: "/home/greg/dev/github.com/lyrixx/gaga-photo/fixtures/grisou.jpg"
  extension: "jpg"
  realPath: "/home/greg/dev/github.com/lyrixx/gaga-photo/fixtures/grisou.jpg"
  aTime: 2015-04-20 23:21:15
  mTime: 2014-08-17 15:37:36
  cTime: 2015-04-20 23:09:51
  inode: 12197643
  size: 966553
  perms: 0100750
  owner: 1000
  group: 1000
  type: "file"
  writable: true
  readable: true
  executable: true
  file: true
  dir: false
  link: false
}
```

For a link:

```
SplFileInfo {#3
  path: ""
  filename: "link"
  basename: "link"
  pathname: "link"
  extension: ""
  realPath: "/home/greg/dev/github.com/symfony/var-dumper/composer.json"
  aTime: 2015-04-20 23:39:15
  mTime: 2015-04-20 23:39:15
  cTime: 2015-04-20 23:39:15
  inode: 11272232
  size: 967
  perms: 0100644
  owner: 1000
  group: 1000
  type: "link"
  writable: true
  readable: true
  executable: false
  file: true
  dir: false
  link: true
  linkTarget: "composer.json"
}
```

For a remote file:

```
SplFileInfo {#3
  path: "http://google.com"
  filename: "foobar.php"
  basename: "foobar.php"
  pathname: "http://google.com/foobar.php"
  extension: "php"
  realPath: false
  writable: false
  readable: false
  executable: false
  file: false
  dir: false
  link: false
}
```

For a CSV:

```
SplFileObject {#3
  path: ""
  filename: "test.csv"
  basename: "test.csv"
  pathname: "test.csv"
  extension: "csv"
  realPath: "/home/greg/dev/github.com/symfony/var-dumper/test.csv"
  aTime: 2015-04-21 12:55:07
  mTime: 2015-04-21 12:55:07
  cTime: 2015-04-21 12:55:07
  inode: 11272237
  size: 0
  perms: 0100644
  owner: 1000
  group: 1000
  type: "file"
  writable: true
  readable: true
  executable: false
  file: true
  dir: false
  link: false
  csvControl: array:2 [
    0 => ","
    1 => """
  ]
  flags: SKIP_EMPTY|READ_CSV
  maxLineLen: 0
  fstat: array:7 [
    "dev" => 64513
    "ino" => 11272237
    "nlink" => 1
    "rdev" => 0
    "blksize" => 4096
    "blocks" => 0
    "…" => "…20"
  ]
  eof: false
  key: 0
}
```
