### PR TITLE
[DebugBundle] Always collect dumps

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -123,10 +123,10 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
         if ($this->dumper) {
             $this->doDump($data, $name, $file, $line);
-        } else {
-            $this->data[] = compact('data', 'name', 'file', 'line', 'fileExcerpt');
-            ++$this->dataCount;
         }
+
+        $this->data[] = compact('data', 'name', 'file', 'line', 'fileExcerpt');
+        ++$this->dataCount;
 
         if ($this->stopwatch) {
             $this->stopwatch->stop('dump');
@@ -136,7 +136,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         // Sub-requests and programmatic calls stay in the collected profile.
-        if (($this->requestStack && $this->requestStack->getMasterRequest() !== $request) || $request->isXmlHttpRequest() || $request->headers->has('Origin')) {
+        if ($this->dumper || ($this->requestStack && $this->requestStack->getMasterRequest() !== $request) || $request->isXmlHttpRequest() || $request->headers->has('Origin')) {
             return;
         }
 
@@ -154,13 +154,9 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                 $this->dumper = new CliDumper('php://output', $this->charset);
             }
 
-            foreach ($this->data as $i => $dump) {
-                $this->data[$i] = null;
+            foreach ($this->data as $dump) {
                 $this->doDump($dump['data'], $dump['name'], $dump['file'], $dump['line']);
             }
-
-            $this->data = array();
-            $this->dataCount = 0;
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -72,6 +72,7 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $output = ob_get_clean();
 
         $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n123\n", $output);
+        $this->assertSame(1, $collector->getDumpsCount());
     }
 
     public function testCollectHtml()
@@ -99,6 +100,7 @@ EOTXT;
         $output = preg_replace('/sf-dump-\d+/', 'sf-dump', $output);
 
         $this->assertSame($xOutput, $output);
+        $this->assertSame(1, $collector->getDumpsCount());
     }
 
     public function testFlush()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | partially #14608 |
| License | MIT |
| Doc PR | - |

Duplicating dumps fits more use cases.

I'll make an other PR on 2.8 (maybe 2.7) to allow changing the `$this->dumper` so that users could have precise control over output destination and format.
