### PR TITLE
[Console] SymfonyStyle : fix blocks output is broken on windows cmd

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -46,8 +46,9 @@ class SymfonyStyle extends OutputStyle
     public function __construct(InputInterface $input, OutputInterface $output)
     {
         $this->input = $input;
-        $this->lineLength = min($this->getTerminalWidth(), self::MAX_LINE_LENGTH);
         $this->bufferedOutput = new BufferedOutput($output->getVerbosity(), false, clone $output->getFormatter());
+        // Windows cmd wraps lines as soon as the terminal width is reached, whether there are following chars or not.
+        $this->lineLength = min($this->getTerminalWidth() - (int) (DIRECTORY_SEPARATOR === '\\'), self::MAX_LINE_LENGTH);
 
         parent::__construct($output);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Using `SymfonyStyle::block` method, output is broken on windows cmd:
![screenshot 2015-05-23 a 18 00 18 - copie](https://cloud.githubusercontent.com/assets/2211145/7788763/43135ea0-0249-11e5-8a82-7f788384bc03.PNG)

Windows cmd seems to wrap lines as soon as the terminal width is reached, whether there are following characters or not.

I've encountered this behavior with multiple command prompts available on Windows, like Console2, ConEmu, Cmdr, ... But as most of them are simple cmd wrappers, the output is identic. The only good fellow in there is Cygwin which provides an Unix-like env and command-line interface.

This PR solves this issue by assuming that the lineLength (not the terminal width), used to wrap lines internally within the `SymfonyStyle::block` method, should be the terminal width - 1.
