### PR TITLE
Time Widget does not let users pass key & value to hours, mins, seconds....

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -127,6 +127,9 @@ class DateTimeType extends AbstractType
                 'hours',
                 'minutes',
                 'seconds',
+                'hours_with_keys',
+                'minutes_with_keys',
+                'seconds_with_keys',
                 'with_minutes',
                 'with_seconds',
                 'empty_value',
@@ -251,6 +254,9 @@ class DateTimeType extends AbstractType
             'hours',
             'minutes',
             'seconds',
+            'hours_with_keys',
+            'minutes_with_keys',
+            'seconds_with_keys',
         ));
 
         $resolver->setAllowedValues('input', array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -57,8 +57,12 @@ class TimeType extends AbstractType
             if ('choice' === $options['widget']) {
                 $hours = $minutes = array();
 
-                foreach ($options['hours'] as $hour) {
-                    $hours[$hour] = str_pad($hour, 2, '0', STR_PAD_LEFT);
+                if (isset($options['hours_with_keys']) && is_array($options['hours_with_keys'])) {
+                    $hours = $options['hours_with_keys'];
+                } else {
+                    foreach ($options['hours'] as $hour) {
+                        $hours[$hour] = str_pad($hour, 2, '0', STR_PAD_LEFT);
+                    }
                 }
 
                 // Only pass a subset of the options to children
@@ -66,8 +70,12 @@ class TimeType extends AbstractType
                 $hourOptions['placeholder'] = $options['placeholder']['hour'];
 
                 if ($options['with_minutes']) {
-                    foreach ($options['minutes'] as $minute) {
-                        $minutes[$minute] = str_pad($minute, 2, '0', STR_PAD_LEFT);
+                    if (isset($options['minutes_with_keys']) && is_array($options['minutes_with_keys'])) {
+                        $minutes = $options['minutes_with_keys'];
+                    } else {
+                        foreach ($options['minutes'] as $minute) {
+                            $minutes[$minute] = str_pad($minute, 2, '0', STR_PAD_LEFT);
+                        }
                     }
 
                     $minuteOptions['choices'] = $minutes;
@@ -77,8 +85,12 @@ class TimeType extends AbstractType
                 if ($options['with_seconds']) {
                     $seconds = array();
 
-                    foreach ($options['seconds'] as $second) {
-                        $seconds[$second] = str_pad($second, 2, '0', STR_PAD_LEFT);
+                    if (isset($options['seconds_with_keys']) && is_array($options['seconds_with_keys'])) {
+                        $seconds = $options['seconds_with_keys'];
+                    } else {
+                        foreach ($options['seconds'] as $second) {
+                            $seconds[$second] = str_pad($second, 2, '0', STR_PAD_LEFT);
+                        }
                     }
 
                     $secondOptions['choices'] = $seconds;
@@ -193,6 +205,9 @@ class TimeType extends AbstractType
             'hours' => range(0, 23),
             'minutes' => range(0, 59),
             'seconds' => range(0, 59),
+            'hours_with_keys' => null,
+            'minutes_with_keys' => null,
+            'seconds_with_keys' => null,
             'widget' => 'choice',
             'input' => 'datetime',
             'with_minutes' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -324,6 +324,49 @@ class TimeTypeTest extends TestCase
         ), $view['hour']->vars['choices']);
     }
 
+    public function testHoursWithKeysOption()
+    {
+        $form = $this->factory->create('time', null, array(
+            'hours_with_keys' => array(17=>'5pm', 18=>'6pm'),
+        ));
+
+        $view = $form->createView();
+
+        $this->assertEquals(array(
+            new ChoiceView('5pm', '17', '17'),
+            new ChoiceView('6pm', '18', '18'),
+        ), $view['hour']->vars['choices']);
+    }
+
+    public function testMinutesWithKeysOption()
+    {
+        $form = $this->factory->create('time', null, array(
+            'minutes_with_keys' => array(5=>'five', 10=>'ten'),
+        ));
+
+        $view = $form->createView();
+
+        $this->assertEquals(array(
+            new ChoiceView('five', '5', '5'),
+            new ChoiceView('ten', '10', '10'),
+        ), $view['minute']->vars['choices']);
+    }
+
+    public function testSecondsWithKeysOption()
+    {
+        $form = $this->factory->create('time', null, array(
+            'with_seconds'=>true,
+            'seconds_with_keys' => array(5=>'five', 10=>'ten'),
+        ));
+
+        $view = $form->createView();
+
+        $this->assertEquals(array(
+            new ChoiceView('five', '5', '5'),
+            new ChoiceView('ten', '10', '10'),
+        ), $view['second']->vars['choices']);
+    }
+
     public function testIsMinuteWithinRangeReturnsTrueIfWithin()
     {
         $form = $this->factory->create('time', null, array(


### PR DESCRIPTION
... Add new option to allow that.

This was sparked by https://github.com/symfony/symfony/issues/6587 - a request to allow 12 hour clocks in the time widget, acknowledged as a feature request by @webmozart 

On looking into the Time Widget, I noticed a problem in "choices" mode. The code will overwrite strings the user passes in as zero padded, always and with no option to override.

It seemed to me if there was an option to pass in programmer defined keys and values with whatever the programmer wanted, this feature request would go away - as programmers could pass in 12 hour, 3 hour or whatever odd clock notation they wanted.

This patch introduces 3 new options,   'hours_with_keys' , 'minutes_with_keys' , 'seconds_with_keys' - all null by default. This is done so the behaviour of 'hours', 'minutes' , 'seconds' is unchanged.

If null pased, old behavior holds. If arrays passed, user can set whatever hours, mins and seconds they want in the app!

Now programmers can set 12 hour choice clocks that obey the conventions for their locality really easily!

```
$hours = array(
        0=>'midnight',
        1=>'1am',
        2=>'2am',
        3=>'3am',
        4=>'4am',
        5=>'5am',
        6=>'6am',
        7=>'7am',
        8=>'8am',
        9=>'9am',
        10=>'10am',
        11=>'11am',
        12=>'noon',
        13=>'1pm',
        14=>'2pm',
        15=>'3pm',
        16=>'4pm',
        17=>'5pm',
        18=>'6pm',
        19=>'7pm',
        20=>'8pm',
        21=>'9pm',
        22=>'10pm',
        23=>'11pm',
    );
$startOptions = array(
        ....
        'hours_with_keys'=> $hours,
    );
$builder->add('start_at', 'datetime' , $startOptions);
```

![screen shot 2015-04-13 at 10 57 50](https://cloud.githubusercontent.com/assets/85656/7113463/0306dcd0-e1cc-11e4-9ea4-aa1fee479d02.png)
