### PR TITLE
[HttpFoundation] Fix base URL bug

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1679,7 +1679,8 @@ class Request
      */
     protected function prepareBaseUrl()
     {
-        $filename = basename($this->server->get('SCRIPT_FILENAME'));
+        $fullFilename = $this->server->get('SCRIPT_FILENAME');
+        $filename = basename($fullFilename);
 
         if (basename($this->server->get('SCRIPT_NAME')) === $filename) {
             $baseUrl = $this->server->get('SCRIPT_NAME');
@@ -1733,6 +1734,13 @@ class Request
         // from PATH_INFO or QUERY_STRING
         if (strlen($requestUri) >= strlen($baseUrl) && (false !== $pos = strpos($requestUri, $baseUrl)) && $pos !== 0) {
             $baseUrl = substr($requestUri, 0, $pos + strlen($baseUrl));
+        }
+
+        $documentRoot = $this->server->get('DOCUMENT_ROOT');
+
+        if (null !== $documentRoot && $fullFilename !== rtrim($documentRoot, '/').'/'.ltrim($baseUrl, '/')){
+            // document root + base URL doesn't equal full filename; fall back to blank
+            return '';
         }
 
         return rtrim($baseUrl, '/');

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1370,6 +1370,28 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 '/foo',
                 '/bar+baz',
             ),
+            array(
+                '/foo/bar/app.php/baz',
+                array(
+                    'DOCUMENT_ROOT' => '/home/John Doe/public_html',
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/app.php',
+                    'SCRIPT_NAME' => '/app.php',
+                    'PHP_SELF' => '/app.php',
+                ),
+                '',
+                '/foo/bar/app.php/baz',
+            ),
+            array(
+                '/foo/bar/app.php/baz',
+                array(
+                    'DOCUMENT_ROOT' => '/home/John Doe/public_html',
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo/app.php',
+                    'SCRIPT_NAME' => '/foo/app.php',
+                    'PHP_SELF' => '/foo/app.php',
+                ),
+                '/foo',
+                '/bar/app.php/baz',
+            ),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13617 |
| License | MIT |
| Doc PR | - |

When `mod_rewrite` is used, the application is running under domain root and it receives a request like:

```
/foo/bar/app.php/blog
```

`prepareBaseUrl()` will return `/foo/bar/app.php` which is wrong! It should be `''`. This causes the the `foo/bar` to be stripped away and the path info will be `/blog`.

Live example: http://cmf.symfony.com/foo/bar/app.php/news

This PR fixes that behavior by adding a sanity check that uses `DOCUMENT_ROOT` (if it is available)
