### PR TITLE
[HttpFoundation] IpUtils::checkIp4() should allow `/0` networks

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -62,14 +62,14 @@ class IpUtils
     public static function checkIp4($requestIp, $ip)
     {
         if (false !== strpos($ip, '/')) {
-            list($address, $netmask) = explode('/', $ip, 2);
-
-            if ($netmask < 0 || $netmask > 32) {
-                return false;
+            if ('0.0.0.0/0' === $ip) {
+                return true;
             }
 
-            if ('0' === $netmask) {
-                return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
+            list($address, $netmask) = explode('/', $ip, 2);
+
+            if ($netmask < 1 || $netmask > 32) {
+                return false;
             }
         } else {
             $address = $ip;

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -64,8 +64,12 @@ class IpUtils
         if (false !== strpos($ip, '/')) {
             list($address, $netmask) = explode('/', $ip, 2);
 
-            if ($netmask < 1 || $netmask > 32) {
+            if ($netmask < 0 || $netmask > 32) {
                 return false;
+            }
+
+            if ($netmask === '0') {
+                return true;
             }
         } else {
             $address = $ip;

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -68,7 +68,7 @@ class IpUtils
                 return false;
             }
 
-            if ($netmask === '0') {
+            if ('0' === $netmask) {
                 return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
             }
         } else {

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -69,7 +69,7 @@ class IpUtils
             }
 
             if ($netmask === '0') {
-                return true;
+                return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
             }
         } else {
             $address = $ip;

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -36,6 +36,7 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
             array(false, '192.168.1.1', array('1.2.3.4/1', '4.3.2.1/1')),
             array(true, '1.2.3.4', '0.0.0.0/0'),
             array(false, '1.2.3.4', '256.256.256/0'),
+            array(false, '1.2.3.4', '192.168.1.0/0'),
         );
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -34,6 +34,7 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
             array(true, '192.168.1.1', array('1.2.3.4/1', '192.168.1.0/24')),
             array(true, '192.168.1.1', array('192.168.1.0/24', '1.2.3.4/1')),
             array(false, '192.168.1.1', array('1.2.3.4/1', '4.3.2.1/1')),
+            array(true, '1.2.3.4', '0.0.0.0/0'),
         );
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -35,6 +35,7 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
             array(true, '192.168.1.1', array('192.168.1.0/24', '1.2.3.4/1')),
             array(false, '192.168.1.1', array('1.2.3.4/1', '4.3.2.1/1')),
             array(true, '1.2.3.4', '0.0.0.0/0'),
+            array(false, '1.2.3.4', '256.256.256/0'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14674 |
| License | MIT |

Technically it's a breaking change, since the result of the

```
IpUtils::checkIp4('1.2.3.4', '0.0.0.0/0')
```

call was `false` now `true`.

Practically - no one should ever relied on this since it's simply wrong
