### PR TITLE
[2.3] Static Code Analysis for Components

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -69,11 +69,20 @@ class Cookie
             $this->rawValue = urlencode($value);
         }
         $this->name = $name;
-        $this->expires = null === $expires ? null : (int) $expires;
         $this->path = empty($path) ? '/' : $path;
         $this->domain = $domain;
         $this->secure = (bool) $secure;
         $this->httponly = (bool) $httponly;
+
+        if (null !== $expires) {
+            $timestampAsDateTime = \DateTime::createFromFormat('U', $expires);
+            if (false === $timestampAsDateTime) {
+                throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.'), $expires);
+            }
+
+            $this->expires = $timestampAsDateTime->getTimestamp();
+        }
+
     }
 
     /**
@@ -91,12 +100,6 @@ class Cookie
 
         if (null !== $this->expires) {
             $dateTime = \DateTime::createFromFormat('U', $this->expires, new \DateTimeZone('GMT'));
-
-            if ($dateTime === false) {
-                // this throw will provoke PHP fatal
-                throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.'), $this->expires);
-            }
-
             $cookie .= '; expires='.str_replace('+0000', '', $dateTime->format(self::$dateFormats[0]));
         }
 

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -332,7 +332,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $client->followRedirect();
             $this->fail('->followRedirect() throws a \LogicException if the request was not redirected');
         } catch (\Exception $e) {
-            $this->assertInstanceof('LogicException', $e, '->followRedirect() throws a \LogicException if the request was not redirected');
+            $this->assertInstanceOf('LogicException', $e, '->followRedirect() throws a \LogicException if the request was not redirected');
         }
 
         $client->setNextResponse(new Response('', 302, array('Location' => 'http://www.example.com/redirected')));
@@ -362,7 +362,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $client->followRedirect();
             $this->fail('->followRedirect() throws a \LogicException if the request did not respond with 30x HTTP Code');
         } catch (\Exception $e) {
-            $this->assertInstanceof('LogicException', $e, '->followRedirect() throws a \LogicException if the request did not respond with 30x HTTP Code');
+            $this->assertInstanceOf('LogicException', $e, '->followRedirect() throws a \LogicException if the request did not respond with 30x HTTP Code');
         }
     }
 
@@ -392,7 +392,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $client->followRedirect();
             $this->fail('->followRedirect() throws a \LogicException if the request was redirected and limit of redirections was reached');
         } catch (\Exception $e) {
-            $this->assertInstanceof('LogicException', $e, '->followRedirect() throws a \LogicException if the request was redirected and limit of redirections was reached');
+            $this->assertInstanceOf('LogicException', $e, '->followRedirect() throws a \LogicException if the request was redirected and limit of redirections was reached');
         }
 
         $client->setNextResponse(new Response('', 302, array('Location' => 'http://www.example.com/redirected')));
@@ -562,7 +562,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $client->request('GET', 'http://www.example.com/foo/foobar');
             $this->fail('->request() throws a \RuntimeException if the script has an error');
         } catch (\Exception $e) {
-            $this->assertInstanceof('RuntimeException', $e, '->request() throws a \RuntimeException if the script has an error');
+            $this->assertInstanceOf('RuntimeException', $e, '->request() throws a \RuntimeException if the script has an error');
         }
     }
 

--- a/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
@@ -74,30 +74,30 @@ class CookieTest extends \PHPUnit_Framework_TestCase
 
     public function testFromStringWithUrl()
     {
-        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::FromString('foo=bar', 'http://www.example.com/'));
-        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::FromString('foo=bar', 'http://www.example.com'));
-        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::FromString('foo=bar', 'http://www.example.com?foo'));
-        $this->assertEquals('foo=bar; domain=www.example.com; path=/foo', (string) Cookie::FromString('foo=bar', 'http://www.example.com/foo/bar'));
-        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::FromString('foo=bar; path=/', 'http://www.example.com/foo/bar'));
-        $this->assertEquals('foo=bar; domain=www.myotherexample.com; path=/', (string) Cookie::FromString('foo=bar; domain=www.myotherexample.com', 'http://www.example.com/'));
+        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::fromString('foo=bar', 'http://www.example.com/'));
+        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::fromString('foo=bar', 'http://www.example.com'));
+        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::fromString('foo=bar', 'http://www.example.com?foo'));
+        $this->assertEquals('foo=bar; domain=www.example.com; path=/foo', (string) Cookie::fromString('foo=bar', 'http://www.example.com/foo/bar'));
+        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::fromString('foo=bar; path=/', 'http://www.example.com/foo/bar'));
+        $this->assertEquals('foo=bar; domain=www.myotherexample.com; path=/', (string) Cookie::fromString('foo=bar; domain=www.myotherexample.com', 'http://www.example.com/'));
     }
 
     public function testFromStringThrowsAnExceptionIfCookieIsNotValid()
     {
         $this->setExpectedException('InvalidArgumentException');
-        Cookie::FromString('foo');
+        Cookie::fromString('foo');
     }
 
     public function testFromStringThrowsAnExceptionIfCookieDateIsNotValid()
     {
         $this->setExpectedException('InvalidArgumentException');
-        Cookie::FromString('foo=bar; expires=Flursday July 31st 2020, 08:49:37 GMT');
+        Cookie::fromString('foo=bar; expires=Flursday July 31st 2020, 08:49:37 GMT');
     }
 
     public function testFromStringThrowsAnExceptionIfUrlIsNotValid()
     {
         $this->setExpectedException('InvalidArgumentException');
-        Cookie::FromString('foo=bar', 'foobar');
+        Cookie::fromString('foo=bar', 'foobar');
     }
 
     public function testGetName()

--- a/src/Symfony/Component/BrowserKit/Tests/HistoryTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HistoryTest.php
@@ -54,7 +54,7 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
             $history->current();
             $this->fail('->current() throws a \LogicException if the history is empty');
         } catch (\Exception $e) {
-            $this->assertInstanceof('LogicException', $e, '->current() throws a \LogicException if the history is empty');
+            $this->assertInstanceOf('LogicException', $e, '->current() throws a \LogicException if the history is empty');
         }
 
         $history->add(new Request('http://www.example.com/', 'get'));
@@ -71,7 +71,7 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
             $history->back();
             $this->fail('->back() throws a \LogicException if the history is already on the first page');
         } catch (\Exception $e) {
-            $this->assertInstanceof('LogicException', $e, '->current() throws a \LogicException if the history is already on the first page');
+            $this->assertInstanceOf('LogicException', $e, '->current() throws a \LogicException if the history is already on the first page');
         }
 
         $history->add(new Request('http://www.example1.com/', 'get'));
@@ -90,7 +90,7 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
             $history->forward();
             $this->fail('->forward() throws a \LogicException if the history is already on the last page');
         } catch (\Exception $e) {
-            $this->assertInstanceof('LogicException', $e, '->forward() throws a \LogicException if the history is already on the last page');
+            $this->assertInstanceOf('LogicException', $e, '->forward() throws a \LogicException if the history is already on the last page');
         }
 
         $history->back();

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -107,7 +107,7 @@ PHP
             $that->assertEquals(E_NOTICE, $exception->getSeverity());
             $that->assertEquals(__LINE__ + 40, $exception->getLine());
             $that->assertEquals(__FILE__, $exception->getFile());
-            $that->assertRegexp('/^Notice: Undefined variable: (foo|bar)/', $exception->getMessage());
+            $that->assertRegExp('/^Notice: Undefined variable: (foo|bar)/', $exception->getMessage());
             $that->assertArrayHasKey('foobar', $exception->getContext());
 
             $trace = $exception->getTrace();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -49,7 +49,7 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
 
         $dumpedString = $dumper->dump();
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services11.php', $dumpedString, '->dump() does not add getDefaultParameters() method call if container have no parameters.');
-        $this->assertNotRegexp("/function getDefaultParameters\(/", $dumpedString, '->dump() does not add getDefaultParameters() method definition.');
+        $this->assertNotRegExp("/function getDefaultParameters\(/", $dumpedString, '->dump() does not add getDefaultParameters() method definition.');
     }
 
     public function testDumpOptimizationString()

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -262,7 +262,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testSort($adapter)
     {
         $finder = $this->buildFinder($adapter);
-        $this->assertSame($finder, $finder->sort(function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealpath(), $b->getRealpath()); }));
+        $this->assertSame($finder, $finder->sort(function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealPath(), $b->getRealPath()); }));
         $this->assertIterator($this->toAbsolute(array('foo', 'foo bar', 'foo/bar.tmp', 'test.php', 'test.py', 'toto')), $finder->in(self::$tmpDir)->getIterator());
     }
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -163,7 +163,7 @@ class SortableIteratorTest extends RealIteratorTestCase
             array(SortableIterator::SORT_BY_ACCESSED_TIME, $this->toAbsolute($sortByAccessedTime)),
             array(SortableIterator::SORT_BY_CHANGED_TIME, $this->toAbsolute($sortByChangedTime)),
             array(SortableIterator::SORT_BY_MODIFIED_TIME, $this->toAbsolute($sortByModifiedTime)),
-            array(function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealpath(), $b->getRealpath()); }, $this->toAbsolute($customComparison)),
+            array(function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealPath(), $b->getRealPath()); }, $this->toAbsolute($customComparison)),
         );
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -219,7 +219,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
             }
 
             if ($this->inputTimezone !== $this->outputTimezone) {
-                $dateTime->setTimeZone(new \DateTimeZone($this->inputTimezone));
+                $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));
             }
         } catch (TransformationFailedException $e) {
             throw $e;

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -60,7 +60,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         try {
             // Wrap in <root> node so we can load HTML with multiple tags at
             // the top level
-            $dom->loadXml('<root>'.$html.'</root>');
+            $dom->loadXML('<root>'.$html.'</root>');
         } catch (\Exception $e) {
             $this->fail(sprintf(
                 "Failed loading HTML:\n\n%s\n\nError: %s",

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -147,7 +147,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
 
         $output = new \DateTime('2010-02-03 16:05:06 Asia/Hong_Kong');
         $input = $output->format('Y-m-d H:i:s');
-        $output->setTimeZone(new \DateTimeZone('America/New_York'));
+        $output->setTimezone(new \DateTimeZone('America/New_York'));
 
         $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1037,7 +1037,7 @@ class Response
         $lastModified = $this->headers->get('Last-Modified');
         $modifiedSince = $request->headers->get('If-Modified-Since');
 
-        if ($etags = $request->getEtags()) {
+        if ($etags = $request->getETags()) {
             $notModified = in_array($this->getEtag(), $etags) || in_array('*', $etags);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -179,7 +179,7 @@ class BinaryFileResponseTest extends ResponseTestCase
 
         $file = new FakeFile($realpath, __DIR__.'/File/Fixtures/test');
 
-        BinaryFileResponse::trustXSendFileTypeHeader();
+        BinaryFileResponse::trustXSendfileTypeHeader();
         $response = new BinaryFileResponse($file);
         $reflection = new \ReflectionObject($response);
         $property = $reflection->getProperty('file');

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -122,7 +122,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                     $this->data['controller'] = array(
                         'class' => is_object($controller[0]) ? get_class($controller[0]) : $controller[0],
                         'method' => $controller[1],
-                        'file' => $r->getFilename(),
+                        'file' => $r->getFileName(),
                         'line' => $r->getStartLine(),
                     );
                 } catch (\ReflectionException $re) {
@@ -141,7 +141,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 $this->data['controller'] = array(
                     'class' => $r->getName(),
                     'method' => null,
-                    'file' => $r->getFilename(),
+                    'file' => $r->getFileName(),
                     'line' => $r->getStartLine(),
                 );
             } else {

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -367,7 +367,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         // We keep the etags from the client to handle the case when the client
         // has a different private valid entry which is not cached here.
         $cachedEtags = $entry->getEtag() ? array($entry->getEtag()) : array();
-        $requestEtags = $request->getEtags();
+        $requestEtags = $request->getETags();
         if ($etags = array_unique(array_merge($cachedEtags, $requestEtags))) {
             $subRequest->headers->set('if_none_match', implode(', ', $etags));
         }

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
@@ -41,7 +41,7 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
             $port = $matches[3];
 
             $memcache = new \Memcache();
-            $memcache->addServer($host, $port);
+            $memcache->addserver($host, $port);
 
             $this->memcache = $memcache;
         }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -36,9 +36,9 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
 
         // if else clause because we don't know it
         if (extension_loaded('xdebug')) {
-            $this->assertTrue($c->hasXdebug());
+            $this->assertTrue($c->hasXDebug());
         } else {
-            $this->assertFalse($c->hasXdebug());
+            $this->assertFalse($c->hasXDebug());
         }
 
         // if else clause because we don't know it

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -875,7 +875,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $dateTime = new \DateTime();
         $dateTime->setTimestamp(null === $timestamp ? time() : $timestamp);
-        $dateTime->setTimeZone(new \DateTimeZone($timeZone));
+        $dateTime->setTimezone(new \DateTimeZone($timeZone));
 
         return $dateTime;
     }

--- a/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
@@ -91,7 +91,7 @@ class PhpExecutableFinderTest extends \PHPUnit_Framework_TestCase
         //TODO maybe php executable is custom or even Windows
         if ('\\' === DIRECTORY_SEPARATOR) {
             $this->assertTrue(is_executable($current));
-            $this->assertTrue((bool) preg_match('/'.addSlashes(DIRECTORY_SEPARATOR).'php\.(exe|bat|cmd|com)$/i', $current), '::find() returns the executable PHP with suffixes');
+            $this->assertTrue((bool) preg_match('/'.addslashes(DIRECTORY_SEPARATOR).'php\.(exe|bat|cmd|com)$/i', $current), '::find() returns the executable PHP with suffixes');
         }
     }
 }

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/EntryTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/EntryTest.php
@@ -36,7 +36,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($ace->isAuditSuccess());
         $ace->setAuditSuccess(false);
         $this->assertFalse($ace->isAuditSuccess());
-        $ace->setAuditsuccess(true);
+        $ace->setAuditSuccess(true);
         $this->assertTrue($ace->isAuditSuccess());
     }
 

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -27,7 +27,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
         $stopwatch = new Stopwatch();
         $event = $stopwatch->start('foo', 'cat');
 
-        $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
+        $this->assertInstanceOf('Symfony\Component\Stopwatch\StopwatchEvent', $event);
         $this->assertEquals('cat', $event->getCategory());
     }
 
@@ -74,7 +74,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
         usleep(200000);
         $event = $stopwatch->stop('foo');
 
-        $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
+        $this->assertInstanceOf('Symfony\Component\Stopwatch\StopwatchEvent', $event);
         $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Static Code Analysis with Php Inspections (EA Extended), no functional changes:
- resolved possible PHP Fatal in \Symfony\Component\BrowserKit\Cookie::__toString
- resolved callable name case mismatches
