### PR TITLE
[FrameworkBundle] Removed unnecessary parameter in TemplateController

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -47,7 +47,7 @@ class TemplateController extends ContainerAware
         if ($private) {
             $response->setPrivate();
         } elseif ($private === false || (null === $private && ($maxAge || $sharedAge))) {
-            $response->setPublic($private);
+            $response->setPublic();
         }
 
         return $response;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | They should |
| License | MIT |

`Response::setPublic()` doesn't have any parameters, so this parameter call is not needed.
