### PR TITLE
[Console] SymfonyStyle : fix blocks failed when $messages is null

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -60,7 +60,7 @@ class SymfonyStyle extends OutputStyle
      */
     public function block($messages, $type = null, $style = null, $prefix = ' ', $padding = false)
     {
-        $messages = array_values((array) $messages);
+        $messages = is_array($messages) ? array_values($messages) : array($messages);
         $lines = array();
 
         // add type


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Using `SymfonyStyle:block` method with `null` as first argument failed, where most of other methods accepting both string and array arguments will simply output an empty string.

At first I wanted to output nothing, or even throw a proper exception. But then I realized how behaves other methods like text or write.

I encountered this issue while executing a console application, in non-interactive mode, that asks questions (without default value) and prints the result immediately using a note block:

``` php
$output->note($output->choice('Choice question', array('choice 1', 'choice 2'));
```

![screenshot 2015-05-16 a 11 42 47](https://cloud.githubusercontent.com/assets/2211145/7665616/ba5f343c-fbc0-11e4-811d-6b109aaa8d27.PNG)
