### PR TITLE
[TwigBridge] Make AppVariable check if security.context exists

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -74,7 +74,9 @@ class AppVariable
             throw new \RuntimeException('The "app.security" variable is not available.');
         }
 
-        return $this->container->get('security.context');
+        if ($this->container->has('security.context')) {
+            return $this->container->get('security.context');
+        }
     }
 
     /**
@@ -89,6 +91,8 @@ class AppVariable
         if (null === $this->tokenStorage) {
             if (null === $this->container) {
                 throw new \RuntimeException('The "app.user" variable is not available.');
+            } elseif (!$this->container->has('security.context')) {
+                return;
             }
 
             $this->tokenStorage = $this->container->get('security.context');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

If security isn't configured in the application, neither the `security.context` service, nor the `security.token_storage` service exists.

Therefore, if a third-party bundle relies on the `app.user` or `app.security` (deprecated) check in Twig templates, an exception was thrown about asking for an non-existing service:

``` yml
security: false
```

``` twig
{% if app.user %}
    <div>
        ...
    </div>
{% endif %}
```

```
You have requested a non-existent service "security.context"
```

Instead, this patch checks if the `security.context` actually exists before trying to use it, and returns null otherwise.

Note that the **GlobalVariables** class, used for twig app globals in previous versions, and still used for PHP templating, behaves the same way.
So this is basically a BC break.
