### PR TITLE
Revert "[HttpKernel] Throw a LogicException when kernel.exception does not led to a Response"

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -229,10 +229,6 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         if (!$event->hasResponse()) {
             $this->finishRequest($request, $type);
 
-            if ($this->dispatcher->hasListeners(KernelEvents::EXCEPTION)) {
-                throw new \LogicException('No listeners of the "kernel.exception" event set a Response', 0, $e);
-            }
-
             throw $e;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -151,7 +151,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         $dispatcher = new EventDispatcher();
         $kernel = new HttpKernel($dispatcher, $this->getResolver(false));
 
-        $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, false);
+        $kernel->handle(new Request());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This partially reverts commit 22f480752209e1877b9b47f486edad464ad079a4:
it broke BC (see https://github.com/silexphp/Silex/pull/1142 and https://github.com/symfony/symfony/commit/22f480752209e1877b9b47f486edad464ad079a4#commitcomment-10857485)
