### PR TITLE
[TwigBundle] add missing Debug component dependency

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/twig-bridge": "~2.6",
+        "symfony/debug": "~2.3",
         "symfony/http-foundation": "~2.5",
         "symfony/http-kernel": "~2.3.24|~2.5.9|~2.6,>=2.6.2"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14480 |
| License | MIT |
| Doc PR |  |

Since #14480, we use the `FlattenException` from the Debug component instead of the deprecated one from the HttpKernel component.
