### PR TITLE
[Console] SymfonyStyle : fix blocks wordwrapping

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -76,7 +76,7 @@ class SymfonyStyle extends OutputStyle
         // wrap and add newlines for each element
         foreach ($messages as $key => $message) {
             $message = OutputFormatter::escape($message);
-            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $this->lineLength - Helper::strlen($prefix), PHP_EOL)));
+            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $this->lineLength - Helper::strlen($prefix), PHP_EOL, true)));
 
             if (count($messages) > 1 && $key < count($messages) - 1) {
                 $lines[] = '';

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -4,6 +4,9 @@ namespace Symfony\Component\Console\Tests\Style;
 
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class SymfonyStyleTest extends PHPUnit_Framework_TestCase
@@ -41,5 +44,21 @@ class SymfonyStyleTest extends PHPUnit_Framework_TestCase
         $baseDir = __DIR__.'/../Fixtures/Style/SymfonyStyle';
 
         return array_map(null, glob($baseDir.'/command/command_*.php'), glob($baseDir.'/output/output_*.txt'));
+    }
+
+    public function testLongWordsBlockWrapping()
+    {
+        $word = 'Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon';
+        $wordLength = strlen($word);
+        $maxLineLength = SymfonyStyle::MAX_LINE_LENGTH - 3;
+
+        $this->command->setCode(function (InputInterface $input, OutputInterface $output) use ($word) {
+            $sfStyle = new SymfonyStyle($input, $output);
+            $sfStyle->block($word, 'CUSTOM', 'fg=white;bg=blue', ' § ', false);
+        });
+
+        $this->tester->execute(array(), array('interactive' => false, 'decorated' => false));
+        $expectedCount = (int) ceil($wordLength / ($maxLineLength)) + (int) ($wordLength > $maxLineLength - 5);
+        $this->assertSame($expectedCount, substr_count($this->tester->getDisplay(true), ' § '));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Allow to print strings with a length greater than the terminal length in a block by allowing to cut words.
Indeed, currently such code won't work:

``` php
//Terminal is 80 chars wide
$sfStyle->caution(str_repeat('#', 78)); //Caution uses 3 chars as prefix (' ! ')
```

> [Symfony\Component\Debug\Exception\ContextErrorException]
>   Warning: str_repeat(): Second argument has to be greater than
>   or equal to 0

Of course, this is only a foolish example. But there is no reason the command should fail when trying to output a long word (as we could imagine it could be a FQCN, absolute path or anything else), nor just because the terminal width is too small.
