### PR TITLE
[Yaml] [Validator] Removed conditional @deprecated tags and moved their descriptions to the method description as a note

### DIFF
--- a/src/Symfony/Component/Validator/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/ExecutionContextInterface.php
@@ -91,6 +91,8 @@ interface ExecutionContextInterface
     /**
      * Adds a violation at the current node of the validation graph.
      *
+     * Note: the parameters $invalidValue, $plural and $code are deprecated since version 2.5 and will be removed in 3.0.
+     *
      * @param string   $message      The error message
      * @param array    $params       The parameters substituted in the error message
      * @param mixed    $invalidValue The invalid, validated value
@@ -98,8 +100,6 @@ interface ExecutionContextInterface
      * @param int|null $code         The violation code
      *
      * @api
-     *
-     * @deprecated the parameters $invalidValue, $plural and $code are deprecated since version 2.5 and will be removed in 3.0.
      */
     public function addViolation($message, array $params = array(), $invalidValue = null, $plural = null, $code = null);
 

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -38,6 +38,8 @@ class Yaml
      * you must validate the input before calling this method. Passing a file
      * as an input is a deprecated feature and will be removed in 3.0.
      *
+     * Note: the ability to pass file names to the Yaml::parse method is deprecated since version 2.2 and will be removed in 3.0. Pass the YAML contents of the file instead.
+     *
      * @param string $input                  Path to a YAML file or a string containing YAML
      * @param bool   $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
      * @param bool   $objectSupport          True if object support is enabled, false otherwise
@@ -46,8 +48,6 @@ class Yaml
      * @return array The YAML converted to a PHP array
      *
      * @throws ParseException If the YAML is not valid
-     *
-     * @deprecated The ability to pass file names to the Yaml::parse method is deprecated since version 2.2 and will be removed in 3.0. Pass the YAML contents of the file instead.
      *
      * @api
      */


### PR DESCRIPTION
[Yaml] [Validator] Removed conditional @deprecated tags and moved their descriptions to the method description as a note.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14815 |
| License | MIT |
