### PR TITLE
[Security][bugfix] "Remember me" cookie cleared on logout with custom "secure"/"httponly"  config options [2]

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -293,7 +293,16 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             $this->logger->debug(sprintf('Clearing remember-me cookie "%s"', $this->options['name']));
         }
 
-        $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie($this->options['name'], null, 1, $this->options['path'], $this->options['domain']));
+        $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie(
+            $this->options['name'],
+            null,
+            1,
+            $this->options['path'],
+            $this->options['domain'],
+            // passing cookie defaults for now, options are currently ignored
+            false,
+            true
+        ));
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -299,9 +299,8 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             1,
             $this->options['path'],
             $this->options['domain'],
-            // passing cookie defaults for now, options are currently ignored
-            false,
-            true
+            isset($this->options['secure']) ? $this->options['secure'] : false,
+            isset($this->options['httponly']) ? $this->options['httponly'] : true
         ));
     }
 

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/AbstractRememberMeServicesTest.php
@@ -109,8 +109,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(array('name' => 'foo', 'path' => '/', 'domain' => null, 'secure' => false, 'httponly' => true)),
-            // "secure" and "httpOnly" options are currently ignored, uncommented shows a failing test
-            //array(array('name' => 'foo', 'path' => '/bar', 'domain' => 'baz.com', 'secure' => true, 'httponly' => false)),
+            array(array('name' => 'foo', 'path' => '/bar', 'domain' => 'baz.com', 'secure' => true, 'httponly' => false)),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14822 |
| License | MIT |
| Doc PR | ~ |
- tests show that currently those options might not exist
- should not be considered BC? if the options are not present, it works as before.
- I can squash the commits before merging
- Alternative solution: #14842
