### PR TITLE
[Security] RememberMeFactory: refactoring (extracted methods)

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -37,7 +37,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         $templateId = $this->getRememberMeServicesTemplateId($config);
         $rememberMeServicesId = $this->getRememberMeServicesId($id, $config);
 
-        $this->addRememberMeServicesToLogoutListener($container, $id, $rememberMeServicesId);
+        $this->addRememberMeServicesToLogoutListener($container, $id, $config);
 
         $rememberMeServices = $container->setDefinition($rememberMeServicesId, new DefinitionDecorator($templateId));
         $rememberMeServices->replaceArgument(1, $config['key']);
@@ -121,12 +121,12 @@ class RememberMeFactory implements SecurityFactoryInterface
         return $authProviderId;
     }
 
-    private function addRememberMeServicesToLogoutListener(ContainerBuilder $container, $id, $rememberMeServicesId)
+    private function addRememberMeServicesToLogoutListener(ContainerBuilder $container, $id, array $config)
     {
         if ($container->hasDefinition('security.logout_listener.'.$id)) {
             $container
                 ->getDefinition('security.logout_listener.'.$id)
-                ->addMethodCall('addHandler', array(new Reference($rememberMeServicesId)))
+                ->addMethodCall('addHandler', array(new Reference($this->getRememberMeServicesId($id, $config))))
             ;
         }
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -82,10 +82,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         }
         $rememberMeServices->replaceArgument(0, $userProviders);
 
-        // remember-me listener
-        $listenerId = 'security.authentication.listener.rememberme.'.$id;
-        $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.rememberme'));
-        $listener->replaceArgument(1, new Reference($rememberMeServicesId));
+        $listenerId = $this->configureRememberMeAuthenticationListener($container, $id, $rememberMeServicesId);
 
         return array($authProviderId, $listenerId, $defaultEntryPoint);
     }
@@ -160,5 +157,15 @@ class RememberMeFactory implements SecurityFactoryInterface
                 ->addMethodCall('addHandler', array(new Reference($rememberMeServicesId)))
             ;
         }
+    }
+
+    private function configureRememberMeAuthenticationListener(ContainerBuilder $container, $id, $rememberMeServicesId)
+    {
+        $listenerId = 'security.authentication.listener.rememberme.'.$id;
+
+        $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.rememberme'));
+        $listener->replaceArgument(1, new Reference($rememberMeServicesId));
+
+        return $listenerId;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -33,26 +33,9 @@ class RememberMeFactory implements SecurityFactoryInterface
     {
         $authProviderId = $this->configureRememberMeAuthenticationProvider($container, $id, $config);
 
-        // remember me services
-        $templateId = $this->getRememberMeServicesTemplateId($config);
-        $rememberMeServicesId = $this->getRememberMeServicesId($id, $config);
-
         $this->addRememberMeServicesToLogoutListener($container, $id, $config);
 
-        $rememberMeServices = $container->setDefinition($rememberMeServicesId, new DefinitionDecorator($templateId));
-        $rememberMeServices->replaceArgument(1, $config['key']);
-        $rememberMeServices->replaceArgument(2, $id);
-
-        if (isset($config['token_provider'])) {
-            $rememberMeServices->addMethodCall('setTokenProvider', array(
-                new Reference($config['token_provider']),
-            ));
-        }
-
-        // remember-me options
-        $rememberMeServices->replaceArgument(3, array_intersect_key($config, $this->options));
-
-        $rememberMeServices->replaceArgument(0, $this->findUserProviders($container, $id, $config));
+        $this->configureRememberMeServices($container, $id, $config);
 
         $listenerId = $this->configureRememberMeAuthenticationListener($container, $id, $config);
 
@@ -129,6 +112,27 @@ class RememberMeFactory implements SecurityFactoryInterface
                 ->addMethodCall('addHandler', array(new Reference($this->getRememberMeServicesId($id, $config))))
             ;
         }
+    }
+
+    private function configureRememberMeServices(ContainerBuilder $container, $id, array $config)
+    {
+        $templateId = $this->getRememberMeServicesTemplateId($config);
+        $rememberMeServicesId = $this->getRememberMeServicesId($id, $config);
+
+        $rememberMeServices = $container->setDefinition($rememberMeServicesId, new DefinitionDecorator($templateId));
+        $rememberMeServices->replaceArgument(1, $config['key']);
+        $rememberMeServices->replaceArgument(2, $id);
+
+        if (isset($config['token_provider'])) {
+            $rememberMeServices->addMethodCall('setTokenProvider', array(
+                new Reference($config['token_provider']),
+            ));
+        }
+
+        // remember-me options
+        $rememberMeServices->replaceArgument(3, array_intersect_key($config, $this->options));
+
+        $rememberMeServices->replaceArgument(0, $this->findUserProviders($container, $id, $config));
     }
 
     private function findUserProviders(ContainerBuilder $container, $id, array $config)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -52,7 +52,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         // remember-me options
         $rememberMeServices->replaceArgument(3, array_intersect_key($config, $this->options));
 
-        $rememberMeServices->replaceArgument(0, $this->findUserProviders($container, $id, $rememberMeServicesId, $config));
+        $rememberMeServices->replaceArgument(0, $this->findUserProviders($container, $id, $config));
 
         $listenerId = $this->configureRememberMeAuthenticationListener($container, $id, $config);
 
@@ -131,9 +131,9 @@ class RememberMeFactory implements SecurityFactoryInterface
         }
     }
 
-    private function findUserProviders(ContainerBuilder $container, $id, $rememberMeServicesId, array $config)
+    private function findUserProviders(ContainerBuilder $container, $id, array $config)
     {
-        $userProviders = $this->findAndAttachToRememberMeAwareListeners($container, $id, $rememberMeServicesId);
+        $userProviders = $this->findAndAttachToRememberMeAwareListeners($container, $id, $config);
 
         if ($config['user_providers']) {
             $userProviders = $this->findUserProvidersInConfig($config);
@@ -146,8 +146,9 @@ class RememberMeFactory implements SecurityFactoryInterface
         return $userProviders;
     }
 
-    private function findAndAttachToRememberMeAwareListeners(ContainerBuilder $container, $id, $rememberMeServicesId)
+    private function findAndAttachToRememberMeAwareListeners(ContainerBuilder $container, $id, array $config)
     {
+        $rememberMeServicesId = $this->getRememberMeServicesId($id, $config);
         $userProviders = array();
 
         foreach ($container->findTaggedServiceIds('security.remember_me_aware') as $serviceId => $attributes) {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -54,7 +54,7 @@ class RememberMeFactory implements SecurityFactoryInterface
 
         $rememberMeServices->replaceArgument(0, $this->findUserProviders($container, $id, $rememberMeServicesId, $config));
 
-        $listenerId = $this->configureRememberMeAuthenticationListener($container, $id, $rememberMeServicesId);
+        $listenerId = $this->configureRememberMeAuthenticationListener($container, $id, $config);
 
         return array($authProviderId, $listenerId, $defaultEntryPoint);
     }
@@ -182,12 +182,12 @@ class RememberMeFactory implements SecurityFactoryInterface
         return $userProviders;
     }
 
-    private function configureRememberMeAuthenticationListener(ContainerBuilder $container, $id, $rememberMeServicesId)
+    private function configureRememberMeAuthenticationListener(ContainerBuilder $container, $id, array $config)
     {
         $listenerId = 'security.authentication.listener.rememberme.'.$id;
 
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.rememberme'));
-        $listener->replaceArgument(1, new Reference($rememberMeServicesId));
+        $listener->replaceArgument(1, new Reference($this->getRememberMeServicesId($id, $config)));
 
         return $listenerId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -31,13 +31,7 @@ class RememberMeFactory implements SecurityFactoryInterface
 
     public function create(ContainerBuilder $container, $id, $config, $userProvider, $defaultEntryPoint)
     {
-        // authentication provider
-        $authProviderId = 'security.authentication.provider.rememberme.'.$id;
-        $container
-            ->setDefinition($authProviderId, new DefinitionDecorator('security.authentication.provider.rememberme'))
-            ->addArgument($config['key'])
-            ->addArgument($id)
-        ;
+        $authProviderId = $this->configureRememberMeAuthenticationProvider($container, $id, $config);
 
         // remember me services
         $templateId = $this->getRememberMeServicesTemplateId($config);
@@ -148,5 +142,18 @@ class RememberMeFactory implements SecurityFactoryInterface
         }
 
         return 'security.authentication.rememberme.services.simplehash';
+    }
+
+    private function configureRememberMeAuthenticationProvider(ContainerBuilder $container, $id, array $config)
+    {
+        $authProviderId = 'security.authentication.provider.rememberme.'.$id;
+
+        $container
+            ->setDefinition($authProviderId, new DefinitionDecorator('security.authentication.provider.rememberme'))
+            ->addArgument($config['key'])
+            ->addArgument($id)
+        ;
+
+        return $authProviderId;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -54,6 +54,7 @@ class RememberMeFactory implements SecurityFactoryInterface
 
         // attach to remember-me aware listeners
         $userProviders = array();
+        
         foreach ($container->findTaggedServiceIds('security.remember_me_aware') as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['id']) || $attribute['id'] !== $id) {
@@ -71,15 +72,15 @@ class RememberMeFactory implements SecurityFactoryInterface
                 ;
             }
         }
+
         if ($config['user_providers']) {
-            $userProviders = array();
-            foreach ($config['user_providers'] as $providerName) {
-                $userProviders[] = new Reference('security.user.provider.concrete.'.$providerName);
-            }
+            $userProviders = $this->findUserProvidersInConfig($config);
         }
+
         if (count($userProviders) === 0) {
             throw new \RuntimeException('You must configure at least one remember-me aware listener (such as form-login) for each firewall that has remember-me enabled.');
         }
+
         $rememberMeServices->replaceArgument(0, $userProviders);
 
         $listenerId = $this->configureRememberMeAuthenticationListener($container, $id, $rememberMeServicesId);
@@ -157,6 +158,17 @@ class RememberMeFactory implements SecurityFactoryInterface
                 ->addMethodCall('addHandler', array(new Reference($rememberMeServicesId)))
             ;
         }
+    }
+
+    private function findUserProvidersInConfig(array $config)
+    {
+        $userProviders = array();
+
+        foreach ($config['user_providers'] as $providerName) {
+            $userProviders[] = new Reference('security.user.provider.concrete.'.$providerName);
+        }
+
+        return $userProviders;
     }
 
     private function configureRememberMeAuthenticationListener(ContainerBuilder $container, $id, $rememberMeServicesId)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -41,7 +41,7 @@ class RememberMeFactory implements SecurityFactoryInterface
 
         // remember me services
         $templateId = $this->getRememberMeServicesTemplateId($config);
-        $rememberMeServicesId = $templateId.'.'.$id;
+        $rememberMeServicesId = $this->getRememberMeServicesId($id, $config);
 
         if ($container->hasDefinition('security.logout_listener.'.$id)) {
             $container
@@ -134,6 +134,11 @@ class RememberMeFactory implements SecurityFactoryInterface
                 $builder->scalarNode($name)->defaultValue($value);
             }
         }
+    }
+
+    private function getRememberMeServicesId($id, array $config)
+    {
+        return $this->getRememberMeServicesTemplateId($config).'.'.$id;
     }
 
     private function getRememberMeServicesTemplateId(array $config)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -40,13 +40,8 @@ class RememberMeFactory implements SecurityFactoryInterface
         ;
 
         // remember me services
-        if (isset($config['token_provider'])) {
-            $templateId = 'security.authentication.rememberme.services.persistent';
-            $rememberMeServicesId = $templateId.'.'.$id;
-        } else {
-            $templateId = 'security.authentication.rememberme.services.simplehash';
-            $rememberMeServicesId = $templateId.'.'.$id;
-        }
+        $templateId = $this->getRememberMeServicesTemplateId($config);
+        $rememberMeServicesId = $templateId.'.'.$id;
 
         if ($container->hasDefinition('security.logout_listener.'.$id)) {
             $container
@@ -139,5 +134,14 @@ class RememberMeFactory implements SecurityFactoryInterface
                 $builder->scalarNode($name)->defaultValue($value);
             }
         }
+    }
+
+    private function getRememberMeServicesTemplateId(array $config)
+    {
+        if (isset($config['token_provider'])) {
+            return 'security.authentication.rememberme.services.persistent';
+        }
+
+        return 'security.authentication.rememberme.services.simplehash';
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -52,17 +52,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         // remember-me options
         $rememberMeServices->replaceArgument(3, array_intersect_key($config, $this->options));
 
-        $userProviders = $this->findAndAttachToRememberMeAwareListeners($container, $id, $rememberMeServicesId);
-
-        if ($config['user_providers']) {
-            $userProviders = $this->findUserProvidersInConfig($config);
-        }
-
-        if (count($userProviders) === 0) {
-            throw new \RuntimeException('You must configure at least one remember-me aware listener (such as form-login) for each firewall that has remember-me enabled.');
-        }
-
-        $rememberMeServices->replaceArgument(0, $userProviders);
+        $rememberMeServices->replaceArgument(0, $this->findUserProviders($container, $id, $rememberMeServicesId, $config));
 
         $listenerId = $this->configureRememberMeAuthenticationListener($container, $id, $rememberMeServicesId);
 
@@ -139,6 +129,21 @@ class RememberMeFactory implements SecurityFactoryInterface
                 ->addMethodCall('addHandler', array(new Reference($rememberMeServicesId)))
             ;
         }
+    }
+
+    private function findUserProviders(ContainerBuilder $container, $id, $rememberMeServicesId, array $config)
+    {
+        $userProviders = $this->findAndAttachToRememberMeAwareListeners($container, $id, $rememberMeServicesId);
+
+        if ($config['user_providers']) {
+            $userProviders = $this->findUserProvidersInConfig($config);
+        }
+
+        if (count($userProviders) === 0) {
+            throw new \RuntimeException('You must configure at least one remember-me aware listener (such as form-login) for each firewall that has remember-me enabled.');
+        }
+
+        return $userProviders;
     }
 
     private function findAndAttachToRememberMeAwareListeners(ContainerBuilder $container, $id, $rememberMeServicesId)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -37,12 +37,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         $templateId = $this->getRememberMeServicesTemplateId($config);
         $rememberMeServicesId = $this->getRememberMeServicesId($id, $config);
 
-        if ($container->hasDefinition('security.logout_listener.'.$id)) {
-            $container
-                ->getDefinition('security.logout_listener.'.$id)
-                ->addMethodCall('addHandler', array(new Reference($rememberMeServicesId)))
-            ;
-        }
+        $this->addRememberMeServicesToLogoutListener($container, $id, $rememberMeServicesId);
 
         $rememberMeServices = $container->setDefinition($rememberMeServicesId, new DefinitionDecorator($templateId));
         $rememberMeServices->replaceArgument(1, $config['key']);
@@ -155,5 +150,15 @@ class RememberMeFactory implements SecurityFactoryInterface
         ;
 
         return $authProviderId;
+    }
+
+    private function addRememberMeServicesToLogoutListener(ContainerBuilder $container, $id, $rememberMeServicesId)
+    {
+        if ($container->hasDefinition('security.logout_listener.'.$id)) {
+            $container
+                ->getDefinition('security.logout_listener.'.$id)
+                ->addMethodCall('addHandler', array(new Reference($rememberMeServicesId)))
+            ;
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

It's easier to read and maintain code, when methods are short and with names that make the code self-describing.
