### PR TITLE
Do not override PHP constants, only use when available

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -186,9 +186,7 @@ EOF
             }
         });
 
-        $flags = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
-
-        $output->writeln(json_encode($filesInfo, $flags));
+        $output->writeln(json_encode($filesInfo, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0));
 
         return min($errors, 1);
     }

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -36,7 +36,7 @@ class LintCommand extends Command
     }
 
     /**
-     * Sets the twig environment
+     * Sets the twig environment.
      *
      * @param \Twig_Environment $twig
      */
@@ -94,7 +94,7 @@ EOF
 
         if (!$filename) {
             if (0 !== ftell(STDIN)) {
-                throw new \RuntimeException("Please provide a filename or pipe template content to STDIN.");
+                throw new \RuntimeException('Please provide a filename or pipe template content to STDIN.');
             }
 
             $template = '';
@@ -198,14 +198,14 @@ EOF
         $line =  $exception->getTemplateLine();
 
         if ($file) {
-            $output->writeln(sprintf("<error>KO</error> in %s (line %s)", $file, $line));
+            $output->writeln(sprintf('<error>KO</error> in %s (line %s)', $file, $line));
         } else {
-            $output->writeln(sprintf("<error>KO</error> (line %s)", $line));
+            $output->writeln(sprintf('<error>KO</error> (line %s)', $line));
         }
 
         foreach ($this->getContext($template, $line) as $no => $code) {
             $output->writeln(sprintf(
-                "%s %-6s %s",
+                '%s %-6s %s',
                 $no == $line ? '<error>>></error>' : '  ',
                 $no,
                 $code

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -11,10 +11,6 @@
 
 namespace Symfony\Bridge\Twig\Command;
 
-if (!defined('JSON_PRETTY_PRINT')) {
-    define('JSON_PRETTY_PRINT', 128);
-}
-
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -190,7 +186,9 @@ EOF
             }
         });
 
-        $output->writeln(json_encode($filesInfo, JSON_PRETTY_PRINT));
+        $flags = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
+
+        $output->writeln(json_encode($filesInfo, $flags));
 
         return min($errors, 1);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -11,10 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
-if (!defined('JSON_PRETTY_PRINT')) {
-    define('JSON_PRETTY_PRINT', 128);
-}
-
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -156,7 +152,9 @@ EOF
             }
         });
 
-        $output->writeln(json_encode($filesInfo, JSON_PRETTY_PRINT));
+        $flags = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
+
+        $output->writeln(json_encode($filesInfo, $flags));
 
         return min($errors, 1);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -152,9 +152,7 @@ EOF
             }
         });
 
-        $flags = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
-
-        $output->writeln(json_encode($filesInfo, $flags));
+        $output->writeln(json_encode($filesInfo, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0));
 
         return min($errors, 1);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -11,10 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 
-if (!defined('JSON_PRETTY_PRINT')) {
-    define('JSON_PRETTY_PRINT', 128);
-}
-
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -174,7 +170,13 @@ class JsonDescriptor extends Descriptor
      */
     private function writeData(array $data, array $options)
     {
-        $this->write(json_encode($data, (isset($options['json_encoding']) ? $options['json_encoding'] : 0) | JSON_PRETTY_PRINT)."\n");
+        $flags = isset($options['json_encoding']) ? $options['json_encoding'] : 0;
+
+        if (defined('JSON_PRETTY_PRINT')) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+
+        $this->write(json_encode($data, $flags)."\n");
     }
 
     /**

--- a/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
@@ -13,10 +13,6 @@ namespace Symfony\Component\Translation\Dumper;
 
 use Symfony\Component\Translation\MessageCatalogue;
 
-if (!defined('JSON_PRETTY_PRINT')) {
-    define('JSON_PRETTY_PRINT', 128);
-}
-
 /**
  * JsonFileDumper generates an json formatted string representation of a message catalogue.
  *
@@ -29,7 +25,9 @@ class JsonFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
-        return json_encode($messages->all($domain), JSON_PRETTY_PRINT);
+        $flags = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
+
+        return json_encode($messages->all($domain), $flags);
     }
 
     /**

--- a/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
@@ -25,9 +25,7 @@ class JsonFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
-        $flags = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
-
-        return json_encode($messages->all($domain), $flags);
+        return json_encode($messages->all($domain), defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

In #12372, the override of internal constants has been deleted, but the definition of `JSON_PRETTY_PRINT` if not available is missing in that PR.
