### PR TITLE
[DX][Form] Show the class name when the deprecated setDefaultOptions is used

### DIFF
--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -212,7 +212,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
             $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType';
 
             if ($isOldOverwritten && !$isNewOverwritten) {
-                trigger_error('The FormTypeInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeInterface with Symfony 3.0.', E_USER_DEPRECATED);
+                trigger_error(get_class($this->innerType).': The FormTypeInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeInterface with Symfony 3.0.', E_USER_DEPRECATED);
             }
 
             foreach ($this->typeExtensions as $extension) {
@@ -225,7 +225,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
                 $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension';
 
                 if ($isOldOverwritten && !$isNewOverwritten) {
-                    trigger_error('The FormTypeExtensionInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeExtensionInterface with Symfony 3.0.', E_USER_DEPRECATED);
+                    trigger_error(get_class($extension).': The FormTypeExtensionInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeExtensionInterface with Symfony 3.0.', E_USER_DEPRECATED);
                 }
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

After upgrading to 2.7 I got plenty of deprecation messages which I could not assign directly as I have updated all of my FormTypes.

![bildschirmfoto 2015-06-07 um 12 02 22](https://cloud.githubusercontent.com/assets/2010989/8024784/8108aeee-0d0d-11e5-8f24-415c553ccb4c.png)

Whit this minor improvement the actual class will be show so the upgrade will be much easier.

![bildschirmfoto 2015-06-07 um 12 01 24](https://cloud.githubusercontent.com/assets/2010989/8024788/93ff37d4-0d0d-11e5-8689-c3e8a933102b.png)

I think same should be considered in other deprecation errors as it gets more difficult to trace down if external libraries are involved.
