### PR TITLE
[Bridge\Twig] Adding a space between the icon and the error message

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -231,7 +231,7 @@
     {% if form.parent %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
     <ul class="list-unstyled">
         {%- for error in errors -%}
-            <li><span class="glyphicon glyphicon-exclamation-sign"></span>{{ error.message }}</li>
+            <li><span class="glyphicon glyphicon-exclamation-sign"></span> {{ error.message }}</li>
         {%- endfor -%}
     </ul>
     {% if form.parent %}</span>{% else %}</div>{% endif %}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7",
         "symfony/finder": "~2.3",
-        "symfony/form": "~2.6,>=2.6.6",
+        "symfony/form": "~2.6,>=2.6.8",
         "symfony/http-kernel": "~2.3",
         "symfony/intl": "~2.3",
         "symfony/routing": "~2.2",

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -118,12 +118,12 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
             [@class="list-unstyled"]
             [
                 ./li
-                    [.="[trans]Error 1[/trans]"]
+                    [.=" [trans]Error 1[/trans]"]
                     [
                         ./span[@class="glyphicon glyphicon-exclamation-sign"]
                     ]
                 /following-sibling::li
-                    [.="[trans]Error 2[/trans]"]
+                    [.=" [trans]Error 2[/trans]"]
                     [
                         ./span[@class="glyphicon glyphicon-exclamation-sign"]
                     ]


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14557 |
| License | MIT |
| Doc PR |  |
