### PR TITLE
[FrameworkBundle] Added missing log in server:run command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php
@@ -34,3 +34,5 @@ $_SERVER = array_merge($_SERVER, $_ENV);
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app_dev.php';
 
 require 'app_dev.php';
+
+error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_prod.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_prod.php
@@ -34,3 +34,5 @@ $_SERVER = array_merge($_SERVER, $_ENV);
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app.php';
 
 require 'app.php';
+
+error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_test.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_test.php
@@ -29,3 +29,5 @@ $_SERVER = array_merge($_SERVER, $_ENV);
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app_test.php';
 
 require 'app_test.php';
+
+error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Because of the current implementation of `php -S` command,
logs are skipped if a front controller is specified.

This patch put back missing logs.

For both samples, I play twice an http request.

Before the patch:

```
>(6)[/tmp/symfony_demo] php app/console server:run  -vvv
[2015-04-28 21:45:28] event.DEBUG: Notified event "console.command" to listener "Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure".  
[2015-04-28 21:45:28] event.DEBUG: Notified event "console.command" to listener "Symfony\Bridge\Monolog\Handler\ConsoleHandler::onCommand".  
Server running on http://127.0.0.1:8000

Quit the server with CONTROL-C.
  RUN  '/usr/bin/php5' '-S' '127.0.0.1:8000' '/tmp/symfony_demo/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php'
  ERR  [Tue Apr 28 21:45:30 2015] 127.0.0.1:42755 [200]: /css/app.css
  ERR  [Tue Apr 28 21:45:30 2015] 127.0.0.1:42757 [200]: /js/app.js
  ERR  [Tue Apr 28 21:45:34 2015] 127.0.0.1:42773 [200]: /css/app.css
  ERR  [Tue Apr 28 21:45:34 2015] 127.0.0.1:42774 [200]: /js/app.js
  ERR  ^C
```

After the pacth

```
>(6)[/tmp/symfony_demo] php app/console server:run  -vvv
[2015-04-28 21:45:58] event.DEBUG: Notified event "console.command" to listener "Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure".  
[2015-04-28 21:45:58] event.DEBUG: Notified event "console.command" to listener "Symfony\Bridge\Monolog\Handler\ConsoleHandler::onCommand".  
Server running on http://127.0.0.1:8000

Quit the server with CONTROL-C.
  RUN  '/usr/bin/php5' '-S' '127.0.0.1:8000' '/tmp/symfony_demo/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php'
  ERR  [Tue Apr 28 21:46:00 2015] 127.0.0.1:42788 [200]: /
  ERR  [Tue Apr 28 21:46:00 2015] 127.0.0.1:42795 [200]: /css/app.css
  ERR  [Tue Apr 28 21:46:00 2015] 127.0.0.1:42797 [200]: /js/app.js
  ERR  [Tue Apr 28 21:46:00 2015] 127.0.0.1:42799 [200]: /_wdt/538cdc
  ERR  [Tue Apr 28 21:46:01 2015] 127.0.0.1:42806 [200]: /
  ERR  [Tue Apr 28 21:46:01 2015] 127.0.0.1:42813 [200]: /css/app.css
  ERR  [Tue Apr 28 21:46:01 2015] 127.0.0.1:42814 [200]: /js/app.js
  ERR  [Tue Apr 28 21:46:01 2015] 127.0.0.1:42817 [200]: /_wdt/52f8aa
  ERR  ^C
```
