### PR TITLE
[Framework] added test for router commands.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class RouterDebugCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDebugAllRoutes()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array('name' => null));
+
+        $this->assertEquals(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('[router] Current routes', $tester->getDisplay());
+    }
+
+    public function testDebugSingleRoute()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array('name' => 'foo'));
+
+        $this->assertEquals(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('[router] Route "foo"', $tester->getDisplay());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testDebugInvalidRoute()
+    {
+        $this->createCommandTester()->execute(array('name' => 'test'));
+    }
+
+    /**
+     * @return CommandTester
+     */
+    private function createCommandTester()
+    {
+        $application = new Application();
+
+        $command = new RouterDebugCommand();
+        $command->setContainer($this->getContainer());
+        $application->add($command);
+
+        return new CommandTester($application->find('router:debug'));
+    }
+
+    private function getContainer()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('foo', new Route('foo'));
+        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router
+            ->expects($this->atLeastOnce())
+            ->method('getRouteCollection')
+            ->will($this->returnValue($routeCollection))
+        ;
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('router')
+            ->will($this->returnValue(true))
+        ;
+        $container
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->with('router')
+            ->will($this->returnValue($router))
+        ;
+
+        return $container;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand;
+use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RequestContext;
+
+class RouterMatchCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWithMatchPath()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array('path_info' => '/foo', 'foo'));
+
+        $this->assertEquals(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('[router] Route "foo"', $tester->getDisplay());
+    }
+
+    public function testWithNotMatchPath()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array('path_info' => '/test', 'foo'));
+
+        $this->assertEquals(1, $ret, 'Returns 1 in case of failure');
+        $this->assertContains('None of the routes match the path "/test"', $tester->getDisplay());
+    }
+
+    /**
+     * @return CommandTester
+     */
+    private function createCommandTester()
+    {
+        $application = new Application();
+
+        $command = new RouterMatchCommand();
+        $command->setContainer($this->getContainer());
+        $application->add($command);
+
+        $command = new RouterDebugCommand();
+        $command->setContainer($this->getContainer());
+        $application->add($command);
+
+        return new CommandTester($application->find('router:match'));
+    }
+
+    private function getContainer()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('foo', new Route('foo'));
+        $requestContext = new RequestContext();
+        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router
+            ->expects($this->any())
+            ->method('getRouteCollection')
+            ->will($this->returnValue($routeCollection))
+        ;
+        $router
+            ->expects($this->any())
+            ->method('getContext')
+            ->will($this->returnValue($requestContext))
+        ;
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('router')
+            ->will($this->returnValue(true))
+        ;
+        $container
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->with('router')
+            ->will($this->returnValue($router))
+        ;
+
+        return $container;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | ~ |
| Tests pass? | yes |
| License | MIT |
- [x] router:debug
- [x] router:match
