### PR TITLE
[expression-language] Raises RuntimeException instead of fatal error when accessing a non-supported property

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -44,6 +44,60 @@ class GetAttrNodeTest extends AbstractNodeTest
         );
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Object of class Symfony\Component\ExpressionLanguage\Tests\Node\Obj does not support property baz.
+     */
+    public function testAccessorException()
+    {
+        $node = new GetAttrNode(
+            new NameNode('foo'),
+            new ConstantNode('baz'),
+            $this->getArrayNode(),
+            GetAttrNode::PROPERTY_CALL
+        );
+        $variables = array('foo' => new Obj());
+        $functions = [];
+
+        $node->evaluate($functions, $variables);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Object of class Symfony\Component\ExpressionLanguage\Tests\Node\Obj does not support call of method baz.
+     */
+    public function testMethodException()
+    {
+        $node = new GetAttrNode(
+            new NameNode('foo'),
+            new ConstantNode('baz'),
+            $this->getArrayNode(),
+            GetAttrNode::METHOD_CALL
+        );
+        $variables = array('foo' => new Obj());
+        $functions = [];
+
+        $node->evaluate($functions, $variables);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to access requested index 0 in array foo.
+     */
+    public function testArrayIndexException()
+    {
+        $node = new GetAttrNode(
+            new NameNode('foo'),
+            new ConstantNode('0'),
+            $this->getArrayNode(),
+            GetAttrNode::ARRAY_CALL
+        );
+        $variables = array('foo' => []);
+        $functions = [];
+
+        $node->evaluate($functions, $variables);
+    }
+
     protected function getArrayNode()
     {
         $array = new ArrayNode();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | — |
| License | MIT |
| Doc PR | — |

Todo 
- [x] ensure test passes

``` SH
$ phpunit -c phpunit.xml.dist --filter=GetAttrNodeTest
PHPUnit 4.2.6 by Sebastian Bergmann.

Configuration read from /Users/amo/Workspace/Splio/symfony/phpunit.xml.dist

...........

Time: 14.06 seconds, Memory: 129.25Mb

OK (11 tests, 12 assertions)
```

I would like expression language to be able to raise a proper exception instead of a fatal error when the expression tries to access a non-existent property or a non supported (through __getmethod) property.

This would be usefull in a product that does rely on the Expression Language engine to give to the final user some controls on the business logic to satisfie before triggering some actions. When they do so, they can use variables on object that does not exists and an Exception would make this use case catchable.

use-case : 

``` PHP

try {
    // Invalid expression, should be customer customer.getBirthDate()
    $this->expressionEngine()->evaluate(
        'customerAge(customer.getBirthDate) > 25',
        ['customer', $customer]
    );
} catch (\RuntimeException $e) {
    // handle the misusage of getBirthDate here
}
```
