### PR TITLE
[HttpFoundation] Fix volatile MongoDbSessionHandlerTest::testRead()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -87,7 +87,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
         // defining the timeout before the actual method call
         // allows to test for "greater than" values in the $criteria
-        $testTimeout = time();
+        $testTimeout = time() + 1;
 
         $collection->expects($this->once())
             ->method('findOne')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
