### PR TITLE
[2.7][SecurityBundle] Remove SecurityContext from Compile

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -100,7 +100,6 @@ class SecurityExtension extends Extension
         // add some required classes for compilation
         $this->addClassesToCompile(array(
             'Symfony\\Component\\Security\\Http\\Firewall',
-            'Symfony\\Component\\Security\\Core\\SecurityContext',
             'Symfony\\Component\\Security\\Core\\User\\UserProviderInterface',
             'Symfony\\Component\\Security\\Core\\Authentication\\AuthenticationProviderManager',
             'Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorage',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no change |
| Fixed tickets | #14831 |
| License | MIT |
| Doc PR | n/a |

Remove the deprecated [SecurityContext](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Core/SecurityContext.php) from the list of classes to compile into `classes.map` and `classes.php`. Prevents `E_USER_DEPRECATED` notices from being thrown on every request.

I am sending this PR into the master branch as I do not believe this patch to be backwards compatible with anything lower than `2.7`; but I'm not good with words and [don't quite understand the documentation](https://symfony.com/doc/current/contributing/code/patches.html#choose-the-right-branch) - let me know if you want it for a different branch.
