### PR TITLE
[HttpKernel] Handle an array vary header in the http cache store

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -127,7 +127,7 @@ class Store implements StoreInterface
         // find a cached entry that matches the request.
         $match = null;
         foreach ($entries as $entry) {
-            if ($this->requestsMatch(isset($entry[1]['vary'][0]) ? $entry[1]['vary'][0] : '', $request->headers->all(), $entry[0])) {
+            if ($this->requestsMatch(isset($entry[1]['vary'][0]) ? implode(', ', $entry[1]['vary']) : '', $request->headers->all(), $entry[0])) {
                 $match = $entry;
 
                 break;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -168,6 +168,16 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->store->lookup($req2));
     }
 
+    public function testDoesNotReturnEntriesThatSlightlyVaryWithLookup()
+    {
+        $req1 = Request::create('/test', 'get', array(), array(), array(), array('HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bar'));
+        $req2 = Request::create('/test', 'get', array(), array(), array(), array('HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bam'));
+        $res = new Response('test', 200, array('Vary' => array('Foo', 'Bar')));
+        $this->store->write($req1, $res);
+
+        $this->assertNull($this->store->lookup($req2));
+    }
+
     public function testStoresMultipleResponsesForEachVaryCombination()
     {
         $req1 = Request::create('/test', 'get', array(), array(), array(), array('HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bar'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12118 |
| License | MIT |
| Doc PR | - |
