### PR TITLE
[Validator] Fixed Choice when an empty array is used in the "choices" option

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -32,7 +32,7 @@ class ChoiceValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!$constraint->choices && !$constraint->callback) {
+        if (!is_array($constraint->choices) && !$constraint->callback) {
             throw new ConstraintDefinitionException('Either "choices" or "callback" must be specified on constraint Choice');
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -143,6 +143,20 @@ class ChoiceValidatorTest extends AbstractConstraintValidatorTest
             ->assertRaised();
     }
 
+    public function testInvalidChoiceEmptyChoices()
+    {
+        $constraint = new Choice(array(
+            'choices' => array(),
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate('baz', $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"baz"')
+            ->assertRaised();
+    }
+
     public function testInvalidChoiceMultiple()
     {
         $constraint = new Choice(array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13853 |
| License | MIT |
| Doc PR | - |

This is a backport of #14448 for the 2.3 branch.
