### PR TITLE
[HttpFoundation] Allow curly braces in trusted host patterns

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -95,7 +95,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
         $paramValues = array('value' => $tokenValue,
                              'lastUsed' => $lastUsed,
                              'series' => $series,);
-        $paramTypes =  array('value' => \PDO::PARAM_STR,
+        $paramTypes = array('value' => \PDO::PARAM_STR,
                              'lastUsed' => DoctrineType::DATETIME,
                              'series' => \PDO::PARAM_STR,);
         $updated = $this->conn->executeUpdate($sql, $paramValues, $paramTypes);

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service.php
@@ -26,9 +26,6 @@ class LazyServiceProjectServiceContainer extends Container
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
-
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
     }

--- a/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
@@ -56,7 +56,7 @@ class TransChoiceTokenParser extends TransTokenParser
         if ($stream->test('into')) {
             // {% transchoice count into "fr" %}
             $stream->next();
-            $locale =  $this->parser->getExpressionParser()->parseExpression();
+            $locale = $this->parser->getExpressionParser()->parseExpression();
         }
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);

--- a/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
@@ -53,7 +53,7 @@ class TransTokenParser extends \Twig_TokenParser
             if ($stream->test('into')) {
                 // {% trans into "fr" %}
                 $stream->next();
-                $locale =  $this->parser->getExpressionParser()->parseExpression();
+                $locale = $this->parser->getExpressionParser()->parseExpression();
             } elseif (!$stream->test(\Twig_Token::BLOCK_END_TYPE)) {
                 throw new \Twig_Error_Syntax('Unexpected token. Twig was looking for the "with", "from", or "into" keyword.', $stream->getCurrent()->getLine(), $stream->getFilename());
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -125,7 +125,7 @@ EOF
                 }
             }
 
-            if ($input->getOption('output-format') == 'xliff') {
+            if ($input->getOption('output-format') == 'xlf') {
                 $output->writeln('Xliff output version is <info>1.2</info>');
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
@@ -51,7 +51,7 @@ class PhpStringTokenParser
 {
     protected static $replacements = array(
         '\\' => '\\',
-        '$' =>  '$',
+        '$' => '$',
         'n' => "\n",
         'r' => "\r",
         't' => "\t",

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
@@ -22,7 +22,7 @@ class FirewallEntryPointTest extends WebTestCase
 
         $client->request('GET', '/secure/resource', array(), array(), array(
             'PHP_AUTH_USER' => 'unknown',
-            'PHP_AUTH_PW'   => 'credentials',
+            'PHP_AUTH_PW' => 'credentials',
         ));
 
         $this->assertEquals(

--- a/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
@@ -110,7 +110,7 @@ EOF
 
     protected function renderException(OutputInterface $output, $template, \Twig_Error $exception, $file = null)
     {
-        $line =  $exception->getTemplateLine();
+        $line = $exception->getTemplateLine();
         $lines = $this->getContext($template, $line);
 
         if ($file) {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -470,7 +470,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             throw new LogicException(sprintf('The service "%s" has a circular reference to itself.', $id));
         }
 
-        if (!$this->hasDefinition($id) && isset($this->aliasDefinitions[$id])) {
+        if (!array_key_exists($id, $this->definitions) && isset($this->aliasDefinitions[$id])) {
             return $this->get($this->aliasDefinitions[$id]);
         }
 
@@ -686,7 +686,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             throw new InvalidArgumentException('$id must be a string, or an Alias object.');
         }
 
-        if ($alias === strtolower($id)) {
+        if ($alias === (string) $id) {
             throw new InvalidArgumentException(sprintf('An alias can not reference itself, got a circular reference on "%s".', $alias));
         }
 
@@ -748,7 +748,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     {
         $id = strtolower($id);
 
-        if (!$this->hasAlias($id)) {
+        if (!isset($this->aliasDefinitions[$id])) {
             throw new InvalidArgumentException(sprintf('The service alias "%s" does not exist.', $id));
         }
 
@@ -866,7 +866,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     {
         $id = strtolower($id);
 
-        if (!$this->hasDefinition($id)) {
+        if (!array_key_exists($id, $this->definitions)) {
             throw new InvalidArgumentException(sprintf('The service definition "%s" does not exist.', $id));
         }
 
@@ -888,8 +888,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function findDefinition($id)
     {
-        while ($this->hasAlias($id)) {
-            $id = (string) $this->getAlias($id);
+        $id = strtolower($id);
+
+        while (isset($this->aliasDefinitions[$id])) {
+            $id = (string) $this->aliasDefinitions[$id];
         }
 
         return $this->getDefinition($id);

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -839,9 +839,6 @@ EOF;
         \$this->services =
         \$this->scopedServices =
         \$this->scopeStacks = array();
-
-        \$this->set('service_container', \$this);
-
 EOF;
 
         $code .= "\n";

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -190,6 +190,13 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($builder->get('bar') === $builder->get('foo'), '->setAlias() creates a service that is an alias to another one');
 
         try {
+            $builder->setAlias('foobar', 'foobar');
+            $this->fail('->setAlias() throws an InvalidArgumentException if the alias references itself');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('An alias can not reference itself, got a circular reference on "foobar".', $e->getMessage(), '->setAlias() throws an InvalidArgumentException if the alias references itself');
+        }
+
+        try {
             $builder->getAlias('foobar');
             $this->fail('->getAlias() throws an InvalidArgumentException if the alias does not exist');
         } catch (\InvalidArgumentException $e) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -29,9 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
-
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services11.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services11.php
@@ -27,9 +27,6 @@ class ProjectServiceContainer extends Container
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
-
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -33,9 +33,6 @@ class ProjectServiceContainer extends Container
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
-
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -29,9 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
-
-        $this->set('service_container', $this);
-
         $this->scopes = array();
         $this->scopeChildren = array();
         $this->methodMap = array(

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -77,7 +77,7 @@ interface EventDispatcherInterface
     public function removeSubscriber(EventSubscriberInterface $subscriber);
 
     /**
-     * Gets the listeners of a specific event or all listeners.
+     * Gets the listeners of a specific event or all listeners sorted by descending priority.
      *
      * @param string $eventName The name of the event
      *

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -553,7 +553,7 @@ class Request
     public static function setTrustedHosts(array $hostPatterns)
     {
         self::$trustedHostPatterns = array_map(function ($hostPattern) {
-            return sprintf('{%s}i', str_replace('}', '\\}', $hostPattern));
+            return sprintf('#%s#i', $hostPattern);
         }, $hostPatterns);
         // we need to reset trusted hosts on trusted host patterns change
         self::$trustedHosts = array();

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -155,7 +155,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
     public function read($sessionId)
     {
         $dbData = $this->getCollection()->findOne(array(
-            $this->options['id_field']   => $sessionId,
+            $this->options['id_field'] => $sessionId,
             $this->options['expiry_field'] => array('$gte' => new \MongoDate()),
         ));
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1601,7 +1601,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('evil.com', $request->getHost());
 
         // add a trusted domain and all its subdomains
-        Request::setTrustedHosts(array('.*\.?trusted.com$'));
+        Request::setTrustedHosts(array('^([a-z]{9}\.)?trusted\.com$'));
 
         // untrusted host
         $request->headers->set('host', 'evil.com');

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -94,14 +94,14 @@ class UriSigner
         ksort($params);
         $url['query'] = http_build_query($params);
 
-        $scheme   = isset($url['scheme']) ? $url['scheme'].'://' : '';
-        $host     = isset($url['host']) ? $url['host'] : '';
-        $port     = isset($url['port']) ? ':'.$url['port'] : '';
-        $user     = isset($url['user']) ? $url['user'] : '';
-        $pass     = isset($url['pass']) ? ':'.$url['pass']  : '';
-        $pass     = ($user || $pass) ? "$pass@" : '';
-        $path     = isset($url['path']) ? $url['path'] : '';
-        $query    = isset($url['query']) && $url['query'] ? '?'.$url['query'] : '';
+        $scheme = isset($url['scheme']) ? $url['scheme'].'://' : '';
+        $host = isset($url['host']) ? $url['host'] : '';
+        $port = isset($url['port']) ? ':'.$url['port'] : '';
+        $user = isset($url['user']) ? $url['user'] : '';
+        $pass = isset($url['pass']) ? ':'.$url['pass']  : '';
+        $pass = ($user || $pass) ? "$pass@" : '';
+        $path = isset($url['path']) ? $url['path'] : '';
+        $query = isset($url['query']) && $url['query'] ? '?'.$url['query'] : '';
         $fragment = isset($url['fragment']) ? '#'.$url['fragment'] : '';
 
         return $scheme.$user.$pass.$host.$port.$path.$query.$fragment;

--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -48,7 +48,7 @@ class ProcessUtils
             }
 
             $escapedArgument = '';
-            $quote =  false;
+            $quote = false;
             foreach (preg_split('/(")/i', $argument, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE) as $part) {
                 if ('"' === $part) {
                     $escapedArgument .= '\\"';

--- a/src/Symfony/Component/PropertyAccess/StringUtil.php
+++ b/src/Symfony/Component/PropertyAccess/StringUtil.php
@@ -60,6 +60,9 @@ class StringUtil
         // indices (index), appendices (appendix), prices (price)
         array('seci', 4, false, true, array('ex', 'ix', 'ice')),
 
+        // selfies (selfie)
+        array('seifles', 7, true, true, 'selfie'),
+
         // movies (movie)
         array('seivom', 6, true, true, 'movie'),
 

--- a/src/Symfony/Component/PropertyAccess/Tests/StringUtilTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/StringUtilTest.php
@@ -119,6 +119,7 @@ class StringUtilTest extends \PHPUnit_Framework_TestCase
             array('sandwiches', array('sandwich', 'sandwiche')),
             array('scarves', array('scarf', 'scarve', 'scarff')),
             array('schemas', 'schema'), //schemata
+            array('selfies', 'selfie'),
             array('sheriffs', 'sheriff'),
             array('shoes', array('sho', 'shoe')),
             array('spies', 'spy'),

--- a/src/Symfony/Component/Security/Resources/translations/security.pt_PT.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.pt_PT.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
-                <target>Ocorreu um excepção durante a autenticação.</target>
+                <target>Ocorreu uma excepção durante a autenticação.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>Authentication credentials could not be found.</source>
@@ -20,7 +20,7 @@
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
-                <target>Este cookie já esta em uso.</target>
+                <target>Este cookie já está em uso.</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>Not privileged to request the resource.</source>
@@ -64,7 +64,7 @@
             </trans-unit>
             <trans-unit id="16">
                 <source>Account is locked.</source>
-                <target>A conta esta trancada.</target>
+                <target>A conta está trancada.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
@@ -26,6 +26,10 @@ class YamlFileDumper extends FileDumper
      */
     protected function format(MessageCatalogue $messages, $domain)
     {
+        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
+            throw new \LogicException('Dumping translations in the YAML format requires the Symfony Yaml component.');
+        }
+
         return Yaml::dump($messages->all($domain));
     }
 

--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -71,7 +71,10 @@ class CsvFileLoader extends ArrayLoader
         }
 
         $catalogue = parent::load($messages, $locale, $domain);
-        $catalogue->addResource(new FileResource($resource));
+
+        if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+            $catalogue->addResource(new FileResource($resource));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Translation/Loader/IcuDatFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IcuDatFileLoader.php
@@ -52,7 +52,10 @@ class IcuDatFileLoader extends IcuResFileLoader
         $messages = $this->flatten($rb);
         $catalogue = new MessageCatalogue($locale);
         $catalogue->add($messages, $domain);
-        $catalogue->addResource(new FileResource($resource.'.dat'));
+
+        if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+            $catalogue->addResource(new FileResource($resource.'.dat'));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Translation/Loader/IcuResFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IcuResFileLoader.php
@@ -52,7 +52,10 @@ class IcuResFileLoader implements LoaderInterface
         $messages = $this->flatten($rb);
         $catalogue = new MessageCatalogue($locale);
         $catalogue->add($messages, $domain);
-        $catalogue->addResource(new DirectoryResource($resource));
+
+        if (class_exists('Symfony\Component\Config\Resource\DirectoryResource')) {
+            $catalogue->addResource(new DirectoryResource($resource));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Translation/Loader/IniFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IniFileLoader.php
@@ -38,7 +38,10 @@ class IniFileLoader extends ArrayLoader
         $messages = parse_ini_file($resource, true);
 
         $catalogue = parent::load($messages, $locale, $domain);
-        $catalogue->addResource(new FileResource($resource));
+
+        if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+            $catalogue->addResource(new FileResource($resource));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Translation/Loader/MoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/MoFileLoader.php
@@ -66,7 +66,10 @@ class MoFileLoader extends ArrayLoader
         }
 
         $catalogue = parent::load($messages, $locale, $domain);
-        $catalogue->addResource(new FileResource($resource));
+
+        if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+            $catalogue->addResource(new FileResource($resource));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
@@ -42,7 +42,10 @@ class PhpFileLoader extends ArrayLoader
         $messages = require $resource;
 
         $catalogue = parent::load($messages, $locale, $domain);
-        $catalogue->addResource(new FileResource($resource));
+
+        if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+            $catalogue->addResource(new FileResource($resource));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -44,7 +44,10 @@ class PoFileLoader extends ArrayLoader
         }
 
         $catalogue = parent::load($messages, $locale, $domain);
-        $catalogue->addResource(new FileResource($resource));
+
+        if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+            $catalogue->addResource(new FileResource($resource));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Translation/Loader/QtFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/QtFileLoader.php
@@ -68,7 +68,10 @@ class QtFileLoader implements LoaderInterface
                 }
                 $translation = $translation->nextSibling;
             }
-            $catalogue->addResource(new FileResource($resource));
+
+            if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+                $catalogue->addResource(new FileResource($resource));
+            }
         }
 
         libxml_use_internal_errors($internalErrors);

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -69,7 +69,10 @@ class XliffFileLoader implements LoaderInterface
 
             $catalogue->set((string) $source, $target, $domain);
         }
-        $catalogue->addResource(new FileResource($resource));
+
+        if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+            $catalogue->addResource(new FileResource($resource));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Translation/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/YamlFileLoader.php
@@ -43,6 +43,10 @@ class YamlFileLoader extends ArrayLoader
             throw new NotFoundResourceException(sprintf('File "%s" not found.', $resource));
         }
 
+        if (!class_exists('Symfony\Component\Yaml\Parser')) {
+            throw new \LogicException('Loading translations from the YAML format requires the Symfony Yaml component.');
+        }
+
         if (null === $this->yamlParser) {
             $this->yamlParser = new YamlParser();
         }
@@ -64,7 +68,10 @@ class YamlFileLoader extends ArrayLoader
         }
 
         $catalogue = parent::load($messages, $locale, $domain);
-        $catalogue->addResource(new FileResource($resource));
+
+        if (class_exists('Symfony\Component\Config\Resource\FileResource')) {
+            $catalogue->addResource(new FileResource($resource));
+        }
 
         return $catalogue;
     }

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -32,7 +32,7 @@ class ChoiceValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!$constraint->choices && !$constraint->callback) {
+        if (!is_array($constraint->choices) && !$constraint->callback) {
             throw new ConstraintDefinitionException('Either "choices" or "callback" must be specified on constraint Choice');
         }
 

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -40,7 +40,7 @@ EOF;
             '42 cannot be used here',
             'this is the message template',
             array(),
-            array('some_value' =>  42),
+            array('some_value' => 42),
             'some_value',
             null
         );

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -143,6 +143,20 @@ class ChoiceValidatorTest extends AbstractConstraintValidatorTest
             ->assertRaised();
     }
 
+    public function testInvalidChoiceEmptyChoices()
+    {
+        $constraint = new Choice(array(
+            'choices' => array(),
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate('baz', $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"baz"')
+            ->assertRaised();
+    }
+
     public function testInvalidChoiceMultiple()
     {
         $constraint = new Choice(array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Let's say I want to whilelist Amazon CloudFront hosts:

``` php
Request::setTrustedHosts(array('^d[a-z0-9]{13}\.cloudfront\.net$'));
```
