### PR TITLE
[DebugBundle] Use output mechanism of dumpers instead of echoing

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -250,20 +250,33 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
     private function doDump($data, $name, $file, $line)
     {
-        if ($this->dumper instanceof HtmlDumper) {
-            $name = $this->htmlEncode($name);
-            $file = $this->htmlEncode($file);
-            if ('' !== $file) {
-                if ($this->fileLinkFormat) {
-                    $link = strtr($this->fileLinkFormat, array('%f' => $file, '%l' => $line));
-                    $name = sprintf('<a href="%s" title="%s">%s</a>', $link, $file, $name);
+        if (PHP_VERSION_ID >= 50400 && $this->dumper instanceof CliDumper) {
+            $contextDumper = function ($name, $file, $line, $fileLinkFormat) {
+                if ($this instanceof HtmlDumper) {
+                    if ('' !== $file) {
+                        $s = $this->style('meta', '%s');
+                        $name = strip_tags($this->style('', $name));
+                        $file = strip_tags($this->style('', $file));
+                        if ($fileLinkFormat) {
+                            $link = strtr($fileLinkFormat, array('%f' => $file, '%l' => (int) $line));
+                            $name = sprintf('<a href="%s" title="%s">'.$s.'</a>', $link, $file, $name);
+                        } else {
+                            $name = sprintf('<abbr title="%s">'.$s.'</abbr>', $file, $name);
+                        }
+                    } else {
+                        $name = $this->style('meta', $name);
+                    }
+                    $this->line = $name.' on line '.$this->style('meta', $line).':';
                 } else {
-                    $name = sprintf('<abbr title="%s">%s</abbr>', $file, $name);
+                    $this->line = $this->style('meta', $name).' on line '.$this->style('meta', $line).':';
                 }
-            }
-            echo "\n<span class=\"sf-dump-meta\">{$name} on line {$line}:</span>";
+                $this->dumpLine(0);
+            };
+            $contextDumper = $contextDumper->bindTo($this->dumper, $this->dumper);
+            $contextDumper($name, $file, $line, $this->fileLinkFormat);
         } else {
-            echo "{$name} on line {$line}:\n";
+            $cloner = new VarCloner();
+            $this->dumper->dump($cloner->cloneVar($name.' on line '.$line.':'));
         }
         $this->dumper->dump($data);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -71,7 +71,11 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $collector->collect(new Request(), new Response());
         $output = ob_get_clean();
 
-        $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n123\n", $output);
+        if (PHP_VERSION_ID >= 50400) {
+            $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n123\n", $output);
+        } else {
+            $this->assertSame("\"DumpDataCollectorTest.php on line {$line}:\"\n123\n", $output);
+        }
     }
 
     public function testCollectHtml()
@@ -84,8 +88,8 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $line = __LINE__ - 1;
         $file = __FILE__;
         $xOutput = <<<EOTXT
-
-<span class="sf-dump-meta"><a href="test://{$file}:{$line}" title="{$file}">DumpDataCollectorTest.php</a> on line {$line}:</span> <pre class=sf-dump id=sf-dump data-indent-pad="  "><span class=sf-dump-num>123</span>
+ <pre class=sf-dump id=sf-dump data-indent-pad="  "><a href="test://{$file}:{$line}" title="{$file}"><span class=sf-dump-meta>DumpDataCollectorTest.php</span></a> on line <span class=sf-dump-meta>{$line}</span>:
+<span class=sf-dump-num>123</span>
 </pre>
 
 EOTXT;
@@ -110,6 +114,10 @@ EOTXT;
 
         ob_start();
         $collector = null;
-        $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n456\n", ob_get_clean());
+        if (PHP_VERSION_ID >= 50400) {
+            $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n456\n", ob_get_clean());
+        } else {
+            $this->assertSame("\"DumpDataCollectorTest.php on line {$line}:\"\n456\n", ob_get_clean());
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Using echo directly is wrong because dumpers can be configured to write anywhere.
