### PR TITLE
[2.8][OptionsResolver][DX] reorganize options alphabetically

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -289,7 +289,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function getRequiredOptions()
     {
-        return array_keys($this->required);
+        return $this->orderValues(array_keys($this->required));
     }
 
     /**
@@ -317,7 +317,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function getMissingOptions()
     {
-        return array_keys(array_diff_key($this->required, $this->defaults));
+        return $this->orderValues(array_keys(array_diff_key($this->required, $this->defaults)));
     }
 
     /**
@@ -370,7 +370,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function getDefinedOptions()
     {
-        return array_keys($this->defined);
+        return $this->orderValues(array_keys($this->defined));
     }
 
     /**
@@ -406,12 +406,11 @@ class OptionsResolver implements Options, OptionsResolverInterface
         if ($this->locked) {
             throw new AccessException('Normalizers cannot be set from a lazy option or normalizer.');
         }
-
         if (!isset($this->defined[$option])) {
             throw new UndefinedOptionsException(sprintf(
                 'The option "%s" does not exist. Defined options are: "%s".',
                 $option,
-                implode('", "', array_keys($this->defined))
+                implode('", "', $this->orderValues(array_keys($this->defined)))
             ));
         }
 
@@ -434,7 +433,6 @@ class OptionsResolver implements Options, OptionsResolverInterface
      * @throws AccessException           If called from a lazy option or normalizer
      *
      * @see setNormalizer()
-     *
      * @deprecated since version 2.6, to be removed in 3.0.
      */
     public function setNormalizers(array $normalizers)
@@ -490,7 +488,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             throw new UndefinedOptionsException(sprintf(
                 'The option "%s" does not exist. Defined options are: "%s".',
                 $option,
-                implode('", "', array_keys($this->defined))
+                implode('", "', $this->orderValues(array_keys($this->defined)))
             ));
         }
 
@@ -546,7 +544,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             throw new UndefinedOptionsException(sprintf(
                 'The option "%s" does not exist. Defined options are: "%s".',
                 $option,
-                implode('", "', array_keys($this->defined))
+                implode('", "', $this->orderValues(array_keys($this->defined)))
             ));
         }
 
@@ -602,7 +600,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             throw new UndefinedOptionsException(sprintf(
                 'The option "%s" does not exist. Defined options are: "%s".',
                 $option,
-                implode('", "', array_keys($this->defined))
+                implode('", "', $this->orderValues(array_keys($this->defined)))
             ));
         }
 
@@ -652,7 +650,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             throw new UndefinedOptionsException(sprintf(
                 'The option "%s" does not exist. Defined options are: "%s".',
                 $option,
-                implode('", "', array_keys($this->defined))
+                implode('", "', $this->orderValues(array_keys($this->defined)))
             ));
         }
 
@@ -760,8 +758,8 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
             throw new UndefinedOptionsException(sprintf(
                 (count($diff) > 1 ? 'The options "%s" do not exist.' : 'The option "%s" does not exist.').' Defined options are: "%s".',
-                implode('", "', array_keys($diff)),
-                implode('", "', array_keys($clone->defined))
+                implode('", "', $this->orderValues(array_keys($diff))),
+                implode('", "', $this->orderValues(array_keys($clone->defined)))
             ));
         }
 
@@ -779,7 +777,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
             throw new MissingOptionsException(sprintf(
                 count($diff) > 1 ? 'The required options "%s" are missing.' : 'The required option "%s" is missing.',
-                implode('", "', array_keys($diff))
+                implode('", "', $this->orderValues(array_keys($diff)))
             ));
         }
 
@@ -827,7 +825,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
                 throw new NoSuchOptionException(sprintf(
                     'The option "%s" does not exist. Defined options are: "%s".',
                     $option,
-                    implode('", "', array_keys($this->defined))
+                    implode('", "', $this->orderValues(array_keys($this->defined)))
                 ));
             }
 
@@ -846,7 +844,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             if (isset($this->calling[$option])) {
                 throw new OptionDefinitionException(sprintf(
                     'The options "%s" have a cyclic dependency.',
-                    implode('", "', array_keys($this->calling))
+                    implode('", "', $this->orderValues(array_keys($this->calling)))
                 ));
             }
 
@@ -943,7 +941,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
             if (isset($this->calling[$option])) {
                 throw new OptionDefinitionException(sprintf(
                     'The options "%s" have a cyclic dependency.',
-                    implode('", "', array_keys($this->calling))
+                    implode('", "', $this->orderValues(array_keys($this->calling)))
                 ));
             }
 
@@ -1205,5 +1203,12 @@ class OptionsResolver implements Options, OptionsResolverInterface
         }
 
         return implode(', ', $values);
+    }
+
+    private function orderValues(array $values)
+    {
+        sort($values, SORT_STRING | SORT_FLAG_CASE);
+
+        return $values;
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -325,7 +325,7 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
         $this->resolver->setDefault('bam', 'baz');
         $this->resolver->setDefault('foo', 'boo');
 
-        $this->assertSame(array('foo', 'bar'), $this->resolver->getRequiredOptions());
+        $this->assertSame(array('bar', 'foo'), $this->resolver->getRequiredOptions());
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -451,7 +451,7 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
         $this->resolver->setDefault('baz', 'bam');
         $this->resolver->setRequired('boo');
 
-        $this->assertSame(array('foo', 'bar', 'baz', 'boo'), $this->resolver->getDefinedOptions());
+        $this->assertSame(array('bar', 'baz', 'boo', 'foo'), $this->resolver->getDefinedOptions());
     }
 
     public function testRemovedOptionsAreNotDefined()


### PR DESCRIPTION
This PR allows developers to have all required / defined options organized alphabetically to be more easily usable when an error occur.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
