### PR TITLE
[Security][bugfix] "Remember me" cookie cleared on logout with custom "secure"/"httponly" config options [1]

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -293,7 +293,16 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             $this->logger->debug(sprintf('Clearing remember-me cookie "%s"', $this->options['name']));
         }
 
-        $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie($this->options['name'], null, 1, $this->options['path'], $this->options['domain']));
+        $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie(
+            $this->options['name'],
+            null,
+            1,
+            $this->options['path'],
+            $this->options['domain'],
+            // passing cookie defaults for now, options are currently ignored
+            false,
+            true
+        ));
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -299,9 +299,8 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             1,
             $this->options['path'],
             $this->options['domain'],
-            // passing cookie defaults for now, options are currently ignored
-            false,
-            true
+            $this->options['secure'],
+            $this->options['httponly']
         ));
     }
 

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -293,15 +293,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             $this->logger->debug(sprintf('Clearing remember-me cookie "%s"', $this->options['name']));
         }
 
-        $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie(
-            $this->options['name'],
-            null,
-            1,
-            $this->options['path'],
-            $this->options['domain'],
-            $this->options['secure'],
-            $this->options['httponly']
-        ));
+        $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie($this->options['name'], null, 1, $this->options['path'], $this->options['domain'], $this->options['secure'], $this->options['httponly']));
     }
 
     /**

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/AbstractRememberMeServicesTest.php
@@ -109,8 +109,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(array('name' => 'foo', 'path' => '/', 'domain' => null, 'secure' => false, 'httponly' => true)),
-            // "secure" and "httpOnly" options are currently ignored, uncommented shows a failing test
-            //array(array('name' => 'foo', 'path' => '/bar', 'domain' => 'baz.com', 'secure' => true, 'httponly' => false)),
+            array(array('name' => 'foo', 'path' => '/bar', 'domain' => 'baz.com', 'secure' => true, 'httponly' => false)),
         );
     }
 
@@ -285,6 +284,13 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         if (null === $userProvider) {
             $userProvider = $this->getProvider();
+        }
+
+        if (!isset($options['secure'])) {
+            $options['secure'] = false;
+        }
+        if (!isset($options['httponly'])) {
+            $options['httponly'] = true;
         }
 
         return $this->getMockForAbstractClass('Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices', array(

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -180,7 +180,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
 
     public function testLogout()
     {
-        $service = $this->getService(null, array('name' => 'foo', 'path' => '/foo', 'domain' => 'foodomain.foo'));
+        $service = $this->getService(null, array('name' => 'foo', 'path' => '/foo', 'domain' => 'foodomain.foo', 'secure' => true, 'httponly' => false));
         $request = new Request();
         $request->cookies->set('foo', $this->encodeCookie(array('fooseries', 'foovalue')));
         $response = new Response();
@@ -201,6 +201,8 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
         $this->assertTrue($cookie->isCleared());
         $this->assertEquals('/foo', $cookie->getPath());
         $this->assertEquals('foodomain.foo', $cookie->getDomain());
+        $this->assertTrue($cookie->isSecure());
+        $this->assertFalse($cookie->isHttpOnly());
     }
 
     public function testLogoutSimplyIgnoresNonSetRequestCookie()
@@ -309,6 +311,13 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
     {
         if (null === $userProvider) {
             $userProvider = $this->getProvider();
+        }
+
+        if (!isset($options['secure'])) {
+            $options['secure'] = false;
+        }
+        if (!isset($options['httponly'])) {
+            $options['httponly'] = true;
         }
 
         return new PersistentTokenBasedRememberMeServices(array($userProvider), 'fookey', 'fookey', $options, $logger, new SecureRandom(sys_get_temp_dir().'/_sf2.seed'));

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -153,7 +153,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 
     public function testLogout()
     {
-        $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null));
+        $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null, 'secure' => true, 'httponly' => false));
         $request = new Request();
         $response = new Response();
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
@@ -164,6 +164,8 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($cookie->isCleared());
         $this->assertEquals('/', $cookie->getPath());
         $this->assertNull($cookie->getDomain());
+        $this->assertTrue($cookie->isSecure());
+        $this->assertFalse($cookie->isHttpOnly());
     }
 
     public function testLoginFail()
@@ -262,6 +264,13 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         if (null === $userProvider) {
             $userProvider = $this->getProvider();
+        }
+
+        if (!isset($options['secure'])) {
+            $options['secure'] = false;
+        }
+        if (!isset($options['httponly'])) {
+            $options['httponly'] = true;
         }
 
         $service = new TokenBasedRememberMeServices(array($userProvider), 'fookey', 'fookey', $options, $logger);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14822 |
| License | MIT |
| Doc PR | ~ |
- test now always pass "secure" and "httponly" options, as they are required
- could be considered BC, but [`RememberMeFactory` passes them](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php#L21), so they should've always been treated as required
- I can squash the commits before merging
- Alternative solution: #14843
