### PR TITLE
Add TypeExtensions and TypeGuessers on FormIntegrationTestCase

### DIFF
--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -11,8 +11,11 @@
 
 namespace Symfony\Component\Form\Test;
 
+use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormTypeExtensionInterface;
+use Symfony\Component\Form\FormTypeGuesserInterface;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -33,16 +36,31 @@ abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
             ->getFormFactory();
     }
 
+    /**
+     * Returns Extensions to be added on FormFactory setUp
+     *
+     * @return FormExtensionInterface[]
+     */
     protected function getExtensions()
     {
         return array();
     }
 
+    /**
+     * Returns TypeExtensions to be added on FormFactory setUp
+     *
+     * @return FormTypeExtensionInterface[]
+     */
     protected function getTypeExtensions()
     {
         return array();
     }
 
+    /**
+     * Returns TypeGuessers to be added on FormFactory setUp
+     *
+     * @return FormTypeGuesserInterface[]
+     */
     protected function getTypeGuessers()
     {
         return array();

--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -28,10 +28,22 @@ abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
     {
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
+            ->addTypeExtensions($this->getTypeExtensions())
+            ->addTypeGuessers($this->getTypeGuessers())
             ->getFormFactory();
     }
 
     protected function getExtensions()
+    {
+        return array();
+    }
+
+    protected function getTypeExtensions()
+    {
+        return array();
+    }
+
+    protected function getTypeGuessers()
     {
         return array();
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This PR is a improvement suggestion about `FormIntegrationTestCase`.

Based on the [documentation](http://symfony.com/doc/current/cookbook/form/unit_testing.html#adding-custom-extensions), we currently have to setUp again all the form builder process just to add a type extension to get, for example, `constraints` option working.

With this modification, we can simply do something like this.

``` php
class ChangePasswordFormTypeTest extends TypeTestCase
{
    protected function getTypeExtensions()
    {
        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
        $validator->method('validate')->will($this->returnValue(new ConstraintViolationList()));

        return array(
            new FormTypeValidatorExtension($validator),
        );
    }

    // [...] Do your tests here.
}
```

Much simpler, isn't it?

I think this could be done also for type guessers. Will work on it.

I'm excited to see yours review comments! :+1: 

**Note:** This should be cherry-pick on 3.0. Could be very useful to have it on 2.7 also because of new LTS. It's up to you.
