### PR TITLE
ContainerInterface: unused exception dropped

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -50,7 +50,6 @@ interface ContainerInterface
      *
      * @return object The associated service
      *
-     * @throws InvalidArgumentException          if the service is not defined
      * @throws ServiceCircularReferenceException When a circular reference is detected
      * @throws ServiceNotFoundException          When the service is not defined
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

`ServiceNotFoundException` is to be used for such a case.

Based on [base Container implementation](https://github.com/symfony/symfony/blob/e60f7159202ee9ac419022b4cf9d42486e11cdba/src/Symfony/Component/DependencyInjection/Container.php#L262), where exception is also mentioned, but never used.

Can fix there as well, when this gets accepted.

---

Note: CI failed due to missing headers, I forgot them and added them right after PR was created.
