### PR TITLE
[Security] Removed unnecessary statement

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -98,7 +98,6 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
             throw new AuthenticationException('The cookie has expired.');
         }
 
-        $series = $persistentToken->getSeries();
         $tokenValue = base64_encode($this->secureRandom->nextBytes(64));
         $this->tokenProvider->updateToken($series, $tokenValue, new \DateTime());
         $request->attributes->set(self::COOKIE_ATTR_NAME,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Removed unnecessary statement from `PersistentTokenBasedRememberMeServices.php`.

`$series` comes from `$cookieParts` and `$this->tokenProvider->loadTokenBySeries($series);` is supposed to find the token with that value. Doing `$persistentToken->getSeries();` should give us exactly the same value, so it is an unnecessary statement.

Why?
- We don't need it? We won't miss it when it's gone.
- It confuses a code reader who starts guessing why would that be needed (at least I did and lost time because of that).

Unless…

It actually is needed, as we want `TokenProviderInterface` implementations to have a possibility to give a `PersistentTokenInterface` with a different series value than asked… I can make a PR to the testing class so that such requirement is checked upon.

I don't believe that this is BC, as this behaviour isn't documented anywhere and no existing (known to me) implementations return different series than the asked ones (and current tests pass successfully).
