### PR TITLE
Change error message to reflect SecurityContext deprecation.

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -50,7 +50,7 @@ class AccessListener implements ListenerInterface
     public function handle(GetResponseEvent $event)
     {
         if (null === $token = $this->tokenStorage->getToken()) {
-            throw new AuthenticationCredentialsNotFoundException('A Token was not found in the SecurityContext.');
+            throw new AuthenticationCredentialsNotFoundException('A Token was not found in the TokenStorage.');
         }
 
         $request = $event->getRequest();


### PR DESCRIPTION
This PR was submitted on the symfony/Security read-only repository by @nickbyfleet and moved automatically to the main Symfony repository (closes symfony/Security#6).
