### PR TITLE
[Debug] Source-Links not properly escaped

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -382,7 +382,7 @@ EOF;
         if ($linkFormat = $this->fileLinkFormat) {
             $link = str_replace(array('%f', '%l'), array($path, $line), $linkFormat);
 
-            return sprintf(' in <a href="%s" title="Go to source">%s line %d</a>', $link, $file, $line);
+            return sprintf(' in <a href="%s" title="Go to source">%s line %d</a>', htmlspecialchars($link), $file, $line);
         }
 
         return sprintf(' in <a title="%s line %3$d" ondblclick="var f=this.innerHTML;this.innerHTML=this.title;this.title=f;">%s line %d</a>', $path, $file, $line);

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -382,10 +382,10 @@ EOF;
         if ($linkFormat = $this->fileLinkFormat) {
             $link = str_replace(array('%f', '%l'), array($path, $line), $linkFormat);
 
-            return sprintf(' in <a href="%s" title="Go to source">%s line %d</a>', htmlspecialchars($link), $file, $line);
+            return sprintf(' in <a href="%s" title="Go to source">%s line %d</a>', htmlspecialchars($link), htmlspecialchars($file), $line);
         }
 
-        return sprintf(' in <a title="%s line %3$d" ondblclick="var f=this.innerHTML;this.innerHTML=this.title;this.title=f;">%s line %d</a>', $path, $file, $line);
+        return sprintf(' in <a title="%s line %3$d" ondblclick="var f=this.innerHTML;this.innerHTML=this.title;this.title=f;">%s line %d</a>', htmlspecialchars($path), htmlspecialchars($file), $line);
     }
 
     /**


### PR DESCRIPTION
Example (PHPstorm Remote Call)

```
xdebug.file_link_format="javascript:var rq = new XMLHttpRequest(); rq.open(\"GET\", \"http://localhost:8091?message=%f:%l\", true); rq.send(null);"
```

causes errors (does not work). With this patch this is fixed
