### PR TITLE
[Form] Remove $data arguments from FormFactory

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -308,6 +308,36 @@ UPGRADE FROM 2.x to 3.0
    echo $form->getErrors(true, false);
    ```
 
+ * The `$data` parameter has been removed from:
+
+    - `Symfony\Component\Form\FormFactoryInterface::create()`
+    - `Symfony\Component\Form\FormFactoryInterface::createNamed()`
+    - `Symfony\Component\Form\FormFactoryInterface::createForProperty()`
+    - `Symfony\Component\Form\FormFactoryInterface::createBuilder()`
+    - `Symfony\Component\Form\FormFactoryInterface::createNamedBuilder()`
+    - `Symfony\Component\Form\FormFactoryInterface::createBuilderForProperty()`
+    - `Symfony\Bundle\FrameworkBundle\Controller\Controller::createForm()`
+    - `Symfony\Bundle\FrameworkBundle\Controller\Controller::createFormBuilder()`
+
+   You should use the `data` option instead.
+
+   Before:
+
+   ```php
+   $checkbox = $formFactory->createNamed('readOnly', 'checkbox', true, array(
+       // options ...
+   ));
+   ```
+
+   After:
+
+   ```php
+   $checkbox = $formFactory->createNamed('readOnly', 'checkbox', array(
+       'data' => true,
+       // options ...
+   ));
+   ```
+
 ### FrameworkBundle
 
  * The `getRequest` method of the base `Controller` class has been deprecated

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -90,7 +90,7 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
         $this->setMaxRunningTime(1);
 
         for ($i = 0; $i < 40; ++$i) {
-            $form = $this->factory->create('entity', null, array(
+            $form = $this->factory->create('entity', array(
                 'class' => self::ENTITY_CLASS,
             ));
 
@@ -108,7 +108,7 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
         $this->setMaxRunningTime(1);
 
         for ($i = 0; $i < 40; ++$i) {
-            $form = $this->factory->create('entity', null, array(
+            $form = $this->factory->create('entity', array(
                 'class' => self::ENTITY_CLASS,
                 'choices' => $choices,
             ));
@@ -127,7 +127,7 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
         $this->setMaxRunningTime(1);
 
         for ($i = 0; $i < 40; ++$i) {
-            $form = $this->factory->create('entity', null, array(
+            $form = $this->factory->create('entity', array(
                     'class' => self::ENTITY_CLASS,
                     'preferred_choices' => $choices,
                 ));

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -115,7 +115,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testInvalidClassOption()
     {
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', 'entity', array(
             'class' => 'foo',
         ));
     }
@@ -127,7 +127,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -144,7 +144,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -161,7 +161,7 @@ class EntityTypeTest extends TypeTestCase
         $this->persist(array($entity1, $entity2));
         $qb = $this->em->createQueryBuilder()->select('e')->from(self::SINGLE_IDENT_CLASS, 'e');
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -177,7 +177,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testConfigureQueryBuilderWithNonQueryBuilderAndNonClosure()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => new \stdClass(),
@@ -189,7 +189,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testConfigureQueryBuilderWithClosureReturningNonQueryBuilder()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function () {
@@ -202,7 +202,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataSingleNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => false,
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
@@ -215,7 +215,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataMultipleExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => true,
             'expanded' => true,
             'em' => 'default',
@@ -229,7 +229,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataMultipleNonExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -243,7 +243,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => false,
             'expanded' => true,
             'em' => 'default',
@@ -257,7 +257,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSubmitSingleNonExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -271,7 +271,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSubmitMultipleNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => true,
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
@@ -289,7 +289,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -311,7 +311,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -335,7 +335,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -360,7 +360,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -391,7 +391,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -417,7 +417,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -447,7 +447,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => false,
             'expanded' => true,
             'em' => 'default',
@@ -473,7 +473,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => true,
             'expanded' => true,
             'em' => 'default',
@@ -503,7 +503,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             // not all persisted entities should be displayed
@@ -528,7 +528,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($item1, $item2, $item3, $item4));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::ITEM_GROUP_CLASS,
             'choices' => array($item1, $item2, $item3, $item4),
@@ -559,7 +559,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'preferred_choices' => array($entity3, $entity2),
@@ -578,7 +578,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choices' => array($entity2, $entity3),
@@ -598,7 +598,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -619,7 +619,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::COMPOSITE_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -642,7 +642,7 @@ class EntityTypeTest extends TypeTestCase
 
         $repository = $this->em->getRepository(self::SINGLE_IDENT_CLASS);
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => $repository->createQueryBuilder('e')
@@ -664,7 +664,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function ($repository) {
@@ -688,7 +688,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::COMPOSITE_IDENT_CLASS,
             'query_builder' => function ($repository) {
@@ -710,7 +710,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -731,7 +731,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -757,7 +757,7 @@ class EntityTypeTest extends TypeTestCase
             ->with(self::SINGLE_IDENT_CLASS)
             ->will($this->returnValue($this->em));
 
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', 'entity', array(
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'choice_label' => 'name',
@@ -772,7 +772,7 @@ class EntityTypeTest extends TypeTestCase
         $this->emRegistry->expects($this->never())
             ->method('getManagerForClass');
 
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', 'entity', array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'choice_label' => 'name',
@@ -848,14 +848,14 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field1 = $this->factory->createNamed('name', 'entity', null, array(
+        $field1 = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'choice_label' => 'name',
         ));
 
-        $field2 = $this->factory->createNamed('name', 'entity', null, array(
+        $field2 = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -876,7 +876,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'entity', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -239,27 +239,25 @@ abstract class Controller extends ContainerAware
      * Creates and returns a Form instance from the type of the form.
      *
      * @param string|FormTypeInterface $type    The built type of the form
-     * @param mixed                    $data    The initial data for the form
      * @param array                    $options Options for the form
      *
      * @return Form
      */
-    protected function createForm($type, $data = null, array $options = array())
+    protected function createForm($type, array $options = array())
     {
-        return $this->container->get('form.factory')->create($type, $data, $options);
+        return $this->container->get('form.factory')->create($type, $options);
     }
 
     /**
      * Creates and returns a form builder instance.
      *
-     * @param mixed $data    The initial data for the form
      * @param array $options Options for the form
      *
      * @return FormBuilder
      */
-    protected function createFormBuilder($data = null, array $options = array())
+    protected function createFormBuilder(array $options = array())
     {
-        return $this->container->get('form.factory')->createBuilder('form', $data, $options);
+        return $this->container->get('form.factory')->createBuilder('form', $options);
     }
 
     /**

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -10,6 +10,15 @@ CHANGELOG
  * removed `AbstractTypeExtension::setDefaultOptions()` method
  * added `FormTypeInterface::configureOptions()` method
  * added `FormTypeExtensionInterface::configureOptions()` method
+ * removed the `$data` parameter from:
+    - `Symfony\Component\Form\FormFactoryInterface::create()`
+    - `Symfony\Component\Form\FormFactoryInterface::createNamed()`
+    - `Symfony\Component\Form\FormFactoryInterface::createForProperty()`
+    - `Symfony\Component\Form\FormFactoryInterface::createBuilder()`
+    - `Symfony\Component\Form\FormFactoryInterface::createNamedBuilder()`
+    - `Symfony\Component\Form\FormFactoryInterface::createBuilderForProperty()`
+    - `Symfony\Bundle\FrameworkBundle\Controller\Controller::createForm()`
+    - `Symfony\Bundle\FrameworkBundle\Controller\Controller::createFormBuilder()`
 
 2.7.0
 -----

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -108,8 +108,9 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             $tokenId = $options['csrf_token_id'] ?: ($form->getName() ?: get_class($form->getConfig()->getType()->getInnerType()));
             $data = (string) $options['csrf_token_manager']->getToken($tokenId);
 
-            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'hidden', $data, array(
+            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'hidden', array(
                 'mapped' => false,
+                'data' => $data
             ));
 
             $view->children[$options['csrf_field_name']] = $csrfForm->createView($view);

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -914,9 +914,9 @@ class Form implements \IteratorAggregate, FormInterface
             }
 
             if (null === $type) {
-                $child = $this->config->getFormFactory()->createForProperty($this->config->getDataClass(), $child, null, $options);
+                $child = $this->config->getFormFactory()->createForProperty($this->config->getDataClass(), $child, $options);
             } else {
-                $child = $this->config->getFormFactory()->createNamed($child, $type, null, $options);
+                $child = $this->config->getFormFactory()->createNamed($child, $type, $options);
             }
         } elseif ($child->getConfig()->getAutoInitialize()) {
             throw new RuntimeException(sprintf(

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -103,10 +103,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
         }
 
         if (null !== $type) {
-            return $this->getFormFactory()->createNamedBuilder($name, $type, null, $options);
+            return $this->getFormFactory()->createNamedBuilder($name, $type, $options);
         }
 
-        return $this->getFormFactory()->createBuilderForProperty($this->getDataClass(), $name, null, $options);
+        return $this->getFormFactory()->createBuilderForProperty($this->getDataClass(), $name, $options);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -34,48 +34,44 @@ class FormFactory implements FormFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create($type = 'form', $data = null, array $options = array())
+    public function create($type = 'form', array $options = array())
     {
-        return $this->createBuilder($type, $data, $options)->getForm();
+        return $this->createBuilder($type, $options)->getForm();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function createNamed($name, $type = 'form', $data = null, array $options = array())
+    public function createNamed($name, $type = 'form', array $options = array())
     {
-        return $this->createNamedBuilder($name, $type, $data, $options)->getForm();
+        return $this->createNamedBuilder($name, $type, $options)->getForm();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function createForProperty($class, $property, $data = null, array $options = array())
+    public function createForProperty($class, $property, array $options = array())
     {
-        return $this->createBuilderForProperty($class, $property, $data, $options)->getForm();
+        return $this->createBuilderForProperty($class, $property, $options)->getForm();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function createBuilder($type = 'form', $data = null, array $options = array())
+    public function createBuilder($type = 'form', array $options = array())
     {
         $name = $type instanceof FormTypeInterface || $type instanceof ResolvedFormTypeInterface
             ? $type->getName()
             : $type;
 
-        return $this->createNamedBuilder($name, $type, $data, $options);
+        return $this->createNamedBuilder($name, $type, $options);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function createNamedBuilder($name, $type = 'form', $data = null, array $options = array())
+    public function createNamedBuilder($name, $type = 'form', array $options = array())
     {
-        if (null !== $data && !array_key_exists('data', $options)) {
-            $options['data'] = $data;
-        }
-
         if ($type instanceof FormTypeInterface) {
             $type = $this->resolveType($type);
         } elseif (is_string($type)) {
@@ -96,10 +92,10 @@ class FormFactory implements FormFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createBuilderForProperty($class, $property, $data = null, array $options = array())
+    public function createBuilderForProperty($class, $property, array $options = array())
     {
         if (null === $guesser = $this->registry->getTypeGuesser()) {
-            return $this->createNamedBuilder($property, 'text', $data, $options);
+            return $this->createNamedBuilder($property, 'text', $options);
         }
 
         $typeGuess = $guesser->guessType($class, $property);
@@ -129,7 +125,7 @@ class FormFactory implements FormFactoryInterface
             $options = array_merge($typeGuess->getOptions(), $options);
         }
 
-        return $this->createNamedBuilder($property, $type, $data, $options);
+        return $this->createNamedBuilder($property, $type, $options);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -22,14 +22,13 @@ interface FormFactoryInterface
      * @see createBuilder()
      *
      * @param string|FormTypeInterface $type    The type of the form
-     * @param mixed                    $data    The initial data
      * @param array                    $options The options
      *
      * @return FormInterface The form named after the type
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the given type
      */
-    public function create($type = 'form', $data = null, array $options = array());
+    public function create($type = 'form', array $options = array());
 
     /**
      * Returns a form.
@@ -38,14 +37,13 @@ interface FormFactoryInterface
      *
      * @param string|int               $name    The name of the form
      * @param string|FormTypeInterface $type    The type of the form
-     * @param mixed                    $data    The initial data
      * @param array                    $options The options
      *
      * @return FormInterface The form
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the given type
      */
-    public function createNamed($name, $type = 'form', $data = null, array $options = array());
+    public function createNamed($name, $type = 'form', array $options = array());
 
     /**
      * Returns a form for a property of a class.
@@ -54,41 +52,38 @@ interface FormFactoryInterface
      *
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
-     * @param mixed  $data     The initial data
      * @param array  $options  The options for the builder
      *
      * @return FormInterface The form named after the property
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the form type
      */
-    public function createForProperty($class, $property, $data = null, array $options = array());
+    public function createForProperty($class, $property, array $options = array());
 
     /**
      * Returns a form builder.
      *
      * @param string|FormTypeInterface $type    The type of the form
-     * @param mixed                    $data    The initial data
      * @param array                    $options The options
      *
      * @return FormBuilderInterface The form builder
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the given type
      */
-    public function createBuilder($type = 'form', $data = null, array $options = array());
+    public function createBuilder($type = 'form', array $options = array());
 
     /**
      * Returns a form builder.
      *
      * @param string|int               $name    The name of the form
      * @param string|FormTypeInterface $type    The type of the form
-     * @param mixed                    $data    The initial data
      * @param array                    $options The options
      *
      * @return FormBuilderInterface The form builder
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the given type
      */
-    public function createNamedBuilder($name, $type = 'form', $data = null, array $options = array());
+    public function createNamedBuilder($name, $type = 'form', array $options = array());
 
     /**
      * Returns a form builder for a property of a class.
@@ -98,12 +93,11 @@ interface FormFactoryInterface
      *
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
-     * @param mixed  $data     The initial data
      * @param array  $options  The options for the builder
      *
      * @return FormBuilderInterface The form builder named after the property
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the form type
      */
-    public function createBuilderForProperty($class, $property, $data = null, array $options = array());
+    public function createBuilderForProperty($class, $property, array $options = array());
 }

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -84,7 +84,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'label' => 'Custom label',
         ));
         $html = $this->renderLabel($form->createView(), null, array(
@@ -155,7 +155,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCheckedCheckbox()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', true);
+        $form = $this->factory->createNamed('name', 'checkbox', array('data' => true));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -173,7 +173,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testUncheckedCheckbox()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', false);
+        $form = $this->factory->createNamed('name', 'checkbox', array('data' => false));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -191,7 +191,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCheckboxWithValue()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', false, array(
+        $form = $this->factory->createNamed('name', 'checkbox', array(
+            'data' => false,
             'value' => 'foo&bar',
         ));
 
@@ -211,7 +212,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoice()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
@@ -233,7 +235,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => false,
@@ -256,7 +259,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceWithPreferred()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -280,7 +284,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceWithPreferredAndNoSeparator()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -303,7 +308,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -327,7 +333,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testChoiceWithOnlyPreferred()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&a', '&b'),
             'multiple' => false,
@@ -344,7 +351,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceNonRequired()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => false,
@@ -368,7 +376,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceNonRequiredNoneSelected()
     {
-        $form = $this->factory->createNamed('name', 'choice', null, array(
+        $form = $this->factory->createNamed('name', 'choice', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => false,
@@ -392,7 +400,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceNonRequiredWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
@@ -417,7 +426,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceRequiredWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
@@ -442,7 +452,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceRequiredWithPlaceholderViaView()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
@@ -466,7 +477,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceGrouped()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array(
                 'Group&1' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
                 'Group&2' => array('&c' => 'Choice&C'),
@@ -497,7 +509,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoice()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => true,
@@ -521,7 +534,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'required' => true,
@@ -546,7 +560,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceSkipsPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => true,
             'expanded' => false,
@@ -569,7 +584,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceNonRequired()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => true,
@@ -592,7 +608,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -627,7 +644,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceExpandedAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => false,
@@ -663,7 +681,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceExpandedWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -708,7 +727,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceExpandedWithBooleanValue()
     {
-        $form = $this->factory->createNamed('name', 'choice', true, array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => true,
             'choices' => array('1' => 'Choice&A', '0' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -743,7 +763,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a', '&c'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
             'multiple' => true,
             'expanded' => true,
@@ -788,7 +809,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceExpandedAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a', '&c'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => true,
@@ -834,7 +856,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCountry()
     {
-        $form = $this->factory->createNamed('name', 'country', 'AT');
+        $form = $this->factory->createNamed('name', 'country', array('data' => 'AT'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/select
@@ -848,7 +870,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCountryWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'country', 'AT', array(
+        $form = $this->factory->createNamed('name', 'country', array(
+            'data' => 'AT',
             'placeholder' => 'Select&Country',
             'required' => false,
         ));
@@ -866,7 +889,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTime()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -902,7 +926,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'datetime', null, array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
@@ -942,7 +966,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     {
         $data = array('year' => '2011', 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5');
 
-        $form = $this->factory->createNamed('name', 'datetime', $data, array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => $data,
             'input' => 'array',
             'required' => false,
         ));
@@ -979,7 +1004,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1020,7 +1046,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeSingleText()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'date_widget' => 'single_text',
             'time_widget' => 'single_text',
@@ -1049,7 +1076,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithWidgetSingleText()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'widget' => 'single_text',
             'model_timezone' => 'UTC',
@@ -1068,7 +1096,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithWidgetSingleTextIgnoreDateAndTimeWidgets()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
@@ -1089,7 +1118,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateChoice()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'date', array(
+            'data' => '2011-02-03',
             'input' => 'string',
             'widget' => 'choice',
         ));
@@ -1118,7 +1148,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateChoiceWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'date', null, array(
+        $form = $this->factory->createNamed('name', 'date', array(
             'input' => 'string',
             'widget' => 'choice',
             'placeholder' => 'Change&Me',
@@ -1149,7 +1179,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateChoiceWithPlaceholderOnYear()
     {
-        $form = $this->factory->createNamed('name', 'date', null, array(
+        $form = $this->factory->createNamed('name', 'date', array(
             'input' => 'string',
             'widget' => 'choice',
             'required' => false,
@@ -1180,7 +1210,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateText()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'date', array(
+            'data' => '2011-02-03',
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -1212,7 +1243,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateSingleText()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'date', array(
+            'data' => '2011-02-03',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -1229,7 +1261,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testBirthDay()
     {
-        $form = $this->factory->createNamed('name', 'birthday', '2000-02-03', array(
+        $form = $this->factory->createNamed('name', 'birthday', array(
+            'data' => '2000-02-03',
             'input' => 'string',
         ));
 
@@ -1257,7 +1290,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testBirthDayWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'birthday', '1950-01-01', array(
+        $form = $this->factory->createNamed('name', 'birthday', array(
+            'data' => '1950-01-01',
             'input' => 'string',
             'placeholder' => '',
             'required' => false,
@@ -1290,7 +1324,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testEmail()
     {
-        $form = $this->factory->createNamed('name', 'email', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'email', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1305,7 +1339,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testEmailWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'email', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'email', array(
+            'data' => 'foo&bar',
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1322,7 +1357,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testHidden()
     {
-        $form = $this->factory->createNamed('name', 'hidden', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'hidden', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1336,7 +1371,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testReadOnly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'read_only' => true,
         ));
 
@@ -1352,7 +1387,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDisabled()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'disabled' => true,
         ));
 
@@ -1368,7 +1403,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testInteger()
     {
-        $form = $this->factory->createNamed('name', 'integer', 123);
+        $form = $this->factory->createNamed('name', 'integer', array('data' => 123));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1382,7 +1417,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLanguage()
     {
-        $form = $this->factory->createNamed('name', 'language', 'de');
+        $form = $this->factory->createNamed('name', 'language', array('data' => 'de'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/select
@@ -1396,7 +1431,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLocale()
     {
-        $form = $this->factory->createNamed('name', 'locale', 'de_AT');
+        $form = $this->factory->createNamed('name', 'locale', array('data' => 'de_AT'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/select
@@ -1410,7 +1445,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMoney()
     {
-        $form = $this->factory->createNamed('name', 'money', 1234.56, array(
+        $form = $this->factory->createNamed('name', 'money', array(
+            'data' => 1234.56,
             'currency' => 'EUR',
         ));
 
@@ -1434,7 +1470,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testNumber()
     {
-        $form = $this->factory->createNamed('name', 'number', 1234.56);
+        $form = $this->factory->createNamed('name', 'number', array('data' => 1234.56));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1448,7 +1484,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPassword()
     {
-        $form = $this->factory->createNamed('name', 'password', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'password', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1461,7 +1497,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPasswordSubmittedWithNotAlwaysEmpty()
     {
-        $form = $this->factory->createNamed('name', 'password', null, array(
+        $form = $this->factory->createNamed('name', 'password', array(
             'always_empty' => false,
         ));
         $form->submit('foo&bar');
@@ -1478,7 +1514,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPasswordWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'password', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'password', array(
+            'data' => 'foo&bar',
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1494,7 +1531,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPercent()
     {
-        $form = $this->factory->createNamed('name', 'percent', 0.1);
+        $form = $this->factory->createNamed('name', 'percent', array('data' => 0.1));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -1516,7 +1553,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCheckedRadio()
     {
-        $form = $this->factory->createNamed('name', 'radio', true);
+        $form = $this->factory->createNamed('name', 'radio', array('data' => true));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -1540,7 +1577,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testUncheckedRadio()
     {
-        $form = $this->factory->createNamed('name', 'radio', false);
+        $form = $this->factory->createNamed('name', 'radio', array('data' => false));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -1563,7 +1600,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testRadioWithValue()
     {
-        $form = $this->factory->createNamed('name', 'radio', false, array(
+        $form = $this->factory->createNamed('name', 'radio', array(
+            'data' => false,
             'value' => 'foo&bar',
         ));
 
@@ -1588,7 +1626,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTextarea()
     {
-        $form = $this->factory->createNamed('name', 'textarea', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'textarea', array(
+            'data' => 'foo&bar',
             'attr' => array('pattern' => 'foo'),
         ));
 
@@ -1604,7 +1643,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testText()
     {
-        $form = $this->factory->createNamed('name', 'text', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'text', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1619,7 +1658,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTextWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'text', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'text', array(
+            'data' => 'foo&bar',
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1636,7 +1676,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSearch()
     {
-        $form = $this->factory->createNamed('name', 'search', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'search', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1651,7 +1691,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTime()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'time', array(
+            'data' => '04:05:06',
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1678,7 +1719,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'time', array(
+            'data' => '04:05:06',
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1713,7 +1755,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeText()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'time', array(
+            'data' => '04:05:06',
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -1746,7 +1789,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeSingleText()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'time', array(
+            'data' => '04:05:06',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -1764,7 +1808,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'time', null, array(
+        $form = $this->factory->createNamed('name', 'time', array(
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
@@ -1791,7 +1835,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeWithPlaceholderOnYear()
     {
-        $form = $this->factory->createNamed('name', 'time', null, array(
+        $form = $this->factory->createNamed('name', 'time', array(
             'input' => 'string',
             'required' => false,
             'placeholder' => array('hour' => 'Change&Me'),
@@ -1818,7 +1862,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimezone()
     {
-        $form = $this->factory->createNamed('name', 'timezone', 'Europe/Vienna');
+        $form = $this->factory->createNamed('name', 'timezone', array('data' => 'Europe/Vienna'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/select
@@ -1837,7 +1881,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimezoneWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'timezone', null, array(
+        $form = $this->factory->createNamed('name', 'timezone', array(
             'placeholder' => 'Select&Timezone',
             'required' => false,
         ));
@@ -1855,7 +1899,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testUrl()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'url', $url);
+        $form = $this->factory->createNamed('name', 'url', array('data' => $url));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1896,7 +1940,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testWidgetAttributes()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'text', array(
+            'data' => 'value',
             'required' => true,
             'disabled' => true,
             'read_only' => true,
@@ -1911,7 +1956,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'text', array(
+            'data' => 'value',
             'attr' => array('foo' => true),
         ));
 
@@ -1923,7 +1969,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testButtonAttributes()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'button', array(
             'disabled' => true,
             'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
         ));
@@ -1936,7 +1982,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testButtonAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'button', array(
             'attr' => array('foo' => true),
         ));
 

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -284,7 +284,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testCollection()
     {
-        $form = $this->factory->createNamed('names', 'collection', array('a', 'b'), array(
+        $form = $this->factory->createNamed('names', 'collection', array(
+            'data' => array('a', 'b'),
             'type' => 'text',
         ));
 
@@ -306,7 +307,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             array('title' => 'a'),
             array('title' => 'b'),
         );
-        $form = $this->factory->createNamed('names', 'collection', $data, array(
+        $form = $this->factory->createNamed('names', 'collection', array(
+            'data' => $data,
             'type' => new AlternatingRowType(),
         ));
 
@@ -324,7 +326,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testEmptyCollection()
     {
-        $form = $this->factory->createNamed('names', 'collection', array(), array(
+        $form = $this->factory->createNamed('names', 'collection', array(
+            'data' => array(),
             'type' => 'text',
         ));
 
@@ -338,12 +341,10 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testCollectionRow()
     {
-        $collection = $this->factory->createNamedBuilder(
-            'collection',
-            'collection',
-            array('a', 'b'),
-            array('type' => 'text')
-        );
+        $collection = $this->factory->createNamedBuilder('collection', 'collection', array(
+            'data' => array('a', 'b'),
+            'type' => 'text'
+        ));
 
         $form = $this->factory->createNamedBuilder('form', 'form')
           ->add($collection)
@@ -452,7 +453,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamedBuilder('name', 'form')
             ->add($this->factory
-                ->createNamedBuilder('child', 'form', null, array('error_bubbling' => false))
+                ->createNamedBuilder('child', 'form', array('error_bubbling' => false))
                 ->add('grandChild', 'form')
             )
             ->getForm();
@@ -497,7 +498,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRepeated()
     {
-        $form = $this->factory->createNamed('name', 'repeated', 'foobar', array(
+        $form = $this->factory->createNamed('name', 'repeated', array(
+            'data' => 'foobar',
             'type' => 'text',
         ));
 
@@ -523,7 +525,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedWithCustomOptions()
     {
-        $form = $this->factory->createNamed('name', 'repeated', null, array(
+        $form = $this->factory->createNamed('name', 'repeated', array(
             // the global required value cannot be overridden
             'first_options' => array('label' => 'Test', 'required' => false),
             'second_options' => array('label' => 'Test2'),
@@ -587,7 +589,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testLabelIsNotRenderedWhenSetToFalse()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'label' => false,
         ));
         $html = $this->renderRow($form->createView());
@@ -671,7 +673,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testCollectionRowWithCustomBlock()
     {
         $collection = array('one', 'two', 'three');
-        $form = $this->factory->createNamedBuilder('names', 'collection', $collection)
+        $form = $this->factory->createNamedBuilder('names', 'collection', array('data' => $collection))
             ->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -691,7 +693,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
      */
     public function testChoiceRowWithCustomBlock()
     {
-        $form = $this->factory->createNamedBuilder('name_c', 'choice', 'a', array(
+        $form = $this->factory->createNamedBuilder('name_c', 'choice', array(
+                'data' => 'a',
                 'choices' => array('a' => 'ChoiceA', 'b' => 'ChoiceB'),
                 'expanded' => true,
             ))
@@ -755,7 +758,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testWidgetContainerAttributes()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'form', array(
             'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
         ));
 
@@ -769,7 +772,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testWidgetContainerAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'form', array(
             'attr' => array('foo' => true),
         ));
 

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -156,7 +156,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelWithCustomTextPassedAsOption()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'label' => 'Custom label',
         ));
         $html = $this->renderLabel($form->createView());
@@ -184,7 +184,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelWithCustomTextPassedAsOptionAndDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'label' => 'Custom label',
         ));
         $html = $this->renderLabel($form->createView(), 'Overridden label');
@@ -252,7 +252,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     // https://github.com/symfony/symfony/issues/5029
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'label' => 'Custom label',
         ));
         $html = $this->renderLabel($form->createView(), null, array(
@@ -306,7 +306,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $options = array('label_format' => 'form.%name%');
 
-        $form = $this->factory->createNamedBuilder('myform', 'form', null, $options)
+        $form = $this->factory->createNamedBuilder('myform', 'form', $options)
             ->add('myfield', 'text')
             ->getForm();
         $view = $form->get('myfield')->createView();
@@ -324,7 +324,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $options = array('label_format' => 'form.%name%');
 
-        $form = $this->factory->createNamedBuilder('myform', 'form', null, $options)
+        $form = $this->factory->createNamedBuilder('myform', 'form', $options)
             ->add('myfield', 'text', array('label_format' => 'field.%name%'))
             ->getForm();
         $view = $form->get('myfield')->createView();
@@ -411,7 +411,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCheckedCheckbox()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', true);
+        $form = $this->factory->createNamed('name', 'checkbox', array('data' => true));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -425,7 +425,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testUncheckedCheckbox()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', false);
+        $form = $this->factory->createNamed('name', 'checkbox', array('data' => false));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -438,7 +438,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCheckboxWithValue()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', false, array(
+        $form = $this->factory->createNamed('name', 'checkbox', array(
+            'data' => false,
             'value' => 'foo&bar',
         ));
 
@@ -453,7 +454,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoice()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
@@ -486,7 +488,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => false,
@@ -508,7 +511,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceWithPreferred()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -531,7 +535,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceWithPreferredAndNoSeparator()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -553,7 +558,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -576,7 +582,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testChoiceWithOnlyPreferred()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&a', '&b'),
             'multiple' => false,
@@ -592,7 +599,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceNonRequired()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => false,
@@ -615,7 +623,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceNonRequiredNoneSelected()
     {
-        $form = $this->factory->createNamed('name', 'choice', null, array(
+        $form = $this->factory->createNamed('name', 'choice', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => false,
@@ -638,7 +646,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceNonRequiredWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
@@ -662,7 +671,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceRequiredWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
@@ -689,7 +699,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceRequiredWithPlaceholderViaView()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
@@ -715,7 +726,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceGrouped()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array(
                 'Group&1' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
                 'Group&2' => array('&c' => 'Choice&C'),
@@ -745,7 +757,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoice()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => true,
@@ -768,7 +781,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'required' => true,
@@ -792,7 +806,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceSkipsPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => true,
             'expanded' => false,
@@ -814,7 +829,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceNonRequired()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => true,
@@ -836,7 +852,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -858,7 +875,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceExpandedAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => false,
@@ -881,7 +899,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceExpandedWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => '&a',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -906,7 +925,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceExpandedWithBooleanValue()
     {
-        $form = $this->factory->createNamed('name', 'choice', true, array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => true,
             'choices' => array('1' => 'Choice&A', '0' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -928,7 +948,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a', '&c'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
             'multiple' => true,
             'expanded' => true,
@@ -953,7 +974,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceExpandedAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
+        $form = $this->factory->createNamed('name', 'choice', array(
+            'data' => array('&a', '&c'),
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => true,
@@ -979,7 +1001,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCountry()
     {
-        $form = $this->factory->createNamed('name', 'country', 'AT');
+        $form = $this->factory->createNamed('name', 'country', array('data' => 'AT'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
@@ -992,7 +1014,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCountryWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'country', 'AT', array(
+        $form = $this->factory->createNamed('name', 'country', array(
+            'data' => 'AT',
             'placeholder' => 'Select&Country',
             'required' => false,
         ));
@@ -1009,7 +1032,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTime()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1048,7 +1072,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'datetime', null, array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
@@ -1090,7 +1114,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $data = array('year' => '2011', 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5');
 
-        $form = $this->factory->createNamed('name', 'datetime', $data, array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => $data,
             'input' => 'array',
             'required' => false,
         ));
@@ -1129,7 +1154,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1171,7 +1197,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeSingleText()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'date_widget' => 'single_text',
             'time_widget' => 'single_text',
@@ -1197,7 +1224,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithWidgetSingleText()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'widget' => 'single_text',
             'model_timezone' => 'UTC',
@@ -1215,7 +1243,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithWidgetSingleTextIgnoreDateAndTimeWidgets()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', array(
+            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
@@ -1235,7 +1264,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateChoice()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'date', array(
+            'data' => '2011-02-03',
             'input' => 'string',
             'widget' => 'choice',
         ));
@@ -1260,7 +1290,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateChoiceWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'date', null, array(
+        $form = $this->factory->createNamed('name', 'date', array(
             'input' => 'string',
             'widget' => 'choice',
             'placeholder' => 'Change&Me',
@@ -1287,7 +1317,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateChoiceWithPlaceholderOnYear()
     {
-        $form = $this->factory->createNamed('name', 'date', null, array(
+        $form = $this->factory->createNamed('name', 'date', array(
             'input' => 'string',
             'widget' => 'choice',
             'required' => false,
@@ -1314,7 +1344,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateText()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'date', array(
+            'data' => '2011-02-03',
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -1342,7 +1373,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateSingleText()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'date', array(
+            'data' => '2011-02-03',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -1370,7 +1402,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testBirthDay()
     {
-        $form = $this->factory->createNamed('name', 'birthday', '2000-02-03', array(
+        $form = $this->factory->createNamed('name', 'birthday', array(
+            'data' => '2000-02-03',
             'input' => 'string',
         ));
 
@@ -1394,7 +1427,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testBirthDayWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'birthday', '1950-01-01', array(
+        $form = $this->factory->createNamed('name', 'birthday', array(
+            'data' => '1950-01-01',
             'input' => 'string',
             'placeholder' => '',
             'required' => false,
@@ -1423,7 +1457,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testEmail()
     {
-        $form = $this->factory->createNamed('name', 'email', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'email', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1437,7 +1471,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testEmailWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'email', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'email', array(
+            'data' => 'foo&bar',
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1464,7 +1499,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testHidden()
     {
-        $form = $this->factory->createNamed('name', 'hidden', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'hidden', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1477,7 +1512,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testReadOnly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'read_only' => true,
         ));
 
@@ -1492,7 +1527,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDisabled()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'disabled' => true,
         ));
 
@@ -1507,7 +1542,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testInteger()
     {
-        $form = $this->factory->createNamed('name', 'integer', 123);
+        $form = $this->factory->createNamed('name', 'integer', array('data' => 123));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1520,7 +1555,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLanguage()
     {
-        $form = $this->factory->createNamed('name', 'language', 'de');
+        $form = $this->factory->createNamed('name', 'language', array('data' => 'de'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
@@ -1533,7 +1568,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLocale()
     {
-        $form = $this->factory->createNamed('name', 'locale', 'de_AT');
+        $form = $this->factory->createNamed('name', 'locale', array('data' => 'de_AT'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
@@ -1546,7 +1581,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMoney()
     {
-        $form = $this->factory->createNamed('name', 'money', 1234.56, array(
+        $form = $this->factory->createNamed('name', 'money', array(
+            'data' => 1234.56,
             'currency' => 'EUR',
         ));
 
@@ -1562,7 +1598,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testNumber()
     {
-        $form = $this->factory->createNamed('name', 'number', 1234.56);
+        $form = $this->factory->createNamed('name', 'number', array('data' => 1234.56));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1575,7 +1611,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testPassword()
     {
-        $form = $this->factory->createNamed('name', 'password', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'password', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1587,7 +1623,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testPasswordSubmittedWithNotAlwaysEmpty()
     {
-        $form = $this->factory->createNamed('name', 'password', null, array(
+        $form = $this->factory->createNamed('name', 'password', array(
             'always_empty' => false,
         ));
         $form->submit('foo&bar');
@@ -1603,7 +1639,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testPasswordWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'password', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'password', array(
+            'data' => 'foo&bar',
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1618,7 +1655,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testPercent()
     {
-        $form = $this->factory->createNamed('name', 'percent', 0.1);
+        $form = $this->factory->createNamed('name', 'percent', array('data' => 0.1));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1632,7 +1669,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCheckedRadio()
     {
-        $form = $this->factory->createNamed('name', 'radio', true);
+        $form = $this->factory->createNamed('name', 'radio', array('data' => true));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1646,7 +1683,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testUncheckedRadio()
     {
-        $form = $this->factory->createNamed('name', 'radio', false);
+        $form = $this->factory->createNamed('name', 'radio', array('data' => false));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1659,7 +1696,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testRadioWithValue()
     {
-        $form = $this->factory->createNamed('name', 'radio', false, array(
+        $form = $this->factory->createNamed('name', 'radio', array(
+            'data' => false,
             'value' => 'foo&bar',
         ));
 
@@ -1674,7 +1712,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTextarea()
     {
-        $form = $this->factory->createNamed('name', 'textarea', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'textarea', array(
+            'data' => 'foo&bar',
             'attr' => array('pattern' => 'foo'),
         ));
 
@@ -1689,7 +1728,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testText()
     {
-        $form = $this->factory->createNamed('name', 'text', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'text', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1703,7 +1742,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTextWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'text', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'text', array(
+            'data' => 'foo&bar',
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1719,7 +1759,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSearch()
     {
-        $form = $this->factory->createNamed('name', 'search', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'search', array('data' => 'foo&bar'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1733,7 +1773,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTime()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'time', array(
+            'data' => '04:05:06',
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1757,7 +1798,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'time', array(
+            'data' => '04:05:06',
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1788,7 +1830,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeText()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'time', array(
+            'data' => '04:05:06',
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -1818,7 +1861,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeSingleText()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'time', array(
+            'data' => '04:05:06',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -1835,7 +1879,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'time', null, array(
+        $form = $this->factory->createNamed('name', 'time', array(
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
@@ -1860,7 +1904,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeWithPlaceholderOnYear()
     {
-        $form = $this->factory->createNamed('name', 'time', null, array(
+        $form = $this->factory->createNamed('name', 'time', array(
             'input' => 'string',
             'required' => false,
             'placeholder' => array('hour' => 'Change&Me'),
@@ -1897,7 +1941,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimezone()
     {
-        $form = $this->factory->createNamed('name', 'timezone', 'Europe/Vienna');
+        $form = $this->factory->createNamed('name', 'timezone', array('data' => 'Europe/Vienna'));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
@@ -1915,7 +1959,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimezoneWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'timezone', null, array(
+        $form = $this->factory->createNamed('name', 'timezone', array(
             'placeholder' => 'Select&Timezone',
             'required' => false,
         ));
@@ -1932,7 +1976,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testUrl()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'url', $url);
+        $form = $this->factory->createNamed('name', 'url', array('data' => $url));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1945,7 +1989,9 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCollectionPrototype()
     {
-        $form = $this->factory->createNamedBuilder('name', 'form', array('items' => array('one', 'two', 'three')))
+        $form = $this->factory->createNamedBuilder('name', 'form', array(
+                'data' => array('items' => array('one', 'two', 'three'))
+            ))
             ->add('items', 'collection', array('allow_add' => true))
             ->getForm()
             ->createView();
@@ -2007,7 +2053,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTag()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'method' => 'get',
             'action' => 'http://example.com/directory',
         ));
@@ -2019,7 +2065,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTagForPutRequest()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'method' => 'put',
             'action' => 'http://example.com/directory',
         ));
@@ -2036,7 +2082,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTagWithOverriddenVars()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'method' => 'put',
             'action' => 'http://example.com/directory',
         ));
@@ -2051,7 +2097,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTagForMultipartForm()
     {
-        $form = $this->factory->createBuilder('form', null, array(
+        $form = $this->factory->createBuilder('form', array(
                 'method' => 'get',
                 'action' => 'http://example.com/directory',
             ))
@@ -2065,7 +2111,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTagWithExtraAttributes()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'method' => 'get',
             'action' => 'http://example.com/directory',
         ));
@@ -2079,7 +2125,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testWidgetAttributes()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'text', array(
+            'data' => 'value',
             'required' => true,
             'disabled' => true,
             'read_only' => true,
@@ -2094,7 +2141,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'text', array(
+            'data' => 'value',
             'attr' => array('foo' => true),
         ));
 
@@ -2106,7 +2154,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testWidgetAttributeHiddenIfFalse()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'text', array(
+            'data' => 'value',
             'attr' => array('foo' => false),
         ));
 
@@ -2117,7 +2166,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testButtonAttributes()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'button', array(
             'disabled' => true,
             'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
         ));
@@ -2130,7 +2179,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testButtonAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'button', array(
             'attr' => array('foo' => true),
         ));
 
@@ -2142,7 +2191,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testButtonAttributeHiddenIfFalse()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'button', array(
             'attr' => array('foo' => false),
         ));
 
@@ -2153,7 +2202,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTextareaWithWhitespaceOnlyContentRetainsValue()
     {
-        $form = $this->factory->createNamed('textarea', 'textarea', '  ');
+        $form = $this->factory->createNamed('textarea', 'textarea', array('data' => '  '));
 
         $html = $this->renderWidget($form->createView());
 
@@ -2162,7 +2211,9 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTextareaWithWhitespaceOnlyContentRetainsValueWhenRenderingForm()
     {
-        $form = $this->factory->createBuilder('form', array('textarea' => '  '))
+        $form = $this->factory->createBuilder('form', array(
+                'data' => array('textarea' => '  ')
+            ))
             ->add('textarea', 'textarea')
             ->getForm();
 
@@ -2173,7 +2224,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testWidgetContainerAttributeHiddenIfFalse()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'form', array(
             'attr' => array('foo' => false),
         ));
 

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -323,7 +323,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($iniMax));
 
         $options = array('post_max_size_message' => 'Max {{ max }}!');
-        $form = $this->factory->createNamed('name', 'text', null, $options);
+        $form = $this->factory->createNamed('name', 'text', $options);
         $this->setRequestData('POST', array(), array());
 
         $this->requestHandler->handleRequest($form, $this->request);

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -42,7 +42,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testLabelIsNotRenderedWhenSetToFalse()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'text', array(
             'label' => false,
         ));
         $html = $this->renderRow($form->createView());
@@ -194,7 +194,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testCollection()
     {
-        $form = $this->factory->createNamed('names', 'collection', array('a', 'b'), array(
+        $form = $this->factory->createNamed('names', 'collection', array(
+            'data' => array('a', 'b'),
             'type' => 'text',
         ));
 
@@ -212,7 +213,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testEmptyCollection()
     {
-        $form = $this->factory->createNamed('names', 'collection', array(), array(
+        $form = $this->factory->createNamed('names', 'collection', array(
+            'data' => array(),
             'type' => 'text',
         ));
 
@@ -317,7 +319,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamedBuilder('name', 'form')
             ->add($this->factory
-                ->createNamedBuilder('child', 'form', null, array('error_bubbling' => false))
+                ->createNamedBuilder('child', 'form', array('error_bubbling' => false))
                 ->add('grandChild', 'form')
             )
             ->getForm();
@@ -365,7 +367,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeated()
     {
-        $form = $this->factory->createNamed('name', 'repeated', 'foobar', array(
+        $form = $this->factory->createNamed('name', 'repeated', array(
+            'data' => 'foobar',
             'type' => 'text',
         ));
 
@@ -399,7 +402,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedWithCustomOptions()
     {
-        $form = $this->factory->createNamed('name', 'repeated', 'foobar', array(
+        $form = $this->factory->createNamed('name', 'repeated', array(
+            'data' => 'foobar',
             'type' => 'password',
             'first_options' => array('label' => 'Test', 'required' => false),
             'second_options' => array('label' => 'Test2'),
@@ -440,7 +444,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     public function testCollectionRowWithCustomBlock()
     {
         $collection = array('one', 'two', 'three');
-        $form = $this->factory->createNamedBuilder('names', 'collection', $collection)
+        $form = $this->factory->createNamedBuilder('names', 'collection', array('data' => $collection))
             ->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -510,7 +514,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testWidgetContainerAttributes()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'form', array(
             'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
         ));
 
@@ -524,7 +528,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testWidgetContainerAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'form', array(
             'attr' => array('foo' => true),
         ));
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -110,7 +110,7 @@ class CompoundFormTest extends AbstractFormTest
         $factory = Forms::createFormFactoryBuilder()
             ->getFormFactory();
 
-        $child = $factory->create('file', null, array('auto_initialize' => false));
+        $child = $factory->create('file', array('auto_initialize' => false));
 
         $this->form->add($child);
         $this->form->submit(array('file' => null), false);
@@ -172,7 +172,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $this->factory->expects($this->once())
             ->method('createNamed')
-            ->with('foo', 'text', null, array(
+            ->with('foo', 'text', array(
                 'bar' => 'baz',
                 'auto_initialize' => false,
             ))
@@ -191,7 +191,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $this->factory->expects($this->once())
             ->method('createNamed')
-            ->with('0', 'text', null, array(
+            ->with('0', 'text', array(
                 'bar' => 'baz',
                 'auto_initialize' => false,
             ))
@@ -253,7 +253,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $this->factory->expects($this->once())
             ->method('createForProperty')
-            ->with('\stdClass', 'foo', null, array(
+            ->with('\stdClass', 'foo', array(
                 'bar' => 'baz',
                 'auto_initialize' => false,
             ))

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -69,11 +69,11 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->at(0))
             ->method('createNamed')
-            ->with(1, 'text', null, array('property_path' => '[1]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
+            ->with(1, 'text', array('property_path' => '[1]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
             ->will($this->returnValue($this->getForm('1')));
         $this->factory->expects($this->at(1))
             ->method('createNamed')
-            ->with(2, 'text', null, array('property_path' => '[2]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
+            ->with(2, 'text', array('property_path' => '[2]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
             ->will($this->returnValue($this->getForm('2')));
 
         $data = array(1 => 'string', 2 => 'string');
@@ -113,7 +113,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->once())
             ->method('createNamed')
-            ->with(1, 'text', null, array('property_path' => '[1]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
+            ->with(1, 'text', array('property_path' => '[1]', 'attr' => array('maxlength' => 10), 'auto_initialize' => false))
             ->will($this->returnValue($this->getForm('1')));
 
         $data = array(0 => 'string', 1 => 'string');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -18,7 +18,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     public function testPassDisabledAsOption()
     {
-        $form = $this->factory->create($this->getTestedType(), null, array('disabled' => true));
+        $form = $this->factory->create($this->getTestedType(), array('disabled' => true));
 
         $this->assertTrue($form->isDisabled());
     }
@@ -69,7 +69,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassTranslationDomainToView()
     {
-        $form = $this->factory->create($this->getTestedType(), null, array(
+        $form = $this->factory->create($this->getTestedType(), array(
             'translation_domain' => 'domain',
         ));
         $view = $form->createView();
@@ -80,7 +80,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testInheritTranslationDomainFromParent()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', 'form', array(
                 'translation_domain' => 'domain',
             ))
             ->add('child', $this->getTestedType())
@@ -93,7 +93,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPreferOwnTranslationDomain()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', 'form', array(
                 'translation_domain' => 'parent_domain',
             ))
             ->add('child', $this->getTestedType(), array(
@@ -117,7 +117,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassLabelToView()
     {
-        $form = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array('label' => 'My label'));
+        $form = $this->factory->createNamed('__test___field', $this->getTestedType(), array('label' => 'My label'));
         $view = $form->createView();
 
         $this->assertSame('My label', $view->vars['label']);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -21,7 +21,7 @@ class BirthdayTypeTest extends BaseTypeTest
      */
     public function testSetInvalidYearsOption()
     {
-        $this->factory->create('birthday', null, array(
+        $this->factory->create('birthday', array(
             'years' => 'bad value',
         ));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -26,7 +26,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassValueToView()
     {
-        $form = $this->factory->create('checkbox', null, array('value' => 'foobar'));
+        $form = $this->factory->create('checkbox', array('value' => 'foobar'));
         $view = $form->createView();
 
         $this->assertEquals('foobar', $view->vars['value']);
@@ -43,7 +43,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testCheckedIfDataTrueWithEmptyValue()
     {
-        $form = $this->factory->create('checkbox', null, array('value' => ''));
+        $form = $this->factory->create('checkbox', array('value' => ''));
         $form->setData(true);
         $view = $form->createView();
 
@@ -61,7 +61,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('checkbox', array(
             'value' => 'foobar',
         ));
         $form->submit('foobar');
@@ -72,7 +72,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithRandomValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('checkbox', array(
             'value' => 'foobar',
         ));
         $form->submit('krixikraxi');
@@ -83,7 +83,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithValueUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('checkbox', array(
             'value' => 'foobar',
         ));
         $form->submit(null);
@@ -94,7 +94,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithEmptyValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('checkbox', array(
             'value' => '',
         ));
         $form->submit('');
@@ -105,7 +105,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithEmptyValueUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('checkbox', array(
             'value' => '',
         ));
         $form->submit(null);
@@ -116,7 +116,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithEmptyValueAndFalseUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('checkbox', array(
             'value' => '',
         ));
         $form->submit(false);
@@ -127,7 +127,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithEmptyValueAndTrueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('checkbox', array(
             'value' => '',
         ));
         $form->submit(true);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
@@ -30,7 +30,8 @@ class ChoiceTypePerformanceTest extends FormPerformanceTestCase
         $choices = range(1, 300);
 
         for ($i = 0; $i < 100; ++$i) {
-            $this->factory->create('choice', rand(1, 400), array(
+            $this->factory->create('choice', array(
+                'data' => rand(1, 400),
                 'choices' => $choices,
             ));
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -72,7 +72,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testChoicesOptionExpectsArrayOrTraversable()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create('choice', array(
             'choices' => new \stdClass(),
         ));
     }
@@ -82,7 +82,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testChoiceListOptionExpectsChoiceListInterface()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create('choice', array(
             'choice_list' => array('foo' => 'foo'),
         ));
     }
@@ -92,7 +92,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testChoiceLoaderOptionExpectsChoiceLoaderInterface()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create('choice', array(
             'choice_loader' => new \stdClass(),
         ));
     }
@@ -104,7 +104,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedChoicesOptionsTurnIntoChildren()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'expanded' => true,
             'choices' => $this->choices,
         ));
@@ -114,7 +114,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderPresentOnNonRequiredExpandedSingleChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -127,7 +127,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderNotPresentIfRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -140,7 +140,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderNotPresentIfMultiple()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'required' => false,
@@ -153,7 +153,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderNotPresentIfEmptyChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -169,7 +169,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedChoicesOptionsAreFlattened()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'expanded' => true,
             'choices' => $this->groupedChoices,
         ));
@@ -188,7 +188,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedCheckboxesAreNeverRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'required' => true,
@@ -202,7 +202,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedRadiosAreRequiredIfChoiceChildIsRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -216,7 +216,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedRadiosAreNotRequiredIfChoiceChildIsNotRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -230,7 +230,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -245,7 +245,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -260,7 +260,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -278,7 +278,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleNonExpandedNullNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -293,7 +293,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -308,7 +308,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedEmptyExplicitEmptyChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(
@@ -331,7 +331,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleNonExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -346,7 +346,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -364,7 +364,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleNonExpandedFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -379,7 +379,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->objectChoices,
@@ -401,7 +401,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testLegacySubmitSingleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choice_list' => new ObjectChoiceList(
@@ -425,7 +425,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -440,7 +440,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -458,7 +458,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitMultipleNonExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => false,
             'choices' => array(),
@@ -473,7 +473,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpandedInvalidScalarChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -488,7 +488,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpandedInvalidArrayChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -503,7 +503,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->objectChoices,
@@ -524,7 +524,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testLegacySubmitMultipleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => false,
             'choice_list' => new ObjectChoiceList(
@@ -547,7 +547,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -575,7 +575,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequiredInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -603,7 +603,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -633,7 +633,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -661,7 +661,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequiredNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -692,7 +692,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredNullNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -709,7 +709,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequiredEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -740,7 +740,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -757,7 +757,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequiredFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -788,7 +788,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -805,7 +805,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -838,7 +838,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredNullNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -855,7 +855,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -888,7 +888,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -905,7 +905,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -938,7 +938,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -955,7 +955,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedWithEmptyChild()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'choices' => array(
@@ -977,7 +977,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'choices' => $this->objectChoices,
@@ -1008,7 +1008,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testLegacySubmitSingleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'choice_list' => new ObjectChoiceList(
@@ -1041,7 +1041,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNumericChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => true,
             'choices' => $this->numericChoices,
@@ -1066,7 +1066,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1093,7 +1093,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedInvalidScalarChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1120,7 +1120,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedInvalidArrayChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1147,7 +1147,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1175,7 +1175,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitMultipleExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choices' => array(),
@@ -1189,7 +1189,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedWithEmptyChild()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choices' => array(
@@ -1214,7 +1214,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->objectChoices,
@@ -1245,7 +1245,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testLegacySubmitMultipleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choice_list' => new ObjectChoiceList(
@@ -1278,7 +1278,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedNumericChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->numericChoices,
@@ -1307,7 +1307,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testSetDataSingleNonExpandedAcceptsBoolean()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->numericChoices,
@@ -1322,7 +1322,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetDataMultipleNonExpandedAcceptsBoolean()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->numericChoices,
@@ -1337,7 +1337,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassRequiredToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => $this->choices,
         ));
         $view = $form->createView();
@@ -1347,7 +1347,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassNonRequiredToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'required' => false,
             'choices' => $this->choices,
         ));
@@ -1358,7 +1358,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassMultipleToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => true,
             'choices' => $this->choices,
         ));
@@ -1369,7 +1369,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassExpandedToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'expanded' => true,
             'choices' => $this->choices,
         ));
@@ -1380,7 +1380,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassChoiceTranslationDomainToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => $this->choices,
         ));
         $view = $form->createView();
@@ -1390,7 +1390,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testChoiceTranslationDomainWithTrueValueToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => $this->choices,
             'choice_translation_domain' => true,
         ));
@@ -1401,7 +1401,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testDefaultChoiceTranslationDomainIsSameAsTranslationDomainToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => $this->choices,
             'translation_domain' => 'foo',
         ));
@@ -1413,7 +1413,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testInheritChoiceTranslationDomainFromParent()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', 'form', array(
                 'translation_domain' => 'domain',
             ))
             ->add('child', 'choice')
@@ -1425,7 +1425,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderIsNullByDefaultIfRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'required' => true,
             'choices' => $this->choices,
@@ -1437,7 +1437,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderIsEmptyStringByDefaultIfNotRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => false,
             'required' => false,
             'choices' => $this->choices,
@@ -1452,7 +1452,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testPassPlaceholderToView($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
@@ -1470,7 +1470,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testPassEmptyValueBC($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
@@ -1490,7 +1490,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testDontPassPlaceholderIfContainedInChoices($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
@@ -1550,7 +1550,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPassChoicesToView()
     {
         $choices = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D');
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => $choices,
         ));
         $view = $form->createView();
@@ -1566,7 +1566,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPassPreferredChoicesToView()
     {
         $choices = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D');
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => $choices,
             'preferred_choices' => array('b', 'd'),
         ));
@@ -1584,7 +1584,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassHierarchicalChoicesToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => $this->groupedChoices,
             'preferred_choices' => array('b', 'd'),
         ));
@@ -1615,7 +1615,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $obj2 = (object) array('value' => 'b', 'label' => 'B');
         $obj3 = (object) array('value' => 'c', 'label' => 'C');
         $obj4 = (object) array('value' => 'd', 'label' => 'D');
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => array($obj1, $obj2, $obj3, $obj4),
             'choices_as_values' => true,
             'choice_label' => 'label',
@@ -1633,7 +1633,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testAdjustFullNameForMultipleNonExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', null, array(
+        $form = $this->factory->createNamed('name', 'choice', array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -1646,7 +1646,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // https://github.com/symfony/symfony/issues/3298
     public function testInitializeWithEmptyChoices()
     {
-        $this->factory->createNamed('name', 'choice', null, array(
+        $this->factory->createNamed('name', 'choice', array(
             'choices' => array(),
         ));
     }
@@ -1658,7 +1658,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $obj3 = (object) array('value' => 'c', 'label' => 'C');
         $obj4 = (object) array('value' => 'd', 'label' => 'D');
 
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('choice', array(
             'choices' => array($obj1, $obj2, $obj3, $obj4),
             'choices_as_values' => true,
             'choice_label' => 'label',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -19,7 +19,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     public function testContainsNoChildByDefault()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
         ));
 
@@ -28,7 +28,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetDataAdjustsSize()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
             'options' => array(
                 'attr' => array('maxlength' => 20),
@@ -57,7 +57,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testThrowsExceptionIfObjectIsNotTraversable()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
         ));
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
@@ -66,7 +66,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotResizedIfSubmittedWithMissingData()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
@@ -80,7 +80,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testResizedDownIfSubmittedWithMissingDataAndAllowDelete()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
             'allow_delete' => true,
         ));
@@ -95,7 +95,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testResizedDownIfSubmittedWithEmptyDataAndDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
             'allow_delete' => true,
             'delete_empty' => true,
@@ -112,7 +112,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testDontAddEmptyDataIfDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
             'allow_add' => true,
             'delete_empty' => true,
@@ -129,7 +129,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNoDeleteEmptyIfDeleteNotAllowed()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
             'allow_delete' => false,
             'delete_empty' => true,
@@ -144,7 +144,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testResizedDownIfSubmittedWithCompoundEmptyDataAndDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => new AuthorType(),
             // If the field is not required, no new Author will be created if the
             // form is completely empty
@@ -167,7 +167,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotResizedIfSubmittedWithExtraData()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
         ));
         $form->setData(array('foo@bar.com'));
@@ -180,7 +180,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testResizedUpIfSubmittedWithExtraDataAndAllowAdd()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'text',
             'allow_add' => true,
         ));
@@ -196,7 +196,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testAllowAddButNoPrototype()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'form',
             'allow_add' => true,
             'prototype' => false,
@@ -208,7 +208,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPrototypeMultipartPropagation()
     {
         $form = $this->factory
-            ->create('collection', null, array(
+            ->create('collection', array(
                 'type' => 'file',
                 'allow_add' => true,
                 'prototype' => true,
@@ -220,7 +220,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testGetDataDoesNotContainsPrototypeNameBeforeDataAreSet()
     {
-        $form = $this->factory->create('collection', array(), array(
+        $form = $this->factory->create('collection', array(
+            'data' => array(),
             'type' => 'file',
             'prototype' => true,
             'allow_add' => true,
@@ -232,7 +233,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testGetDataDoesNotContainsPrototypeNameAfterDataAreSet()
     {
-        $form = $this->factory->create('collection', array(), array(
+        $form = $this->factory->create('collection', array(
+            'data' => array(),
             'type' => 'file',
             'allow_add' => true,
             'prototype' => true,
@@ -245,7 +247,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPrototypeNameOption()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'form',
             'prototype' => true,
             'allow_add' => true,
@@ -253,7 +255,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertSame('__name__', $form->getConfig()->getAttribute('prototype')->getName(), '__name__ is the default');
 
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create('collection', array(
             'type' => 'form',
             'prototype' => true,
             'allow_add' => true,
@@ -265,7 +267,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPrototypeDefaultLabel()
     {
-        $form = $this->factory->create('collection', array(), array(
+        $form = $this->factory->create('collection', array(
             'type' => 'file',
             'allow_add' => true,
             'prototype' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -40,7 +40,7 @@ class CountryTypeTest extends TestCase
 
     public function testUnknownCountryIsNotIncluded()
     {
-        $form = $this->factory->create('country', 'country');
+        $form = $this->factory->create('country', array('data' => 'country'));
         $view = $form->createView();
         $choices = $view->vars['choices'];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -26,7 +26,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDateTime()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -53,7 +53,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitString()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -78,7 +78,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitTimestamp()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -105,7 +105,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitWithoutMinutes()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -134,7 +134,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitWithSeconds()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -165,7 +165,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentTimezones()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'date_widget' => 'choice',
@@ -196,7 +196,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentTimezonesDateTime()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'widget' => 'single_text',
@@ -215,7 +215,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitStringSingleText()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -230,7 +230,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitStringSingleTextWithSeconds()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -246,7 +246,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentPattern()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'date_format' => 'MM*yyyy*dd',
             'date_widget' => 'single_text',
             'time_widget' => 'single_text',
@@ -268,12 +268,12 @@ class DateTimeTypeTest extends TestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->factory->create('datetime', new \DateTime());
+        $this->factory->create('datetime', array('data' => new \DateTime()));
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'widget' => 'single_text',
         ));
 
@@ -283,7 +283,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'required' => false,
             'with_seconds' => true,
         ));
@@ -299,7 +299,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'required' => true,
             'with_seconds' => true,
         ));
@@ -315,7 +315,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'placeholder' => 'Empty',
             'with_seconds' => true,
         ));
@@ -331,7 +331,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'empty_value' => 'Empty',
             'with_seconds' => true,
         ));
@@ -353,7 +353,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
@@ -376,7 +376,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'required' => false,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -398,7 +398,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'required' => true,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -420,7 +420,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'widget' => 'single_text',
         ));
 
@@ -430,7 +430,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'widget' => 'single_text',
             'html5' => false,
         ));
@@ -441,7 +441,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'widget' => 'single_text',
             'format' => 'yyyy-MM-dd HH:mm',
         ));
@@ -452,7 +452,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfNotSingleText()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'widget' => 'text',
         ));
 
@@ -463,7 +463,7 @@ class DateTimeTypeTest extends TestCase
     public function testDateTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null);
+        $form = $this->factory->create('datetime');
 
         $form['date']->addError($error);
 
@@ -474,7 +474,7 @@ class DateTimeTypeTest extends TestCase
     public function testDateTypeSingleTextErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'date_widget' => 'single_text',
         ));
 
@@ -487,7 +487,7 @@ class DateTimeTypeTest extends TestCase
     public function testTimeTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null);
+        $form = $this->factory->create('datetime');
 
         $form['time']->addError($error);
 
@@ -498,7 +498,7 @@ class DateTimeTypeTest extends TestCase
     public function testTimeTypeSingleTextErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('datetime', array(
             'time_widget' => 'single_text',
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -42,7 +42,7 @@ class DateTypeTest extends TestCase
      */
     public function testInvalidWidgetOption()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'widget' => 'fake_widget',
         ));
     }
@@ -52,14 +52,14 @@ class DateTypeTest extends TestCase
      */
     public function testInvalidInputOption()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'input' => 'fake_input',
         ));
     }
 
     public function testSubmitFromSingleTextDateTimeWithDefaultFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -74,7 +74,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextDateTime()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -90,7 +90,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextString()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -106,7 +106,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextTimestamp()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -124,7 +124,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextRaw()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -146,7 +146,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromText()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'text',
@@ -168,7 +168,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromChoice()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -190,7 +190,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromChoiceEmpty()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -211,7 +211,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputDateTimeDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -227,7 +227,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputStringDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -243,7 +243,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputTimestampDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -261,7 +261,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputRawDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -286,7 +286,7 @@ class DateTypeTest extends TestCase
      */
     public function testDatePatternWithFormatOption($format, $pattern)
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => $format,
         ));
 
@@ -312,7 +312,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsNoPattern()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'format' => '0',
             'widget' => 'single_text',
             'input' => 'string',
@@ -324,7 +324,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatDoesNotContainYearMonthAndDay()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'months' => array(6, 7),
             'format' => 'yy',
         ));
@@ -335,7 +335,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsNoConstant()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'format' => 105,
         ));
     }
@@ -345,7 +345,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'format' => array(),
         ));
     }
@@ -355,7 +355,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfYearsIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'years' => 'bad value',
         ));
     }
@@ -365,7 +365,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfMonthsIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'months' => 'bad value',
         ));
     }
@@ -375,14 +375,14 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfDaysIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('date', array(
             'days' => 'bad value',
         ));
     }
 
     public function testSetDataWithNegativeTimezoneOffsetStringInput()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'America/New_York',
@@ -399,7 +399,7 @@ class DateTypeTest extends TestCase
 
     public function testSetDataWithNegativeTimezoneOffsetDateTimeInput()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'America/New_York',
@@ -419,7 +419,7 @@ class DateTypeTest extends TestCase
 
     public function testYearsOption()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'years' => array(2010, 2011),
         ));
 
@@ -433,7 +433,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOption()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'months' => array(6, 7),
         ));
 
@@ -447,7 +447,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOptionShortFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'months' => array(1, 4),
             'format' => 'dd.MMM.yy',
         ));
@@ -462,7 +462,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOptionLongFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'months' => array(1, 4),
             'format' => 'dd.MMMM.yy',
         ));
@@ -477,7 +477,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOptionLongFormatWithDifferentTimezone()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'months' => array(1, 4),
             'format' => 'dd.MMMM.yy',
         ));
@@ -492,7 +492,7 @@ class DateTypeTest extends TestCase
 
     public function testIsDayWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'days' => array(6, 7),
         ));
 
@@ -508,7 +508,7 @@ class DateTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -523,7 +523,7 @@ class DateTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -542,7 +542,7 @@ class DateTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -561,7 +561,7 @@ class DateTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -586,7 +586,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToViewDifferentFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => \IntlDateFormatter::LONG,
         ));
 
@@ -597,7 +597,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToViewDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => 'MMyyyydd',
         ));
 
@@ -608,7 +608,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToViewDifferentPatternWithSeparators()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'format' => 'MM*yyyy*dd',
         ));
 
@@ -619,7 +619,7 @@ class DateTypeTest extends TestCase
 
     public function testDontPassDatePatternIfText()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => 'single_text',
         ));
         $view = $form->createView();
@@ -629,7 +629,7 @@ class DateTypeTest extends TestCase
 
     public function testPassWidgetToView()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => 'single_text',
         ));
         $view = $form->createView();
@@ -647,7 +647,7 @@ class DateTypeTest extends TestCase
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => 'single_text',
         ));
 
@@ -657,7 +657,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'required' => false,
         ));
 
@@ -669,7 +669,7 @@ class DateTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'required' => true,
         ));
 
@@ -681,7 +681,7 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'placeholder' => 'Empty',
         ));
 
@@ -693,7 +693,7 @@ class DateTypeTest extends TestCase
 
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'empty_value' => 'Empty',
         ));
 
@@ -708,7 +708,7 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
@@ -724,7 +724,7 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'required' => false,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -740,7 +740,7 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'required' => true,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -756,7 +756,7 @@ class DateTypeTest extends TestCase
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => 'single_text',
         ));
 
@@ -766,7 +766,7 @@ class DateTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => 'single_text',
             'html5' => false,
         ));
@@ -777,7 +777,7 @@ class DateTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => 'single_text',
             'format' => \IntlDateFormatter::MEDIUM,
         ));
@@ -788,7 +788,7 @@ class DateTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfNotSingleText()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => 'text',
         ));
 
@@ -810,7 +810,7 @@ class DateTypeTest extends TestCase
     public function testYearErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => $widget,
         ));
         $form['year']->addError($error);
@@ -825,7 +825,7 @@ class DateTypeTest extends TestCase
     public function testMonthErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => $widget,
         ));
         $form['month']->addError($error);
@@ -840,7 +840,7 @@ class DateTypeTest extends TestCase
     public function testDayErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'widget' => $widget,
         ));
         $form['day']->addError($error);
@@ -856,7 +856,7 @@ class DateTypeTest extends TestCase
                 'PHP must be compiled in 32 bit mode to run this test');
         }
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('date', array(
             'years' => range(1900, 2040),
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -46,7 +46,7 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultiple()
     {
-        $form = $this->factory->createBuilder('file', null, array(
+        $form = $this->factory->createBuilder('file', array(
             'multiple' => true,
         ))->getForm();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -58,11 +58,11 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassRequiredAsOption()
     {
-        $form = $this->factory->create('form', null, array('required' => false));
+        $form = $this->factory->create('form', array('required' => false));
 
         $this->assertFalse($form->isRequired());
 
-        $form = $this->factory->create('form', null, array('required' => true));
+        $form = $this->factory->create('form', array('required' => true));
 
         $this->assertTrue($form->isRequired());
     }
@@ -85,7 +85,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmittedDataIsNotTrimmedBeforeTransformingIfNoTrimming()
     {
-        $form = $this->factory->createBuilder('form', null, array('trim' => false))
+        $form = $this->factory->createBuilder('form', array('trim' => false))
             ->addViewTransformer(new FixedDataTransformer(array(
                 null => '',
                 'reverse[ a ]' => ' a ',
@@ -101,7 +101,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('read_only' => true))
+        $view = $this->factory->createNamedBuilder('parent', 'form', array('read_only' => true))
             ->add('child', 'form')
             ->getForm()
             ->createView();
@@ -131,7 +131,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMaxLengthToView()
     {
-        $form = $this->factory->create('form', null, array('attr' => array('maxlength' => 10)));
+        $form = $this->factory->create('form', array('attr' => array('maxlength' => 10)));
         $view = $form->createView();
 
         $this->assertSame(10, $view->vars['attr']['maxlength']);
@@ -139,7 +139,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMaxLengthBCToView()
     {
-        $form = $this->factory->create('form', null, array('max_length' => 10));
+        $form = $this->factory->create('form', array('max_length' => 10));
         $view = $form->createView();
 
         $this->assertSame(10, $view->vars['attr']['maxlength']);
@@ -147,21 +147,21 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataClassMayBeNull()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder('form', array(
             'data_class' => null,
         ));
     }
 
     public function testDataClassMayBeAbstractClass()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder('form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\AbstractAuthor',
         ));
     }
 
     public function testDataClassMayBeInterface()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder('form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\AuthorInterface',
         ));
     }
@@ -171,14 +171,14 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testDataClassMustBeValidClassOrInterface()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder('form', array(
             'data_class' => 'foobar',
         ));
     }
 
     public function testSubmitWithEmptyDataCreatesObjectIfClassAvailable()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ));
@@ -199,7 +199,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataCreatesObjectIfInitiallySubmittedWithObject()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('form', array(
             // data class is inferred from the passed object
             'data' => new Author(),
             'required' => false,
@@ -221,7 +221,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataCreatesArrayIfDataClassIsNull()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('form', array(
             'data_class' => null,
             'required' => false,
         ));
@@ -236,7 +236,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitEmptyWithEmptyDataCreatesNoObjectIfNotRequired()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ));
@@ -252,7 +252,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitEmptyWithEmptyDataCreatesObjectIfRequired()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => true,
         ));
@@ -302,7 +302,7 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new Author();
 
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'empty_data' => $author,
         ));
@@ -331,7 +331,7 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testSetDataThroughParamsWithZero($data, $dataAsString)
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'data' => $data,
             'compound' => false,
         ));
@@ -348,7 +348,7 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testAttributesException()
     {
-        $this->factory->create('form', null, array('attr' => ''));
+        $this->factory->create('form', array('attr' => ''));
     }
 
     public function testNameCanBeEmptyString()
@@ -362,7 +362,7 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder('form', $author);
+        $builder = $this->factory->createBuilder('form', array('data' => $author));
         $builder->add('reference', 'form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
         ));
@@ -385,7 +385,7 @@ class FormTypeTest extends BaseTypeTest
         $author = new FormTest_AuthorWithoutRefSetter(null);
         $newReference = new Author();
 
-        $builder = $this->factory->createBuilder('form', $author);
+        $builder = $this->factory->createBuilder('form', array('data' => $author));
         $builder->add('referenceCopy', 'form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
         ));
@@ -408,7 +408,7 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder('form', $author);
+        $builder = $this->factory->createBuilder('form', array('data' => $author));
         $builder->add('referenceCopy', 'form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'by_reference' => false,
@@ -431,7 +431,7 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter('scalar');
 
-        $builder = $this->factory->createBuilder('form', $author);
+        $builder = $this->factory->createBuilder('form', array('data' => $author));
         $builder->add('referenceCopy', 'form');
         $builder->get('referenceCopy')->addViewTransformer(new CallbackTransformer(
             function () {},
@@ -500,7 +500,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testErrorBubblingIfCompound()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'compound' => true,
         ));
 
@@ -509,7 +509,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNoErrorBubblingIfNotCompound()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'compound' => false,
         ));
 
@@ -518,7 +518,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testOverrideErrorBubbling()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'compound' => false,
             'error_bubbling' => true,
         ));
@@ -528,7 +528,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPropertyPath()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'property_path' => 'foo',
         ));
 
@@ -538,7 +538,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPropertyPathNullImpliesDefault()
     {
-        $form = $this->factory->createNamed('name', 'form', null, array(
+        $form = $this->factory->createNamed('name', 'form', array(
             'property_path' => null,
         ));
 
@@ -548,7 +548,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNotMapped()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'property_path' => 'foo',
             'mapped' => false,
         ));
@@ -590,7 +590,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataOptionSupersedesSetDataCalls()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'data' => 'default',
             'compound' => false,
         ));
@@ -602,7 +602,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataOptionSupersedesSetDataCallsIfNull()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('form', array(
             'data' => null,
             'compound' => false,
         ));
@@ -629,7 +629,7 @@ class FormTypeTest extends BaseTypeTest
     // https://github.com/symfony/symfony/issues/6862
     public function testPassZeroLabelToView()
     {
-        $view = $this->factory->create('form', null, array(
+        $view = $this->factory->create('form', array(
                 'label' => '0',
             ))
             ->createView();
@@ -642,7 +642,7 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testCanGetErrorsWhenButtonInForm()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('form', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -39,7 +39,7 @@ class LanguageTypeTest extends TestCase
 
     public function testMultipleLanguagesIsNotIncluded()
     {
-        $form = $this->factory->create('language', 'language');
+        $form = $this->factory->create('language', array('data' => 'language'));
         $view = $form->createView();
         $choices = $view->vars['choices'];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -39,7 +39,7 @@ class MoneyTypeTest extends TestCase
     {
         \Locale::setDefault('en_US');
 
-        $form = $this->factory->create('money', null, array('currency' => 'JPY'));
+        $form = $this->factory->create('money', array('currency' => 'JPY'));
         $view = $form->createView();
         $this->assertTrue((bool) strstr($view->vars['money_pattern'], '¥'));
     }
@@ -49,8 +49,8 @@ class MoneyTypeTest extends TestCase
     {
         \Locale::setDefault('de_DE');
 
-        $form1 = $this->factory->create('money', null, array('currency' => 'GBP'));
-        $form2 = $this->factory->create('money', null, array('currency' => 'EUR'));
+        $form1 = $this->factory->create('money', array('currency' => 'GBP'));
+        $form2 = $this->factory->create('money', array('currency' => 'EUR'));
         $view1 = $form1->createView();
         $view2 = $form2->createView();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -37,7 +37,7 @@ class NumberTypeTest extends TestCase
 
     public function testDefaultFormattingWithGrouping()
     {
-        $form = $this->factory->create('number', null, array('grouping' => true));
+        $form = $this->factory->create('number', array('grouping' => true));
         $form->setData('12345.67890');
         $view = $form->createView();
 
@@ -46,7 +46,7 @@ class NumberTypeTest extends TestCase
 
     public function testDefaultFormattingWithScale()
     {
-        $form = $this->factory->create('number', null, array('scale' => 2));
+        $form = $this->factory->create('number', array('scale' => 2));
         $form->setData('12345.67890');
         $view = $form->createView();
 
@@ -55,7 +55,7 @@ class NumberTypeTest extends TestCase
 
     public function testDefaultFormattingWithRounding()
     {
-        $form = $this->factory->create('number', null, array('scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP));
+        $form = $this->factory->create('number', array('scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP));
         $form->setData('12345.54321');
         $view = $form->createView();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -33,7 +33,7 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotEmptyIfSubmittedAndNotAlwaysEmpty()
     {
-        $form = $this->factory->create('password', null, array('always_empty' => false));
+        $form = $this->factory->create('password', array('always_empty' => false));
         $form->submit('pAs5w0rd');
         $view = $form->createView();
 
@@ -42,7 +42,7 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotTrimmed()
     {
-        $form = $this->factory->create('password', null);
+        $form = $this->factory->create('password');
         $form->submit(' pAs5w0rd ');
         $data = $form->getData();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -19,7 +19,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         parent::setUp();
 
-        $this->form = $this->factory->create('repeated', null, array(
+        $this->form = $this->factory->create('repeated', array(
             'type' => 'text',
         ));
         $this->form->setData(null);
@@ -35,7 +35,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetOptions()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('repeated', array(
             'type' => 'text',
             'options' => array('label' => 'Global'),
         ));
@@ -48,7 +48,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetOptionsPerChild()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('repeated', array(
             // the global required value cannot be overridden
             'type' => 'text',
             'first_options' => array('label' => 'Test', 'required' => false),
@@ -63,7 +63,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetRequired()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('repeated', array(
             'required' => false,
             'type' => 'text',
         ));
@@ -77,7 +77,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testSetInvalidOptions()
     {
-        $this->factory->create('repeated', null, array(
+        $this->factory->create('repeated', array(
             'type' => 'text',
             'options' => 'bad value',
         ));
@@ -88,7 +88,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testSetInvalidFirstOptions()
     {
-        $this->factory->create('repeated', null, array(
+        $this->factory->create('repeated', array(
             'type' => 'text',
             'first_options' => 'bad value',
         ));
@@ -99,7 +99,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testSetInvalidSecondOptions()
     {
-        $this->factory->create('repeated', null, array(
+        $this->factory->create('repeated', array(
             'type' => 'text',
             'second_options' => 'bad value',
         ));
@@ -107,7 +107,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetErrorBubblingToTrue()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('repeated', array(
             'error_bubbling' => true,
         ));
 
@@ -118,7 +118,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetErrorBubblingToFalse()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('repeated', array(
             'error_bubbling' => false,
         ));
 
@@ -129,7 +129,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetErrorBubblingIndividually()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('repeated', array(
             'error_bubbling' => true,
             'options' => array('error_bubbling' => false),
             'second_options' => array('error_bubbling' => true),
@@ -142,7 +142,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetOptionsPerChildAndOverwrite()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('repeated', array(
             'type' => 'text',
             'options' => array('label' => 'Label'),
             'second_options' => array('label' => 'Second label'),

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -27,7 +27,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitDateTime()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -48,7 +48,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitString()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -67,7 +67,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitTimestamp()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -88,7 +88,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArray()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -107,7 +107,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitDatetimeSingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -122,7 +122,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitDatetimeSingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -138,7 +138,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -158,7 +158,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -178,7 +178,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleTextWithSeconds()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -200,7 +200,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitStringSingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -215,7 +215,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitStringSingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -231,7 +231,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -245,7 +245,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataWithSeconds()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -259,7 +259,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataDifferentTimezones()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'string',
@@ -285,7 +285,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataDifferentTimezonesDateTime()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'datetime',
@@ -312,7 +312,7 @@ class TimeTypeTest extends TestCase
 
     public function testHoursOption()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'hours' => array(6, 7),
         ));
 
@@ -326,7 +326,7 @@ class TimeTypeTest extends TestCase
 
     public function testIsMinuteWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'minutes' => array(6, 7),
         ));
 
@@ -340,7 +340,7 @@ class TimeTypeTest extends TestCase
 
     public function testIsSecondWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'seconds' => array(6, 7),
             'with_seconds' => true,
         ));
@@ -357,7 +357,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'choice',
         ));
 
@@ -373,7 +373,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -391,7 +391,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'choice',
         ));
 
@@ -407,7 +407,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -425,7 +425,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -443,7 +443,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -461,7 +461,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -480,12 +480,12 @@ class TimeTypeTest extends TestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->factory->create('time', new \DateTime());
+        $this->factory->create('time', array('data' => new \DateTime()));
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'single_text',
         ));
 
@@ -495,7 +495,7 @@ class TimeTypeTest extends TestCase
 
     public function testSingleTextWidgetWithSecondsShouldHaveRightStepAttribute()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'single_text',
             'with_seconds' => true,
         ));
@@ -507,7 +507,7 @@ class TimeTypeTest extends TestCase
 
     public function testSingleTextWidgetWithSecondsShouldNotOverrideStepAttribute()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'single_text',
             'with_seconds' => true,
             'attr' => array(
@@ -522,7 +522,7 @@ class TimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => 'single_text',
             'html5' => false,
         ));
@@ -533,7 +533,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'required' => false,
             'with_seconds' => true,
         ));
@@ -546,7 +546,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'required' => true,
             'with_seconds' => true,
         ));
@@ -559,7 +559,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'placeholder' => 'Empty',
             'with_seconds' => true,
         ));
@@ -572,7 +572,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'empty_value' => 'Empty',
             'with_seconds' => true,
         ));
@@ -588,7 +588,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'placeholder' => array(
                 'hour' => 'Empty hour',
                 'minute' => 'Empty minute',
@@ -605,7 +605,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'required' => false,
             'placeholder' => array(
                 'hour' => 'Empty hour',
@@ -622,7 +622,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'required' => true,
             'placeholder' => array(
                 'hour' => 'Empty hour',
@@ -651,7 +651,7 @@ class TimeTypeTest extends TestCase
     public function testHourErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => $widget,
         ));
         $form['hour']->addError($error);
@@ -666,7 +666,7 @@ class TimeTypeTest extends TestCase
     public function testMinuteErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => $widget,
         ));
         $form['minute']->addError($error);
@@ -681,7 +681,7 @@ class TimeTypeTest extends TestCase
     public function testSecondErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('time', array(
             'widget' => $widget,
             'with_seconds' => true,
         ));
@@ -696,7 +696,7 @@ class TimeTypeTest extends TestCase
      */
     public function testInitializeWithSecondsAndWithoutMinutes()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create('time', array(
             'with_minutes' => false,
             'with_seconds' => true,
         ));
@@ -707,7 +707,7 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfHoursIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create('time', array(
             'hours' => 'bad value',
         ));
     }
@@ -717,7 +717,7 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfMinutesIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create('time', array(
             'minutes' => 'bad value',
         ));
     }
@@ -727,7 +727,7 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfSecondsIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create('time', array(
             'seconds' => 'bad value',
         ));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -17,7 +17,7 @@ class UrlTypeTest extends TestCase
 {
     public function testSubmitAddsDefaultProtocolIfNoneIsIncluded()
     {
-        $form = $this->factory->create('url', 'name');
+        $form = $this->factory->create('url', array('data' => 'name'));
 
         $form->submit('www.domain.com');
 
@@ -27,7 +27,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfAlreadyIncluded()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create('url', array(
             'default_protocol' => 'http',
         ));
 
@@ -39,7 +39,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfEmpty()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create('url', array(
             'default_protocol' => 'http',
         ));
 
@@ -51,7 +51,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfNull()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create('url', array(
             'default_protocol' => 'http',
         ));
 
@@ -63,7 +63,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfSetToNull()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create('url', array(
             'default_protocol' => null,
         ));
 
@@ -78,7 +78,7 @@ class UrlTypeTest extends TestCase
      */
     public function testThrowExceptionIfDefaultProtocolIsInvalid()
     {
-        $this->factory->create('url', null, array(
+        $this->factory->create('url', array(
             'default_protocol' => array(),
         ));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -71,7 +71,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testCsrfProtectionByDefaultIfRootAndCompound()
     {
         $view = $this->factory
-            ->create('form', null, array(
+            ->create('form', array(
                 'csrf_field_name' => 'csrf',
                 'compound' => true,
             ))
@@ -85,7 +85,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $view = $this->factory
             ->createNamedBuilder('root', 'form')
             ->add($this->factory
-                ->createNamedBuilder('form', 'form', null, array(
+                ->createNamedBuilder('form', 'form', array(
                     'csrf_field_name' => 'csrf',
                     'compound' => true,
                 ))
@@ -100,7 +100,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testNoCsrfProtectionByDefaultIfRootButNotCompound()
     {
         $view = $this->factory
-            ->create('form', null, array(
+            ->create('form', array(
                 'csrf_field_name' => 'csrf',
                 'compound' => false,
             ))
@@ -112,7 +112,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testCsrfProtectionCanBeDisabled()
     {
         $view = $this->factory
-            ->create('form', null, array(
+            ->create('form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_protection' => false,
                 'compound' => true,
@@ -130,7 +130,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue(new CsrfToken('TOKEN_ID', 'token')));
 
         $view = $this->factory
-            ->create('form', null, array(
+            ->create('form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_token_id' => 'TOKEN_ID',
@@ -149,7 +149,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue('token'));
 
         $view = $this->factory
-            ->createNamed('FORM_NAME', 'form', null, array(
+            ->createNamed('FORM_NAME', 'form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
@@ -167,7 +167,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue('token'));
 
         $view = $this->factory
-            ->createNamed('', 'form', null, array(
+            ->createNamed('', 'form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
@@ -196,7 +196,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue($valid));
 
         $form = $this->factory
-            ->createBuilder('form', null, array(
+            ->createBuilder('form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_token_id' => 'TOKEN_ID',
@@ -228,7 +228,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue($valid));
 
         $form = $this->factory
-            ->createNamedBuilder('FORM_NAME', 'form', null, array(
+            ->createNamedBuilder('FORM_NAME', 'form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
@@ -259,7 +259,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue($valid));
 
         $form = $this->factory
-            ->createNamedBuilder('', 'form', null, array(
+            ->createNamedBuilder('', 'form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
@@ -285,7 +285,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->method('isTokenValid');
 
         $form = $this->factory
-            ->createBuilder('form', null, array(
+            ->createBuilder('form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_token_id' => 'TOKEN_ID',
@@ -314,7 +314,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $form = $this->factory
             ->createNamedBuilder('root', 'form')
             ->add($this->factory
-                ->createNamedBuilder('form', 'form', null, array(
+                ->createNamedBuilder('form', 'form', array(
                     'csrf_field_name' => 'csrf',
                     'csrf_token_manager' => $this->tokenManager,
                     'csrf_token_id' => 'TOKEN_ID',
@@ -336,7 +336,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->method('isTokenValid');
 
         $form = $this->factory
-            ->create('form', null, array(
+            ->create('form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_token_id' => 'TOKEN_ID',
@@ -351,7 +351,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testNoCsrfProtectionOnPrototype()
     {
         $prototypeView = $this->factory
-            ->create('collection', null, array(
+            ->create('collection', array(
                 'type' => new FormTypeCsrfExtensionTest_ChildType(),
                 'options' => array(
                     'csrf_field_name' => 'csrf',
@@ -379,7 +379,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
              ->will($this->returnValue('[trans]Foobar[/trans]'));
 
         $form = $this->factory
-            ->createBuilder('form', null, array(
+            ->createBuilder('form', array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_message' => 'Foobar',

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -20,7 +20,6 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
     {
         $builder = $this->factory->createBuilder(
             'form',
-            null,
             array(
                 'validation_groups' => 'group',
             )
@@ -65,6 +64,6 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = array())
     {
-        return $this->factory->create('form', null, $options);
+        return $this->factory->create('form', $options);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
@@ -15,6 +15,6 @@ class SubmitTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 {
     protected function createForm(array $options = array())
     {
-        return $this->factory->create('submit', null, $options);
+        return $this->factory->create('submit', $options);
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -148,7 +148,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('foo', 'text', null, array())
+            ->with('foo', 'text', array())
         ;
 
         $this->builder->create('foo');
@@ -168,7 +168,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with($expectedName, $expectedType, null, $expectedOptions)
+            ->with($expectedName, $expectedType, $expectedOptions)
             ->will($this->returnValue($this->getFormBuilder()));
 
         $this->builder->add($expectedName, $expectedType, $expectedOptions);
@@ -184,7 +184,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->once())
             ->method('createBuilderForProperty')
-            ->with('stdClass', $expectedName, null, $expectedOptions)
+            ->with('stdClass', $expectedName, $expectedOptions)
             ->will($this->returnValue($this->getFormBuilder()));
 
         $this->builder = new FormBuilder('name', 'stdClass', $this->dispatcher, $this->factory);

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -96,7 +96,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
-        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', 'type', null, $options));
+        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', 'type', $options));
     }
 
     public function testCreateNamedBuilderWithTypeInstance()
@@ -124,7 +124,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
-        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, null, $options));
+        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, $options));
     }
 
     public function testCreateNamedBuilderWithTypeInstanceWithParentType()
@@ -158,7 +158,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
-        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, null, $options));
+        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, $options));
     }
 
     public function testCreateNamedBuilderWithTypeInstanceWithParentTypeInstance()
@@ -192,7 +192,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
-        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, null, $options));
+        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, $options));
     }
 
     public function testCreateNamedBuilderWithResolvedTypeInstance()
@@ -214,7 +214,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
-        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $resolvedType, null, $options));
+        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $resolvedType, $options));
     }
 
     public function testCreateNamedBuilderFillsDataOption()
@@ -242,7 +242,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
-        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', 'type', 'DATA', $givenOptions));
+        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', 'type', array_merge(array('data' => 'DATA'), $givenOptions)));
     }
 
     public function testCreateNamedBuilderDoesNotOverrideExistingDataOption()
@@ -269,7 +269,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
-        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', 'type', 'DATA', $options));
+        $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', 'type', array_merge(array('data' => 'DATA'), $options)));
     }
 
     /**
@@ -309,7 +309,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('getForm')
             ->will($this->returnValue('FORM'));
 
-        $this->assertSame('FORM', $this->factory->create('TYPE', null, $options));
+        $this->assertSame('FORM', $this->factory->create('TYPE', $options));
     }
 
     public function testCreateUsesTypeNameIfTypeGivenAsObject()
@@ -339,7 +339,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('getForm')
             ->will($this->returnValue('FORM'));
 
-        $this->assertSame('FORM', $this->factory->create($resolvedType, null, $options));
+        $this->assertSame('FORM', $this->factory->create($resolvedType, $options));
     }
 
     public function testCreateNamed()
@@ -370,7 +370,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('getForm')
             ->will($this->returnValue('FORM'));
 
-        $this->assertSame('FORM', $this->factory->createNamed('name', 'type', null, $options));
+        $this->assertSame('FORM', $this->factory->createNamed('name', 'type', $options));
     }
 
     public function testCreateBuilderForPropertyWithoutTypeGuesser()
@@ -383,7 +383,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array())
+            ->with('firstName', 'text', array())
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
@@ -415,7 +415,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'password', null, array('attr' => array('maxlength' => 7)))
+            ->with('firstName', 'password', array('attr' => array('maxlength' => 7)))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
@@ -457,13 +457,12 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('attr' => array('maxlength' => 11)))
+            ->with('firstName', 'text', array('attr' => array('maxlength' => 11)))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
             'firstName',
-            null,
             array('attr' => array('maxlength' => 11))
         );
 
@@ -492,7 +491,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('attr' => array('maxlength' => 20)))
+            ->with('firstName', 'text', array('attr' => array('maxlength' => 20)))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
@@ -525,13 +524,12 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('attr' => array('maxlength' => 20, 'pattern' => '.{5,}', 'class' => 'tinymce')))
+            ->with('firstName', 'text', array('attr' => array('maxlength' => 20, 'pattern' => '.{5,}', 'class' => 'tinymce')))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
             'firstName',
-            null,
             array('attr' => array('class' => 'tinymce'))
         );
 
@@ -560,7 +558,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('required' => false))
+            ->with('firstName', 'text', array('required' => false))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
@@ -593,7 +591,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('attr' => array('pattern' => '[a-zA-Z]')))
+            ->with('firstName', 'text', array('attr' => array('pattern' => '[a-zA-Z]')))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9175 |
| License | MIT |
| Doc PR | - |

This PR removes the `$data` argument (in favor of the `data` option) from:
- `FormFactoryInterface::create()`
- `FormFactoryInterface::createNamed()`
- `FormFactoryInterface::createForProperty()`
- `FormFactoryInterface::createBuilder()`
- `FormFactoryInterface::createNamedBuilder()`
- `FormFactoryInterface::createBuilderForProperty()`
