### PR TITLE
[TwigBundle] Fix deprecated use of FlattenException

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/PreviewErrorController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/PreviewErrorController.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\Controller;
 
-use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -35,7 +35,7 @@ class PreviewErrorController
 
     public function previewErrorPageAction(Request $request, $code)
     {
-        $exception = FlattenException::create(new \Exception("Something has intentionally gone wrong."), $code);
+        $exception = FlattenException::create(new \Exception('Something has intentionally gone wrong.'), $code);
 
         /*
          * This Request mimics the parameters set by

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\TwigBundle\Tests\Controller;
 
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController;
-use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 
 class ExceptionControllerTest extends TestCase


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
