### PR TITLE
[2.7][DI] Definition deprecation notice includes the parameters given

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -98,7 +98,7 @@ class Definition
      */
     public function setFactoryClass($factoryClass)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
+        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', __METHOD__, $factoryClass), E_USER_DEPRECATED);
 
         $this->factoryClass = $factoryClass;
 
@@ -134,7 +134,7 @@ class Definition
      */
     public function setFactoryMethod($factoryMethod)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
+        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', __METHOD__, $factoryMethod), E_USER_DEPRECATED);
 
         $this->factoryMethod = $factoryMethod;
 
@@ -205,7 +205,7 @@ class Definition
      */
     public function setFactoryService($factoryService)
     {
-        trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', E_USER_DEPRECATED);
+        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', __METHOD__, $factoryService), E_USER_DEPRECATED);
 
         $this->factoryService = $factoryService;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #14687 |
| License | MIT |

This PR won't fix the issue at hand, but should make it a bit easier to debug. Because this is used by the configuration loader, it's hard to trace back where and how it's actually used.
