### PR TITLE
[DX] Switch user from the WDT

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -24,6 +24,17 @@
                 {{ collector.tokenClass|abbr_class }}
             </div>
             {% endif %}
+            {% if 'ROLE_PREVIOUS_ADMIN' in collector.roles %}
+                <div class="sf-toolbar-info-piece">
+                    <b>Switch to user</b>
+                    <a href="?_switch_user=_exit" title="Switch back">Exit</a>
+                </div>
+            {% elseif 'ROLE_ALLOWED_TO_SWITCH' in collector.roles %}
+                <form class="sf-toolbar-info-piece">
+                    <b>Switch to user</b>
+                    <input name="_switch_user" placeholder="username" required="required" size="15"/>
+                </form>
+            {% endif %}
         {% elseif collector.enabled %}
             You are not authenticated.
         {% else %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -296,6 +296,11 @@
     overflow-y: auto;
 }
 
+.sf-toolbar-block input {
+    border: 1px solid #bbb;
+    padding: 0 4px;
+}
+
 .sf-toolbar-ajax-requests th, .sf-toolbar-ajax-requests td {
     border-bottom: 1px solid #ddd;
     padding: 0 4px;


### PR DESCRIPTION
Before going further, I would like to get your opinion on this feature.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When working with user permissions, it's very convenient to switch between roles and the impersonating feature of Symfony is really useful for that.

http://symfony.com/doc/current/cookbook/security/impersonating_user.html

**Input field to choose the user to impersonate**
![switch_user](https://cloud.githubusercontent.com/assets/400034/7307456/55b49aaa-ea0d-11e4-86b4-3270fa2de1b4.png)

**Link to quit and return to the previous user**
![switch_user_exit](https://cloud.githubusercontent.com/assets/400034/7307462/5bcb71e8-ea0d-11e4-83ab-3c88177ec652.png)

**TODO LIST:**
- [ ] Support customized URL parameter (`_switch_user`)
- [ ] Check roles with `isGranted` instead of looking at the list of roles
- [ ] Support customized role (`ROLE_ALLOWED_TO_SWITCH`)
