### PR TITLE
[CssSelector] Added support for caching parsed css selectors

### DIFF
--- a/src/Symfony/Component/CssSelector/SelectorCache/ArraySelectorCache.php
+++ b/src/Symfony/Component/CssSelector/SelectorCache/ArraySelectorCache.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\CssSelector\SelectorCache;
+
+/**
+ * @author Diego Saint Esteben <diego@saintesteben.me>
+ */
+class ArraySelectorCache implements SelectorCacheInterface
+{
+    /**
+     * @var array
+     */
+    private $cache = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save($key, $expr)
+    {
+        $this->cache[$key] = $expr;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($key)
+    {
+        return isset($this->cache[$key]) ? $this->cache[$key] : null;
+    }
+}

--- a/src/Symfony/Component/CssSelector/SelectorCache/SelectorCacheInterface.php
+++ b/src/Symfony/Component/CssSelector/SelectorCache/SelectorCacheInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\CssSelector\SelectorCache;
+
+/**
+ * @author Diego Saint Esteben <diego@saintesteben.me>
+ */
+interface SelectorCacheInterface
+{
+    /**
+     * Saves an XPath expression in the cache.
+     *
+     * @param string $key  The cache key
+     * @param string $expr A XPath expression.
+     */
+    public function save($key, $expr);
+
+    /**
+     * Fetches an XPath expression from the cache.
+     *
+     * @param string $key The cache key
+     *
+     * @return string|null
+     */
+    public function fetch($key);
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | - |

This PR adds support for caching the parsed css selectors to improve performance.

![screenshot from 2015-04-23 10 31 07](https://cloud.githubusercontent.com/assets/510842/7298262/c2f20fd0-e9a4-11e4-8416-229e7ee67fb8.png)

The script used is:

``` php
<?php

require_once __DIR__.'/vendor/autoload.php';

use Symfony\Component\CssSelector\CssSelector;

for ($i = 0; $i < 1000; $i++) {
    echo CssSelector::toXpath('div.foo#bar') . PHP_EOL;
}
```
