### PR TITLE
[Filesystem] deprecate chmod support in dumpFile()

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -480,6 +480,10 @@ class Filesystem
 
         $this->rename($tmpFile, $filename, true);
         if (null !== $mode) {
+            if (func_num_args() > 2) {
+                trigger_error('Support for modifying file permissions is deprecated since version 2.3.12 and will be removed in 3.0.', E_USER_DEPRECATED);
+            }
+
             $this->chmod($filename, $mode);
         }
     }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class FilesystemTest extends FilesystemTestCase
 {
     /**
-     * @var \Symfony\Component\Filesystem\Filesystem $filesystem
+     * @var \Symfony\Component\Filesystem\Filesystem
      */
     private $filesystem = null;
 
@@ -956,6 +956,19 @@ class FilesystemTest extends FilesystemTestCase
     }
 
     public function testDumpFile()
+    {
+        $filename = $this->workspace.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'baz.txt';
+
+        $this->filesystem->dumpFile($filename, 'bar');
+
+        $this->assertFileExists($filename);
+        $this->assertSame('bar', file_get_contents($filename));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDumpFileAndSetPermissions()
     {
         $filename = $this->workspace.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'baz.txt';
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The ability to support a custom permission mask in the `dumpFile()` method is deprecated since Symfony Symfony 2.3.12. This commit adds the `trigger_error()` call if a custom permission mask is passed.
