### PR TITLE
[Security] TokenBasedRememberMeServices test to show why encoding username is required

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -36,9 +36,6 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
         }
 
         list($class, $username, $expires, $hash) = $cookieParts;
-        if (false === $username = base64_decode($username, true)) {
-            throw new AuthenticationException('$username contains a character from outside the base64 alphabet.');
-        }
         try {
             $user = $this->getUserProvider($class)->loadUserByUsername($username);
         } catch (\Exception $ex) {
@@ -127,7 +124,7 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
     {
         return $this->encodeCookie(array(
             $class,
-            base64_encode($username),
+            $username,
             $expires,
             $this->generateCookieHash($class, $username, $expires, $password),
         ));

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -36,6 +36,9 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
         }
 
         list($class, $username, $expires, $hash) = $cookieParts;
+        if (false === $username = base64_decode($username, true)) {
+            throw new AuthenticationException('$username contains a character from outside the base64 alphabet.');
+        }
         try {
             $user = $this->getUserProvider($class)->loadUserByUsername($username);
         } catch (\Exception $ex) {
@@ -122,9 +125,11 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      */
     protected function generateCookieValue($class, $username, $expires, $password)
     {
+        // $username is encoded because it might contain COOKIE_DELIMITER,
+        // we assume other values don't
         return $this->encodeCookie(array(
             $class,
-            $username,
+            base64_encode($username),
             $expires,
             $this->generateCookieHash($class, $username, $expires, $password),
         ));

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -60,7 +60,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
         $userProvider = $this->getProvider();
         $service = $this->getService($userProvider, array('name' => 'foo', 'path' => null, 'domain' => null, 'always_remember_me' => true, 'lifetime' => 3600));
         $request = new Request();
-        $request->cookies->set('foo', base64_encode('class:'.base64_encode('foouser').':123456789:fooHash'));
+        $request->cookies->set('foo', base64_encode('class:foouser:123456789:fooHash'));
 
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $user
@@ -136,6 +136,27 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', $returnedToken);
         $this->assertSame($user, $returnedToken->getUser());
         $this->assertEquals('fookey', $returnedToken->getKey());
+    }
+
+    // this is temporary, just to show that, without encoding username, cookie value is invalid
+    public function testUsernameMustBeEncodedAsItMightContainCookiePartsDelimiter()
+    {
+        $username = 'foo'.TokenBasedRememberMeServices::COOKIE_DELIMITER.'user';
+
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger
+            ->expects($this->at(1))
+            ->method('debug')
+            ->with('Remember-Me authentication failed: The cookie is invalid.');
+
+        $service = $this->getService($this->getProvider(), array('name' => 'foo', 'always_remember_me' => true, 'path' => null, 'domain' => null, 'lifetime' => 3600), $logger);
+        $request = new Request();
+        $request->cookies->set('foo', $this->getCookie('fooclass', $username, time() + 3600, 'foopass'));
+
+        $returnedToken = $service->autoLogin($request);
+
+        $this->assertNull($returnedToken);
+        $this->assertTrue($request->attributes->get(RememberMeServicesInterface::COOKIE_ATTR_NAME)->isCleared());
     }
 
     public function testLogout()

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -146,10 +146,8 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     public function provideUsernamesForAutoLogin()
     {
         return array(
-            // simple case
-            array('foouser'),
-            // username might contain the delimiter
-            array('foo'.TokenBasedRememberMeServices::COOKIE_DELIMITER.'user'),
+            array('foouser', 'Simple username'),
+            array('foo'.TokenBasedRememberMeServices::COOKIE_DELIMITER.'user', 'Username might contain the delimiter'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14577 |
| License | MIT |
| Doc PR | no |

241538d shows that it's not actually tested, 257b796 reimplements it with test.

I can remove the POC commit if it's not needed.
