### PR TITLE
Fixed the indentation in the compiled template for the DumpNode

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/DumpNode.php
+++ b/src/Symfony/Bridge/Twig/Node/DumpNode.php
@@ -79,6 +79,6 @@ class DumpNode extends \Twig_Node
 
         $compiler
             ->outdent()
-            ->raw("}\n");
+            ->write("}\n");
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Node/DumpNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/DumpNodeTest.php
@@ -39,6 +39,30 @@ EOTXT;
         $this->assertSame($expected, $compiler->compile($node)->getSource());
     }
 
+    public function testIndented()
+    {
+        $node = new DumpNode('bar', null, 7);
+
+        $env = new \Twig_Environment();
+        $compiler = new \Twig_Compiler($env);
+
+        $expected = <<<'EOTXT'
+    if ($this->env->isDebug()) {
+        $barvars = array();
+        foreach ($context as $barkey => $barval) {
+            if (!$barval instanceof \Twig_Template) {
+                $barvars[$barkey] = $barval;
+            }
+        }
+        // line 7
+        \Symfony\Component\VarDumper\VarDumper::dump($barvars);
+    }
+
+EOTXT;
+
+        $this->assertSame($expected, $compiler->compile($node, 1)->getSource());
+    }
+
     public function testOneVar()
     {
         $vars = new \Twig_Node(array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The Twig codebase is very careful at making compiled templates readable by formatting them properly. This fixes a case where Symfony does not respect this careful formatting (yes, I went debugging things into my compiled template today)
