### PR TITLE
[UPGRADE] Mention the CSS strategy and it's effects

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -534,3 +534,33 @@ Validator
  * The PHP7-incompatible constraints (Null, True, False) and related validators
    (NullValidator, TrueValidator, FalseValidator) are marked as deprecated
    in favor of their `Is`-prefixed equivalent.
+
+TwigBundle
+----------
+
+ * The `Symfony\Bundle\TwigBundle\TwigDefaultEscapingStrategy` is deprecated and no longer
+   used in favor of `Twig_FileExtensionEscapingStrategy`. This means that CSS files automatically
+   use the CSS escape strategy. This can cause different behaviour when outputting reserved
+   characters.
+
+   Before:
+
+   ```css
+   {# styles.css.twig #}
+
+   {# with brand_color: '#123456' #}
+   body {
+       background: {{ brand_color }};
+   }
+   ```
+
+   After:
+
+   ```css
+   {# styles.css.twig #}
+
+   {# with brand_Color: '#123456' #}
+   body {
+       background: {{ brand_color|raw }};
+   }
+   ```

--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -559,7 +559,7 @@ TwigBundle
    ```css
    {# styles.css.twig #}
 
-   {# with brand_Color: '#123456' #}
+   {# with brand_color: '#123456' #}
    body {
        background: {{ brand_color|raw }};
    }


### PR DESCRIPTION
The CSS strategy, which is automatically applied to Twig CSS files as of Symfony 2.7, results in different behaviour when outputting reserved characters like `#123456`. This has to be documented in the UPGRADE file.

See https://github.com/javiereguiluz/EasyAdminBundle/pull/305 for an example.

| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |
