### PR TITLE
Adding UPGRADE-2.7 about small BC break in InputDefinition

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -559,6 +559,31 @@ Validator
    (NullValidator, TrueValidator, FalseValidator) are marked as deprecated
    in favor of their `Is`-prefixed equivalent.
 
+Console
+-------
+
+ * The `Symfony\Component\Console\Input\InputDefinition::getSynopsis()` method
+   now has an optional argument (it previously had no arguments). If you override
+   this method, you'll need to add this argument so that your signature matches:
+
+   Before:
+
+   ```php
+   public function getSynopsis()
+   {
+       // ...
+   }
+   ```
+
+   After:
+
+   ```php
+   public function getSynopsis($short = false)
+   {
+       // ...
+   }
+   ```
+
 TwigBundle
 ----------
 

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -391,7 +391,7 @@ class InputDefinition
     /**
      * Gets the synopsis.
      *
-     * @param bool $short Whether to return the short version (with options foloded) or not
+     * @param bool $short Whether to return the short version (with options folded) or not
      *
      * @return string The synopsis
      */


### PR DESCRIPTION
Hi guys!

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13220 |
| License | MIT |
| Doc PR | n/a |

In #13220, a small BC break was introduced when `InputDefinition::getSynopsis()` was given an optional argument. This, for example, breaks Behat 2.5, which overrides this method. I don't think this was noticed before, and it may be too late (or not worth it) to reverse the BC break.

So, I've at least doc'ed it.

Thanks!
