### PR TITLE
[Validator] Add "format" option to DateTime constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+* deprecated `Date` and `Time` constraints
+* deprecated `DateValidator` and `TimeValidator` validators
+* deprecated `PATTERN` constant in `DateTimeValidator`
+* added new optional `format` option to `DateTime` constraint
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -20,6 +20,8 @@ use Symfony\Component\Validator\Constraint;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ * 
+ * @deprecated since version 2.8, to be removed in 3.0. Use {@link DateTime} instead.
  */
 class Date extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraint;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Radu Murzea <radu.murzea@gmail.com>
  *
  * @api
  */
@@ -34,4 +35,5 @@ class DateTime extends Constraint
     );
 
     public $message = 'This value is not a valid datetime.';
+    public $format = 'Y-m-d H:i:s';
 }

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -20,6 +20,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ * 
+ * @deprecated since version 2.8, to be removed in 3.0. Use {@link DateTimeValidator} instead.
  */
 class DateValidator extends ConstraintValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -20,6 +20,8 @@ use Symfony\Component\Validator\Constraint;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ * 
+ * @deprecated since version 2.8, to be removed in 3.0. Use {@link DateTime} instead.
  */
 class Time extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -20,6 +20,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
+ * 
+ * @deprecated since version 2.8, to be removed in 3.0. Use {@link DateTimeValidator} instead.
  */
 class TimeValidator extends ConstraintValidator
 {

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -98,6 +98,8 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
             array('foobar', DateTime::INVALID_FORMAT_ERROR),
             array('2010-01-01', DateTime::INVALID_FORMAT_ERROR),
             array('00:00:00', DateTime::INVALID_FORMAT_ERROR),
+            array('2010-0101 01:02:03', DateTime::INVALID_FORMAT_ERROR),
+            array('2010-01-01X01:02:03', DateTime::INVALID_FORMAT_ERROR),
             array('2010-01-01 00:00', DateTime::INVALID_FORMAT_ERROR),
             array('2010-13-01 00:00:00', DateTime::INVALID_DATE_ERROR),
             array('2010-04-32 00:00:00', DateTime::INVALID_DATE_ERROR),
@@ -105,6 +107,29 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
             array('2010-01-01 24:00:00', DateTime::INVALID_TIME_ERROR),
             array('2010-01-01 00:60:00', DateTime::INVALID_TIME_ERROR),
             array('2010-01-01 00:00:60', DateTime::INVALID_TIME_ERROR),
+        );
+    }
+
+    /**
+     * @dataProvider getCustomDateTimes
+     */
+    public function testCustomFormatDateTime($format, $dateTime)
+    {
+        $constraint = new DateTime(array(
+            'format' => $format,
+        ));
+
+        $this->validator->validate($dateTime, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function getCustomDateTimes()
+    {
+        return array(
+            array('d-m-Y', '15-07-2015'),
+            array('m-Y-d i:H', '11-2013-29 47:19'),
+            array('Y F d', '2002 March 17'),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -15,6 +15,9 @@ use Symfony\Component\Validator\Constraints\Date;
 use Symfony\Component\Validator\Constraints\DateValidator;
 use Symfony\Component\Validator\Validation;
 
+/**
+ * @deprecated since version 2.8, to be removed in 3.0.
+ */
 class DateValidatorTest extends AbstractConstraintValidatorTest
 {
     protected function getApiVersion()

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -15,6 +15,9 @@ use Symfony\Component\Validator\Constraints\Time;
 use Symfony\Component\Validator\Constraints\TimeValidator;
 use Symfony\Component\Validator\Validation;
 
+/**
+ * @deprecated since version 2.8, to be removed in 3.0.
+ */
 class TimeValidatorTest extends AbstractConstraintValidatorTest
 {
     protected function getApiVersion()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #14521  and partial #14510 |
| License | MIT |
| Doc PR | None yet |

This PR adds a new `format` option to the `DateTime` constraint and deprecates `Date` and `Time` constraints.

I will do a PR with necessary changes on SymfonyDocumentation if accepted.
