### PR TITLE
[Validator] Ensure nested validations for Collections happen in a separate context

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -60,7 +60,7 @@ class CollectionValidator extends ConstraintValidator
                 if (count($fieldConstraint->constraints) > 0) {
                     if ($context instanceof ExecutionContextInterface) {
                         $context->getValidator()
-                            ->inContext($context)
+                            ->inContext(clone $context)
                             ->atPath('['.$field.']')
                             ->validate($value[$field], $fieldConstraint->constraints);
                     } else {

--- a/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Validator;
 
 use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Traverse;
@@ -769,6 +770,24 @@ abstract class Abstract2Dot5ApiTest extends AbstractValidatorTest
     {
         $constraint = new FailingConstraint();
         $violations = $this->validate('Foobar', $constraint);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame($constraint, $violations[0]->getConstraint());
+    }
+
+    public function testCollectionConstraitViolationHasCorrectContext()
+    {
+        $data = array(
+            'foo' => 'fooValue',
+        );
+
+        // Missing field must not be the first in the collection validation
+        $constraint = new Collection(array(
+            'foo' => new NotNull(),
+            'bar' => new NotNull(),
+        ));
+
+        $violations = $this->validate($data, $constraint);
 
         $this->assertCount(1, $violations);
         $this->assertSame($constraint, $violations[0]->getConstraint());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14639 |
| License | MIT |
| Doc PR | n/a |
