### PR TITLE
[FrameworkBundle] Add a doctrine cache service definition for validator mapping

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -39,6 +39,16 @@
             <argument>%validator.mapping.cache.prefix%</argument>
         </service>
 
+        <service id="validator.mapping.cache.doctrine.apc" class="Symfony\Component\Validator\Mapping\Cache\DoctrineCache" public="false">
+            <argument type="service">
+                <service class="Doctrine\Common\Cache\ApcCache">
+                    <call method="setNamespace">
+                        <argument>%validator.mapping.cache.prefix%</argument>
+                    </call>
+                </service>
+            </argument>
+        </service>
+
         <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">
             <argument type="service" id="service_container" />
             <argument type="collection" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/5409 |

Following #12975, this PR only registers a new service so it's possible to use the new doctrine based cache implementation instead of the deprecated one. To use it, the end user would need to configure it in his `config.yml`:

``` yaml
framework:
    validation:
        cache: validator.mapping.cache.doctrine.apc
```

In 3.0 we'll be able to replace the deprecated definition by aliasing `validator.mapping.cache.apc` to `validator.mapping.cache.doctrine.apc`.

I thought of automatic wrapping of services which implement doctrine interface, but decided it would be too magic.

I'm not convinced if APC is a good default anymore and hope for some discussion. I've used it as it's also used in serializer, and probably translation (see #13986). Since there's a built in opcache in more recent PHP versions, and apcu doesn't seem to be stable, there are better choices. Perhaps a better default would be a filesystem cache (not better performing, but it works anywhere).
