### PR TITLE
[StringUtil] Fixed singularification of 'selfies'

### DIFF
--- a/src/Symfony/Component/PropertyAccess/StringUtil.php
+++ b/src/Symfony/Component/PropertyAccess/StringUtil.php
@@ -60,6 +60,9 @@ class StringUtil
         // indices (index), appendices (appendix), prices (price)
         array('seci', 4, false, true, array('ex', 'ix', 'ice')),
 
+        // selfies (selfie)
+        array('seifles', 7, true, true, 'selfie'),
+
         // movies (movie)
         array('seivom', 6, true, true, 'movie'),
 

--- a/src/Symfony/Component/PropertyAccess/Tests/StringUtilTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/StringUtilTest.php
@@ -119,6 +119,7 @@ class StringUtilTest extends \PHPUnit_Framework_TestCase
             array('sandwiches', array('sandwich', 'sandwiche')),
             array('scarves', array('scarf', 'scarve', 'scarff')),
             array('schemas', 'schema'), //schemata
+            array('selfies', 'selfie'),
             array('sheriffs', 'sheriff'),
             array('shoes', array('sho', 'shoe')),
             array('spies', 'spy'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Related to #14191.

At tonights PHP Stockholm meetup we discussed #14191, and we noticed that "selfie" was incorrectly handled as well. One selfie, many selfies.
