### PR TITLE
[Security] AbstractRememberMeServices::encodeCookie() validates cookie parts

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -268,9 +268,17 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
      * @param array $cookieParts
      *
      * @return string
+     *
+     * @throws \InvalidArgumentException When $cookieParts contain the cookie delimiter. Extending class should either remove or escape it.
      */
     protected function encodeCookie(array $cookieParts)
     {
+        foreach ($cookieParts as $cookiePart) {
+            if (false !== strpos($cookiePart, self::COOKIE_DELIMITER)) {
+                throw new \InvalidArgumentException(sprintf('$cookieParts should not contain the cookie delimiter "%s"', self::COOKIE_DELIMITER));
+            }
+        }
+
         return base64_encode(implode(self::COOKIE_DELIMITER, $cookieParts));
     }
 

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -119,8 +119,6 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      * @param int    $expires  The Unix timestamp when the cookie expires
      * @param string $password The encoded password
      *
-     * @throws \RuntimeException if username contains invalid chars
-     *
      * @return string
      */
     protected function generateCookieValue($class, $username, $expires, $password)
@@ -140,8 +138,6 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      * @param string $username The username
      * @param int    $expires  The Unix timestamp when the cookie expires
      * @param string $password The encoded password
-     *
-     * @throws \RuntimeException when the private key is empty
      *
      * @return string
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14577 |
| License | MIT |
| Doc PR | no |

`AbstractRememberMeServices::encodeCookie()` guards against `COOKIE_DELIMITER` in `$cookieParts`.
- it would make `AbstractRememberMeServices::cookieDecode()` broken
- all current extending classes do it anyway (see #14670 )
- added tests – it's not a public method, but it is expected to be used by user implementations – as such, it's good to know that it works properly
