### PR TITLE
[DomCrawler] Throw an exception if a form field path is incomplete

### DIFF
--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -124,13 +124,15 @@ class FormFieldRegistry
     public function set($name, $value)
     {
         $target = &$this->get($name);
-        if (!is_array($value) || $target instanceof Field\ChoiceFormField) {
+        if ((!is_array($value) && $target instanceof Field\FormField) || $target instanceof Field\ChoiceFormField) {
             $target->setValue($value);
-        } else {
+        } elseif (is_array($value)) {
             $fields = self::create($name, $value);
             foreach ($fields->all() as $k => $v) {
                 $this->set($k, $v);
             }
+        } else {
+            throw new \InvalidArgumentException(sprintf('Cannot set value on a compound field "%s".', $name));
         }
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -787,6 +787,31 @@ class FormTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Cannot set value on a compound field "foo[bar]".
+     */
+    public function testFormRegistrySetValueOnCompoundField()
+    {
+        $registry = new FormFieldRegistry();
+        $registry->add($this->getFormFieldMock('foo[bar][baz]'));
+
+        $registry->set('foo[bar]', 'fbb');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Unreachable field "0"
+     */
+    public function testFormRegistrySetArrayOnNotCompoundField()
+    {
+
+        $registry = new FormFieldRegistry();
+        $registry->add($this->getFormFieldMock('bar'));
+
+        $registry->set('bar', array('baz'));
+    }
+
     public function testDifferentFieldTypesWithSameName()
     {
         $dom = new \DOMDocument();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11807 |
| License | MIT |
| Doc PR | - |
