### PR TITLE
Add caller to Definition deprecation notices

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -98,7 +98,8 @@ class Definition
      */
     public function setFactoryClass($factoryClass)
     {
-        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', __METHOD__, $factoryClass), E_USER_DEPRECATED);
+        $caller = (PHP_VERSION_ID >= 50400) ? current(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 1)) : current(debug_backtrace());
+        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead. Called from %s', __METHOD__, $factoryClass, $caller['file'] . "::" . $caller['function']), E_USER_DEPRECATED);
 
         $this->factoryClass = $factoryClass;
 
@@ -134,7 +135,8 @@ class Definition
      */
     public function setFactoryMethod($factoryMethod)
     {
-        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', __METHOD__, $factoryMethod), E_USER_DEPRECATED);
+        $caller = (PHP_VERSION_ID >= 50400) ? current(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 1)) : current(debug_backtrace());
+        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead. Called from %s', __METHOD__, $factoryMethod, $caller['file'] . "::" . $caller['function']), E_USER_DEPRECATED);
 
         $this->factoryMethod = $factoryMethod;
 
@@ -205,7 +207,8 @@ class Definition
      */
     public function setFactoryService($factoryService)
     {
-        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', __METHOD__, $factoryService), E_USER_DEPRECATED);
+        $caller = (PHP_VERSION_ID >= 50400) ? current(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 1)) : current(debug_backtrace());
+        trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead. Called from %s', __METHOD__, $factoryService, $caller['file'] . "::" . $caller['function']), E_USER_DEPRECATED);
 
         $this->factoryService = $factoryService;
 


### PR DESCRIPTION
... so it becomes visible where to look while fixing these notices. 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The deprecation notice now is:

> PHP Deprecated:  Symfony\Component\DependencyInjection\Definition::setFactoryMethod(getInstance) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead. in /var/www/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Definition.php on line 141

Afterwards:

> PHP Deprecated:  Symfony\Component\DependencyInjection\Definition::setFactoryMethod(getInstance) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead. Called from /var/www/scribbr/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php::parseDefinition in /var/www/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Definition.php on line 141
