### PR TITLE
[RFC][Form] Allow FormTypeExtension to apply to every FormType

### DIFF
--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -112,6 +112,15 @@ class FormRegistry implements FormRegistryInterface
 
         $typeExtensions = array();
 
+        if (!$parentType) {
+            foreach ($this->extensions as $extension) {
+                $typeExtensions = array_merge(
+                    $typeExtensions,
+                    $extension->getTypeExtensions(FormTypeExtensionInterface::ALL_TYPES)
+                );
+            }
+        }
+
         foreach ($this->extensions as $extension) {
             $typeExtensions = array_merge(
                 $typeExtensions,

--- a/src/Symfony/Component/Form/FormTypeExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormTypeExtensionInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 interface FormTypeExtensionInterface
 {
+    const ALL_TYPES = 'ALL';
+
     /**
      * Builds the form.
      *

--- a/src/Symfony/Component/Form/Tests/Fixtures/GenericTypeExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/GenericTypeExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class GenericTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->setAttribute('generic_foo', 'x');
+    }
+
+    public function getExtendedType()
+    {
+        return self::ALL_TYPES;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Tests\Fixtures\FooSubTypeWithParentInstance;
 use Symfony\Component\Form\Tests\Fixtures\FooSubType;
 use Symfony\Component\Form\Tests\Fixtures\FooTypeBazExtension;
 use Symfony\Component\Form\Tests\Fixtures\FooTypeBarExtension;
+use Symfony\Component\Form\Tests\Fixtures\GenericTypeExtension;
 use Symfony\Component\Form\Tests\Fixtures\FooType;
 
 /**
@@ -103,6 +104,27 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
         $this->resolvedTypeFactory->expects($this->once())
             ->method('createResolvedType')
             ->with($type, array($ext1, $ext2))
+            ->will($this->returnValue($resolvedType));
+
+        $resolvedType->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('foo'));
+
+        $this->assertSame($resolvedType, $this->registry->getType('foo'));
+    }
+
+    public function testGetTypeWithoutParentWithGenericTypeExtensions()
+    {
+        $type = new FooType();
+        $ext = new GenericTypeExtension();
+        $resolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+
+        $this->extension2->addType($type);
+        $this->extension1->addTypeExtension($ext);
+
+        $this->resolvedTypeFactory->expects($this->once())
+            ->method('createResolvedType')
+            ->with($type, array($ext))
             ->will($this->returnValue($resolvedType));
 
         $resolvedType->expects($this->any())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no, but doc discrepancy/regression fixed |
| New feature? | yes, but it was present in previous versions (2.3) and is already mentioned explicitly in doc |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | symfony/symfony-docs#5154 (needs to be rewritten once design is agreed upon) |

In symfony/symfony-docs#5154, @stof seems to imply that there is no way to have a truly generic FormTypeExtension although the documentation definitely mentions it.

Although we could just fix the documentation and let it go, I think the feature could be useful enough and was present in previous versions of Symfony (because the `field` type was extended by all FormTypes). I therefore think this is a regression and the feature should be restored.

I think the current PR is ready to be merged but some design decisions might generate discussion and the doc PR needs to be rewritten once the PR is merged.

Travis build fail is unrelated (Fatal Error [class declared twice] in Component/Debug and Failed test in Bundle/Security).
- [ ] Doc PR need to be rewritten
