### PR TITLE
[Form] Swap new ChoiceView constructor arguments to ease migrating from the deprecated one

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -176,24 +176,8 @@ Form
  * `Symfony\Component\Form\Extension\Core\ChoiceList\View\ChoiceView` was
    deprecated and will be removed in Symfony 3.0. You should use
    `Symfony\Component\Form\ChoiceList\View\ChoiceView` instead.
-
-   Note that the order of the arguments passed to the constructor was inverted.
-
-   Before:
-
-   ```php
-   use Symfony\Component\Form\Extension\Core\ChoiceList\View\ChoiceView;
-
-   $view = new ChoiceView($data, 'value', 'Label');
-   ```
-
-   After:
-
-   ```php
-   use Symfony\Component\Form\ChoiceList\View\ChoiceView;
-
-   $view = new ChoiceView('Label', 'value', $data);
-   ```
+   The constructor arguments of the new class are in the same order than in the
+   deprecated one (this was not true in 2.7.0 but has been fixed in 2.7.1).
 
  * `Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList` was
    deprecated and will be removed in Symfony 3.0. You should use

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -134,7 +134,7 @@ class EntityTypeTest extends TypeTestCase
             'choice_label' => 'name',
         ));
 
-        $this->assertEquals(array(1 => new ChoiceView('Foo', '1', $entity1), 2 => new ChoiceView('Bar', '2', $entity2)), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     public function testSetDataToUninitializedEntityWithNonRequiredToString()
@@ -150,7 +150,7 @@ class EntityTypeTest extends TypeTestCase
             'required' => false,
         ));
 
-        $this->assertEquals(array(1 => new ChoiceView('Foo', '1', $entity1), 2 => new ChoiceView('Bar', '2', $entity2)), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     public function testSetDataToUninitializedEntityWithNonRequiredQueryBuilder()
@@ -169,7 +169,7 @@ class EntityTypeTest extends TypeTestCase
             'query_builder' => $qb,
         ));
 
-        $this->assertEquals(array(1 => new ChoiceView('Foo', '1', $entity1), 2 => new ChoiceView('Bar', '2', $entity2)), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     /**
@@ -513,7 +513,7 @@ class EntityTypeTest extends TypeTestCase
 
         $field->submit('2');
 
-        $this->assertEquals(array(1 => new ChoiceView('Foo', '1', $entity1), 2 => new ChoiceView('Bar', '2', $entity2)), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity2, $field->getData());
         $this->assertSame('2', $field->getViewData());
@@ -541,13 +541,13 @@ class EntityTypeTest extends TypeTestCase
         $this->assertSame('2', $field->getViewData());
         $this->assertEquals(array(
             'Group1' => new ChoiceGroupView('Group1', array(
-                1 => new ChoiceView('Foo', '1', $item1),
-                2 => new ChoiceView('Bar', '2', $item2),
+                1 => new ChoiceView($item1, '1', 'Foo'),
+                2 => new ChoiceView($item2, '2', 'Bar'),
             )),
             'Group2' => new ChoiceGroupView('Group2', array(
-                3 => new ChoiceView('Baz', '3', $item3),
+                3 => new ChoiceView($item3, '3', 'Baz'),
             )),
-            4 => new ChoiceView('Boo!', '4', $item4),
+            4 => new ChoiceView($item4, '4', 'Boo!'),
         ), $field->createView()->vars['choices']);
     }
 
@@ -566,8 +566,8 @@ class EntityTypeTest extends TypeTestCase
             'choice_label' => 'name',
         ));
 
-        $this->assertEquals(array(3 => new ChoiceView('Baz', '3', $entity3), 2 => new ChoiceView('Bar', '2', $entity2)), $field->createView()->vars['preferred_choices']);
-        $this->assertEquals(array(1 => new ChoiceView('Foo', '1', $entity1)), $field->createView()->vars['choices']);
+        $this->assertEquals(array(3 => new ChoiceView($entity3, '3', 'Baz'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['preferred_choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo')), $field->createView()->vars['choices']);
     }
 
     public function testOverrideChoicesWithPreferredChoices()
@@ -586,8 +586,8 @@ class EntityTypeTest extends TypeTestCase
             'choice_label' => 'name',
         ));
 
-        $this->assertEquals(array(3 => new ChoiceView('Baz', '3', $entity3)), $field->createView()->vars['preferred_choices']);
-        $this->assertEquals(array(2 => new ChoiceView('Bar', '2', $entity2)), $field->createView()->vars['choices']);
+        $this->assertEquals(array(3 => new ChoiceView($entity3, '3', 'Baz')), $field->createView()->vars['preferred_choices']);
+        $this->assertEquals(array(2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     public function testDisallowChoicesThatAreNotIncludedChoicesSingleIdentifier()
@@ -883,7 +883,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $this->assertEquals(array(1 => new ChoiceView('Foo', '1', $entity1), 2 => new ChoiceView('Bar', '2', $entity2)), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     protected function createRegistryMock($name, $em)

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -23,7 +23,7 @@
         "symfony/phpunit-bridge": "~2.7",
         "symfony/stopwatch": "~2.2",
         "symfony/dependency-injection": "~2.2",
-        "symfony/form": "~2.7",
+        "symfony/form": "~2.7,>=2.7.1",
         "symfony/http-kernel": "~2.2",
         "symfony/property-access": "~2.3",
         "symfony/security": "~2.2",

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -136,7 +136,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
      */
     public function testIsChoiceSelected($expected, $choice, $value)
     {
-        $choice = new ChoiceView($choice.' label', $choice, $choice);
+        $choice = new ChoiceView($choice, $choice, $choice.' label');
 
         $this->assertSame($expected, $this->extension->isSelectedChoice($choice, $value));
     }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/phpunit-bridge": "~2.7",
         "symfony/asset": "~2.7",
         "symfony/finder": "~2.3",
-        "symfony/form": "~2.7",
+        "symfony/form": "~2.7,>=2.7.1",
         "symfony/http-kernel": "~2.3",
         "symfony/intl": "~2.3",
         "symfony/routing": "~2.2",

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -144,7 +144,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         if ($list instanceof LegacyChoiceListInterface && empty($preferredChoices)
             && null === $label && null === $index && null === $groupBy && null === $attr) {
             $mapToNonLegacyChoiceView = function (LegacyChoiceView $choiceView) {
-                return new ChoiceView($choiceView->label, $choiceView->value, $choiceView->data);
+                return new ChoiceView($choiceView->data, $choiceView->value, $choiceView->label);
             };
 
             return new ChoiceListView(
@@ -245,10 +245,10 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         $nextIndex = is_int($index) ? $index++ : call_user_func($index, $choice, $key, $value);
 
         $view = new ChoiceView(
+            $choice,
+            $value,
             // If the labels are null, use the choice key by default
             null === $label ? (string) $key : (string) call_user_func($label, $choice, $key, $value),
-            $value,
-            $choice,
             // The attributes may be a callable or a mapping from choice indices
             // to nested arrays
             is_callable($attr) ? call_user_func($attr, $choice, $key, $value) : (isset($attr[$key]) ? $attr[$key] : array())

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -78,12 +78,12 @@ class ChoiceView extends LegacyChoiceView
     /**
      * Creates a new choice view.
      *
-     * @param string $label The label displayed to humans
-     * @param string $value The view representation of the choice
      * @param mixed  $data  The original choice
+     * @param string $value The view representation of the choice
+     * @param string $label The label displayed to humans
      * @param array  $attr  Additional attributes for the HTML tag
      */
-    public function __construct($label, $value, $data, array $attr = array())
+    public function __construct($data, $value, $label, array $attr = array())
     {
         parent::__construct($data, $value, $label);
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator;
-use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Factory\DefaultChoiceListFactory;
@@ -71,7 +70,7 @@ class ChoiceType extends AbstractType
             // Check if the choices already contain the empty value
             // Only add the placeholder option if this is not the case
             if (null !== $options['placeholder'] && 0 === count($options['choice_list']->getChoicesForValues(array('')))) {
-                $placeholderView = new ChoiceView($options['placeholder'], '', null);
+                $placeholderView = new ChoiceView(null, '', $options['placeholder']);
 
                 // "placeholder" is a reserved name
                 $this->addSubForm($builder, 'placeholder', $placeholderView, $options);
@@ -436,7 +435,7 @@ class ChoiceType extends AbstractType
         // information from the "choices" option for creating groups
         if (!$options['group_by'] && $options['choices']) {
             $options['group_by'] = !$options['choices_as_values']
-                ? ChoiceType::flipRecursive($options['choices'])
+                ? self::flipRecursive($options['choices'])
                 : $options['choices'];
         }
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -320,10 +320,10 @@ class DefaultChoiceListFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(new ChoiceListView(
                 array(
-                    0 => new ChoiceView('A', '0', $this->obj1),
-                    1 => new ChoiceView('B', '1', $this->obj2),
-                    2 => new ChoiceView('C', '2', $this->obj3),
-                    3 => new ChoiceView('D', '3', $this->obj4),
+                    0 => new ChoiceView($this->obj1, '0', 'A'),
+                    1 => new ChoiceView($this->obj2, '1', 'B'),
+                    2 => new ChoiceView($this->obj3, '2', 'C'),
+                    3 => new ChoiceView($this->obj4, '3', 'D'),
                 ), array()
         ), $view);
     }
@@ -347,10 +347,10 @@ class DefaultChoiceListFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(new ChoiceListView(
                 array(
-                    0 => new ChoiceView('A', '0', $this->obj1),
-                    1 => new ChoiceView('B', '1', $this->obj2),
-                    2 => new ChoiceView('C', '2', $this->obj3),
-                    3 => new ChoiceView('D', '3', $this->obj4),
+                    0 => new ChoiceView($this->obj1, '0', 'A'),
+                    1 => new ChoiceView($this->obj2, '1', 'B'),
+                    2 => new ChoiceView($this->obj3, '2', 'C'),
+                    3 => new ChoiceView($this->obj4, '3', 'D'),
                 ), array()
         ), $view);
     }
@@ -751,8 +751,8 @@ class DefaultChoiceListFactoryTest extends \PHPUnit_Framework_TestCase
 
         $view = $this->factory->createView($list);
 
-        $this->assertEquals(array(new ChoiceView('Other', 'y', 'y')), $view->choices);
-        $this->assertEquals(array(new ChoiceView('Preferred', 'x', 'x')), $view->preferredChoices);
+        $this->assertEquals(array(new ChoiceView('y', 'y', 'Other')), $view->choices);
+        $this->assertEquals(array(new ChoiceView('x', 'x', 'Preferred')), $view->preferredChoices);
     }
 
     private function assertScalarListWithGeneratedValues(ChoiceListInterface $list)
@@ -827,11 +827,11 @@ class DefaultChoiceListFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(new ChoiceListView(
                 array(
-                    0 => new ChoiceView('A', '0', $this->obj1),
-                    3 => new ChoiceView('D', '3', $this->obj4),
+                    0 => new ChoiceView($this->obj1, '0', 'A'),
+                    3 => new ChoiceView($this->obj4, '3', 'D'),
                 ), array(
-                    1 => new ChoiceView('B', '1', $this->obj2),
-                    2 => new ChoiceView('C', '2', $this->obj3),
+                    1 => new ChoiceView($this->obj2, '1', 'B'),
+                    2 => new ChoiceView($this->obj3, '2', 'C'),
                 )
         ), $view);
     }
@@ -840,11 +840,11 @@ class DefaultChoiceListFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(new ChoiceListView(
                 array(
-                    'w' => new ChoiceView('A', '0', $this->obj1),
-                    'z' => new ChoiceView('D', '3', $this->obj4),
+                    'w' => new ChoiceView($this->obj1, '0', 'A'),
+                    'z' => new ChoiceView($this->obj4, '3', 'D'),
                 ), array(
-                    'x' => new ChoiceView('B', '1', $this->obj2),
-                    'y' => new ChoiceView('C', '2', $this->obj3),
+                    'x' => new ChoiceView($this->obj2, '1', 'B'),
+                    'y' => new ChoiceView($this->obj3, '2', 'C'),
                 )
         ), $view);
     }
@@ -853,19 +853,19 @@ class DefaultChoiceListFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(new ChoiceListView(
                 array(
-                    0 => new ChoiceView('A', '0', $this->obj1),
-                    3 => new ChoiceView('D', '3', $this->obj4),
+                    0 => new ChoiceView($this->obj1, '0', 'A'),
+                    3 => new ChoiceView($this->obj4, '3', 'D'),
                 ), array(
                     1 => new ChoiceView(
-                        'B',
-                        '1',
                         $this->obj2,
+                        '1',
+                        'B',
                         array('attr1' => 'value1')
                     ),
                     2 => new ChoiceView(
-                        'C',
-                        '2',
                         $this->obj3,
+                        '2',
+                        'C',
                         array('attr2' => 'value2')
                     ),
                 )
@@ -878,20 +878,20 @@ class DefaultChoiceListFactoryTest extends \PHPUnit_Framework_TestCase
                 array(
                     'Group 1' => new ChoiceGroupView(
                         'Group 1',
-                        array(0 => new ChoiceView('A', '0', $this->obj1))
+                        array(0 => new ChoiceView($this->obj1, '0', 'A'))
                     ),
                     'Group 2' => new ChoiceGroupView(
                         'Group 2',
-                        array(3 => new ChoiceView('D', '3', $this->obj4))
+                        array(3 => new ChoiceView($this->obj4, '3', 'D'))
                     ),
                 ), array(
                     'Group 1' => new ChoiceGroupView(
                         'Group 1',
-                        array(1 => new ChoiceView('B', '1', $this->obj2))
+                        array(1 => new ChoiceView($this->obj2, '1', 'B'))
                     ),
                     'Group 2' => new ChoiceGroupView(
                         'Group 2',
-                        array(2 => new ChoiceView('C', '2', $this->obj3))
+                        array(2 => new ChoiceView($this->obj3, '2', 'C'))
                     ),
                 )
         ), $view);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1556,10 +1556,10 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('A', 'a', 'a'),
-            new ChoiceView('B', 'b', 'b'),
-            new ChoiceView('C', 'c', 'c'),
-            new ChoiceView('D', 'd', 'd'),
+            new ChoiceView('a', 'a', 'A'),
+            new ChoiceView('b', 'b', 'B'),
+            new ChoiceView('c', 'c', 'C'),
+            new ChoiceView('d', 'd', 'D'),
         ), $view->vars['choices']);
     }
 
@@ -1573,12 +1573,12 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            0 => new ChoiceView('A', 'a', 'a'),
-            2 => new ChoiceView('C', 'c', 'c'),
+            0 => new ChoiceView('a', 'a', 'A'),
+            2 => new ChoiceView('c', 'c', 'C'),
         ), $view->vars['choices']);
         $this->assertEquals(array(
-            1 => new ChoiceView('B', 'b', 'b'),
-            3 => new ChoiceView('D', 'd', 'd'),
+            1 => new ChoiceView('b', 'b', 'B'),
+            3 => new ChoiceView('d', 'd', 'D'),
         ), $view->vars['preferred_choices']);
     }
 
@@ -1592,19 +1592,19 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertEquals(array(
             'Symfony' => new ChoiceGroupView('Symfony', array(
-                0 => new ChoiceView('Bernhard', 'a', 'a'),
-                2 => new ChoiceView('Kris', 'c', 'c'),
+                0 => new ChoiceView('a', 'a', 'Bernhard'),
+                2 => new ChoiceView('c', 'c', 'Kris'),
             )),
             'Doctrine' => new ChoiceGroupView('Doctrine', array(
-                4 => new ChoiceView('Roman', 'e', 'e'),
+                4 => new ChoiceView('e', 'e', 'Roman'),
             )),
         ), $view->vars['choices']);
         $this->assertEquals(array(
             'Symfony' => new ChoiceGroupView('Symfony', array(
-                1 => new ChoiceView('Fabien', 'b', 'b'),
+                1 => new ChoiceView('b', 'b', 'Fabien'),
             )),
             'Doctrine' => new ChoiceGroupView('Doctrine', array(
-                3 => new ChoiceView('Jon', 'd', 'd'),
+                3 => new ChoiceView('d', 'd', 'Jon'),
             )),
         ), $view->vars['preferred_choices']);
     }
@@ -1624,10 +1624,10 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('A', 'a', $obj1),
-            new ChoiceView('B', 'b', $obj2),
-            new ChoiceView('C', 'c', $obj3),
-            new ChoiceView('D', 'd', $obj4),
+            new ChoiceView($obj1, 'a', 'A'),
+            new ChoiceView($obj2, 'b', 'B'),
+            new ChoiceView($obj3, 'c', 'C'),
+            new ChoiceView($obj4, 'd', 'D'),
         ), $view->vars['choices']);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -31,11 +31,11 @@ class CountryTypeTest extends TestCase
         $choices = $view->vars['choices'];
 
         // Don't check objects for identity
-        $this->assertContains(new ChoiceView('Germany', 'DE', 'DE'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('United Kingdom', 'GB', 'GB'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('United States', 'US', 'US'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('France', 'FR', 'FR'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('Malaysia', 'MY', 'MY'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('DE', 'DE', 'Germany'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('GB', 'GB', 'United Kingdom'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('US', 'US', 'United States'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('FR', 'FR', 'France'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('MY', 'MY', 'Malaysia'), $choices, '', false, false);
     }
 
     public function testUnknownCountryIsNotIncluded()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -30,8 +30,8 @@ class CurrencyTypeTest extends TestCase
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
-        $this->assertContains(new ChoiceView('Euro', 'EUR', 'EUR'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('US Dollar', 'USD', 'USD'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('Slovenian Tolar', 'SIT', 'SIT'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('EUR', 'EUR', 'Euro'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('USD', 'USD', 'US Dollar'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('SIT', 'SIT', 'Slovenian Tolar'), $choices, '', false, false);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -440,8 +440,8 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('06', '6', '6'),
-            new ChoiceView('07', '7', '7'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['month']->vars['choices']);
     }
 
@@ -455,8 +455,8 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('Jän', '1', '1'),
-            new ChoiceView('Apr.', '4', '4'),
+            new ChoiceView('1', '1', 'Jän'),
+            new ChoiceView('4', '4', 'Apr.'),
         ), $view['month']->vars['choices']);
     }
 
@@ -470,8 +470,8 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('Jänner', '1', '1'),
-            new ChoiceView('April', '4', '4'),
+            new ChoiceView('1', '1', 'Jänner'),
+            new ChoiceView('4', '4', 'April'),
         ), $view['month']->vars['choices']);
     }
 
@@ -485,8 +485,8 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('Jänner', '1', '1'),
-            new ChoiceView('April', '4', '4'),
+            new ChoiceView('1', '1', 'Jänner'),
+            new ChoiceView('4', '4', 'April'),
         ), $view['month']->vars['choices']);
     }
 
@@ -499,8 +499,8 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('06', '6', '6'),
-            new ChoiceView('07', '7', '7'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['day']->vars['choices']);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -30,11 +30,11 @@ class LanguageTypeTest extends TestCase
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
-        $this->assertContains(new ChoiceView('English', 'en', 'en'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('British English', 'en_GB', 'en_GB'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('American English', 'en_US', 'en_US'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('French', 'fr', 'fr'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('Burmese', 'my', 'my'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en', 'en', 'English'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'British English'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en_US', 'en_US', 'American English'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('fr', 'fr', 'French'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('my', 'my', 'Burmese'), $choices, '', false, false);
     }
 
     public function testMultipleLanguagesIsNotIncluded()
@@ -43,6 +43,6 @@ class LanguageTypeTest extends TestCase
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
-        $this->assertNotContains(new ChoiceView('Mehrsprachig', 'mul', 'mul'), $choices, '', false, false);
+        $this->assertNotContains(new ChoiceView('mul', 'mul', 'Mehrsprachig'), $choices, '', false, false);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -30,8 +30,8 @@ class LocaleTypeTest extends TestCase
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
-        $this->assertContains(new ChoiceView('English', 'en', 'en'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('English (United Kingdom)', 'en_GB', 'en_GB'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('Chinese (Traditional, Macau SAR China)', 'zh_Hant_MO', 'zh_Hant_MO'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en', 'en', 'English'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'English (United Kingdom)'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'Chinese (Traditional, Macau SAR China)'), $choices, '', false, false);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -319,8 +319,8 @@ class TimeTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('06', '6', '6'),
-            new ChoiceView('07', '7', '7'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['hour']->vars['choices']);
     }
 
@@ -333,8 +333,8 @@ class TimeTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('06', '6', '6'),
-            new ChoiceView('07', '7', '7'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['minute']->vars['choices']);
     }
 
@@ -348,8 +348,8 @@ class TimeTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('06', '6', '6'),
-            new ChoiceView('07', '7', '7'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['second']->vars['choices']);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -22,9 +22,9 @@ class TimezoneTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $choices = $view->vars['choices'];
 
         $this->assertArrayHasKey('Africa', $choices);
-        $this->assertContains(new ChoiceView('Kinshasa', 'Africa/Kinshasa', 'Africa/Kinshasa'), $choices['Africa'], '', false, false);
+        $this->assertContains(new ChoiceView('Africa/Kinshasa', 'Africa/Kinshasa', 'Kinshasa'), $choices['Africa'], '', false, false);
 
         $this->assertArrayHasKey('America', $choices);
-        $this->assertContains(new ChoiceView('New York', 'America/New_York', 'America/New_York'), $choices['America'], '', false, false);
+        $this->assertContains(new ChoiceView('America/New_York', 'America/New_York', 'New York'), $choices['America'], '', false, false);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14193 |
| License | MIT |
| Doc PR | - |
