### PR TITLE
[TwigBundle] Reconfigure twig paths when they are updated

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\TwigBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -74,23 +75,30 @@ class TwigExtension extends Extension
             } else {
                 $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
             }
+            $container->addResource(new FileExistenceResource($path));
         }
 
         // register bundles as Twig namespaces
         foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {
-            if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
+            $dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views';
+            if (is_dir($dir)) {
                 $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
             }
+            $container->addResource(new FileExistenceResource($dir));
 
             $reflection = new \ReflectionClass($class);
-            if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
+            $dir = dirname($reflection->getFilename()).'/Resources/views';
+            if (is_dir($dir)) {
                 $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
             }
+            $container->addResource(new FileExistenceResource($dir));
         }
 
-        if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/views')) {
+        $dir = $container->getParameter('kernel.root_dir').'/Resources/views';
+        if (is_dir($dir)) {
             $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
         }
+        $container->addResource(new FileExistenceResource($dir));
 
         if (!empty($config['globals'])) {
             $def = $container->getDefinition('twig');

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -75,7 +75,6 @@ class TwigExtension extends Extension
             } else {
                 $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
             }
-            $container->addResource(new FileExistenceResource($path));
         }
 
         // register bundles as Twig namespaces

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -27,7 +27,7 @@
         "symfony/stopwatch": "~2.2|~3.0.0",
         "symfony/dependency-injection": "~2.6,>=2.6.6|~3.0.0",
         "symfony/expression-language": "~2.4|~3.0.0",
-        "symfony/config": "~2.2|~3.0.0",
+        "symfony/config": "~2.8|~3.0.0",
         "symfony/routing": "~2.1|~3.0.0",
         "symfony/templating": "~2.1|~3.0.0",
         "symfony/framework-bundle": "~2.7|~3.0.0"

--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -32,7 +32,7 @@ class FileExistenceResource implements ResourceInterface, \Serializable
      */
     public function __construct($resource)
     {
-        $this->resource = $resource;
+        $this->resource = (string) $resource;
         $this->exists = file_exists($resource);
     }
 
@@ -41,7 +41,7 @@ class FileExistenceResource implements ResourceInterface, \Serializable
      */
     public function __toString()
     {
-        return (string) $this->resource;
+        return $this->resource;
     }
 
     /**

--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Symfony\Component\Config\Resource;
+/**
+ * FileExistenceResource represents a resource stored on the filesystem.
+ * Freshness is only evaluated against resource creation or deletion.
+ *
+ * The resource can be a file or a directory.
+ *
+ * @author Charles-Henri Bruyand <charleshenri.bruyand@gmail.com>
+ */
+class FileExistenceResource implements ResourceInterface, \Serializable
+{
+    private $resource;
+    private $exists;
+    /**
+     * Constructor.
+     *
+     * @param string $resource The file path to the resource
+     */
+    public function __construct($resource)
+    {
+        $this->resource = $resource;
+        $this->exists = file_exists($resource);
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return (string) $this->resource;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function getResource()
+    {
+        return $this->resource;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function isFresh($timestamp)
+    {
+        return file_exists($this->resource) === $this->exists;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize(array($this->resource, $this->exists));
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        list($this->resource, $this->exists) = unserialize($serialized);
+    }
+}

--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Symfony package.
  *
@@ -7,7 +8,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Symfony\Component\Config\Resource;
+
 /**
  * FileExistenceResource represents a resource stored on the filesystem.
  * Freshness is only evaluated against resource creation or deletion.
@@ -19,7 +22,9 @@ namespace Symfony\Component\Config\Resource;
 class FileExistenceResource implements ResourceInterface, \Serializable
 {
     private $resource;
+
     private $exists;
+
     /**
      * Constructor.
      *
@@ -30,6 +35,7 @@ class FileExistenceResource implements ResourceInterface, \Serializable
         $this->resource = $resource;
         $this->exists = file_exists($resource);
     }
+
     /**
      * {@inheritdoc}
      */
@@ -37,6 +43,7 @@ class FileExistenceResource implements ResourceInterface, \Serializable
     {
         return (string) $this->resource;
     }
+
     /**
      * {@inheritdoc}
      */
@@ -44,6 +51,7 @@ class FileExistenceResource implements ResourceInterface, \Serializable
     {
         return $this->resource;
     }
+
     /**
      * {@inheritdoc}
      */
@@ -51,6 +59,7 @@ class FileExistenceResource implements ResourceInterface, \Serializable
     {
         return file_exists($this->resource) === $this->exists;
     }
+
     /**
      * {@inheritdoc}
      */
@@ -58,6 +67,7 @@ class FileExistenceResource implements ResourceInterface, \Serializable
     {
         return serialize(array($this->resource, $this->exists));
     }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Resource;
+
+use Symfony\Component\Config\Resource\FileExistenceResource;
+
+class FileExistenceResourceTest extends \PHPUnit_Framework_TestCase
+{
+    protected $resource;
+    protected $file;
+    protected $time;
+
+    protected function setUp()
+    {
+        $this->file = realpath(sys_get_temp_dir()).'/tmp.xml';
+        $this->time = time();
+        $this->resource = new FileExistenceResource($this->file);
+    }
+
+    protected function tearDown()
+    {
+        if (file_exists($this->file)) {
+            unlink($this->file);
+        }
+    }
+
+    public function testToString()
+    {
+        $this->assertSame($this->file, (string) $this->resource);
+    }
+
+    public function testGetResource()
+    {
+        $this->assertSame($this->file, $this->resource->getResource(), '->getResource() returns the path to the resource');
+    }
+
+    public function testIsFreshWithExistingResource()
+    {
+        touch($this->file, $this->time);
+        $serialized = serialize(new FileExistenceResource($this->file));
+
+        $resource = unserialize($serialized);
+        $this->assertTrue($resource->isFresh($this->time), '->isFresh() returns true if the resource is still present');
+
+        unlink($this->file);
+        $resource = unserialize($serialized);
+        $this->assertFalse($resource->isFresh($this->time), '->isFresh() returns false if the resource has been deleted');
+    }
+
+    public function testIsFreshWithAbsentResource()
+    {
+        $serialized = serialize(new FileExistenceResource($this->file));
+
+        $resource = unserialize($serialized);
+        $this->assertTrue($resource->isFresh($this->time), '->isFresh() returns true if the resource is still absent');
+
+        touch($this->file, $this->time);
+        $resource = unserialize($serialized);
+        $this->assertFalse($resource->isFresh($this->time), '->isFresh() returns false if the resource has been created');
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14771, #14768, #14262, #14778 |
| License | MIT |

Refresh twig paths upon creation and deletion. As we don't care neither about path's modification time nor path's content, a new Resource has been added in the Config Component.
Full discussion in #14778.
