### PR TITLE
Fix the rendering of deprecation log messages

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -112,6 +112,7 @@
 {% macro display_message(log_index, log, is_deprecation) %}
     {% if is_deprecation %}
         {% set stack = log.context.stack|default([]) %}
+        {% set id = 'sf-call-stack-' ~ log_index %}
 
         {% if stack %}
             <a href="#" onclick="Sfjs.toggle('{{ id }}', document.getElementById('{{ id }}-on'), document.getElementById('{{ id }}-off')); return false;">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14695 |
| License | MIT |
| Doc PR | n/a |

A Twig variable was removed by mistake in #14182
