### PR TITLE
[WebProfiler] fix html syntax for input types

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -5,26 +5,27 @@
     </h3>
     <form action="{{ path('_profiler_search') }}" method="get">
         <label for="ip">IP</label>
-        <input type="text" name="ip" id="ip" value="{{ ip }}" placeholder="e.g. 127.0.0.1">
+        <input type="text" name="ip" id="ip" value="{{ ip }}">
         <div class="clear-fix"></div>
         <label for="method">Method</label>
         <select name="method" id="method">
-            {% for m in ['', 'DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT'] %}
+            <option value=""{{ '' == method ? ' selected="selected"' : '' }}>&nbsp;</option>
+            {% for m in ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT'] %}
                 <option{{ m == method ? ' selected="selected"' : '' }}>{{ m }}</option>
             {% endfor %}
         </select>
         <div class="clear-fix"></div>
         <label for="url">URL</label>
-        <input type="text" name="url" id="url" value="{{ url }}" placeholder="e.g. {{ request.baseUrl }}">
+        <input type="text" name="url" id="url" value="{{ url }}">
         <div class="clear-fix"></div>
         <label for="token">Token</label>
-        <input type="text" name="token" id="token" value="{{ token }}" placeholder="e.g. 1f321b">
+        <input type="text" name="token" id="token" value="{{ token }}">
         <div class="clear-fix"></div>
         <label for="start">From</label>
-        <input type="date" name="start" id="start" value="{{ start }}" placeholder="e.g. {{ '-2days'|date('d.m.Y') }}">
+        <input type="date" name="start" id="start" value="{{ start }}">
         <div class="clear-fix"></div>
         <label for="end">Until</label>
-        <input type="date" name="end" id="end" value="{{ end }}" placeholder="e.g. {{ 'now'|date('d.m.Y') }}">
+        <input type="date" name="end" id="end" value="{{ end }}">
         <div class="clear-fix"></div>
         <label for="limit">Limit</label>
         <select name="limit" id="limit">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

HTML validator:

> Attribute placeholder is only allowed when the input type is email, number, password, search, tel, text, or url.
> 
> Element option without attribute label must not be empty.

The other placeholders are totatlly useless. For url it usually just says `e.g.` without a value because the baseUrl is empty...
