### PR TITLE
[RFC] Factor loading and caching out of Translator

### DIFF
--- a/src/Symfony/Component/Translation/Provider/Cache.php
+++ b/src/Symfony/Component/Translation/Provider/Cache.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Provider;
+
+use Symfony\Component\Config\ConfigCacheFactory;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+/**
+ * Caches the results provided by a MessageCatalogueProviderInterface
+ * in a ConfigCacheInterface instance.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+class Cache implements MessageCatalogueProviderInterface
+{
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    /**
+     * @var ConfigCacheFactoryInterface|null
+     */
+    private $configCacheFactory;
+
+    /**
+     * @var array
+     */
+    private $resources = array();
+
+    /**
+     * @var MessageCatalogueProviderInterface
+     */
+    private $inner;
+
+    public function __construct(MessageCatalogueProviderInterface $inner, $debug, $cacheDir)
+    {
+        $this->inner = $inner;
+        $this->debug = $debug;
+        $this->cacheDir = $cacheDir;
+    }
+
+    /**
+     * Sets the ConfigCache factory to use.
+     *
+     * @param ConfigCacheFactoryInterface $configCacheFactory
+     */
+    public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
+    {
+        $this->configCacheFactory = $configCacheFactory;
+    }
+
+    public function addLoader($format, LoaderInterface $loader)
+    {
+        $this->inner->addLoader($format, $loader);
+    }
+
+    public function getLoaders()
+    {
+        return $this->inner->getLoaders();
+    }
+
+    public function addResource($format, $resource, $locale, $domain = null)
+    {
+        // track resources for cache file path only
+        $this->resources[$locale][] = array($format, $resource, $domain ?: 'messages');
+        $this->inner->addResource($format, $resource, $locale, $domain);
+    }
+
+    public function provideCatalogue($locale, $fallbackLocales = array())
+    {
+        $tmpCatalogue = null;
+
+        $self = $this; // required for PHP 5.3 where "$this" cannot be use()d in anonymous functions. Change in Symfony 3.0.
+        $cache = $this->getConfigCacheFactory()->cache($this->getCatalogueCachePath($locale, $fallbackLocales),
+            function (ConfigCacheInterface $cache) use ($self, $locale, $fallbackLocales, &$tmpCatalogue) {
+                $tmpCatalogue = $self->dumpCatalogue($locale, $fallbackLocales, $cache);
+            }
+        );
+
+        if ($tmpCatalogue !== null) {
+            /* Catalogue has been initialized as it was written out to cache. */
+            return $tmpCatalogue;
+        }
+
+        /* Read catalogue from cache. */
+        return include $cache->getPath();
+    }
+
+    /**
+     * This method is public because it needs to be callable from a closure in PHP 5.3. It should be made protected (or even private, if possible) in 3.0.
+     *
+     * @internal
+     */
+    public function dumpCatalogue($locale, $fallbackLocales, ConfigCacheInterface $cache)
+    {
+        $catalogue = $this->inner->provideCatalogue($locale, $fallbackLocales);
+        $fallbackContent = $this->getFallbackContent($catalogue);
+
+        $content = sprintf(<<<EOF
+<?php
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+\$catalogue = new MessageCatalogue('%s', %s);
+
+%s
+return \$catalogue;
+
+EOF
+            ,
+            $locale,
+            var_export($catalogue->all(), true),
+            $fallbackContent
+        );
+
+        $cache->write($content, $catalogue->getResources());
+
+        return $catalogue;
+    }
+
+    private function getFallbackContent(MessageCatalogueInterface $catalogue)
+    {
+        $fallbackContent = '';
+        $current = '';
+        $replacementPattern = '/[^a-z0-9_]/i';
+        $fallbackCatalogue = $catalogue->getFallbackCatalogue();
+        while ($fallbackCatalogue) {
+            $fallback = $fallbackCatalogue->getLocale();
+            $fallbackSuffix = ucfirst(preg_replace($replacementPattern, '_', $fallback));
+            $currentSuffix = ucfirst(preg_replace($replacementPattern, '_', $current));
+
+            $fallbackContent .= sprintf(<<<EOF
+\$catalogue%s = new MessageCatalogue('%s', %s);
+\$catalogue%s->addFallbackCatalogue(\$catalogue%s);
+
+EOF
+                ,
+                $fallbackSuffix,
+                $fallback,
+                var_export($fallbackCatalogue->all(), true),
+                $currentSuffix,
+                $fallbackSuffix
+            );
+            $current = $fallbackCatalogue->getLocale();
+            $fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue();
+        }
+
+        return $fallbackContent;
+    }
+
+    private function getCatalogueCachePath($locale, $fallbackLocales)
+    {
+        $catalogueHash = sha1(serialize(array(
+            'resources' => isset($this->resources[$locale]) ? $this->resources[$locale] : array(),
+            'fallback_locales' => $fallbackLocales,
+        )));
+
+        return $this->cacheDir.'/catalogue.'.$locale.'.'.$catalogueHash.'.php';
+    }
+
+    /**
+     * Provides the ConfigCache factory implementation, falling back to a
+     * default implementation if necessary.
+     *
+     * @return ConfigCacheFactoryInterface $configCacheFactory
+     */
+    private function getConfigCacheFactory()
+    {
+        if (!$this->configCacheFactory) {
+            $this->configCacheFactory = new ConfigCacheFactory($this->debug);
+        }
+
+        return $this->configCacheFactory;
+    }
+}

--- a/src/Symfony/Component/Translation/Provider/DefaultProvider.php
+++ b/src/Symfony/Component/Translation/Provider/DefaultProvider.php
@@ -19,6 +19,8 @@ use Symfony\Component\Translation\MessageCatalogueInterface;
 /**
  * The default implementation for MessageCatalogueProviderInterface.
  *
+ * Loaders and Resources can be registered and will be used to load catalogues.
+ *
  * @author Matthias Pigulla <mp@webfactory.de>
  */
 class DefaultProvider implements MessageCatalogueProviderInterface
@@ -49,7 +51,7 @@ class DefaultProvider implements MessageCatalogueProviderInterface
             $domain = 'messages';
         }
 
-        $this->resources[$locale][] = array($format, $resource, $domain);
+        $this->resources[$locale][] = array('format' => $format, 'resource' => $resource, 'domain' => $domain);
     }
 
     public function provideCatalogue($locale, $fallbackLocales = array())
@@ -72,10 +74,11 @@ class DefaultProvider implements MessageCatalogueProviderInterface
     {
         if (isset($this->resources[$locale])) {
             foreach ($this->resources[$locale] as $resource) {
-                if (!isset($this->loaders[$resource[0]])) {
-                    throw new \RuntimeException(sprintf('The "%s" translation loader is not registered.', $resource[0]));
+                $format = $resource['format'];
+                if (!isset($this->loaders[$format])) {
+                    throw new \RuntimeException(sprintf('The "%s" translation loader is not registered.', $format));
                 }
-                $catalogue->addCatalogue($this->loaders[$resource[0]]->load($resource[1], $locale, $resource[2]));
+                $catalogue->addCatalogue($this->loaders[$format]->load($resource['resource'], $locale, $resource['domain']));
             }
         }
     }

--- a/src/Symfony/Component/Translation/Provider/DefaultProvider.php
+++ b/src/Symfony/Component/Translation/Provider/DefaultProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Provider;
+
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+/**
+ * The default implementation for MessageCatalogueProviderInterface.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+class DefaultProvider implements MessageCatalogueProviderInterface
+{
+    /**
+     * @var LoaderInterface[]
+     */
+    private $loaders = array();
+
+    /**
+     * @var array
+     */
+    private $resources = array();
+
+    public function addLoader($format, LoaderInterface $loader)
+    {
+        $this->loaders[$format] = $loader;
+    }
+
+    public function getLoaders()
+    {
+        return $this->loaders;
+    }
+
+    public function addResource($format, $resource, $locale, $domain = null)
+    {
+        if (null === $domain) {
+            $domain = 'messages';
+        }
+
+        $this->resources[$locale][] = array($format, $resource, $domain);
+    }
+
+    public function provideCatalogue($locale, $fallbackLocales = array())
+    {
+        $catalogue = new MessageCatalogue($locale);
+
+        try {
+            $this->doLoadCatalogue($catalogue, $locale);
+        } catch (NotFoundResourceException $e) {
+            if (!$fallbackLocales) {
+                throw $e;
+            }
+        }
+        $this->loadFallbackCatalogues($catalogue, $fallbackLocales);
+
+        return $catalogue;
+    }
+
+    private function doLoadCatalogue(MessageCatalogueInterface $catalogue, $locale)
+    {
+        if (isset($this->resources[$locale])) {
+            foreach ($this->resources[$locale] as $resource) {
+                if (!isset($this->loaders[$resource[0]])) {
+                    throw new \RuntimeException(sprintf('The "%s" translation loader is not registered.', $resource[0]));
+                }
+                $catalogue->addCatalogue($this->loaders[$resource[0]]->load($resource[1], $locale, $resource[2]));
+            }
+        }
+    }
+
+    private function loadFallbackCatalogues(MessageCatalogueInterface $catalogue, $fallbackLocales)
+    {
+        $current = $catalogue;
+
+        foreach ($fallbackLocales as $fallback) {
+            $fallbackCatalogue = new MessageCatalogue($fallback);
+            $this->doLoadCatalogue($fallbackCatalogue, $fallback);
+            $current->addFallbackCatalogue($fallbackCatalogue);
+            $current = $fallbackCatalogue;
+        }
+    }
+}

--- a/src/Symfony/Component/Translation/Provider/MessageCatalogueProviderInterface.php
+++ b/src/Symfony/Component/Translation/Provider/MessageCatalogueProviderInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Provider;
+
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+/**
+ * MessageCatalogueProviderInterface describes a class that can take
+ * Loaders (@see LoaderInterface), some resources and then provide
+ * a MessageCatalogue chain for a given primary and possibly additional
+ * fallback locales.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+interface MessageCatalogueProviderInterface
+{
+    /**
+     * Adds a Loader.
+     *
+     * @param string          $format The name of the loader (@see addResource())
+     * @param LoaderInterface $loader A LoaderInterface instance
+     */
+    public function addLoader($format, LoaderInterface $loader);
+
+    /**
+     * Gets the loaders.
+     *
+     * @return array LoaderInterface[]
+     */
+    public function getLoaders();
+
+    /**
+     * Adds a Resource.
+     *
+     * @param string $format   The name of the loader (@see addLoader())
+     * @param mixed  $resource The resource name
+     * @param string $locale   The locale
+     * @param string $domain   The domain
+     *
+     * @throws \InvalidArgumentException If the locale contains invalid characters
+     */
+    public function addResource($format, $resource, $locale, $domain = null);
+
+    /**
+     * Provide a MessageCatalogue chain.
+     *
+     * @param $locale          The primary locale
+     * @param $fallbackLocales Locales (in order) for the fallback catalogues
+     *
+     * @return MessageCatalogueInterface
+     */
+    public function provideCatalogue($locale, $fallbackLocales = array());
+}

--- a/src/Symfony/Component/Translation/Provider/TranslatorLegacyHelper.php
+++ b/src/Symfony/Component/Translation/Provider/TranslatorLegacyHelper.php
@@ -31,6 +31,7 @@ use Symfony\Component\Translation\Translator;
  * "inner" instance in turn.
  *
  * @internal
+ *
  * @author Matthias Pigulla <mp@webfactory.de>
  */
 class TranslatorLegacyHelper implements MessageCatalogueProviderInterface

--- a/src/Symfony/Component/Translation/Provider/TranslatorLegacyHelper.php
+++ b/src/Symfony/Component/Translation/Provider/TranslatorLegacyHelper.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Provider;
+
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\Translator;
+
+/**
+ * Implements MessageCatalogueProviderInterface by dispatching back
+ * to a Translator instance.
+ *
+ * This is needed for providing a BC upgrade path. As of writing, the actual
+ * loading of MessageCatalogues takes place below the protected Translator::initializeCatalogue()
+ * method.
+ *
+ * Translator now features an accessInitializeCatalogue() method to allow access to possible
+ * subclass implementations.
+ *
+ * This class expects to decorate another MessageCatalogueProviderInterface instance. Configuration
+ * will be forwarded to this inner instance, however the provideCatalogue() implementation will
+ * dispatch to the Translator. It is expected that the Translator will actually call the
+ * "inner" instance in turn.
+ *
+ * @internal
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+class TranslatorLegacyHelper implements MessageCatalogueProviderInterface
+{
+    /**
+     * @var MessageCatalogueProviderInterface
+     */
+    private $inner;
+
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    public function __construct(Translator $translator, MessageCatalogueProviderInterface $inner)
+    {
+        $this->translator = $translator;
+        $this->inner = $inner;
+    }
+
+    public function addLoader($format, LoaderInterface $loader)
+    {
+        $this->inner->addLoader($format, $loader);
+    }
+
+    public function getLoaders()
+    {
+        return $this->inner->getLoaders();
+    }
+
+    public function addResource($format, $resource, $locale, $domain = null)
+    {
+        $this->inner->addResource($format, $resource, $locale, $domain);
+    }
+
+    public function provideCatalogue($locale, $fallbackLocales = array())
+    {
+        return $this->translator->accessInitializeCatalogue($locale);
+    }
+}

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -12,10 +12,11 @@
 namespace Symfony\Component\Translation;
 
 use Symfony\Component\Translation\Loader\LoaderInterface;
-use Symfony\Component\Translation\Exception\NotFoundResourceException;
-use Symfony\Component\Config\ConfigCacheInterface;
 use Symfony\Component\Config\ConfigCacheFactoryInterface;
-use Symfony\Component\Config\ConfigCacheFactory;
+use Symfony\Component\Translation\Provider\Cache;
+use Symfony\Component\Translation\Provider\DefaultProvider;
+use Symfony\Component\Translation\Provider\MessageCatalogueProviderInterface;
+use Symfony\Component\Translation\Provider\TranslatorLegacyHelper;
 
 /**
  * Translator.
@@ -40,34 +41,30 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     private $fallbackLocales = array();
 
     /**
-     * @var LoaderInterface[]
-     */
-    private $loaders = array();
-
-    /**
-     * @var array
-     */
-    private $resources = array();
-
-    /**
      * @var MessageSelector
      */
     private $selector;
 
     /**
-     * @var string
+     * The MessageCatalogueProviderInterface instance that will be used
+     * from within loadCatalogue().
+     *
+     * @var MessageCatalogueProviderInterface
      */
-    private $cacheDir;
+    private $provider;
 
     /**
-     * @var bool
+     * The MessageCatalogueProviderInterface instance that actually does the
+     * loading.
+     *
+     * We need to keep this as a separate entity so that it can be called
+     * independently from within initializeCatalogue(), which is a protected
+     * method and might be called by subclasses without going through loadCatalogue()
+     * or without using the "regular" ::$messageCatalogueProvider.
+     *
+     * @var MessageCatalogueProviderInterface
      */
-    private $debug;
-
-    /**
-     * @var ConfigCacheFactoryInterface|null
-     */
-    private $configCacheFactory;
+    private $loader;
 
     /**
      * Constructor.
@@ -83,8 +80,16 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     {
         $this->setLocale($locale);
         $this->selector = $selector ?: new MessageSelector();
-        $this->cacheDir = $cacheDir;
-        $this->debug = $debug;
+
+        $this->loader = new DefaultProvider();
+
+        $provider = new TranslatorLegacyHelper($this, $this->loader);
+
+        if ($cacheDir !== null) {
+            $this->provider = new Cache($provider, $debug, $cacheDir);
+        } else {
+            $this->provider = $provider;
+        }
     }
 
     /**
@@ -94,7 +99,9 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
     {
-        $this->configCacheFactory = $configCacheFactory;
+        if ($this->provider instanceof Cache) {
+            $this->provider->setConfigCacheFactory($configCacheFactory);
+        }
     }
 
     /**
@@ -105,7 +112,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     public function addLoader($format, LoaderInterface $loader)
     {
-        $this->loaders[$format] = $loader;
+        $this->provider->addLoader($format, $loader);
     }
 
     /**
@@ -120,13 +127,8 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     public function addResource($format, $resource, $locale, $domain = null)
     {
-        if (null === $domain) {
-            $domain = 'messages';
-        }
-
         $this->assertValidLocale($locale);
-
-        $this->resources[$locale][] = array($format, $resource, $domain);
+        $this->provider->addResource($format, $resource, $locale, $domain);
 
         if (in_array($locale, $this->fallbackLocales)) {
             $this->catalogues = array();
@@ -258,7 +260,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     protected function getLoaders()
     {
-        return $this->loaders;
+        return $this->provider->getLoaders();
     }
 
     /**
@@ -288,11 +290,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     protected function loadCatalogue($locale)
     {
-        if (null === $this->cacheDir) {
-            $this->initializeCatalogue($locale);
-        } else {
-            $this->initializeCacheCatalogue($locale);
-        }
+        $this->catalogues[$locale] = $this->provider->provideCatalogue($locale, $this->computeFallbackLocales($locale));
     }
 
     /**
@@ -301,136 +299,20 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     protected function initializeCatalogue($locale)
     {
         $this->assertValidLocale($locale);
-
-        try {
-            $this->doLoadCatalogue($locale);
-        } catch (NotFoundResourceException $e) {
-            if (!$this->computeFallbackLocales($locale)) {
-                throw $e;
-            }
-        }
-        $this->loadFallbackCatalogues($locale);
+        $this->catalogues[$locale] = $this->loader->provideCatalogue($locale, $this->computeFallbackLocales($locale));
     }
 
     /**
-     * @param string $locale
-     */
-    private function initializeCacheCatalogue($locale)
-    {
-        if (isset($this->catalogues[$locale])) {
-            /* Catalogue already initialized. */
-            return;
-        }
-
-        $this->assertValidLocale($locale);
-        $self = $this; // required for PHP 5.3 where "$this" cannot be use()d in anonymous functions. Change in Symfony 3.0.
-        $cache = $this->getConfigCacheFactory()->cache($this->getCatalogueCachePath($locale),
-            function (ConfigCacheInterface $cache) use ($self, $locale) {
-                $self->dumpCatalogue($locale, $cache);
-            }
-        );
-
-        if (isset($this->catalogues[$locale])) {
-            /* Catalogue has been initialized as it was written out to cache. */
-            return;
-        }
-
-        /* Read catalogue from cache. */
-        $this->catalogues[$locale] = include $cache->getPath();
-    }
-
-    /**
-     * This method is public because it needs to be callable from a closure in PHP 5.3. It should be made protected (or even private, if possible) in 3.0.
+     * This serves as an access point for TranslatorLegacyHelper to dispatch back to the
+     * (possibly overriden) initializeCatalogue() method.
      *
      * @internal
      */
-    public function dumpCatalogue($locale, ConfigCacheInterface $cache)
+    public function accessInitializeCatalogue($locale)
     {
         $this->initializeCatalogue($locale);
-        $fallbackContent = $this->getFallbackContent($this->catalogues[$locale]);
 
-        $content = sprintf(<<<EOF
-<?php
-
-use Symfony\Component\Translation\MessageCatalogue;
-
-\$catalogue = new MessageCatalogue('%s', %s);
-
-%s
-return \$catalogue;
-
-EOF
-            ,
-            $locale,
-            var_export($this->catalogues[$locale]->all(), true),
-            $fallbackContent
-        );
-
-        $cache->write($content, $this->catalogues[$locale]->getResources());
-    }
-
-    private function getFallbackContent(MessageCatalogue $catalogue)
-    {
-        $fallbackContent = '';
-        $current = '';
-        $replacementPattern = '/[^a-z0-9_]/i';
-        $fallbackCatalogue = $catalogue->getFallbackCatalogue();
-        while ($fallbackCatalogue) {
-            $fallback = $fallbackCatalogue->getLocale();
-            $fallbackSuffix = ucfirst(preg_replace($replacementPattern, '_', $fallback));
-            $currentSuffix = ucfirst(preg_replace($replacementPattern, '_', $current));
-
-            $fallbackContent .= sprintf(<<<EOF
-\$catalogue%s = new MessageCatalogue('%s', %s);
-\$catalogue%s->addFallbackCatalogue(\$catalogue%s);
-
-EOF
-                ,
-                $fallbackSuffix,
-                $fallback,
-                var_export($fallbackCatalogue->all(), true),
-                $currentSuffix,
-                $fallbackSuffix
-            );
-            $current = $fallbackCatalogue->getLocale();
-            $fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue();
-        }
-
-        return $fallbackContent;
-    }
-
-    private function getCatalogueCachePath($locale)
-    {
-        return $this->cacheDir.'/catalogue.'.$locale.'.'.sha1(serialize($this->fallbackLocales)).'.php';
-    }
-
-    private function doLoadCatalogue($locale)
-    {
-        $this->catalogues[$locale] = new MessageCatalogue($locale);
-
-        if (isset($this->resources[$locale])) {
-            foreach ($this->resources[$locale] as $resource) {
-                if (!isset($this->loaders[$resource[0]])) {
-                    throw new \RuntimeException(sprintf('The "%s" translation loader is not registered.', $resource[0]));
-                }
-                $this->catalogues[$locale]->addCatalogue($this->loaders[$resource[0]]->load($resource[1], $locale, $resource[2]));
-            }
-        }
-    }
-
-    private function loadFallbackCatalogues($locale)
-    {
-        $current = $this->catalogues[$locale];
-
-        foreach ($this->computeFallbackLocales($locale) as $fallback) {
-            if (!isset($this->catalogues[$fallback])) {
-                $this->doLoadCatalogue($fallback);
-            }
-
-            $fallbackCatalogue = new MessageCatalogue($fallback, $this->catalogues[$fallback]->all());
-            $current->addFallbackCatalogue($fallbackCatalogue);
-            $current = $fallbackCatalogue;
-        }
+        return $this->catalogues[$locale];
     }
 
     protected function computeFallbackLocales($locale)
@@ -463,20 +345,5 @@ EOF
         if (1 !== preg_match('/^[a-z0-9@_\\.\\-]*$/i', $locale)) {
             throw new \InvalidArgumentException(sprintf('Invalid "%s" locale.', $locale));
         }
-    }
-
-    /**
-     * Provides the ConfigCache factory implementation, falling back to a
-     * default implementation if necessary.
-     *
-     * @return ConfigCacheFactoryInterface $configCacheFactory
-     */
-    private function getConfigCacheFactory()
-    {
-        if (!$this->configCacheFactory) {
-            $this->configCacheFactory = new ConfigCacheFactory($this->debug);
-        }
-
-        return $this->configCacheFactory;
     }
 }

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Translation;
 
-use Symfony\Component\Config\ConfigCacheFactory;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Config\ConfigCacheFactoryInterface;
 use Symfony\Component\Translation\Provider\Cache;
@@ -59,6 +58,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      * the initializeCatalogue() method in 3.0.
      *
      * @var MessageCatalogueProviderInterface
+     *
      * @deprecated from the start and @internal
      */
     private $initializeCatalogueMessageCatalogueProvider;
@@ -370,7 +370,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
         $reflectorMethod = $reflector->getMethod($method);
         if ($reflectorMethod->getDeclaringClass()->getName() !== __CLASS__) {
             @trigger_error(
-                'Overwriting methods in ' . __CLASS__ . ' has been deprecated in 2.8 and will not work anymore in 3.0. Check your implementation of ' . $method . '.',
+                'Overwriting methods in '.__CLASS__.' has been deprecated in 2.8 and will not work anymore in 3.0. Check your implementation of '.$method.'.',
                 E_USER_DEPRECATED
             );
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | not yet added to the code, but will follow |
| Tests pass? | yes |
| Fixed tickets | 14622 |
| License | MIT |
| Doc PR | none |

See #14530 for a discussion what this PR tries to achieve.

This is WIP, so for the time being please comment on the general approach and not on CS glitches.
## Todo:
- [ ] Move fallback locales from the `Translator` into the new `DefaultProvider`? That way the Providers would resemble (or could even implement) `TranslatorBagInterface`.
- [ ] Discuss/finalize namings
- [ ] Figure out how to deprecate `protected` methods appropriately
- [ ] Come up with a plan how the final result in 3.0 should look like.
- [ ] Can I preserve git history for code moved around?
- [ ] Refactor existing and possibly add new tests
- [ ] Make sure `assertValidLocale` calls are put in a few but "strategically right" places to prevent fixed problems from re-appearing (also when possibly using new components in isolation). 
