### PR TITLE
Add a check to make sure the session column can hold the data 

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -323,6 +323,12 @@ class PdoSessionHandler implements \SessionHandlerInterface
     {
         $maxlifetime = (int) ini_get('session.gc_maxlifetime');
 
+        $metaStmnt = $this->pdo->prepare('SELECT `' . $this->dataCol . '` FROM ' . $this->table);
+        $metaStmnt->execute();
+        if (strlen($data) > $metaStmnt->getColumnMeta(0)['len']) {
+            throw new \DomainException('The data to be saved in session table exceeds the size of the field');
+        }
+        
         try {
             // We use a single MERGE SQL query when supported by the database.
             $mergeSql = $this->getMergeSql();

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -323,7 +323,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
     {
         $maxlifetime = (int) ini_get('session.gc_maxlifetime');
 
-        $metaStmnt = $this->pdo->prepare('SELECT `' . $this->dataCol . '` FROM ' . $this->table);
+        $metaStmnt = $this->pdo->prepare('SELECT `'.$this->dataCol.'` FROM '.$this->table);
         $metaStmnt->execute();
         if (strlen($data) > $metaStmnt->getColumnMeta(0)['len']) {
             throw new \DomainException('The data to be saved in session table exceeds the size of the field');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

We faced a problem in our app where the session data was being reset without any reason. 
We traced it down to the data being truncated when saving, so when it was read, being corrupt, it was reset.
There was no error anywhere, so we thought this check would be nice to have.
