### PR TITLE
[WebProfilerBundle] Fix compatiblity with HttpKernel < 2.7

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -8,7 +8,7 @@
             <span>
                 {% if collector.applicationname %}
                     {{ collector.applicationname }} {{ collector.applicationversion }}
-                {% else %}
+                {% elseif collector.symfonyState is defined %}
                     {% if 'unknown' == collector.symfonyState -%}
                     <span class="sf-toolbar-status sf-toolbar-info-piece-additional" title="Unable to retrieve information about the Symfony version.">
                     {%- elseif 'eol' == collector.symfonyState -%}


### PR DESCRIPTION
The WebProfilerBundle version 2.7 is supposed to be compatible with HttpKernel 2.4, but the template of the config profile uses a property `symfonyState` that has been added in Symfony 2.7 by #13626.

> Twig_Error_Runtime: Method "symfonyState" for object "Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector" does not exist in "@WebProfiler/Collector/config.html.twig" at line 12

This fix makes the property optional.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/silexphp/Silex-WebProfiler/pull/63 |
| License | MIT |
