### PR TITLE
Minor fix

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
@@ -38,6 +38,6 @@ class TokenStorage implements TokenStorageInterface
      */
     public function setToken(TokenInterface $token = null)
     {
-        $this->token = $token;
+        return $this->token = $token;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

return has to be added. The old SecurityContext has 'return $this->tokenStorage->setToken($token)' in its file. If return isn't added in the setToken function in this file, it will return false even if the token is succesfully set.
