### PR TITLE
[Validator] Added a format option to the DateTime constraint.

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----
 
  * added the BIC (SWIFT-Code) validator
+ * deprecated `DateTimeValidator::PATTERN` constant
+ * added a `format` option to the `DateTime` constraint
 
 2.7.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -31,5 +31,6 @@ class DateTime extends Constraint
         self::INVALID_TIME_ERROR => 'INVALID_TIME_ERROR',
     );
 
+    public $format = 'Y-m-d H:i:s';
     public $message = 'This value is not a valid datetime.';
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -56,12 +56,30 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate(new \stdClass(), new DateTime());
     }
 
+    public function testDateTimeWithDefaultFormat()
+    {
+        $this->validator->validate('1995-05-10 19:33:00', new DateTime());
+
+        $this->assertNoViolation();
+
+        $this->validator->validate('1995-03-24', new DateTime());
+
+        $this->buildViolation('This value is not a valid datetime.')
+            ->setParameter('{{ value }}', '"1995-03-24"')
+            ->setCode(DateTime::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
     /**
      * @dataProvider getValidDateTimes
      */
-    public function testValidDateTimes($dateTime)
+    public function testValidDateTimes($format, $dateTime)
     {
-        $this->validator->validate($dateTime, new DateTime());
+        $constraint = new DateTime(array(
+            'format' => $format,
+        ));
+
+        $this->validator->validate($dateTime, $constraint);
 
         $this->assertNoViolation();
     }
@@ -69,19 +87,22 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
     public function getValidDateTimes()
     {
         return array(
-            array('2010-01-01 01:02:03'),
-            array('1955-12-12 00:00:00'),
-            array('2030-05-31 23:59:59'),
+            array('Y-m-d H:i:s e', '1995-03-24 00:00:00 UTC'),
+            array('Y-m-d H:i:s', '2010-01-01 01:02:03'),
+            array('Y/m/d H:i', '2010/01/01 01:02'),
+            array('F d, Y', 'December 31, 1999'),
+            array('d-m-Y', '10-05-1995'),
         );
     }
 
     /**
      * @dataProvider getInvalidDateTimes
      */
-    public function testInvalidDateTimes($dateTime, $code)
+    public function testInvalidDateTimes($format, $dateTime, $code)
     {
         $constraint = new DateTime(array(
             'message' => 'myMessage',
+            'format' => $format,
         ));
 
         $this->validator->validate($dateTime, $constraint);
@@ -95,16 +116,16 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
     public function getInvalidDateTimes()
     {
         return array(
-            array('foobar', DateTime::INVALID_FORMAT_ERROR),
-            array('2010-01-01', DateTime::INVALID_FORMAT_ERROR),
-            array('00:00:00', DateTime::INVALID_FORMAT_ERROR),
-            array('2010-01-01 00:00', DateTime::INVALID_FORMAT_ERROR),
-            array('2010-13-01 00:00:00', DateTime::INVALID_DATE_ERROR),
-            array('2010-04-32 00:00:00', DateTime::INVALID_DATE_ERROR),
-            array('2010-02-29 00:00:00', DateTime::INVALID_DATE_ERROR),
-            array('2010-01-01 24:00:00', DateTime::INVALID_TIME_ERROR),
-            array('2010-01-01 00:60:00', DateTime::INVALID_TIME_ERROR),
-            array('2010-01-01 00:00:60', DateTime::INVALID_TIME_ERROR),
+            array('Y-m-d', 'foobar', DateTime::INVALID_FORMAT_ERROR),
+            array('H:i', '00:00:00', DateTime::INVALID_FORMAT_ERROR),
+            array('Y-m-d', '2010-01-01 00:00', DateTime::INVALID_FORMAT_ERROR),
+            array('Y-m-d e', '2010-01-01 TCU', DateTime::INVALID_FORMAT_ERROR),
+            array('Y-m-d H:i:s', '2010-13-01 00:00:00', DateTime::INVALID_DATE_ERROR),
+            array('Y-m-d H:i:s', '2010-04-32 00:00:00', DateTime::INVALID_DATE_ERROR),
+            array('Y-m-d H:i:s', '2010-02-29 00:00:00', DateTime::INVALID_DATE_ERROR),
+            array('Y-m-d H:i:s', '2010-01-01 24:00:00', DateTime::INVALID_TIME_ERROR),
+            array('Y-m-d H:i:s', '2010-01-01 00:60:00', DateTime::INVALID_TIME_ERROR),
+            array('Y-m-d H:i:s', '2010-01-01 00:00:60', DateTime::INVALID_TIME_ERROR),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #14521 |
| License | MIT |
| Doc PR | symfony/symfony-docs#5223 |

This PR adds a new `format` option to the `DateTime` constraint and deprecate the `Date` and `Time` constraints in favor of this new option.
- [x] update docs
