### PR TITLE
[2.7] Improved exception message if custom implementation of OptionsResolverInterface is used

### DIFF
--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -45,6 +45,9 @@ abstract class AbstractType implements FormTypeInterface
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        if (!$resolver instanceof OptionsResolver) {
+            throw new \InvalidArgumentException(sprintf('Custom resolver %s must extend Symfony\Component\OptionsResolver\OptionsResolver', get_class($resolver)));
+        }
         $this->configureOptions($resolver);
     }
 

--- a/src/Symfony/Component/Form/AbstractTypeExtension.php
+++ b/src/Symfony/Component/Form/AbstractTypeExtension.php
@@ -45,6 +45,9 @@ abstract class AbstractTypeExtension implements FormTypeExtensionInterface
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        if (!$resolver instanceof OptionsResolver) {
+            throw new \InvalidArgumentException(sprintf('Custom resolver %s must extend Symfony\Component\OptionsResolver\OptionsResolver', get_class($resolver)));
+        }
         $this->configureOptions($resolver);
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractExtensionTest.php
@@ -28,6 +28,17 @@ class AbstractExtensionTest extends \PHPUnit_Framework_TestCase
         $loader = new ConcreteExtension();
         $this->assertInstanceOf('Symfony\Component\Form\Tests\Fixtures\FooType', $loader->getType('foo'));
     }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Custom resolver Symfony\Component\Form\Tests\Fixtures\CustomOptionsResolver must extend Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    public function testCustomOptionsResolver()
+    {
+        $extension = new Fixtures\FooTypeBarExtension();
+        $resolver = new Fixtures\CustomOptionsResolver();
+        $extension->setDefaultOptions($resolver);
+    }
 }
 
 class ConcreteExtension extends AbstractExtension

--- a/src/Symfony/Component/Form/Tests/Fixtures/CustomOptionsResolver.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/CustomOptionsResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class CustomOptionsResolver implements OptionsResolverInterface
+{
+    public function setDefaults(array $defaultValues)
+    {
+    }
+
+    public function replaceDefaults(array $defaultValues)
+    {
+    }
+
+    public function setOptional(array $optionNames)
+    {
+    }
+
+    public function setRequired($optionNames)
+    {
+    }
+
+    public function setAllowedValues($allowedValues)
+    {
+    }
+
+    public function addAllowedValues($allowedValues)
+    {
+    }
+
+    public function setAllowedTypes($allowedTypes)
+    {
+    }
+
+    public function addAllowedTypes($allowedTypes)
+    {
+    }
+
+    public function setNormalizers(array $normalizers)
+    {
+    }
+
+    public function isKnown($option)
+    {
+    }
+
+    public function isRequired($option)
+    {
+    }
+
+    public function resolve(array $options = array())
+    {
+    }
+}

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -1057,6 +1057,17 @@ class SimpleFormTest extends AbstractFormTest
         $child->initialize();
     }
 
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Custom resolver Symfony\Component\Form\Tests\Fixtures\CustomOptionsResolver must extend Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    public function testCustomOptionsResolver()
+    {
+        $fooType = new Fixtures\FooType();
+        $resolver = new Fixtures\CustomOptionsResolver();
+        $fooType->setDefaultOptions($resolver);
+    }
+
     protected function createForm()
     {
         return $this->getBuilder()->getForm();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Improved exception message if custom implementation of `OptionsResolverInterface` is used within `AbstractType::setDefaultOptions()` or `AbstractTypeExtension::setDefaultOptions()`.

Before:

```
Argument 1 passed to Symfony\Component\Form\AbstractType::configureOptions() must be an instance of Symfony\Component\OptionsResolver\OptionsResolver, instance of Symfony\Component\Form\Tests\Fixtures\CustomOptionsResolver given
```

After:

```
Argument 1 passed to Symfony\Component\Form\AbstractType::setDefaultOptions() must be an instance of Symfony\Component\OptionsResolver\OptionsResolver, instance of Symfony\Component\Form\Tests\Fixtures\CustomOptionsResolver given
```
