### PR TITLE
 Allow new lines in Messages translated with transchoice() (replacement for #14867) 

### DIFF
--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -57,7 +57,7 @@ class MessageSelector
         foreach ($parts as $part) {
             $part = trim($part);
 
-            if (preg_match('/^(?P<interval>'.Interval::getIntervalRegexp().')\s*(?P<message>.*?)$/x', $part, $matches)) {
+            if (preg_match('/^(?P<interval>'.Interval::getIntervalRegexp().')\s*(?P<message>.*?)$/xs', $part, $matches)) {
                 $explicitRules[$matches['interval']] = $matches['message'];
             } elseif (preg_match('/^\w+\:\s*(.*?)$/', $part, $matches)) {
                 $standardRules[] = $matches[1];

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -95,18 +95,15 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are no apples', '{0.0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
     
             // Test texts with new-lines
-            array('This is text with a
-            new-line in it. Selector = 0.', '{0}This is a text with a
+            array('This is text with a\n            new-line in it. Selector = 0.', '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 0),
-            array('This is text with a
-            new-line in it. Selector = 1.', '{0}This is a text with a
+            array('This is text with a\n            new-line in it. Selector = 1.', '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 1),
-            array('This is text with a
-            new-line in it. Selector > 1.', '{0}This is a text with a
+            array('This is text with a\n            new-line in it. Selector > 1.', '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 5),

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -95,18 +95,15 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are no apples', '{0.0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
     
             // Test texts with new-lines
-            array('This is text with a
-            new-line in it. Selector = 0.', '{0}This is a text with a
+            array("This is text with a\n            new-line in it. Selector = 0.", '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 0),
-            array('This is text with a
-            new-line in it. Selector = 1.', '{0}This is a text with a
+            array("This is text with a\n            new-line in it. Selector = 1.", '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 1),
-            array('This is text with a
-            new-line in it. Selector > 1.', '{0}This is a text with a
+            array("This is text with a\n            new-line in it. Selector > 1.", '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 5),

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -95,15 +95,18 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are no apples', '{0.0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
     
             // Test texts with new-lines
-            array('This is text with a\n            new-line in it. Selector = 0.', '{0}This is a text with a
+            array('This is text with a
+            new-line in it. Selector = 0.', '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 0),
-            array('This is text with a\n            new-line in it. Selector = 1.', '{0}This is a text with a
+            array('This is text with a
+            new-line in it. Selector = 1.', '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 1),
-            array('This is text with a\n            new-line in it. Selector > 1.', '{0}This is a text with a
+            array('This is text with a
+            new-line in it. Selector > 1.', '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 5),

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -93,20 +93,38 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are no apples', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
             array('There are no apples', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0.0),
             array('There are no apples', '{0.0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
-    
+
             // Test texts with new-lines
-            array("This is text with a\n            new-line in it. Selector = 0.", '{0}This is a text with a
+            // with double-quotes and \n in id and double-quotes and actual newlines in text
+            array("This is a text with a\n            new-line in it. Selector = 0.", "{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
-            new-line in it. Selector > 1.', 0),
-            array("This is text with a\n            new-line in it. Selector = 1.", '{0}This is a text with a
+            new-line in it. Selector > 1.", 0),
+            // with double-quotes and \n in id and single-quotes and actual newlines in text
+            array("This is a text with a\n            new-line in it. Selector = 1.", '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 1),
-            array("This is text with a\n            new-line in it. Selector > 1.", '{0}This is a text with a
+            array("This is a text with a\n            new-line in it. Selector > 1.", '{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a
             new-line in it. Selector > 1.', 5),
+            // with double-quotes and id split accros lines
+            array("This is a text with a
+            new-line in it. Selector = 1.", '{0}This is a text with a
+            new-line in it. Selector = 0.|{1}This is a text with a
+            new-line in it. Selector = 1.|[1,Inf]This is a text with a
+            new-line in it. Selector > 1.', 1),
+            // with single-quotes and id split accros lines
+            array('This is a text with a
+            new-line in it. Selector > 1.', '{0}This is a text with a
+            new-line in it. Selector = 0.|{1}This is a text with a
+            new-line in it. Selector = 1.|[1,Inf]This is a text with a
+            new-line in it. Selector > 1.', 5),
+            // with single-quotes and \n in text
+            array('This is a text with a\nnew-line in it. Selector = 0.', '{0}This is a text with a\nnew-line in it. Selector = 0.|{1}This is a text with a\nnew-line in it. Selector = 1.|[1,Inf]This is a text with a\nnew-line in it. Selector > 1.', 0),
+            // with double-quotes and id split accros lines
+            array("This is a text with a\nnew-line in it. Selector = 1.", "{0}This is a text with a\nnew-line in it. Selector = 0.|{1}This is a text with a\nnew-line in it. Selector = 1.|[1,Inf]This is a text with a\nnew-line in it. Selector > 1.", 1),
         );
     }
 }

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -93,6 +93,23 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are no apples', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
             array('There are no apples', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0.0),
             array('There are no apples', '{0.0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
+            
+            // Test texts with new-lines
+            array('This is text with a
+            new-line in it. Selector = 0.', '{0}This is a text with a
+            new-line in it. Selector = 0.|{1}This is a text with a
+            new-line in it. Selector = 1.|[1,Inf]This is a text with a
+            new-line in it. Selector > 1.', 0),
+            array('This is text with a
+            new-line in it. Selector = 1.', '{0}This is a text with a
+            new-line in it. Selector = 0.|{1}This is a text with a
+            new-line in it. Selector = 1.|[1,Inf]This is a text with a
+            new-line in it. Selector > 1.', 1),
+            array('This is text with a
+            new-line in it. Selector > 1.', '{0}This is a text with a
+            new-line in it. Selector = 0.|{1}This is a text with a
+            new-line in it. Selector = 1.|[1,Inf]This is a text with a
+            new-line in it. Selector > 1.', 5),
         );
     }
 }

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -93,7 +93,7 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are no apples', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
             array('There are no apples', '{0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0.0),
             array('There are no apples', '{0.0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
-            
+    
             // Test texts with new-lines
             array('This is text with a
             new-line in it. Selector = 0.', '{0}This is a text with a

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -95,7 +95,7 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There are no apples', '{0.0} There are no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
 
             // Test texts with new-lines
-            // with double-quotes and \n in id and double-quotes and actual newlines in text
+            // with double-quotes and \n in id & double-quotes and actual newlines in text
             array("This is a text with a\n            new-line in it. Selector = 0.", "{0}This is a text with a
             new-line in it. Selector = 0.|{1}This is a text with a
             new-line in it. Selector = 1.|[1,Inf]This is a text with a


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Hi,
I found that the MessageSelector does not handle new lines in messages very well. 
I suggest adding the "s" modifier to the regexp used to identify the parts and ranges.
What do you think?

PS: would be nice to have this change also in Symfony 2.6 & 2.7
