### PR TITLE
[Form] Fix call to removed method (BC broken in 2.3)

### DIFF
--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -93,11 +93,6 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      */
     public function getTypeExtensions()
     {
-        // BC
-        if ($this->innerType instanceof AbstractType) {
-            return $this->innerType->getExtensions();
-        }
-
         return $this->typeExtensions;
     }
 


### PR DESCRIPTION
ResolvedFormType#getTypeExtensions() was calling method
AbstractType#getExtensions() which has been removed in
commit b3081e85a062abb8fc8a22f20a2b3289db2ff501

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
