### PR TITLE
[Console] SymfonyStyle : EOL consistency

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -71,7 +71,7 @@ class SymfonyStyle extends OutputStyle
         // wrap and add newlines for each element
         foreach ($messages as $key => $message) {
             $message = OutputFormatter::escape($message);
-            $lines = array_merge($lines, explode("\n", wordwrap($message, $this->lineLength - Helper::strlen($prefix))));
+            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $this->lineLength - Helper::strlen($prefix), PHP_EOL)));
 
             if (count($messages) > 1 && $key < count($messages) - 1) {
                 $lines[] = '';
@@ -92,7 +92,8 @@ class SymfonyStyle extends OutputStyle
             }
         }
 
-        $this->writeln(implode("\n", $lines)."\n");
+        $this->writeln($lines);
+        $this->newLine();
     }
 
     /**
@@ -100,7 +101,12 @@ class SymfonyStyle extends OutputStyle
      */
     public function title($message)
     {
-        $this->writeln(sprintf("\n<comment>%s</>\n<comment>%s</>\n", $message, str_repeat('=', strlen($message))));
+        $this->newLine();
+        $this->writeln(array(
+            sprintf('<comment>%s</>', $message),
+            sprintf('<comment>%s</>', str_repeat('=', strlen($message))),
+        ));
+        $this->newLine();
     }
 
     /**
@@ -108,7 +114,11 @@ class SymfonyStyle extends OutputStyle
      */
     public function section($message)
     {
-        $this->writeln(sprintf("<comment>%s</>\n<comment>%s</>\n", $message, str_repeat('-', strlen($message))));
+        $this->writeln(array(
+            sprintf('<comment>%s</>', $message),
+            sprintf('<comment>%s</>', str_repeat('-', strlen($message))),
+        ));
+        $this->newLine();
     }
 
     /**
@@ -122,7 +132,8 @@ class SymfonyStyle extends OutputStyle
             $elements
         );
 
-        $this->writeln(implode("\n", $elements)."\n");
+        $this->writeln($elements);
+        $this->newLine();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Fix EOL inconsistency - especially on Windows platforms where both `LF` and `CRLF` were mixed - by relying as much as possible on output implementation.

Indeed, `PHP_EOL` is used in [`OutputStyle::newLine()`](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Console/Style/OutputStyle.php#L38-L41) and [`StreamOutput`](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Console/Output/StreamOutput.php#L75-L83), so there was no reason for using `LF` in `SymfonyStyle`.

However,  [`BufferedOutput`](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Console/Output/BufferedOutput.php) uses `LF`. Then, EOL inconsistency might still be a problem if someone is using `SymfonyStyle`/`OutputStyle` with a `BufferedOutput` instance.
