### PR TITLE
[Stopwatch] Fix volatile tests

### DIFF
--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -113,7 +113,9 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         $event->start();
         usleep(100000);
         $event->ensureStopped();
-        $this->assertEquals(300, $event->getDuration(), null, self::DELTA);
+        $duration = $event->getDuration();
+        usleep(100000);
+        $this->assertEquals($duration, $event->getDuration());
     }
 
     public function testStartTime()

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -20,8 +20,6 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 class StopwatchTest extends \PHPUnit_Framework_TestCase
 {
-    const DELTA = 20;
-
     public function testStart()
     {
         $stopwatch = new Stopwatch();
@@ -71,11 +69,12 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
     {
         $stopwatch = new Stopwatch();
         $stopwatch->start('foo', 'cat');
-        usleep(200000);
+        usleep(100000);
         $event = $stopwatch->stop('foo');
-
+        $duration = $event->getDuration();
+        usleep(100000);
         $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
-        $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
+        $this->assertEquals($duration, $event->getDuration());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14444 |
| License | MIT |

This PR fixes some volatile tests, instead of asserting for a specific duration, check if after some time the duration is the same.
