### PR TITLE
Adding a new interface that give voters access to AccessDecisionManager

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -56,6 +56,13 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
         $this->strategy = $strategyMethod;
         $this->allowIfAllAbstainDecisions = (bool) $allowIfAllAbstainDecisions;
         $this->allowIfEqualGrantedDeniedDecisions = (bool) $allowIfEqualGrantedDeniedDecisions;
+
+        // inject this AccessDecisionManager into any voters that want it
+        foreach ($this->voters as $voter) {
+            if ($voter instanceof AccessDecisionManagerAwareInterface) {
+                $voter->setAccessDecisionManager($this);
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerAwareInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerAwareInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+/**
+ * If a Voter implements this interface, AccessDecisionManager will call
+ * setAccessDecisionManager on the voter before calling vote().
+ *
+ * This allows Voters to get access to the AccessDecisionManager so that
+ * they can check the result of other voters internally.
+ */
+interface AccessDecisionManagerAwareInterface
+{
+    /**
+     * This method is called on a voter that implements this interface
+     * before calling vote().
+     *
+     * @param AccessDecisionManagerInterface $decisionManager
+     */
+    public function setAccessDecisionManager(AccessDecisionManagerInterface $decisionManager);
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -65,14 +65,21 @@ class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testAccessDecisionManagerInterfaceSetting()
     {
-        // mock our stub voter that implements the AccessDecisionManagerAwareInterface
-        $voter = $this->getMock('Symfony\Component\Security\Core\Tests\Authorization\VoterWithAccessDecisionManagerAwareInterfaceStub');
+        $strategies = array('affirmative', 'consensus', 'unanimous');
 
-        $voter->expects($this->once())
-              ->method('setAccessDecisionManager')
-              ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authorization\AccessDecisionManager'));
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        foreach ($strategies as $strategy) {
+            // mock our stub voter that implements the AccessDecisionManagerAwareInterface
+            $voter = $this->getMock('Symfony\Component\Security\Core\Tests\Authorization\VoterWithAccessDecisionManagerAwareInterfaceStub');
 
-        $manager = new AccessDecisionManager(array($voter));
+            $manager = new AccessDecisionManager(array($voter), $strategy);
+
+            $voter->expects($this->once())
+                  ->method('setAccessDecisionManager')
+                  ->with($manager);
+
+            $manager->decide($token, array('ROLE_DOES_NOT_MATTER'));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerAwareInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
@@ -60,6 +61,18 @@ class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
     public function testSetUnsupportedStrategy()
     {
         new AccessDecisionManager(array($this->getVoter(VoterInterface::ACCESS_GRANTED)), 'fooBar');
+    }
+
+    public function testAccessDecisionManagerInterfaceSetting()
+    {
+        // mock our stub voter that implements the AccessDecisionManagerAwareInterface
+        $voter = $this->getMock('Symfony\Component\Security\Core\Tests\Authorization\VoterWithAccessDecisionManagerAwareInterfaceStub');
+
+        $voter->expects($this->once())
+              ->method('setAccessDecisionManager')
+              ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authorization\AccessDecisionManager'));
+
+        $manager = new AccessDecisionManager(array($voter));
     }
 
     /**
@@ -195,4 +208,9 @@ class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
 
         return $voter;
     }
+}
+
+// stub class that implements AccessDecisionManagerAwareInterface
+abstract class VoterWithAccessDecisionManagerAwareInterfaceStub implements VoterInterface, AccessDecisionManagerAwareInterface
+{
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | partially #12360 |
| License | MIT |
| Doc PR | not yet (but I'm good for it) |

Hi guys!

**Problem**: From inside a voter, if you want to check an attribute from another voter, you can't do that easily. You need the `security.access.decision_manager` service, but injecting it (or `security.authorization_checker`) causes a circular reference exception. So, you need to inject the entire container.

**Solution**: With this, if your voter implements the new `AccessDecisionManagerAwareInterface`, then `setAccessDecisionManager` is called on it before `vote()`.

This allows code like:

``` php
public function vote(TokenInterface $token, $object, array $attributes)
{
    if ($this->accessDecisionManager->decide($token, array('ROLE_ADMIN')) {
        return self::ACCESS_GRANTED;
    }

    // ... your normal logic
}
```

Thanks!
