### PR TITLE
[Fix] DependencyInjection, deprecated setFactoryXXX in XmlFileLoader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -147,7 +147,7 @@ class XmlFileLoader extends FileLoader
 
         foreach (array('class', 'scope', 'public', 'factory-class', 'factory-method', 'factory-service', 'synthetic', 'synchronized', 'lazy', 'abstract') as $key) {
             if ($value = $service->getAttribute($key)) {
-                $method = 'set'.str_replace('-', '', $key);
+                $method = 'set'.explode('-', $key)[0];
                 $definition->$method(XmlUtils::phpize($value));
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -219,7 +219,7 @@ class XmlFileLoader extends FileLoader
     }
 
     /**
-     * Parses a XML file to a \DOMDocument
+     * Parses a XML file to a \DOMDocument.
      *
      * @param string $file Path to a file
      *
@@ -376,7 +376,7 @@ class XmlFileLoader extends FileLoader
     }
 
     /**
-     * Get child elements by name
+     * Get child elements by name.
      *
      * @param \DOMNode $node
      * @param mixed    $name

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -147,8 +147,11 @@ class XmlFileLoader extends FileLoader
 
         foreach (array('class', 'scope', 'public', 'factory-class', 'factory-method', 'factory-service', 'synthetic', 'synchronized', 'lazy', 'abstract') as $key) {
             if ($value = $service->getAttribute($key)) {
-                $method = 'set'.explode('-', $key)[0];
-                $definition->$method(XmlUtils::phpize($value));
+                $name = explode('-', $key);
+                if (isset($name[0])) {
+                    $method = 'set'.$name[0];
+                    $definition->$method(XmlUtils::phpize($value));
+                }
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The XmlFileLoader is still using a deprecated method : setFactoryMethod.
The error message displayed : Fatal error: Call to undefined method Symfony\Component\DependencyInjection\Definition::setfactory-method())
