### PR TITLE
[Translation] Remove TranslatorBagInterface to allow for optimized caching in 3.0

### DIFF
--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -40,7 +40,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
      */
     public function __construct(TranslatorInterface $translator)
     {
-        if (!($translator instanceof TranslatorBagInterface)) {
+        if (!$translator instanceof TranslatorBagInterface) {
             throw new \InvalidArgumentException(sprintf('The Translator "%s" must implement TranslatorInterface and TranslatorBagInterface.', get_class($translator)));
         }
 

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -40,14 +40,13 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
      */
     public function __construct(TranslatorInterface $translator)
     {
-        if (!$translator instanceof TranslatorBagInterface) {
-            throw new \InvalidArgumentException(sprintf('The Translator "%s" must implement TranslatorInterface and TranslatorBagInterface.', get_class($translator)));
-        }
-
-        if (!($translator instanceof FallbackLocaleAwareInterface)) {
+        if ($translator instanceof FallbackLocaleAwareInterface) {
+            $this->fallbackLocaleAware = $translator;
+        } else if ($translator instanceof TranslatorBagInterface) {
+            @trigger_error(sprintf('The Translator "%" should implement \Symfony\Component\Translation\FallbackLocaleAwareInterface instead of (or in addtion to) \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)), E_USER_DEPRECATED);
             $this->fallbackLocaleAware = new TranslatorBagToFallbackLocaleAwareAdapter($translator);
         } else {
-            $this->fallbackLocaleAware = $translator;
+            throw new \InvalidArgumentException(sprintf('The Translator "%s" implements neither \Symfony\Component\Translation\FallbackLocaleAwareInterface nor the deprecated \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)));
         }
 
         $this->translator = $translator;
@@ -108,6 +107,10 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
      */
     public function getCatalogue($locale = null)
     {
+        if (!$this->translator instanceof TranslatorBagInterface) {
+            throw new \RuntimeException(sprintf('You called the deprecated \Symfony\Component\Translation\DataCollectorTranslator::getCatalogue() method, but the Translator provided to the \Symfony\Component\Translation\DataCollectorTranslator constructor does not implement TranslatorBagInterface. (Hint: The class is %s.)',  get_class($this->translator)));
+        }
+
         return $this->translator->getCatalogue($locale);
     }
 

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -103,6 +103,8 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated TranslatorBagInterface implementation will be removed in 3.0.
      */
     public function getCatalogue($locale = null)
     {

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -31,12 +31,23 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     private $messages = array();
 
     /**
+     * @var FallbackLocaleAwareInterface
+     */
+    private $fallbackLocaleAware;
+
+    /**
      * @param TranslatorInterface $translator The translator must implement TranslatorBagInterface
      */
     public function __construct(TranslatorInterface $translator)
     {
-        if (!($translator instanceof TranslatorBagInterface && $translator instanceof FallbackLocaleAwareInterface)) {
-            throw new \InvalidArgumentException(sprintf('The Translator "%s" must implement TranslatorInterface, TranslatorBagInterface and FallbackLocaleAwareInterface.', get_class($translator)));
+        if (!($translator instanceof TranslatorBagInterface)) {
+            throw new \InvalidArgumentException(sprintf('The Translator "%s" must implement TranslatorInterface and TranslatorBagInterface.', get_class($translator)));
+        }
+
+        if (!($translator instanceof FallbackLocaleAwareInterface)) {
+            $this->fallbackLocaleAware = new TranslatorBagToFallbackLocaleAwareAdapter($translator);
+        } else {
+            $this->fallbackLocaleAware = $translator;
         }
 
         $this->translator = $translator;
@@ -69,7 +80,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
      */
     public function resolveLocale($id, $domain = null, $locale = null)
     {
-        return $this->translator->resolveLocale($id, $domain, $locale);
+        return $this->fallbackLocaleAware->resolveLocale($id, $domain, $locale);
     }
 
     /**

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -149,7 +149,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
         $resolvedLocale = $this->translator->resolveLocale($id, $domain, $locale);
 
         switch (true) {
-            case $resolvedLocale == $locale:
+            case $resolvedLocale === $locale:
                 $state = self::MESSAGE_DEFINED;
                 break;
 

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -43,7 +43,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
         if ($translator instanceof FallbackLocaleAwareInterface) {
             $this->fallbackLocaleAware = $translator;
         } else if ($translator instanceof TranslatorBagInterface) {
-            @trigger_error(sprintf('The Translator "%" should implement \Symfony\Component\Translation\FallbackLocaleAwareInterface instead of (or in addtion to) \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The Translator "%" should implement \Symfony\Component\Translation\FallbackLocaleAwareInterface instead of (or in addition to) \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)), E_USER_DEPRECATED);
             $this->fallbackLocaleAware = new TranslatorBagToFallbackLocaleAwareAdapter($translator);
         } else {
             throw new \InvalidArgumentException(sprintf('The Translator "%s" implements neither \Symfony\Component\Translation\FallbackLocaleAwareInterface nor the deprecated \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)));

--- a/src/Symfony/Component/Translation/FallbackLocaleAwareInterface.php
+++ b/src/Symfony/Component/Translation/FallbackLocaleAwareInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+/**
+ * An implementing class handles multiple locales and possible MessageCatalogues
+ * to find appropriate translations with some kind of fallback strategy.
+ *
+ * Through this interface it is possible to query which locale the translation
+ * for a given message id and domain will be taken from.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+interface FallbackLocaleAwareInterface
+{
+    /**
+     * Determines the locale that the translation will ultimately be taken from.
+     *
+     * @param string      $id     The message id (may also be an object that can be cast to string)
+     * @param string|null $domain The domain for the message or null to use the default
+     * @param string|null $locale The locale or null to use the default
+     *
+     * @return string|null The locale of the best available translation or null for unknown messages.
+     */
+    public function resolveLocale($id, $domain = null, $locale = null);
+}

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -103,6 +103,8 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated TranslatorBagInterface implementation will be removed in 3.0.
      */
     public function getCatalogue($locale = null)
     {

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -142,7 +142,9 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
 
         if ($locale === $resolvedLocale) {
             return;
-        } elseif ($resolvedLocale === null) {
+        }
+
+        if ($resolvedLocale === null) {
             $this->logger->warning('Translation not found.', array('id' => $id, 'domain' => $domain, 'locale' => $locale));
         } else {
             $this->logger->debug('Translation use fallback catalogue.', array('id' => $id, 'domain' => $domain, 'locale' => $resolvedLocale));

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -42,7 +42,7 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
         if ($translator instanceof FallbackLocaleAwareInterface) {
             $this->fallbackLocaleAware = $translator;
         } else if ($translator instanceof TranslatorBagInterface) {
-            @trigger_error(sprintf('The Translator "%" should implement \Symfony\Component\Translation\FallbackLocaleAwareInterface instead of (or in addtion to) \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The Translator "%" should implement \Symfony\Component\Translation\FallbackLocaleAwareInterface instead of (or in addition to) \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)), E_USER_DEPRECATED);
             $this->fallbackLocaleAware = new TranslatorBagToFallbackLocaleAwareAdapter($translator);
         } else {
             throw new \InvalidArgumentException(sprintf('The Translator "%s" implements neither \Symfony\Component\Translation\FallbackLocaleAwareInterface nor the deprecated \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)));

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -39,7 +39,7 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
      */
     public function __construct(TranslatorInterface $translator, LoggerInterface $logger)
     {
-        if (!($translator instanceof TranslatorBagInterface)) {
+        if (!$translator instanceof TranslatorBagInterface) {
             throw new \InvalidArgumentException(sprintf('The Translator "%s" must implement TranslatorInterface and TranslatorBagInterface.', get_class($translator)));
         }
 

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -29,13 +29,24 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
     private $logger;
 
     /**
+     * @var FallbackLocaleAwareInterface
+     */
+    private $fallbackLocaleAware;
+
+    /**
      * @param TranslatorInterface $translator The translator must implement TranslatorBagInterface
      * @param LoggerInterface     $logger
      */
     public function __construct(TranslatorInterface $translator, LoggerInterface $logger)
     {
-        if (!($translator instanceof TranslatorBagInterface && $translator instanceof FallbackLocaleAwareInterface)) {
-            throw new \InvalidArgumentException(sprintf('The Translator "%s" must implement TranslatorInterface, TranslatorBagInterface and FallbackLocaleAwareInterface.', get_class($translator)));
+        if (!($translator instanceof TranslatorBagInterface)) {
+            throw new \InvalidArgumentException(sprintf('The Translator "%s" must implement TranslatorInterface and TranslatorBagInterface.', get_class($translator)));
+        }
+
+        if (!($translator instanceof FallbackLocaleAwareInterface)) {
+            $this->fallbackLocaleAware = new TranslatorBagToFallbackLocaleAwareAdapter($translator);
+        } else {
+            $this->fallbackLocaleAware = $translator;
         }
 
         $this->translator = $translator;
@@ -69,7 +80,7 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
      */
     public function resolveLocale($id, $domain = null, $locale = null)
     {
-        return $this->translator->resolveLocale($id, $domain, $locale);
+        return $this->fallbackLocaleAware->resolveLocale($id, $domain, $locale);
     }
 
     /**

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -39,14 +39,13 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
      */
     public function __construct(TranslatorInterface $translator, LoggerInterface $logger)
     {
-        if (!$translator instanceof TranslatorBagInterface) {
-            throw new \InvalidArgumentException(sprintf('The Translator "%s" must implement TranslatorInterface and TranslatorBagInterface.', get_class($translator)));
-        }
-
-        if (!($translator instanceof FallbackLocaleAwareInterface)) {
+        if ($translator instanceof FallbackLocaleAwareInterface) {
+            $this->fallbackLocaleAware = $translator;
+        } else if ($translator instanceof TranslatorBagInterface) {
+            @trigger_error(sprintf('The Translator "%" should implement \Symfony\Component\Translation\FallbackLocaleAwareInterface instead of (or in addtion to) \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)), E_USER_DEPRECATED);
             $this->fallbackLocaleAware = new TranslatorBagToFallbackLocaleAwareAdapter($translator);
         } else {
-            $this->fallbackLocaleAware = $translator;
+            throw new \InvalidArgumentException(sprintf('The Translator "%s" implements neither \Symfony\Component\Translation\FallbackLocaleAwareInterface nor the deprecated \Symfony\Component\Translation\TranslatorBagInterface.', get_class($translator)));
         }
 
         $this->translator = $translator;
@@ -108,6 +107,10 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
      */
     public function getCatalogue($locale = null)
     {
+        if (!$this->translator instanceof TranslatorBagInterface) {
+            throw new \RuntimeException(sprintf('You called the deprecated \Symfony\Component\Translation\LoggingTranslator::getCatalogue() method, but the Translator provided to the \Symfony\Component\Translation\LoggingTranslator constructor does not implement TranslatorBagInterface. (Hint: The class is %s.)',  get_class($this->translator)));
+        }
+
         return $this->translator->getCatalogue($locale);
     }
 

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -178,10 +178,11 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $translator->trans('bar'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyPrimaryAndFallbackCataloguesContainTheSameMessagesRegardlessOfCaching()
     {
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
-
         /*
          * As a safeguard against potential BC breaks, make sure that primary and fallback
          * catalogues (reachable via getFallbackCatalogue()) always contain the full set of

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -178,54 +178,6 @@ class TranslatorCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $translator->trans('bar'));
     }
 
-    public function testPrimaryAndFallbackCataloguesContainTheSameMessagesRegardlessOfCaching()
-    {
-        /*
-         * As a safeguard against potential BC breaks, make sure that primary and fallback
-         * catalogues (reachable via getFallbackCatalogue()) always contain the full set of
-         * messages provided by the loader. This must also be the case when these catalogues
-         * are (internally) read from a cache.
-         *
-         * Optimizations inside the translator must not change this behaviour.
-         */
-
-        /*
-         * Create a translator that loads two catalogues for two different locales.
-         * The catalogues contain distinct sets of messages.
-         */
-        $translator = new Translator('a', null, $this->tmpDir);
-        $translator->setFallbackLocales(array('b'));
-
-        $translator->addLoader('array', new ArrayLoader());
-        $translator->addResource('array', array('foo' => 'foo (a)'), 'a');
-        $translator->addResource('array', array('foo' => 'foo (b)'), 'b');
-        $translator->addResource('array', array('bar' => 'bar (b)'), 'b');
-
-        $catalogue = $translator->getCatalogue('a');
-        $this->assertFalse($catalogue->defines('bar')); // Sure, the "a" catalogue does not contain that message.
-
-        $fallback = $catalogue->getFallbackCatalogue();
-        $this->assertTrue($fallback->defines('foo')); // "foo" is present in "a" and "b"
-
-        /*
-         * Now, repeat the same test.
-         * Behind the scenes, the cache is used. But that should not matter, right?
-         */
-        $translator = new Translator('a', null, $this->tmpDir);
-        $translator->setFallbackLocales(array('b'));
-
-        $translator->addLoader('array', new ArrayLoader());
-        $translator->addResource('array', array('foo' => 'foo (a)'), 'a');
-        $translator->addResource('array', array('foo' => 'foo (b)'), 'b');
-        $translator->addResource('array', array('bar' => 'bar (b)'), 'b');
-
-        $catalogue = $translator->getCatalogue('a');
-        $this->assertFalse($catalogue->defines('bar'));
-
-        $fallback = $catalogue->getFallbackCatalogue();
-        $this->assertTrue($fallback->defines('foo'));
-    }
-
     public function testRefreshCacheWhenResourcesAreNoLongerFresh()
     {
         $resource = $this->getMock('Symfony\Component\Config\Resource\SelfCheckingResourceInterface');

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -75,10 +75,11 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($locale, $translator->getLocale());
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyGetCatalogue()
     {
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
-
         $translator = new Translator('en');
 
         $this->assertEquals(new MessageCatalogue('en'), $translator->getCatalogue());
@@ -87,10 +88,11 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new MessageCatalogue('fr'), $translator->getCatalogue('fr'));
     }
 
+    /**
+     * @deprecated
+     */
     public function testLegacyGetCatalogueReturnsConsolidatedCatalogue()
     {
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
-
         /*
          * This will be useful once we refactor so that different domains will be loaded lazily (on-demand).
          * In that case, getCatalogue() will probably have to load all missing domains in order to return

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Translation\Tests;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\Loader\ArrayLoader;
-use Symfony\Component\Translation\MessageCatalogue;
 
 class TranslatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -73,40 +72,6 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $translator->setLocale($locale);
 
         $this->assertEquals($locale, $translator->getLocale());
-    }
-
-    public function testGetCatalogue()
-    {
-        $translator = new Translator('en');
-
-        $this->assertEquals(new MessageCatalogue('en'), $translator->getCatalogue());
-
-        $translator->setLocale('fr');
-        $this->assertEquals(new MessageCatalogue('fr'), $translator->getCatalogue('fr'));
-    }
-
-    public function testGetCatalogueReturnsConsolidatedCatalogue()
-    {
-        /*
-         * This will be useful once we refactor so that different domains will be loaded lazily (on-demand).
-         * In that case, getCatalogue() will probably have to load all missing domains in order to return
-         * one complete catalogue.
-         */
-
-        $locale = 'whatever';
-        $translator = new Translator($locale);
-        $translator->addLoader('loader-a', new ArrayLoader());
-        $translator->addLoader('loader-b', new ArrayLoader());
-        $translator->addResource('loader-a', array('foo' => 'foofoo'), $locale, 'domain-a');
-        $translator->addResource('loader-b', array('bar' => 'foobar'), $locale, 'domain-b');
-
-        /*
-         * Test that we get a single catalogue comprising messages
-         * from different loaders and different domains
-         */
-        $catalogue = $translator->getCatalogue($locale);
-        $this->assertTrue($catalogue->defines('foo', 'domain-a'));
-        $this->assertTrue($catalogue->defines('bar', 'domain-b'));
     }
 
     public function testSetFallbackLocales()

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Translation\Tests;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\MessageCatalogue;
 
 class TranslatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -72,6 +73,44 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $translator->setLocale($locale);
 
         $this->assertEquals($locale, $translator->getLocale());
+    }
+
+    public function testLegacyGetCatalogue()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        $translator = new Translator('en');
+
+        $this->assertEquals(new MessageCatalogue('en'), $translator->getCatalogue());
+
+        $translator->setLocale('fr');
+        $this->assertEquals(new MessageCatalogue('fr'), $translator->getCatalogue('fr'));
+    }
+
+    public function testLegacyGetCatalogueReturnsConsolidatedCatalogue()
+    {
+        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
+
+        /*
+         * This will be useful once we refactor so that different domains will be loaded lazily (on-demand).
+         * In that case, getCatalogue() will probably have to load all missing domains in order to return
+         * one complete catalogue.
+         */
+
+        $locale = 'whatever';
+        $translator = new Translator($locale);
+        $translator->addLoader('loader-a', new ArrayLoader());
+        $translator->addLoader('loader-b', new ArrayLoader());
+        $translator->addResource('loader-a', array('foo' => 'foofoo'), $locale, 'domain-a');
+        $translator->addResource('loader-b', array('bar' => 'foobar'), $locale, 'domain-b');
+
+        /*
+         * Test that we get a single catalogue comprising messages
+         * from different loaders and different domains
+         */
+        $catalogue = $translator->getCatalogue($locale);
+        $this->assertTrue($catalogue->defines('foo', 'domain-a'));
+        $this->assertTrue($catalogue->defines('bar', 'domain-b'));
     }
 
     public function testSetFallbackLocales()

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -494,7 +494,10 @@ EOF
     }
 
     /**
-     * Could be renamed back to getCatalogue() and made private once we drop TranslatorBagInterface in 3.0.
+     * Used internally to circumvent deprecation message in getCatalogue().
+     *
+     * Once TranslatorBagInterface has been removed in 3.0, we should rename this back to getCatalogue()
+     * but keep it private.
      *
      * @param string $locale
      *

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -496,6 +496,13 @@ EOF
         return $this->configCacheFactory;
     }
 
+    /**
+     * Could be renamed back to getCatalogue() and made private once we drop TranslatorBagInterface in 3.0.
+     *
+     * @param string $locale
+     *
+     * @return MessageCatalogueInterface
+     */
     private function getCatalogueInternal($locale = null)
     {
         if (null === $locale) {

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -259,10 +259,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, Fallbac
      */
     public function getCatalogue($locale = null)
     {
-        trigger_error(
-            'The Translator will no longer implement TranslatorBagInterface in 3.0. If you want to find the locale actually used for a translation, use the resolveLocale() method instead.',
-            E_USER_DEPRECATED
-        );
+        @trigger_error('The Translator will no longer implement \Symfony\Component\Translation\TranslatorBagInterface in 3.0.', E_USER_DEPRECATED);
 
         return $this->getCatalogueInternal($locale);
     }

--- a/src/Symfony/Component/Translation/TranslatorBagInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorBagInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Translation;
  * TranslatorBagInterface.
  *
  * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
+ *
+ * @deprecated since 2.8, to be removed in 3.0.
  */
 interface TranslatorBagInterface
 {

--- a/src/Symfony/Component/Translation/TranslatorBagToFallbackLocaleAwareAdapter.php
+++ b/src/Symfony/Component/Translation/TranslatorBagToFallbackLocaleAwareAdapter.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+/**
+ * Implements the FallbackLocaleAwareInterface by using the
+ * TranslatorBagInterface.
+ *
+ * It will iterate along the catalogue chain in order to find the
+ * first locale that contains a given message.
+ *
+ * Needed for a BC transition from Symfony 2.8 to 3.0. To be removed
+ * Symfony 3.0.
+ *
+ * @deprecated
+ */
+class TranslatorBagToFallbackLocaleAwareAdapter implements FallbackLocaleAwareInterface
+{
+    private $translatorBag;
+
+    public function __construct(TranslatorBagInterface $translatorBag)
+    {
+        $this->translatorBag = $translatorBag;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveLocale($id, $domain = null, $locale = null)
+    {
+        $id = (string)$id;
+        $catalogue = $this->translatorBag->getCatalogue($locale);
+        $locale = $catalogue->getLocale();
+
+        while (!$catalogue->defines($id, $domain)) {
+            if ($cat = $catalogue->getFallbackCatalogue()) {
+                $catalogue = $cat;
+                $locale = $catalogue->getLocale();
+            } else {
+                return null;
+            }
+        }
+
+        return $locale;
+    }
+}

--- a/src/Symfony/Component/Translation/TranslatorBagToFallbackLocaleAwareAdapter.php
+++ b/src/Symfony/Component/Translation/TranslatorBagToFallbackLocaleAwareAdapter.php
@@ -37,7 +37,7 @@ class TranslatorBagToFallbackLocaleAwareAdapter implements FallbackLocaleAwareIn
      */
     public function resolveLocale($id, $domain = null, $locale = null)
     {
-        $id = (string)$id;
+        $id = (string) $id;
         $catalogue = $this->translatorBag->getCatalogue($locale);
         $locale = $catalogue->getLocale();
 
@@ -46,7 +46,7 @@ class TranslatorBagToFallbackLocaleAwareAdapter implements FallbackLocaleAwareIn
                 $catalogue = $cat;
                 $locale = $catalogue->getLocale();
             } else {
-                return null;
+                return;
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | n/a |

We would like the `Translator` to be able to perform various optimizations on the `MessageCatalogues` it holds internally. One particular example is working with reduced catalogues for fallback locales that only contain the messages not present in one of the more preferred locales, or possibly do a lazy-loading of catalogues for fallback locales.

These optimizations are not possible as long as clients are able to retrieve the `MessageCatalogue` instances used inside the `Translator` by means of the `TranslatorBagInterface` and expect them to be full-fledged and complete catalogue instances (so the initial attempt had to be reverted in #14315, also see #14380 for a discussion). 

In other words, `TranslatorBagInterface` breaks a boundary of encapsulation important for optimizations.

The two clients of the interface inside Symfony are not really interested in the catalogues per se, but only need them to iterate along the fallback chain in order to figure out the locale ultimately used. This information can now be obtained through the new `FallbackLocaleAwareInterface`.

**To be discussed:**
- In 3.0, should `FallbackLocaleAwareInterface` remain a dedicated interface or become part of `TranslatorInterface`?
- Shall we keep the `TranslatorBagInterface` in the future, especially if `Translator` does not implement it?
