### PR TITLE
without this change allways the legacy code get called

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -59,13 +59,13 @@ class ValidatorExtension extends AbstractExtension
 
     public function loadTypeGuesser()
     {
-        // 2.4 API
-        if ($this->validator instanceof LegacyValidatorInterface) {
-            return new ValidatorTypeGuesser($this->validator->getMetadataFactory());
+        // 2.5 API
+        if ($this->validator instanceof ValidatorInterface) {
+            return new ValidatorTypeGuesser($this->validator);
         }
 
-        // 2.5 API - ValidatorInterface extends MetadataFactoryInterface
-        return new ValidatorTypeGuesser($this->validator);
+        // 2.4 API
+        return new ValidatorTypeGuesser($this->validator->getMetadataFactory());
     }
 
     protected function loadTypeExtensions()


### PR DESCRIPTION
[Form] [Validator] prevent that always the legacy validator logic get called

| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [] |
