### PR TITLE
[Securty] PhpDoc fix in AbstractRememberMeServices

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -217,7 +217,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
      * @param array   $cookieParts
      * @param Request $request
      *
-     * @return TokenInterface
+     * @return UserInterface
      */
     abstract protected function processAutoLoginCookie(array $cookieParts, Request $request);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

All extending classes return `UserInterface`, not `TokenInterface`:
- https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php#L64
- https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php#L116

And `AbstractRememberMeServices` actually requires the return value to be `UserInterface`:

```
$user = $this->processAutoLoginCookie($cookieParts, $request);

if (!$user instanceof UserInterface) {
    throw new \RuntimeException('processAutoLoginCookie() must return a UserInterface implementation.');
}
```
