### PR TITLE
[FrameworkBundle] Applied new styles to the config:debug & config:dump-reference commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\StyleInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
@@ -27,24 +28,21 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
 {
     protected function listBundles(OutputInterface $output)
     {
-        $output->writeln('Available registered bundles with their extension alias if available:');
-
-        if (class_exists('Symfony\Component\Console\Helper\Table')) {
-            $table = new Table($output);
-        } else {
-            $table = $this->getHelperSet()->get('table');
-        }
-
-        $table->setHeaders(array('Bundle name', 'Extension alias'));
+        $headers = array('Bundle name', 'Extension alias');
+        $rows = array();
         foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
             $extension = $bundle->getContainerExtension();
-            $table->addRow(array($bundle->getName(), $extension ? $extension->getAlias() : ''));
+            $rows[] = array($bundle->getName(), $extension ? $extension->getAlias() : '');
         }
 
-        if (class_exists('Symfony\Component\Console\Helper\Table')) {
-            $table->render();
+        $message = 'Available registered bundles with their extension alias if available:';
+        if ($output instanceof StyleInterface) {
+            $output->writeln(' '.$message);
+            $output->table($headers, $rows);
         } else {
-            $table->render($output);
+            $output->writeln($message);
+            $table = new Table($output);
+            $table->setHeaders($headers)->setRows($rows)->render($output);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -57,8 +58,9 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $output = new SymfonyStyle($input, $output);
         if (false !== strpos($input->getFirstArgument(), ':d')) {
-            $output->writeln('<comment>The use of "config:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:config" instead.</comment>');
+            $output->caution('The use of "config:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:config" instead.');
         }
 
         $name = $input->getArgument('name');

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * A console command for dumping available configuration reference.
@@ -66,6 +67,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $output = new SymfonyStyle($input, $output);
         $name = $input->getArgument('name');
 
         if (empty($name)) {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7",
         "symfony/browser-kit": "~2.4",
-        "symfony/console": "~2.6",
+        "symfony/console": "~2.7",
         "symfony/css-selector": "~2.0,>=2.0.5",
         "symfony/dom-crawler": "~2.0,>=2.0.5",
         "symfony/finder": "~2.0,>=2.0.5",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | Partially #14138 |
| License | MIT |
| Doc PR | - |

Min dependency on `symfony/console` is changed to `~2.7` in the FrameworkBundle, as it will be a requirement in order to update each command provided in this bundle.
