### PR TITLE
Use NullLogger when available

### DIFF
--- a/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
+++ b/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Propel1\Logger;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Psr\Log\LoggerInterface;
 
@@ -47,7 +48,7 @@ class PropelLogger
      */
     public function __construct(LoggerInterface $logger = null, Stopwatch $stopwatch = null)
     {
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
         $this->queries = array();
         $this->stopwatch = $stopwatch;
         $this->isPrepared = false;
@@ -60,9 +61,7 @@ class PropelLogger
      */
     public function alert($message)
     {
-        if (null !== $this->logger) {
-            $this->logger->alert($message);
-        }
+        $this->logger->alert($message);
     }
 
     /**
@@ -72,9 +71,7 @@ class PropelLogger
      */
     public function crit($message)
     {
-        if (null !== $this->logger) {
-            $this->logger->critical($message);
-        }
+        $this->logger->critical($message);
     }
 
     /**
@@ -84,9 +81,7 @@ class PropelLogger
      */
     public function err($message)
     {
-        if (null !== $this->logger) {
-            $this->logger->error($message);
-        }
+        $this->logger->error($message);
     }
 
     /**
@@ -96,9 +91,7 @@ class PropelLogger
      */
     public function warning($message)
     {
-        if (null !== $this->logger) {
-            $this->logger->warning($message);
-        }
+        $this->logger->warning($message);
     }
 
     /**
@@ -108,9 +101,7 @@ class PropelLogger
      */
     public function notice($message)
     {
-        if (null !== $this->logger) {
-            $this->logger->notice($message);
-        }
+        $this->logger->notice($message);
     }
 
     /**
@@ -120,9 +111,7 @@ class PropelLogger
      */
     public function info($message)
     {
-        if (null !== $this->logger) {
-            $this->logger->info($message);
-        }
+        $this->logger->info($message);
     }
 
     /**
@@ -152,9 +141,7 @@ class PropelLogger
 
         if ($add) {
             $this->queries[] = $message;
-            if (null !== $this->logger) {
-                $this->logger->debug($message);
-            }
+            $this->logger->debug($message);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Routing;
 
+use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\Config\Exception\FileLoaderLoadException;
 use Symfony\Component\Config\Loader\DelegatingLoader as BaseDelegatingLoader;
@@ -41,7 +42,7 @@ class DelegatingLoader extends BaseDelegatingLoader
     public function __construct(ControllerNameParser $parser, LoggerInterface $logger = null, LoaderResolverInterface $resolver)
     {
         $this->parser = $parser;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
 
         parent::__construct($resolver);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Debugger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Debugger.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Templating;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Templating\DebuggerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -30,7 +31,7 @@ class Debugger implements DebuggerInterface
      */
     public function __construct(LoggerInterface $logger = null)
     {
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**
@@ -40,8 +41,6 @@ class Debugger implements DebuggerInterface
      */
     public function log($message)
     {
-        if (null !== $this->logger) {
-            $this->logger->debug($message);
-        }
+        $this->logger->debug($message);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Controller;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -36,7 +37,7 @@ class ControllerResolver implements ControllerResolverInterface
      */
     public function __construct(LoggerInterface $logger = null)
     {
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**
@@ -57,9 +58,7 @@ class ControllerResolver implements ControllerResolverInterface
     public function getController(Request $request)
     {
         if (!$controller = $request->attributes->get('_controller')) {
-            if (null !== $this->logger) {
-                $this->logger->warning('Unable to look for the controller as the "_controller" parameter is missing');
-            }
+            $this->logger->warning('Unable to look for the controller as the "_controller" parameter is missing');
 
             return false;
         }

--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorsLoggerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorsLoggerListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -31,14 +32,12 @@ class ErrorsLoggerListener implements EventSubscriberInterface
     public function __construct($channel, LoggerInterface $logger = null)
     {
         $this->channel = $channel;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     public function injectLogger()
     {
-        if (null !== $this->logger) {
-            ErrorHandler::setLogger($this->logger, $this->channel);
-        }
+        ErrorHandler::setLogger($this->logger, $this->channel);
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -58,7 +59,7 @@ class RouterListener implements EventSubscriberInterface
 
         $this->matcher = $matcher;
         $this->context = $context ?: $matcher->getContext();
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**
@@ -102,9 +103,7 @@ class RouterListener implements EventSubscriberInterface
                 $parameters = $this->matcher->match($request->getPathInfo());
             }
 
-            if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
-            }
+            $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
 
             $request->attributes->add($parameters);
             unset($parameters['_route'], $parameters['_controller']);

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Profiler;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
@@ -52,7 +53,7 @@ class Profiler
     public function __construct(ProfilerStorageInterface $storage, LoggerInterface $logger = null)
     {
         $this->storage = $storage;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**
@@ -108,7 +109,7 @@ class Profiler
      */
     public function saveProfile(Profile $profile)
     {
-        if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {
+        if (!($ret = $this->storage->write($profile))) {
             $this->logger->warning('Unable to store the profiler information.');
         }
 

--- a/src/Symfony/Component/Security/Core/Util/SecureRandom.php
+++ b/src/Symfony/Component/Security/Core/Util/SecureRandom.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Util;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * A secure random number generator implementation.
@@ -40,15 +41,13 @@ final class SecureRandom implements SecureRandomInterface
     public function __construct($seedFile = null, LoggerInterface $logger = null)
     {
         $this->seedFile = $seedFile;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
 
         // determine whether to use OpenSSL
         if ('\\' === DIRECTORY_SEPARATOR && PHP_VERSION_ID < 50304) {
             $this->useOpenSsl = false;
         } elseif (!function_exists('openssl_random_pseudo_bytes')) {
-            if (null !== $this->logger) {
-                $this->logger->notice('It is recommended that you enable the "openssl" extension for random number generation.');
-            }
+            $this->logger->notice('It is recommended that you enable the "openssl" extension for random number generation.');
             $this->useOpenSsl = false;
         } else {
             $this->useOpenSsl = true;
@@ -68,9 +67,7 @@ final class SecureRandom implements SecureRandomInterface
                 return $bytes;
             }
 
-            if (null !== $this->logger) {
-                $this->logger->info('OpenSSL did not produce a secure random number.');
-            }
+            $this->logger->info('OpenSSL did not produce a secure random number.');
         }
 
         // initialize seed

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Authentication;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Psr\Log\LoggerInterface;
@@ -47,7 +48,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
     {
         $this->httpKernel = $httpKernel;
         $this->httpUtils = $httpUtils;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
 
         $this->options = array_merge(array(
             'failure_path' => null,
@@ -71,9 +72,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
         }
 
         if ($this->options['failure_forward']) {
-            if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Forwarding to %s', $this->options['failure_path']));
-            }
+            $this->logger->debug(sprintf('Forwarding to %s', $this->options['failure_path']));
 
             $subRequest = $this->httpUtils->createRequest($request, $this->options['failure_path']);
             $subRequest->attributes->set(SecurityContextInterface::AUTHENTICATION_ERROR, $exception);
@@ -81,9 +80,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
             return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Redirecting to %s', $this->options['failure_path']));
-        }
+        $this->logger->debug(sprintf('Redirecting to %s', $this->options['failure_path']));
 
         $request->getSession()->set(SecurityContextInterface::AUTHENTICATION_ERROR, $exception);
 

--- a/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\EntryPoint;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\NonceExpiredException;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,7 +35,7 @@ class DigestAuthenticationEntryPoint implements AuthenticationEntryPointInterfac
         $this->realmName = $realmName;
         $this->key = $key;
         $this->nonceValiditySeconds = $nonceValiditySeconds;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**
@@ -53,9 +54,7 @@ class DigestAuthenticationEntryPoint implements AuthenticationEntryPointInterfac
             $authenticateHeader .= ', stale="true"';
         }
 
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('WWW-Authenticate header sent to user agent: "%s"', $authenticateHeader));
-        }
+        $this->logger->debug(sprintf('WWW-Authenticate header sent to user agent: "%s"', $authenticateHeader));
 
         $response = new Response();
         $response->headers->set('WWW-Authenticate', $authenticateHeader);

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
@@ -102,7 +103,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
             'failure_forward' => false,
             'require_previous_session' => true,
         ), $options);
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
         $this->dispatcher = $dispatcher;
         $this->httpUtils = $httpUtils;
     }
@@ -191,9 +192,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
 
     private function onFailure(GetResponseEvent $event, Request $request, AuthenticationException $failed)
     {
-        if (null !== $this->logger) {
-            $this->logger->info(sprintf('Authentication request failed: %s', $failed->getMessage()));
-        }
+        $this->logger->info(sprintf('Authentication request failed: %s', $failed->getMessage()));
 
         $token = $this->securityContext->getToken();
         if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey()) {
@@ -211,9 +210,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
 
     private function onSuccess(GetResponseEvent $event, Request $request, TokenInterface $token)
     {
-        if (null !== $this->logger) {
-            $this->logger->info(sprintf('User "%s" has been authenticated successfully', $token->getUsername()));
-        }
+        $this->logger->info(sprintf('User "%s" has been authenticated successfully', $token->getUsername()));
 
         $this->securityContext->setToken($token);
 

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -32,7 +33,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
     {
         $this->context = $context;
         $this->key = $key;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**
@@ -47,9 +48,6 @@ class AnonymousAuthenticationListener implements ListenerInterface
         }
 
         $this->context->setToken(new AnonymousToken($this->key, 'anon.', array()));
-
-        if (null !== $this->logger) {
-            $this->logger->info('Populated SecurityContext with an anonymous Token');
-        }
+        $this->logger->info('Populated SecurityContext with an anonymous Token');
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
@@ -43,7 +44,7 @@ class BasicAuthenticationListener implements ListenerInterface
         $this->authenticationManager = $authenticationManager;
         $this->providerKey = $providerKey;
         $this->authenticationEntryPoint = $authenticationEntryPoint;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
         $this->ignoreFailure = false;
     }
 
@@ -66,9 +67,7 @@ class BasicAuthenticationListener implements ListenerInterface
             }
         }
 
-        if (null !== $this->logger) {
-            $this->logger->info(sprintf('Basic Authentication Authorization header found for user "%s"', $username));
-        }
+        $this->logger->info(sprintf('Basic Authentication Authorization header found for user "%s"', $username));
 
         try {
             $token = $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $request->headers->get('PHP_AUTH_PW'), $this->providerKey));
@@ -79,9 +78,7 @@ class BasicAuthenticationListener implements ListenerInterface
                 $this->securityContext->setToken(null);
             }
 
-            if (null !== $this->logger) {
-                $this->logger->info(sprintf('Authentication request failed for user "%s": %s', $username, $failed->getMessage()));
-            }
+            $this->logger->info(sprintf('Authentication request failed for user "%s": %s', $username, $failed->getMessage()));
 
             if ($this->ignoreFailure) {
                 return;

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Psr\Log\LoggerInterface;
@@ -32,7 +33,7 @@ class ChannelListener implements ListenerInterface
     {
         $this->map = $map;
         $this->authenticationEntryPoint = $authenticationEntryPoint;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**
@@ -47,9 +48,7 @@ class ChannelListener implements ListenerInterface
         list($attributes, $channel) = $this->map->getPatterns($request);
 
         if ('https' === $channel && !$request->isSecure()) {
-            if (null !== $this->logger) {
-                $this->logger->info('Redirecting to HTTPS');
-            }
+            $this->logger->info('Redirecting to HTTPS');
 
             $response = $this->authenticationEntryPoint->start($request);
 
@@ -59,9 +58,7 @@ class ChannelListener implements ListenerInterface
         }
 
         if ('http' === $channel && $request->isSecure()) {
-            if (null !== $this->logger) {
-                $this->logger->info('Redirecting to HTTP');
-            }
+            $this->logger->info('Redirecting to HTTP');
 
             $response = $this->authenticationEntryPoint->start($request);
 

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -55,7 +56,7 @@ class ContextListener implements ListenerInterface
         $this->context = $context;
         $this->userProviders = $userProviders;
         $this->contextKey = $contextKey;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
         $this->dispatcher = $dispatcher;
     }
 
@@ -81,17 +82,12 @@ class ContextListener implements ListenerInterface
         }
 
         $token = unserialize($token);
-
-        if (null !== $this->logger) {
-            $this->logger->debug('Read SecurityContext from the session');
-        }
+        $this->logger->debug('Read SecurityContext from the session');
 
         if ($token instanceof TokenInterface) {
             $token = $this->refreshUser($token);
         } elseif (null !== $token) {
-            if (null !== $this->logger) {
-                $this->logger->warning(sprintf('Session includes a "%s" where a security token is expected', is_object($token) ? get_class($token) : gettype($token)));
-            }
+            $this->logger->warning(sprintf('Session includes a "%s" where a security token is expected', is_object($token) ? get_class($token) : gettype($token)));
 
             $token = null;
         }

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -48,7 +49,7 @@ class RememberMeListener implements ListenerInterface
         $this->securityContext = $securityContext;
         $this->rememberMeServices = $rememberMeServices;
         $this->authenticationManager = $authenticationManager;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
         $this->dispatcher = $dispatcher;
     }
 
@@ -77,17 +78,14 @@ class RememberMeListener implements ListenerInterface
                 $this->dispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN, $loginEvent);
             }
 
-            if (null !== $this->logger) {
-                $this->logger->debug('SecurityContext populated with remember-me token.');
-            }
+            $this->logger->debug('SecurityContext populated with remember-me token.');
+
         } catch (AuthenticationException $failed) {
-            if (null !== $this->logger) {
-                $this->logger->warning(
-                    'SecurityContext not populated with remember-me token as the'
-                   .' AuthenticationManager rejected the AuthenticationToken returned'
-                   .' by the RememberMeServices: '.$failed->getMessage()
-                );
-            }
+            $this->logger->warning(
+                'SecurityContext not populated with remember-me token as the'
+               .' AuthenticationManager rejected the AuthenticationToken returned'
+               .' by the RememberMeServices: '.$failed->getMessage()
+            );
 
             $this->rememberMeServices->loginFail($request);
         }

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -63,7 +64,7 @@ class SwitchUserListener implements ListenerInterface
         $this->accessDecisionManager = $accessDecisionManager;
         $this->usernameParameter = $usernameParameter;
         $this->role = $role;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
         $this->dispatcher = $dispatcher;
     }
 
@@ -127,9 +128,7 @@ class SwitchUserListener implements ListenerInterface
 
         $username = $request->get($this->usernameParameter);
 
-        if (null !== $this->logger) {
-            $this->logger->info(sprintf('Attempt to switch to user "%s"', $username));
-        }
+        $this->logger->info(sprintf('Attempt to switch to user "%s"', $username));
 
         $user = $this->provider->loadUserByUsername($username);
         $this->userChecker->checkPostAuth($user);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Use  `Psr\Log\NullLogger` when available in order to avoid littering code with `if ($this->logger) { }` blocks.

Changes were made only in component and bundles where `psr\log` is declared as a dependency in `composer.json`, or at least `symfony/http-kernel` which requires it.

If this is accepted for merging, some changes might remain to do in newest branches.
