### PR TITLE
[FrameworkBundle] Fix assets test

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -47,6 +47,9 @@ $container->loadFromExtension('framework', array(
         ),
         'hinclude_default_template' => 'global_hinclude_template',
     ),
+    'assets' => array(
+        'version' => 'v1',
+    ),
     'translator' => array(
         'enabled' => true,
         'fallback' => 'fr',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -34,6 +34,7 @@
                  <framework:resource>theme2</framework:resource>
             </framework:form>
         </framework:templating>
+        <framework:assets version="v1" />
         <framework:translator enabled="true" fallback="fr" logging="true" />
         <framework:validation enabled="true" cache="apc" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -36,6 +36,8 @@ framework:
         form:
             resources:    [theme1, theme2]
         hinclude_default_template: global_hinclude_template
+    assets:
+        version: v1
     translator:
         enabled:  true
         fallback: fr

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -467,9 +467,8 @@ abstract class FrameworkExtensionTest extends TestCase
     public function testAssetHelperWhenTemplatesAreEnabledAndAssetsAreDisabled()
     {
         $container = $this->createContainerFromFile('assets_disabled');
-        $packages = $container->getDefinition('templating.helper.assets')->getArgument(0);
 
-        $this->assertSame('assets.packages', (string) $packages);
+        $this->assertFalse($container->hasDefinition('templating.helper.assets'));
     }
 
     protected function createContainer(array $data = array())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I'm not sure about this change, but the tests introduced in #14419 are failing in master, the same error ocurrs in both tests: `Symfony\Component\DependencyInjection\Exception\InvalidArgumentException: The service definition "templating.helper.assets" does not exist.`
