### PR TITLE
[YAML] Removed ext/ctype dependency

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -121,7 +121,7 @@ class Inline
                 return 'true';
             case false === $value:
                 return 'false';
-            case ctype_digit($value):
+            case preg_match('/^\d+$/D', $value):
                 return is_string($value) ? "'$value'" : (int) $value;
             case is_numeric($value):
                 $locale = setlocale(LC_NUMERIC, 0);
@@ -481,12 +481,12 @@ class Inline
                         return;
                     case 0 === strpos($scalar, '!!float '):
                         return (float) substr($scalar, 8);
-                    case ctype_digit($scalar):
+                    case preg_match('/^\d+$/D', $scalar):
                         $raw = $scalar;
                         $cast = (int) $scalar;
 
                         return '0' == $scalar[0] ? octdec($scalar) : (((string) $raw == (string) $cast) ? $cast : $raw);
-                    case '-' === $scalar[0] && ctype_digit(substr($scalar, 1)):
+                    case '-' === $scalar[0] && preg_match('/^\d+$/D', substr($scalar, 1)):
                         $raw = $scalar;
                         $cast = (int) $scalar;
 


### PR DESCRIPTION
Dropped dependency to ext/ctype which in `--disable-all` compiled php version is not available.

Less dependencies makes the component usable on even more plattforms. 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14509 |
| License | MIT |
| Doc PR | no |
