### PR TITLE
[HttpFoundation] Added ability to parse json request into parameter bag.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -306,6 +306,10 @@ class Request
         ) {
             parse_str($request->getContent(), $data);
             $request->request = new ParameterBag($data);
+        } elseif (in_array($request->headers->get('CONTENT_TYPE'), array('application/json', 'application/x-json')) &&
+            in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('POST', 'PUT', 'DELETE', 'PATCH'))
+        ) {
+            $request->request = new ParameterBag(json_decode($request->getContent(), true));
         }
 
         return $request;

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -311,7 +311,7 @@ class Request
         ) {
             $data = json_decode($request->getContent(), true);
 
-            if (false !== $data && is_array($data)) {
+            if (null !== $data && is_array($data)) {
                 $request->request = new ParameterBag(json_decode($request->getContent(), true));
             }
         }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -309,7 +309,11 @@ class Request
         } elseif (in_array($request->headers->get('CONTENT_TYPE'), array('application/json', 'application/x-json')) &&
             in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('POST', 'PUT', 'DELETE', 'PATCH'))
         ) {
-            $request->request = new ParameterBag(json_decode($request->getContent(), true));
+            $data = json_decode($request->getContent(), true);
+
+            if (false !== $data && is_array($data)) {
+                $request->request = new ParameterBag(json_decode($request->getContent(), true));
+            }
         }
 
         return $request;

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1032,6 +1032,13 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         unset($_SERVER['REQUEST_METHOD'], $_SERVER['CONTENT_TYPE']);
 
+        $_SERVER['REQUEST_METHOD'] = $method;
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+        $request = RequestJsonContentProxy::createFromGlobals();
+        $this->assertEquals('mycontent', $request->request->get('content'));
+
+        unset($_SERVER['REQUEST_METHOD'], $_SERVER['CONTENT_TYPE']);
+
         Request::createFromGlobals();
         Request::enableHttpMethodParameterOverride();
         $_POST['_method'] = $method;
@@ -1811,6 +1818,14 @@ class RequestContentProxy extends Request
     public function getContent($asResource = false)
     {
         return http_build_query(array('_method' => 'PUT', 'content' => 'mycontent'));
+    }
+}
+
+class RequestJsonContentProxy extends Request
+{
+    public function getContent($asResource = false)
+    {
+        return json_encode(array('content' => 'mycontent'));
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |

Added ability for Request::createFromGlobals() to recognise an incoming JSON request (default format in many Javascript frameworks such as Angular) and parse it into the request parameter bag.

I've checked the 'CONTENT_TYPE' server parameter directly to be consistent with the way that form data is tested for (line 304). Having said this, the Request::getContentType() method would return 'form' and 'json' in each scenario. Checking this would tidy both of these lines up and keep the MIME types in one place.
