### PR TITLE
[FrameworkBundle] Applied new styles to translation commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7",
         "symfony/browser-kit": "~2.4",
-        "symfony/console": "~2.6",
+        "symfony/console": "~2.7",
         "symfony/css-selector": "~2.0,>=2.0.5",
         "symfony/dom-crawler": "~2.0,>=2.0.5",
         "symfony/finder": "~2.0,>=2.0.5",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | Partially #14138 |
| License | MIT |
| Doc PR | - |
## Translation debug

_Only the table layout and deprecation note is changed_

![screenshot 2015-05-09 a 17 09 17](https://cloud.githubusercontent.com/assets/2211145/7550802/45f9a53c-f670-11e4-8e33-6ec9de973c99.PNG)
![screenshot 2015-05-09 a 17 13 47](https://cloud.githubusercontent.com/assets/2211145/7551396/d57523e2-f686-11e4-907c-8b4183183ee1.PNG)
## Translation update
### Before:

![screenshot 2015-05-09 a 17 15 51](https://cloud.githubusercontent.com/assets/2211145/7550791/06cee3a4-f670-11e4-80f1-320e2768290c.PNG)
### After:

![screenshot 2015-05-09 a 17 03 59](https://cloud.githubusercontent.com/assets/2211145/7550797/45f3baaa-f670-11e4-9beb-ad6c6b10442c.PNG)
![screenshot 2015-05-09 a 17 04 35](https://cloud.githubusercontent.com/assets/2211145/7550799/45f7ed64-f670-11e4-9b77-9b602ea2920b.PNG)
![screenshot 2015-05-09 a 17 05 06](https://cloud.githubusercontent.com/assets/2211145/7550800/45f97904-f670-11e4-8b60-c73095b74800.PNG)
![screenshot 2015-05-09 a 17 06 07](https://cloud.githubusercontent.com/assets/2211145/7550798/45f6508a-f670-11e4-9c21-7247691df985.PNG)
