### PR TITLE
[2.8][Translation] added message cache.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -582,6 +582,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue(array('en'))
                         ->end()
                         ->booleanNode('logging')->defaultValue($this->debug)->end()
+                        ->scalarNode('cache')->defaultValue('translation.cache.default')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -665,6 +665,14 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('translator.logging', $config['logging']);
 
+        if (isset($config['cache'])) {
+            $container->setParameter(
+                'translator.cache.prefix',
+                'translator_'.hash('sha256', $container->getParameter('kernel.root_dir'))
+            );
+            $container->setAlias('translation.cache', $config['cache']);
+        }
+
         // Discover translation directories
         $dirs = array();
         if (class_exists('Symfony\Component\Validator\Validation')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -187,6 +187,7 @@
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="fallback" type="xsd:string" />
         <xsd:attribute name="logging" type="xsd:boolean" />
+        <xsd:attribute name="cache" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="validation">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -33,6 +33,7 @@
         <parameter key="translation.loader.class">Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader</parameter>
         <parameter key="translation.extractor.class">Symfony\Component\Translation\Extractor\ChainExtractor</parameter>
         <parameter key="translation.writer.class">Symfony\Component\Translation\Writer\TranslationWriter</parameter>
+        <parameter key="translator.cache.prefix" />
     </parameters>
 
     <services>
@@ -44,7 +45,7 @@
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>
                 <argument key="debug">%kernel.debug%</argument>
             </argument>
-            <argument type="collection" /> <!-- translation resources -->
+            <argument type="service" id="translation.cache" on-invalid="null" />
         </service>
 
         <service id="translator.logging" class="Symfony\Component\Translation\LoggingTranslator" public="false">
@@ -156,6 +157,12 @@
         <service id="translation.warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\TranslationsCacheWarmer" public="false">
             <argument type="service" id="translator" />
             <tag name="kernel.cache_warmer" />
+        </service>
+
+        <!-- Cache -->
+        <service id="translation.cache.default" class="Symfony\Component\Translation\MessageCache" public="false">
+            <argument>%kernel.cache_dir%/translations</argument> <!-- cache_dir -->
+            <argument>%kernel.debug%</argument> <!-- debug -->
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -146,6 +146,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'enabled' => false,
                 'fallbacks' => array('en'),
                 'logging' => true,
+                'cache' => 'translation.cache.default',
             ),
             'validation' => array(
                 'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -247,6 +247,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $calls = $container->getDefinition('translator.default')->getMethodCalls();
         $this->assertEquals(array('fr'), $calls[0][1][0]);
+        $this->assertContains('translator_', $container->getParameter('translator.cache.prefix'));
     }
 
     public function testTranslatorMultipleFallbacks()

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Translation\Translator as BaseTranslator;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Translation\MessageCacheInterface;
 
 /**
  * Translator.
@@ -46,14 +47,15 @@ class Translator extends BaseTranslator implements WarmableInterface
      *   * debug:     Whether to enable debugging or not (false by default)
      *   * resource_files: List of translation resources available grouped by locale.
      *
-     * @param ContainerInterface $container A ContainerInterface instance
-     * @param MessageSelector    $selector  The message selector for pluralization
-     * @param array              $loaderIds An array of loader Ids
-     * @param array              $options   An array of options
+     * @param ContainerInterface    $container A ContainerInterface instance
+     * @param MessageSelector       $selector  The message selector for pluralization
+     * @param array                 $loaderIds An array of loader Ids
+     * @param array                 $options   An array of options
+     * @param MessageCacheInterface $cache     The message cache
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array())
+    public function __construct(ContainerInterface $container, MessageSelector $selector, $loaderIds = array(), array $options = array(), MessageCacheInterface $cache = null)
     {
         $this->container = $container;
         $this->loaderIds = $loaderIds;
@@ -69,7 +71,8 @@ class Translator extends BaseTranslator implements WarmableInterface
             $this->loadResources();
         }
 
-        parent::__construct($container->getParameter('kernel.default_locale'), $selector, $this->options['cache_dir'], $this->options['debug']);
+        $cache = $cache ?: $this->options['cache_dir'];
+        parent::__construct($container->getParameter('kernel.default_locale'), $selector, $cache, $this->options['debug']);
     }
 
     /**

--- a/src/Symfony/Component/Translation/MessageCache.php
+++ b/src/Symfony/Component/Translation/MessageCache.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheFactory;
+
+/**
+ * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
+ */
+class MessageCache implements MessageCacheInterface
+{
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @var ConfigCacheFactoryInterface
+     */
+    private $configCacheFactory;
+
+    /**
+     * @param string                      $cacheDir
+     * @param bool                        $debug
+     * @param ConfigCacheFactoryInterface $configCacheFactory
+     */
+    public function __construct($cacheDir, $debug = false, ConfigCacheFactoryInterface $configCacheFactory = null)
+    {
+        $this->cacheDir = $cacheDir;
+        $this->debug = $debug;
+
+        if (null === $configCacheFactory) {
+            $configCacheFactory = new ConfigCacheFactory($debug);
+        }
+
+        $this->configCacheFactory = $configCacheFactory;
+    }
+
+    /**
+     * Sets the ConfigCache factory to use.
+     *
+     * @param ConfigCacheFactoryInterface $configCacheFactory
+     */
+    public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
+    {
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
+        $this->configCacheFactory = $configCacheFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cache($locale, array $options = array())
+    {
+        $defaultOptions = array(
+            'resources' => array(),
+            'fallback_locales' => array(),
+            'initialize_catalogue' => function ($locale) {
+                return new MessageCatalogue($locale);
+            },
+        );
+
+        $options = array_merge($defaultOptions, $options);
+        $self = $this; // required for PHP 5.3 where "$this" cannot be used in anonymous functions. Change in Symfony 3.0.
+        $cache = $this->configCacheFactory->cache($this->getCatalogueCachePath($locale, $options),
+            function (ConfigCacheInterface $cache) use ($self, $locale, $options) {
+                $self->dumpCatalogue($locale, $options, $cache);
+            }
+        );
+
+        /* Read catalogue from cache. */
+        return include $cache->getPath();
+    }
+
+    /**
+     * This method is public because it needs to be callable from a closure in PHP 5.3. It should be made protected (or even private, if possible) in 3.0.
+     *
+     * @internal
+     */
+    public function dumpCatalogue($locale, $options, ConfigCacheInterface $cache)
+    {
+        $catalogue = $options['initialize_catalogue']($locale);
+        $fallbackContent = $this->getFallbackContent($catalogue, $options);
+        $content = sprintf(<<<EOF
+<?php
+use Symfony\Component\Translation\MessageCatalogue;
+\$catalogue = new MessageCatalogue('%s', %s);
+%s
+return \$catalogue;
+EOF
+            ,
+            $locale,
+            var_export($catalogue->all(), true),
+            $fallbackContent
+        );
+        $cache->write($content, $catalogue->getResources());
+    }
+    private function getFallbackContent(MessageCatalogue $catalogue, $options)
+    {
+        $fallbackContent = '';
+        $current = '';
+        $replacementPattern = '/[^a-z0-9_]/i';
+        $fallbackCatalogue = $catalogue->getFallbackCatalogue();
+        while ($fallbackCatalogue) {
+            $fallback = $fallbackCatalogue->getLocale();
+            $fallbackSuffix = ucfirst(preg_replace($replacementPattern, '_', $fallback));
+            $currentSuffix = ucfirst(preg_replace($replacementPattern, '_', $current));
+            $fallbackContent .= sprintf(<<<EOF
+\$catalogue%s = new MessageCatalogue('%s', %s);
+\$catalogue%s->addFallbackCatalogue(\$catalogue%s);
+EOF
+                ,
+                $fallbackSuffix,
+                $fallback,
+                var_export($fallbackCatalogue->all(), true),
+                $currentSuffix,
+                $fallbackSuffix
+            );
+            $current = $fallbackCatalogue->getLocale();
+            $fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue();
+        }
+
+        return $fallbackContent;
+    }
+
+    private function getCatalogueCachePath($locale, $options)
+    {
+        $catalogueHash = sha1(serialize(array(
+            'resources' => $options['resources'],
+            'fallback_locales' => $options['fallback_locales'],
+        )));
+
+        return $this->cacheDir.'/catalogue.'.$locale.'.'.$catalogueHash.'.php';
+    }
+}

--- a/src/Symfony/Component/Translation/MessageCacheInterface.php
+++ b/src/Symfony/Component/Translation/MessageCacheInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+/**
+ * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
+ */
+interface MessageCacheInterface
+{
+    /**
+     * Loads a catalogue from cache and (re-)initializes it if necessary.
+     *
+     * @param string $locale
+     * @param array  $options
+     *
+     * @return MessageCatalogueInterface A MessageCatalogue instance
+     */
+    public function cache($locale, array $options = array());
+}

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -17,21 +17,21 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetLocale()
     {
-        $catalogue = new MessageCatalogue('en');
+        $catalogue = $this->getCatalogue('en');
 
         $this->assertEquals('en', $catalogue->getLocale());
     }
 
     public function testGetDomains()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array(), 'domain2' => array()));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array(), 'domain2' => array()));
 
         $this->assertEquals(array('domain1', 'domain2'), $catalogue->getDomains());
     }
 
     public function testAll()
     {
-        $catalogue = new MessageCatalogue('en', $messages = array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', $messages = array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
 
         $this->assertEquals(array('foo' => 'foo'), $catalogue->all('domain1'));
         $this->assertEquals(array(), $catalogue->all('domain88'));
@@ -40,7 +40,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testHas()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
 
         $this->assertTrue($catalogue->has('foo', 'domain1'));
         $this->assertFalse($catalogue->has('bar', 'domain1'));
@@ -49,7 +49,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSet()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->set('foo1', 'foo1', 'domain1');
 
         $this->assertEquals('foo', $catalogue->get('foo', 'domain1'));
@@ -58,7 +58,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testAdd()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->add(array('foo1' => 'foo1'), 'domain1');
 
         $this->assertEquals('foo', $catalogue->get('foo', 'domain1'));
@@ -74,7 +74,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testReplace()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->replace($messages = array('foo1' => 'foo1'), 'domain1');
 
         $this->assertEquals($messages, $catalogue->all('domain1'));
@@ -88,10 +88,10 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
         $r1 = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
 
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->addResource($r);
 
-        $catalogue1 = new MessageCatalogue('en', array('domain1' => array('foo1' => 'foo1')));
+        $catalogue1 = $this->getCatalogue('en', array('domain1' => array('foo1' => 'foo1')));
         $catalogue1->addResource($r1);
 
         $catalogue->addCatalogue($catalogue1);
@@ -110,10 +110,10 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
         $r1 = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
 
-        $catalogue = new MessageCatalogue('en_US', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en_US', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->addResource($r);
 
-        $catalogue1 = new MessageCatalogue('en', array('domain1' => array('foo' => 'bar', 'foo1' => 'foo1')));
+        $catalogue1 = $this->getCatalogue('en', array('domain1' => array('foo' => 'bar', 'foo1' => 'foo1')));
         $catalogue1->addResource($r1);
 
         $catalogue->addFallbackCatalogue($catalogue1);
@@ -129,8 +129,8 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddFallbackCatalogueWithCircularReference()
     {
-        $main = new MessageCatalogue('en_US');
-        $fallback = new MessageCatalogue('fr_FR');
+        $main = $this->getCatalogue('en_US');
+        $fallback = $this->getCatalogue('fr_FR');
 
         $fallback->addFallbackCatalogue($main);
         $main->addFallbackCatalogue($fallback);
@@ -141,13 +141,13 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddCatalogueWhenLocaleIsNotTheSameAsTheCurrentOne()
     {
-        $catalogue = new MessageCatalogue('en');
-        $catalogue->addCatalogue(new MessageCatalogue('fr', array()));
+        $catalogue = $this->getCatalogue('en');
+        $catalogue->addCatalogue($this->getCatalogue('fr', array()));
     }
 
     public function testGetAddResource()
     {
-        $catalogue = new MessageCatalogue('en');
+        $catalogue = $this->getCatalogue('en');
         $r = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
         $catalogue->addResource($r);
@@ -161,7 +161,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testMetadataDelete()
     {
-        $catalogue = new MessageCatalogue('en');
+        $catalogue = $this->getCatalogue('en');
         $this->assertEquals(array(), $catalogue->getMetadata('', ''), 'Metadata is empty');
         $catalogue->deleteMetadata('key', 'messages');
         $catalogue->deleteMetadata('', 'messages');
@@ -170,7 +170,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testMetadataSetGetDelete()
     {
-        $catalogue = new MessageCatalogue('en');
+        $catalogue = $this->getCatalogue('en');
         $catalogue->setMetadata('key', 'value');
         $this->assertEquals('value', $catalogue->getMetadata('key', 'messages'), "Metadata 'key' = 'value'");
 
@@ -178,23 +178,28 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $catalogue->getMetadata('key2', 'messages'), 'Metadata key2 is array');
 
         $catalogue->deleteMetadata('key2', 'messages');
-        $this->assertEquals(null, $catalogue->getMetadata('key2', 'messages'), 'Metadata key2 should is deleted.');
+        $this->assertNull($catalogue->getMetadata('key2', 'messages'), 'Metadata key2 should is deleted.');
 
         $catalogue->deleteMetadata('key2', 'domain');
-        $this->assertEquals(null, $catalogue->getMetadata('key2', 'domain'), 'Metadata key2 should is deleted.');
+        $this->assertNull($catalogue->getMetadata('key2', 'domain'), 'Metadata key2 should is deleted.');
     }
 
     public function testMetadataMerge()
     {
-        $cat1 = new MessageCatalogue('en');
+        $cat1 = $this->getCatalogue('en');
         $cat1->setMetadata('a', 'b');
         $this->assertEquals(array('messages' => array('a' => 'b')), $cat1->getMetadata('', ''), 'Cat1 contains messages metadata.');
 
-        $cat2 = new MessageCatalogue('en');
+        $cat2 = $this->getCatalogue('en');
         $cat2->setMetadata('b', 'c', 'domain');
         $this->assertEquals(array('domain' => array('b' => 'c')), $cat2->getMetadata('', ''), 'Cat2 contains domain metadata.');
 
         $cat1->addCatalogue($cat2);
         $this->assertEquals(array('messages' => array('a' => 'b'), 'domain' => array('b' => 'c')), $cat1->getMetadata('', ''), 'Cat1 contains merged metadata.');
+    }
+
+    protected function getCatalogue($locale, $messages = array())
+    {
+        return new MessageCatalogue($locale, $messages);
     }
 }

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCache;
 
 class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
 {
@@ -62,13 +63,13 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         $msgid = 'test';
 
         // Prime the cache
-        $translator = new Translator($locale, null, $this->tmpDir, $debug);
+        $translator = $this->getTranslator($locale, $debug);
         $translator->addLoader($format, new ArrayLoader());
         $translator->addResource($format, array($msgid => 'OK'), $locale);
         $translator->trans($msgid);
 
         // Try again and see we get a valid result whilst no loader can be used
-        $translator = new Translator($locale, null, $this->tmpDir, $debug);
+        $translator = $this->getTranslator($locale, $debug);
         $translator->addLoader($format, $this->createFailingLoader());
         $translator->addResource($format, array($msgid => 'OK'), $locale);
         $this->assertEquals('OK', $translator->trans($msgid), '-> caching does not work in '.($debug ? 'debug' : 'production'));
@@ -85,7 +86,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
             ))))
         ;
 
-        $translator = new Translator('fr', null, $this->tmpDir, true);
+        $translator = $this->getTranslator('fr', true);
         $translator->setLocale('fr');
         $translator->addLoader('loader', $loader);
         $translator->addResource('loader', 'foo', 'fr');
@@ -101,7 +102,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
             ))))
         ;
 
-        $translator = new Translator('fr', null, $this->tmpDir, true);
+        $translator = $this->getTranslator('fr', true);
         $translator->setLocale('fr');
         $translator->addLoader('loader', $loader);
         $translator->addResource('loader', 'bar', 'fr');
@@ -126,7 +127,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         $format = 'some_format';
         $msgid = 'test';
 
-        $catalogue = new MessageCatalogue($locale, array());
+        $catalogue = $this->getCatalogue($locale, array());
         $catalogue->addResource(new StaleResource()); // better use a helper class than a mock, because it gets serialized in the cache and re-loaded
 
         /** @var LoaderInterface|\PHPUnit_Framework_MockObject_MockObject $loader */
@@ -138,13 +139,13 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         ;
 
         // 1st pass
-        $translator = new Translator($locale, null, $this->tmpDir, true);
+        $translator = $this->getTranslator($locale, true);
         $translator->addLoader($format, $loader);
         $translator->addResource($format, null, $locale);
         $translator->trans($msgid);
 
         // 2nd pass
-        $translator = new Translator($locale, null, $this->tmpDir, true);
+        $translator = $this->getTranslator($locale, true);
         $translator->addLoader($format, $loader);
         $translator->addResource($format, null, $locale);
         $translator->trans($msgid);
@@ -165,19 +166,19 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         $msgid = 'test';
 
         // Create a Translator and prime its cache
-        $translator = new Translator($locale, null, $this->tmpDir, $debug);
+        $translator = $this->getTranslator($locale, $debug);
         $translator->addLoader($format, new ArrayLoader());
         $translator->addResource($format, array($msgid => 'OK'), $locale);
         $translator->trans($msgid);
 
         // Create another Translator with a different catalogue for the same locale
-        $translator = new Translator($locale, null, $this->tmpDir, $debug);
+        $translator = $this->getTranslator($locale, $debug);
         $translator->addLoader($format, new ArrayLoader());
         $translator->addResource($format, array($msgid => 'FAIL'), $locale);
         $translator->trans($msgid);
 
         // Now the first translator must still have a useable cache.
-        $translator = new Translator($locale, null, $this->tmpDir, $debug);
+        $translator = $this->getTranslator($locale, $debug);
         $translator->addLoader($format, $this->createFailingLoader());
         $translator->addResource($format, array($msgid => 'OK'), $locale);
         $this->assertEquals('OK', $translator->trans($msgid), '-> the cache was overwritten by another translator instance in '.($debug ? 'debug' : 'production'));
@@ -190,7 +191,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
          * catalogues, we must take the set of fallback locales into consideration when
          * loading a catalogue from the cache.
          */
-        $translator = new Translator('a', null, $this->tmpDir);
+        $translator = $this->getTranslator('a', false);
         $translator->setFallbackLocales(array('b'));
 
         $translator->addLoader('array', new ArrayLoader());
@@ -204,7 +205,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $translator->trans('bar'));
 
         // Use a fresh translator with no fallback locales, result should be the same
-        $translator = new Translator('a', null, $this->tmpDir);
+        $translator = $this->getTranslator('a', false);
 
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foo (a)'), 'a');
@@ -228,7 +229,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
          * Create a translator that loads two catalogues for two different locales.
          * The catalogues contain distinct sets of messages.
          */
-        $translator = new Translator('a', null, $this->tmpDir);
+        $translator = $this->getTranslator('a', false);
         $translator->setFallbackLocales(array('b'));
 
         $translator->addLoader('array', new ArrayLoader());
@@ -246,7 +247,7 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
          * Now, repeat the same test.
          * Behind the scenes, the cache is used. But that should not matter, right?
          */
-        $translator = new Translator('a', null, $this->tmpDir);
+        $translator = $this->getTranslator('a', false);
         $translator->setFallbackLocales(array('b'));
 
         $translator->addLoader('array', new ArrayLoader());
@@ -272,16 +273,23 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->getCatalogue('fr', array(), array($resource))));
 
         // prime the cache
-        $translator = new Translator('fr', null, $this->tmpDir, true);
+        $translator = $this->getTranslator('fr', true);
         $translator->addLoader('loader', $loader);
         $translator->addResource('loader', 'foo', 'fr');
         $translator->trans('foo');
 
         // prime the cache second time
-        $translator = new Translator('fr', null, $this->tmpDir, true);
+        $translator = $this->getTranslator('fr', true);
         $translator->addLoader('loader', $loader);
         $translator->addResource('loader', 'foo', 'fr');
         $translator->trans('foo');
+    }
+
+    protected function getTranslator($locale, $debug)
+    {
+        $cache = new MessageCache($this->tmpDir, $debug);
+
+        return new Translator($locale, null, $cache);
     }
 
     protected function getCatalogue($locale, $messages, $resources = array())

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -13,9 +13,6 @@ namespace Symfony\Component\Translation;
 
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\Exception\NotFoundResourceException;
-use Symfony\Component\Config\ConfigCacheInterface;
-use Symfony\Component\Config\ConfigCacheFactoryInterface;
-use Symfony\Component\Config\ConfigCacheFactory;
 
 /**
  * Translator.
@@ -57,37 +54,29 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     private $selector;
 
     /**
-     * @var string
+     * @var MessageCacheInterface
      */
-    private $cacheDir;
+    private $cache;
 
     /**
-     * @var bool
-     */
-    private $debug;
-
-    /**
-     * @var ConfigCacheFactoryInterface|null
-     */
-    private $configCacheFactory;
-
-    /**
-     * Constructor.
-     *
-     * @param string               $locale   The locale
-     * @param MessageSelector|null $selector The message selector for pluralization
-     * @param string|null          $cacheDir The directory to use for the cache
-     * @param bool                 $debug    Use cache in debug mode ?
+     * @param string                            $locale   The locale
+     * @param MessageSelector|null              $selector The message selector for pluralization
+     * @param string|null|MessageCacheInterface $cache    The message cache or a directory to use for the default cache
+     * @param bool                              $debug    Use cache in debug mode ?
      *
      * @throws \InvalidArgumentException If a locale contains invalid characters
      *
      * @api
      */
-    public function __construct($locale, MessageSelector $selector = null, $cacheDir = null, $debug = false)
+    public function __construct($locale, MessageSelector $selector = null, $cache = null, $debug = false)
     {
         $this->setLocale($locale);
         $this->selector = $selector ?: new MessageSelector();
-        $this->cacheDir = $cacheDir;
+        if (null !== $cache && !$cache instanceof MessageCacheInterface) {
+            $cache = new MessageCache($cache, $debug);
+        }
+
+        $this->cache = $cache;
         $this->debug = $debug;
     }
 
@@ -98,7 +87,11 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
     {
-        $this->configCacheFactory = $configCacheFactory;
+        trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
+        if ($this->cache instanceof MessageCache) {
+            $this->cache->setConfigCacheFactory($configCacheFactory);
+        }
     }
 
     /**
@@ -311,7 +304,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     protected function loadCatalogue($locale)
     {
-        if (null === $this->cacheDir) {
+        if (null === $this->cache) {
             $this->initializeCatalogue($locale);
         } else {
             $this->initializeCacheCatalogue($locale);
@@ -345,21 +338,16 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
             return;
         }
 
-        $this->assertValidLocale($locale);
-        $self = $this; // required for PHP 5.3 where "$this" cannot be use()d in anonymous functions. Change in Symfony 3.0.
-        $cache = $this->getConfigCacheFactory()->cache($this->getCatalogueCachePath($locale),
-            function (ConfigCacheInterface $cache) use ($self, $locale) {
-                $self->dumpCatalogue($locale, $cache);
-            }
+        $self = $this; // required for PHP 5.3 where "$this" cannot be used in anonymous functions. Change in Symfony 3.0.
+        $options = array(
+            'resources' => isset($this->resources[$locale]) ? $this->resources[$locale] : array(),
+            'fallback_locales' => $this->fallbackLocales,
+            'initialize_catalogue' => function ($locale) use ($self) {
+                return $self->dumpCatalogue($locale);
+            },
         );
 
-        if (isset($this->catalogues[$locale])) {
-            /* Catalogue has been initialized as it was written out to cache. */
-            return;
-        }
-
-        /* Read catalogue from cache. */
-        $this->catalogues[$locale] = include $cache->getPath();
+        $this->catalogues[$locale] = $this->cache->cache($locale, $options);
     }
 
     /**
@@ -367,69 +355,11 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      *
      * @internal
      */
-    public function dumpCatalogue($locale, ConfigCacheInterface $cache)
+    public function dumpCatalogue($locale)
     {
         $this->initializeCatalogue($locale);
-        $fallbackContent = $this->getFallbackContent($this->catalogues[$locale]);
 
-        $content = sprintf(<<<EOF
-<?php
-
-use Symfony\Component\Translation\MessageCatalogue;
-
-\$catalogue = new MessageCatalogue('%s', %s);
-
-%s
-return \$catalogue;
-
-EOF
-            ,
-            $locale,
-            var_export($this->catalogues[$locale]->all(), true),
-            $fallbackContent
-        );
-
-        $cache->write($content, $this->catalogues[$locale]->getResources());
-    }
-
-    private function getFallbackContent(MessageCatalogue $catalogue)
-    {
-        $fallbackContent = '';
-        $current = '';
-        $replacementPattern = '/[^a-z0-9_]/i';
-        $fallbackCatalogue = $catalogue->getFallbackCatalogue();
-        while ($fallbackCatalogue) {
-            $fallback = $fallbackCatalogue->getLocale();
-            $fallbackSuffix = ucfirst(preg_replace($replacementPattern, '_', $fallback));
-            $currentSuffix = ucfirst(preg_replace($replacementPattern, '_', $current));
-
-            $fallbackContent .= sprintf(<<<EOF
-\$catalogue%s = new MessageCatalogue('%s', %s);
-\$catalogue%s->addFallbackCatalogue(\$catalogue%s);
-
-EOF
-                ,
-                $fallbackSuffix,
-                $fallback,
-                var_export($fallbackCatalogue->all(), true),
-                $currentSuffix,
-                $fallbackSuffix
-            );
-            $current = $fallbackCatalogue->getLocale();
-            $fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue();
-        }
-
-        return $fallbackContent;
-    }
-
-    private function getCatalogueCachePath($locale)
-    {
-        $catalogueHash = sha1(serialize(array(
-            'resources' => isset($this->resources[$locale]) ? $this->resources[$locale] : array(),
-            'fallback_locales' => $this->fallbackLocales,
-        )));
-
-        return $this->cacheDir.'/catalogue.'.$locale.'.'.$catalogueHash.'.php';
+        return $this->catalogues[$locale];
     }
 
     private function doLoadCatalogue($locale)
@@ -490,20 +420,5 @@ EOF
         if (1 !== preg_match('/^[a-z0-9@_\\.\\-]*$/i', $locale)) {
             throw new \InvalidArgumentException(sprintf('Invalid "%s" locale.', $locale));
         }
-    }
-
-    /**
-     * Provides the ConfigCache factory implementation, falling back to a
-     * default implementation if necessary.
-     *
-     * @return ConfigCacheFactoryInterface $configCacheFactory
-     */
-    private function getConfigCacheFactory()
-    {
-        if (!$this->configCacheFactory) {
-            $this->configCacheFactory = new ConfigCacheFactory($this->debug);
-        }
-
-        return $this->configCacheFactory;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #13676 |
| Tests pass? | yes |
| License | MIT |

``` yml
# app/config/config.yml
framework:
    translator:
        cache: translation.cache.default
```

The message cache Interface contains now only one method:

``` php
interface MessageCacheInterface
{
    public function cache($locale, array $options = array());
}
```

for more details see #13986.
