### PR TITLE
Avoid using the app global variable in the profiler templates

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\EventListener;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -101,7 +102,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
             return;
         }
 
-        $this->injectToolbar($response);
+        $this->injectToolbar($response, $request);
     }
 
     /**
@@ -109,7 +110,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
      *
      * @param Response $response A Response instance
      */
-    protected function injectToolbar(Response $response)
+    protected function injectToolbar(Response $response, Request $request)
     {
         $content = $response->getContent();
         $pos = strripos($content, '</body>');
@@ -121,6 +122,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
                     'position' => $this->position,
                     'excluded_ajax_paths' => $this->excludedAjaxPaths,
                     'token' => $response->headers->get('X-Debug-Token'),
+                    'request' => $request,
                 )
             ))."\n";
             $content = substr($content, 0, $pos).$toolbar.substr($content, $pos);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -205,12 +205,12 @@
                     /* prevent logging AJAX calls to static and inline files, like templates */
                     var path = url;
                     if (url.substr(0, 1) === '/') {
-                        if (0 === url.indexOf('{{ app.request.basePath|e('js') }}')) {
-                            path = url.substr({{ app.request.basePath|length }});
+                        if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
+                            path = url.substr({{ request.basePath|length }});
                         }
                     }
-                    else if (0 === url.indexOf('{{ (app.request.schemeAndHttpHost ~ app.request.basePath)|e('js') }}')) {
-                        path = url.substr({{ (app.request.schemeAndHttpHost ~ app.request.basePath)|length }});
+                    else if (0 === url.indexOf('{{ (request.schemeAndHttpHost ~ request.basePath)|e('js') }}')) {
+                        path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
                     }
 
                     if (path.substr(0, 1) === '/' && !path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | small one for people overwriting the WebDebugToolbarListener methods |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/silexphp/Silex-WebProfiler/issues/64 |
| License | MIT |
| Doc PR | n/a |
#14217 introduced a usage of the `app` global variables in profiler templates, while we previously removed all such usages to avoid the dependency on TwigBundle in these templates.

This keeps them usable outside the fullstack framework (for instance in Silex).

I had to do a small BC break to be able to pass the request in the place where we were not yet injecting the Request in the template.
