### PR TITLE
Avoid unnecessary calls to strtolower().

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -314,11 +314,9 @@ class Container implements IntrospectableContainerInterface
                     }
 
                     throw new ServiceNotFoundException($id, null, null, $alternatives);
-                }
-                if ($strtolower) {
+                } else if ($strtolower) {
                     return;
-                }
-                else {
+                } else {
                     continue;
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -290,57 +290,62 @@ class Container implements IntrospectableContainerInterface
             if (isset($this->services[$id]) || array_key_exists($id, $this->services)) {
                 return $this->services[$id];
             }
-        }
 
-        if (isset($this->loading[$id])) {
-            throw new ServiceCircularReferenceException($id, array_keys($this->loading));
-        }
-
-        if (isset($this->methodMap[$id])) {
-            $method = $this->methodMap[$id];
-        } elseif (method_exists($this, $method = 'get'.strtr($id, array('_' => '', '.' => '_', '\\' => '_')).'Service')) {
-            // $method is set to the right value, proceed
-        } else {
-            if (self::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
-                if (!$id) {
-                    throw new ServiceNotFoundException($id);
-                }
-
-                $alternatives = array();
-                foreach ($this->services as $key => $associatedService) {
-                    $lev = levenshtein($id, $key);
-                    if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {
-                        $alternatives[] = $key;
-                    }
-                }
-
-                throw new ServiceNotFoundException($id, null, null, $alternatives);
+            if (isset($this->loading[$id])) {
+                throw new ServiceCircularReferenceException($id, array_keys($this->loading));
             }
 
-            return;
-        }
+            if (isset($this->methodMap[$id])) {
+                $method = $this->methodMap[$id];
+            } elseif (method_exists($this, $method = 'get'.strtr($id, array('_' => '', '.' => '_', '\\' => '_')).'Service')) {
+                // $method is set to the right value, proceed
+            } else {
+                if ($strtolower && self::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
+                    if (!$id) {
+                        throw new ServiceNotFoundException($id);
+                    }
 
-        $this->loading[$id] = true;
+                    $alternatives = array();
+                    foreach ($this->services as $key => $associatedServices) {
+                        $lev = levenshtein($id, $key);
+                        if ($lev <= strlen($id) / 3 || false !== strpos($key, $id)) {
+                            $alternatives[] = $key;
+                        }
+                    }
 
-        try {
-            $service = $this->$method();
-        } catch (\Exception $e) {
+                    throw new ServiceNotFoundException($id, null, null, $alternatives);
+                }
+                if ($strtolower) {
+                    return;
+                }
+                else {
+                    continue;
+                }
+
+            }
+
+            $this->loading[$id] = true;
+
+            try {
+                $service = $this->$method();
+            } catch (\Exception $e) {
+                unset($this->loading[$id]);
+
+                if (array_key_exists($id, $this->services)) {
+                    unset($this->services[$id]);
+                }
+
+                if ($e instanceof InactiveScopeException && self::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
+                    return;
+                }
+
+                throw $e;
+            }
+
             unset($this->loading[$id]);
 
-            if (array_key_exists($id, $this->services)) {
-                unset($this->services[$id]);
-            }
-
-            if ($e instanceof InactiveScopeException && self::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
-                return;
-            }
-
-            throw $e;
+            return $service;
         }
-
-        unset($this->loading[$id]);
-
-        return $service;
     }
 
     /**


### PR DESCRIPTION
DependencyInjection - remove unnecessary calls to strtolower()

I noticed when profiling Drupal 8, that each service requested via container::get() requires a strtolower() call. This was previously saved for multiple calls to the same service with e4b30397, but we can also avoid the initial call too but slightly re-organising the code. Most of the diff is indentation.

Drupal.org issue here which shows the (very modest, about 0.5ms in my profiling) performance improvement: https://www.drupal.org/node/2480943

| Q | A |
| --- | --- |
| Bug fix? | [yes |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [] |
