### PR TITLE
[Console] Fix QuestionHelperTest

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -227,15 +227,20 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         $dialog->setHelperSet($helperSet);
 
         $question = new ChoiceQuestion('Please select the environment to load', $possibleChoices);
+        $question->setMaxAttempts(1);
         $answer = $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question);
 
         $this->assertSame($expectedValue, $answer);
     }
 
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The provided answer is ambiguous. Value should be one of env_2 or env_3.
+     */
     public function testAmbiguousChoiceFromChoicelist()
     {
         $possibleChoices = array(
-            'env_1' => 'My environment 1',
+            'env_1' => 'My first environment',
             'env_2' => 'My environment',
             'env_3' => 'My environment',
         );
@@ -246,12 +251,9 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         $dialog->setHelperSet($helperSet);
 
         $question = new ChoiceQuestion('Please select the environment to load', $possibleChoices);
+        $question->setMaxAttempts(1);
 
-        try {
-            $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question);
-        } catch (\InvalidArgumentException $e) {
-            $this->assertEquals('The provided answer is ambiguous. Value should be one of env_2 or env_3.', $e->getMessage());
-        }
+        $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question);
     }
 
     public function answerProvider()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR fixes the following issues in `QuestionHelperTest`:
- When using the `InputInterface` mock with interactive option, asking a ChoiceQuestion without specifying max attempts nor a default value led to an infinite loop when invalid values are submitted. In case there is something wrong in tests, it wasn't obvious to understand what's happening, as the process was constantly waiting for inputs.
- `testAmbiguousChoiceFromChoicelist` test was wrong as the autocompleter filled the value and the test was never triggered (+max attempt issue).
