### PR TITLE
[Debug] Fixed ClassNotFoundFatalErrorHandlerTest

### DIFF
--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -181,11 +181,11 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testCannotRedeclareClass()
     {
-        if (!file_exists(__DIR__.'/../FIXTURES/REQUIREDTWICE.PHP')) {
+        if (!file_exists(__DIR__.'/../FIXTURES2/REQUIREDTWICE.PHP')) {
             $this->markTestSkipped('Can only be run on case insensitive filesystems');
         }
 
-        require_once __DIR__.'/../FIXTURES/REQUIREDTWICE.PHP';
+        require_once __DIR__.'/../FIXTURES2/REQUIREDTWICE.PHP';
 
         $error = array(
             'type' => 1,

--- a/src/Symfony/Component/Debug/Tests/Fixtures/RequiredTwice.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/RequiredTwice.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Symfony\Component\Debug\Tests\Fixtures;
-
-class RequiredTwice
-{
-}

--- a/src/Symfony/Component/Debug/Tests/Fixtures2/RequiredTwice.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures2/RequiredTwice.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures2;
+
+class RequiredTwice
+{
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14573 |
| License | MIT |
| Doc PR |  |

Since `testCannotRedeclareClass` is skipped on case-sensitive filesystems, it won't have any effect on the travis build, but fixes the issue described in #14573 for e.g. OS X.
