### PR TITLE
[HttpKernel] use ConfigCacheFactory to create ConfigCache instances

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -1,6 +1,12 @@
 UPGRADE FROM 2.6 to 2.7
 =======================
 
+HttpKernel
+----------
+
+ * The `$cache` argument type of the `dumpContainer()` method in the `Symfony\Component\HttpKernel\Kernel`
+   class was changed from `Symfony\Component\Config\ConfigCache` to `Symfony\Component\Config\ConfigCacheInterface`.
+
 Router
 ------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
#14178 introduced a new `ConfigCacheFactory` to create `ConfigCache` instances. The `Router` and the `Translator` class had been updated. However, the `Kernel` class still created the `ConfigCache` on its own.
