### PR TITLE
[HttpKernel] Allow to inject PSR-7 ServerRequest in controllers and to return a PSR-7 response.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -15,6 +15,12 @@
             "homepage": "https://symfony.com/contributors"
         }
     ],
+    "repositories": [
+      {
+        "type": "vcs",
+        "url": "https://github.com/dunglas/psr-http-message-bridge"
+      }
+    ],
     "require": {
         "php": ">=5.3.9",
         "symfony/asset": "~2.7|~3.0.0",
@@ -46,7 +52,9 @@
         "symfony/expression-language": "~2.6|~3.0.0",
         "symfony/process": "~2.0,>=2.0.5|~3.0.0",
         "symfony/validator": "~2.5|~3.0.0",
-        "symfony/yaml": "~2.0,>=2.0.5|~3.0.0"
+        "symfony/yaml": "~2.0,>=2.0.5|~3.0.0",
+        "symfony/psr-http-message-bridge": "dev-wip",
+        "zendframework/zend-diactoros": "~1.0"
     },
     "suggest": {
         "symfony/console": "For using the console commands",

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel;
 
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -38,6 +40,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     protected $dispatcher;
     protected $resolver;
     protected $requestStack;
+    protected $httpFoundationFactory;
 
     /**
      * Constructor.
@@ -48,11 +51,15 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      *
      * @api
      */
-    public function __construct(EventDispatcherInterface $dispatcher, ControllerResolverInterface $resolver, RequestStack $requestStack = null)
+    public function __construct(EventDispatcherInterface $dispatcher, ControllerResolverInterface $resolver, RequestStack $requestStack = null, HttpFoundationFactory $httpFoundationFactory = null)
     {
         $this->dispatcher = $dispatcher;
         $this->resolver = $resolver;
         $this->requestStack = $requestStack ?: new RequestStack();
+
+        if (null === $httpFoundationFactory && class_exists('Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory')) {
+            $this->httpFoundationFactory = new HttpFoundationFactory();
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -146,6 +146,15 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         // call controller
         $response = call_user_func_array($controller, $arguments);
 
+        // handle PSR-7 responses
+        if ($response instanceof ResponseInterface) {
+            if (null === $this->httpFoundationFactory) {
+                throw new \RuntimeException('The PSR-7 Bridge must be installed to handle instances of Psr\Http\Message\ResponseInterface.');
+            }
+
+            $response = $this->httpFoundationFactory->createResponse($response);
+        }
+
         // view
         if (!$response instanceof Response) {
             $event = new GetResponseForControllerResultEvent($this, $request, $type, $response);

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -37,10 +37,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class HttpKernel implements HttpKernelInterface, TerminableInterface
 {
+    private $httpFoundationFactory;
     protected $dispatcher;
     protected $resolver;
     protected $requestStack;
-    protected $httpFoundationFactory;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Controller;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolver;
 use Symfony\Component\HttpFoundation\Request;
@@ -195,6 +196,11 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $controller = array(new self(), 'controllerMethod5');
         $this->assertEquals(array($request), $resolver->getArguments($request, $controller), '->getArguments() injects the request');
+
+        $request = Request::create('/');
+        $controller = array(new self(), 'controllerMethod6');
+        $args = $resolver->getArguments($request, $controller);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $args[0], '->getArguments() injects the PSR ServerRequest');
     }
 
     public function testCreateControllerCanReturnAnyCallable()
@@ -233,6 +239,10 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     protected function controllerMethod5(Request $request)
+    {
+    }
+
+    protected function controllerMethod6(ServerRequestInterface $request)
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Tests;
 
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\Response as PsrResponse;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\Stream as PsrStream;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -206,6 +208,14 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         $this->assertResponseEquals(new Response('foo'), $kernel->handle(new Request()));
     }
 
+    public function testHandleWhenTheControllerReturnsAPsrResponse()
+    {
+        $kernel = new HttpKernel(new EventDispatcher(), $this->getResolver(array(new Controller(), 'psrController')));
+
+        $response = $kernel->handle(new Request());
+        $this->assertResponseEquals(new Response('Les-Tilleuls.coop'), $response);
+    }
+
     /**
      * @expectedException \LogicException
      */
@@ -305,6 +315,11 @@ class Controller
     public function controller()
     {
         return new Response('foo');
+    }
+
+    public function psrController()
+    {
+        return new PsrResponse('1.0', array(), new PsrStream('Les-Tilleuls.coop'), 200);
     }
 
     public static function staticController()

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -15,6 +15,12 @@
             "homepage": "https://symfony.com/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/dunglas/psr-http-message-bridge"
+        }
+    ],
     "require": {
         "php": ">=5.3.9",
         "symfony/event-dispatcher": "~2.5.9|~2.6,>=2.6.2|~3.0.0",
@@ -38,7 +44,9 @@
         "symfony/stopwatch": "~2.3|~3.0.0",
         "symfony/templating": "~2.2|~3.0.0",
         "symfony/translation": "~2.0,>=2.0.5|~3.0.0",
-        "symfony/var-dumper": "~2.6|~3.0.0"
+        "symfony/var-dumper": "~2.6|~3.0.0",
+        "symfony/psr-http-message-bridge": "dev-wip",
+        "zendframework/zend-diactoros": "~1.0"
     },
     "conflict": {
         "symfony/config": "<2.7"
@@ -50,7 +58,9 @@
         "symfony/console": "",
         "symfony/dependency-injection": "",
         "symfony/finder": "",
-        "symfony/var-dumper": ""
+        "symfony/var-dumper": "",
+        "symfony/psr-http-message-bridge": "To enable PSR-7 support.",
+        "zendframework/zend-diactoros": "To enable PSR-7 support."
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpKernel\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | not yet |

Use [the PSR-7 Bridge](https://github.com/symfony/psr-http-message-bridge/pull/1) to inject an instance of `Psr\Http\Message\ServerRequestInterface` in controllers. Handle PSR-7 `Psr\Http\Message\ResponseInterface` returned by controllers.
