### PR TITLE
[DependencyInjection] Fix self-referenced 'service_container' service

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
@@ -27,8 +27,6 @@ class LazyServiceProjectServiceContainer extends Container
         $this->scopedServices =
         $this->scopeStacks = array();
 
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -86,8 +86,6 @@ class Container implements IntrospectableContainerInterface
     public function __construct(ParameterBagInterface $parameterBag = null)
     {
         $this->parameterBag = $parameterBag ?: new ParameterBag();
-
-        $this->set('service_container', $this);
     }
 
     /**
@@ -197,12 +195,10 @@ class Container implements IntrospectableContainerInterface
 
         $id = strtolower($id);
 
-        if ('service_container' === $id) {
-            // BC: 'service_container' is no longer a self-reference but always
-            // $this, so ignore this call.
-            // @todo Throw InvalidArgumentException in next major release.
-            return;
+        if (self::CONTAINER_ID === $id) {
+            throw new InvalidArgumentException(sprintf('You cannot overwrite the "%s" service.', self::CONTAINER_ID));
         }
+
         if (self::SCOPE_CONTAINER !== $scope) {
             if (!isset($this->scopedServices[$scope])) {
                 throw new RuntimeException(sprintf('You cannot set service "%s" of inactive scope.', $id));
@@ -239,7 +235,7 @@ class Container implements IntrospectableContainerInterface
     {
         $id = strtolower($id);
 
-        if ('service_container' === $id) {
+        if (self::CONTAINER_ID === $id) {
             return true;
         }
 
@@ -280,7 +276,7 @@ class Container implements IntrospectableContainerInterface
             if ($strtolower) {
                 $id = strtolower($id);
             }
-            if ('service_container' === $id) {
+            if (self::CONTAINER_ID === $id) {
                 return $this;
             }
             if (isset($this->aliases[$id])) {
@@ -354,9 +350,7 @@ class Container implements IntrospectableContainerInterface
     {
         $id = strtolower($id);
 
-        if ('service_container' === $id) {
-            // BC: 'service_container' was a synthetic service previously.
-            // @todo Change to false in next major release.
+        if (self::CONTAINER_ID === $id) {
             return true;
         }
 
@@ -381,7 +375,7 @@ class Container implements IntrospectableContainerInterface
                 $ids[] = self::underscore($match[1]);
             }
         }
-        $ids[] = 'service_container';
+        $ids[] = self::CONTAINER_ID;
 
         return array_unique(array_merge($ids, array_keys($this->services)));
     }

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -28,6 +28,7 @@ interface ContainerInterface
     const EXCEPTION_ON_INVALID_REFERENCE = 1;
     const NULL_ON_INVALID_REFERENCE = 2;
     const IGNORE_ON_INVALID_REFERENCE = 3;
+    const CONTAINER_ID = 'service_container';
     const SCOPE_CONTAINER = 'container';
     const SCOPE_PROTOTYPE = 'prototype';
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -185,7 +185,7 @@ class GraphvizDumper extends Dumper
             }
 
             if (!$container->hasDefinition($id)) {
-                $class = ('service_container' === $id) ? get_class($this->container) : get_class($service);
+                $class = (ContainerInterface::CONTAINER_ID === $id) ? get_class($this->container) : get_class($service);
                 $nodes[$id] = array('class' => str_replace('\\', '\\\\', $class), 'attributes' => $this->options['node.instance']);
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -203,7 +203,7 @@ class PhpDumper extends Dumper
 
         $code = '';
         foreach ($calls as $id => $callCount) {
-            if ('service_container' === $id || $id === $cId) {
+            if (ContainerInterface::CONTAINER_ID === $id || $id === $cId) {
                 continue;
             }
 
@@ -905,8 +905,6 @@ EOF;
         \$this->scopedServices =
         \$this->scopeStacks = array();
 
-        \$this->set('service_container', \$this);
-
 EOF;
 
         $code .= "\n";
@@ -1431,7 +1429,7 @@ EOF;
      */
     private function getServiceCall($id, Reference $reference = null)
     {
-        if ('service_container' === $id) {
+        if (ContainerInterface::CONTAINER_ID === $id) {
             return '$this';
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/legacy-container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/legacy-container9.php
@@ -4,7 +4,6 @@ require_once __DIR__.'/../includes/classes.php';
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\ExpressionLanguage\Expression;
 
 $container = new ContainerBuilder();
 $container->

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -30,8 +30,6 @@ class ProjectServiceContainer extends Container
         $this->scopedServices =
         $this->scopeStacks = array();
 
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -34,8 +34,6 @@ class ProjectServiceContainer extends Container
         $this->scopedServices =
         $this->scopeStacks = array();
 
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -30,8 +30,6 @@ class ProjectServiceContainer extends Container
         $this->scopedServices =
         $this->scopeStacks = array();
 
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
         $this->methodMap = array(


### PR DESCRIPTION
..to allow garbage collection.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Follow up of #11422

I created the constant `Symfony\Component\DependencyInjection\ContainerInterface::CONTAINER_ID` while I was at it and removed an unused use statement in a test. Let me know if I should remove the constant again or create a separate PR.
