### PR TITLE
[FrameworkBundle] [DX] Controller managing 404

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -219,6 +219,27 @@ class Controller extends ContainerAware
     }
 
     /**
+     * Throws a NotFoundHttpException.
+     *
+     * This will result in a 404 response code. Usage example:
+     *
+     *     $object = ...;
+     *     $this->createNotFoundExceptionIfNotExist($object, 'Object does not exist');
+     *
+     * @param mixed           $object   The object
+     * @param string          $message  A message
+     * @param \Exception|null $previous The previous exception
+     *
+     * @throws NotFoundHttpException If the object does not exists
+     */
+    public function createNotFoundExceptionIfNotExist($object = null, $message = 'Not Found', \Exception $previous = null)
+    {
+        if (!$object) {
+            throw $this->createNotFoundException($message, $previous);
+        }
+    }
+
+    /**
      * Returns an AccessDeniedException.
      *
      * This will result in a 403 response code. Usage example:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | if PR accepted |

Hi,

I know there are ParamConverters to do this kind of job before the Controller, 
but newcomers are not aware of it at first.

I use this code in a personal BaseControler, and I thought it could be useful for those devs.
Also, I think this one could minimize the number of lines in an action, and let the dev focus on business logic :)

```
$product = ...;
if (!$product) {
    throw $this->createNotFoundException('The product does not exist');
}
```

```
$product = ...;
$this->createNotFoundExceptionIfNotExist($product, 'The product does not exist');
```
