### PR TITLE
Adding notes about deprecated warnings in 2.7

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -1,6 +1,30 @@
 UPGRADE FROM 2.6 to 2.7
 =======================
 
+Global
+------
+
+ * `E_USER_DEPRECATED` warnings -
+   `trigger_error('... is deprecated ...', E_USER_DEPRECATED)` -
+   are now triggered when using all deprecated functionality.
+   To avoid filling up error logs, you may need to add
+   `~E_USER_DEPRECATED` to your `error_reporting` setting in
+   `php.ini` to *not* add these errors to your log.
+
+   In the Symfony Framework, `~E_USER_DEPRECATED` is added to
+   `bootstrap.php.cache` automatically, but you need at least
+   version `2.3.14` or `3.0.21` of the
+   [SensioDistributionBundle](https://github.com/sensiolabs/SensioDistributionBundle).
+   So, you may need to upgrade:
+
+   ```bash
+   composer update sensio/distribution-bundle
+   ```
+
+   The [phpunit-bridge](https://github.com/symfony/phpunit-bridge)
+   was introduced to silence deprecation warnings while running your
+   tests and give you a report of deprecated function calls.
+
 Router
 ------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Hi guys!

When I upgraded, my project exploded with deprecated warnings. I'm certain we'll get a lot of questions about these, so I think we should try to get ahead of these questions as much as possible. I'm adding this - if I'm mistaken in anything, please let me know. I also think we should mention this in the release blog post so that people are aware.

I'm about to propose a short docs entry to explain things there too (so that hopefully if someone googles for the issue, they'll find our explanation).

Thanks!
