### PR TITLE
[HttpKernel][Bundle] Check extension implements ExtensionInterface

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -76,6 +76,13 @@ abstract class Bundle extends ContainerAware implements BundleInterface
             if (class_exists($class)) {
                 $extension = new $class();
 
+                if (!$extension instanceof ExtensionInterface) {
+                    throw new \LogicException(sprintf(
+                        'Extension %s must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface.',
+                        $class
+                    ));
+                }
+
                 // check naming convention
                 $basename = preg_replace('/Bundle$/', '', $this->getName());
                 $expectedAlias = Container::underscore($basename);

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Bundle;
 
+use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionNotValidBundle\ExtensionNotValidBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\ExtensionPresentBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionAbsentBundle\ExtensionAbsentBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Command\FooCommand;
@@ -29,5 +30,15 @@ class BundleTest extends \PHPUnit_Framework_TestCase
         $bundle2 = new ExtensionAbsentBundle();
 
         $this->assertNull($bundle2->registerCommands($app));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface
+     */
+    public function testGetContainerExtensionWithInvalidClass()
+    {
+        $bundle = new ExtensionNotValidBundle();
+        $bundle->getContainerExtension();
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/ExtensionNotValidBundle/DependencyInjection/ExtensionNotValidExtension.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/ExtensionNotValidBundle/DependencyInjection/ExtensionNotValidExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionNotValidBundle\DependencyInjection;
+
+class ExtensionNotValidExtension
+{
+    public function getAlias()
+    {
+        return 'extension_not_valid';
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/ExtensionNotValidBundle/ExtensionNotValidBundle.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/ExtensionNotValidBundle/ExtensionNotValidBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionNotValidBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class ExtensionNotValidBundle extends Bundle
+{
+}


### PR DESCRIPTION
- Avoid fatal errors on line 89 (calling getAlias on objects of
  unknown type).
- Help developers solve problems with their extensions

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
