### PR TITLE
[ProxyBridge] Fix proxy classnames generation

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -27,6 +27,11 @@ use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
 class ProxyDumper implements DumperInterface
 {
     /**
+     * @var string
+     */
+    private $salt;
+
+    /**
      * @var LazyLoadingValueHolderGenerator
      */
     private $proxyGenerator;
@@ -38,9 +43,12 @@ class ProxyDumper implements DumperInterface
 
     /**
      * Constructor.
+     *
+     * @param string $salt
      */
-    public function __construct()
+    public function __construct($salt = '')
     {
+        $this->salt = $salt;
         $this->proxyGenerator = new LazyLoadingValueHolderGenerator();
         $this->classGenerator = new BaseGeneratorStrategy();
     }
@@ -109,6 +117,6 @@ EOF;
      */
     private function getProxyClassName(Definition $definition)
     {
-        return str_replace('\\', '', $definition->getClass()).'_'.spl_object_hash($definition);
+        return str_replace('\\', '', $definition->getClass()).'_'.spl_object_hash($definition).$this->salt;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -243,7 +243,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @throws \RuntimeException if a custom resource is hidden by a resource in a derived bundle
      */
@@ -683,7 +683,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $dumper = new PhpDumper($container);
 
         if (class_exists('ProxyManager\Configuration')) {
-            $dumper->setProxyDumper(new ProxyDumper());
+            $dumper->setProxyDumper(new ProxyDumper(md5((string) $cache)));
         }
 
         $content = $dumper->dump(array('class' => $class, 'base_class' => $baseClass, 'file' => (string) $cache));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

When having many lazy services based on the same class, proxy classnames collision is more prone to happen on cache regeneration.

The problem comes from [`ProxyDumper`](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php#L112) usage of [`spl_object_hash`](http://php.net/manual/en/function.spl-object-hash.php), because object hashes may be reused for others when destroyed.

To solve this, I added more entropy with an optional salt to allow multiple passes of the `ProxyDumper`, each time with a value coming from the filepath of the cache we're building, so no collision could happen.

This applies from `symfony/2.3` to `symfony/2.7`.
Related tests are passing.
