### PR TITLE
[HttpFoundation] Add missing Response::getStatusText() method.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -500,6 +500,16 @@ class Response
     }
 
     /**
+     * Retrieves the status text for the current web response.
+     *
+     * @return string
+     */
+    public function getStatusText()
+    {
+        return $this->statusText;
+    }
+
+    /**
      * Sets the response charset.
      *
      * @param string $charset Character set

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -661,11 +661,8 @@ class ResponseTest extends ResponseTestCase
         $response = new Response();
 
         $response->setStatusCode($code, $text);
-
-        $statusText = new \ReflectionProperty($response, 'statusText');
-        $statusText->setAccessible(true);
-
-        $this->assertEquals($expectedText, $statusText->getValue($response));
+        $this->assertEquals($code, $response->getStatusCode());
+        $this->assertEquals($expectedText, $response->getStatusText());
     }
 
     public function getStatusCodeFixtures()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Proposed as new feature but would be nice to have it as "bug fix" in 2.3 for the http bridge.
