### PR TITLE
[DependencyInjection] Changed config prepending order across bundles

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -31,7 +31,7 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
         $aliases = $container->getAliases();
         $exprLangProviders = $container->getExpressionLanguageProviders();
 
-        foreach ($container->getExtensions() as $extension) {
+        foreach (array_reverse($container->getExtensions()) as $extension) {
             if ($extension instanceof PrependExtensionInterface) {
                 $extension->prepend($container);
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -6,6 +6,8 @@ use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPa
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
+require_once __DIR__.'/../Fixtures/includes/PrependExtension.php';
+
 class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
 {
     public function testExpressionLanguageProviderForwarding()
@@ -42,5 +44,58 @@ class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
         $pass->process($container);
 
         $this->assertEquals(array($provider), $tmpProviders);
+    }
+
+    public function testPrependingOrderAcrossBundles()
+    {
+        $one   = array('foo' => 'one');
+        $two   = array('foo' => 'two');
+        $three = array('foo' => 'three');
+        $four  = array('foo' => 'four');
+        $five  = array('foo' => 'five');
+
+        $extensionA = $this->getMock('PrependExtension');
+        $extensionA->expects($this->any())
+            ->method('getAlias')
+            ->will($this->returnValue('bundle_a'));
+        $extensionA->expects($this->once())
+            ->method('prepend')
+            ->will($this->returnCallback(function (ContainerBuilder $container) use ($one) {
+                $container->prependExtensionConfig('some_bundle', $one);
+            }));
+
+        $extensionB = $this->getMock('PrependExtension');
+        $extensionB->expects($this->any())
+            ->method('getAlias')
+            ->will($this->returnValue('bundle_b'));
+        $extensionB->expects($this->once())
+            ->method('prepend')
+            ->will($this->returnCallback(function (ContainerBuilder $container) use ($two) {
+                $container->prependExtensionConfig('some_bundle', $two);
+            }));
+
+        $extensionC = $this->getMock('PrependExtension');
+        $extensionC->expects($this->any())
+            ->method('getAlias')
+            ->will($this->returnValue('bundle_c'));
+        $extensionC->expects($this->once())
+            ->method('prepend')
+            ->will($this->returnCallback(function (ContainerBuilder $container) use ($three, $four, $five) {
+                $container->prependExtensionConfig('some_bundle', $three);
+                $container->prependExtensionConfig('some_bundle', $four);
+                $container->prependExtensionConfig('some_bundle', $five);
+            }));
+
+        $container = new ContainerBuilder(new ParameterBag());
+        $container->registerExtension($extensionA);
+        $container->registerExtension($extensionB);
+        $container->registerExtension($extensionC);
+
+        $pass = new MergeExtensionConfigurationPass();
+        $pass->process($container);
+
+        //across extensions the config is FIFO i.e. extension A, B and then C
+        //within an extension the config is FILO (hence 3/4/5 are revered)
+        $this->assertEquals(array($one, $two, $five, $four, $three), $container->getExtensionConfig('some_bundle'));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -37,7 +37,7 @@ class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
         $provider = $this->getMock('Symfony\\Component\\ExpressionLanguage\\ExpressionFunctionProviderInterface');
         $container = new ContainerBuilder(new ParameterBag());
         $container->registerExtension($extension);
-        $container->prependExtensionConfig('foo', array('bar' => true ));
+        $container->prependExtensionConfig('foo', array('bar' => true));
         $container->addExpressionLanguageProvider($provider);
 
         $pass = new MergeExtensionConfigurationPass();
@@ -48,11 +48,11 @@ class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
 
     public function testPrependingOrderAcrossBundles()
     {
-        $one   = array('foo' => 'one');
-        $two   = array('foo' => 'two');
+        $one = array('foo' => 'one');
+        $two = array('foo' => 'two');
         $three = array('foo' => 'three');
-        $four  = array('foo' => 'four');
-        $five  = array('foo' => 'five');
+        $four = array('foo' => 'four');
+        $five = array('foo' => 'five');
 
         $extensionA = $this->getMock('PrependExtension');
         $extensionA->expects($this->any())

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/PrependExtension.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/PrependExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+
+class PrependExtension extends Extension implements PrependExtensionInterface
+{
+    public function prepend(ContainerBuilder $container)
+    {
+    }
+
+    public function load(array $configs, ContainerBuilder $container)
+    {
+    }
+
+    public function getAlias()
+    {
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14748 |
| License | MIT |
| Doc PR | - |

I see this as a bug, but at the same time I do not see a way to fix this without breaking BC. If someone used it as-is and was relying on the reversed order, then they might see some things breaking (that's why I am targeting 3.0 rather than 2.3).
