### PR TITLE
Add TypeExtensions and TypeGuessers on FormIntegrationTestCase

### DIFF
--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -28,10 +28,22 @@ abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
     {
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
+            ->addTypeExtensions($this->getTypeExtensions())
+            ->addTypeGuessers($this->getTypeGuessers())
             ->getFormFactory();
     }
 
     protected function getExtensions()
+    {
+        return array();
+    }
+
+    protected function getTypeExtensions()
+    {
+        return array();
+    }
+
+    protected function getTypeGuessers()
     {
         return array();
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Cherry-pick of #14506.
