### PR TITLE
[2.7][DoctrineBridge] Handle EntityManagerDecorator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Decorator\EntityManagerDecorator;
 
 /**
  * Loads entities using a {@link QueryBuilder} instance.
@@ -59,7 +60,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
         if ($queryBuilder instanceof \Closure) {
             trigger_error('Passing a QueryBuilder closure to '.__CLASS__.'::__construct() is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
 
-            if (!$manager instanceof EntityManager) {
+            if (!$manager instanceof EntityManager && !$manager instanceof EntityManagerDecorator) {
                 throw new UnexpectedTypeException($manager, 'Doctrine\ORM\EntityManager');
             }
 

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -14,8 +14,7 @@ namespace Symfony\Bridge\Doctrine\Form\ChoiceList;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Decorator\EntityManagerDecorator;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Loads entities using a {@link QueryBuilder} instance.
@@ -60,8 +59,8 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
         if ($queryBuilder instanceof \Closure) {
             trigger_error('Passing a QueryBuilder closure to '.__CLASS__.'::__construct() is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
 
-            if (!$manager instanceof EntityManager && !$manager instanceof EntityManagerDecorator) {
-                throw new UnexpectedTypeException($manager, 'Doctrine\ORM\EntityManager');
+            if (!$manager instanceof EntityManagerInterface) {
+                throw new UnexpectedTypeException($manager, 'Doctrine\ORM\EntityManagerInterface');
             }
 
             trigger_error('Passing an EntityManager to '.__CLASS__.'::__construct() is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
@@ -97,7 +96,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
 
         // Guess type
         $entity = current($qb->getRootEntities());
-        $metadata = $qb->getEntityManager()->getClassMetadata($entity);
+        $metadata = $qb->getEntityManager(En)->getClassMetadata($entity);
         if (in_array($metadata->getTypeOfField($identifier), array('integer', 'bigint', 'smallint'))) {
             $parameterType = Connection::PARAM_INT_ARRAY;
         } else {

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -96,7 +96,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
 
         // Guess type
         $entity = current($qb->getRootEntities());
-        $metadata = $qb->getEntityManager(En)->getClassMetadata($entity);
+        $metadata = $qb->getEntityManager()->getClassMetadata($entity);
         if (in_array($metadata->getTypeOfField($identifier), array('integer', 'bigint', 'smallint'))) {
             $parameterType = Connection::PARAM_INT_ARRAY;
         } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Manager can either be a EntityManager or an EntityManagerDecorator.
EntityManagerDecorator is used when the default EntityManager has been decorated into an other service.
