### PR TITLE
Include working directory in ProcessFailedException

### DIFF
--- a/src/Symfony/Component/Process/Exception/ProcessFailedException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessFailedException.php
@@ -28,10 +28,11 @@ class ProcessFailedException extends RuntimeException
             throw new InvalidArgumentException('Expected a failed process, but the given process was successful.');
         }
 
-        $error = sprintf('The command "%s" failed.'."\nExit Code: %s(%s)",
+        $error = sprintf('The command "%s" failed.'."\n\nExit Code: %s(%s)\n\nWorking directory: %s",
             $process->getCommandLine(),
             $process->getExitCode(),
-            $process->getExitCodeText()
+            $process->getExitCodeText(),
+            $process->getWorkingDirectory()
         );
 
         if (!$process->isOutputDisabled()) {

--- a/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
@@ -51,10 +51,11 @@ class ProcessFailedExceptionTest extends \PHPUnit_Framework_TestCase
         $exitText = 'General error';
         $output = 'Command output';
         $errorOutput = 'FATAL: Unexpected error';
+        $workingDirectory = getcwd();
 
         $process = $this->getMock(
             'Symfony\Component\Process\Process',
-            array('isSuccessful', 'getOutput', 'getErrorOutput', 'getExitCode', 'getExitCodeText', 'isOutputDisabled'),
+            array('isSuccessful', 'getOutput', 'getErrorOutput', 'getExitCode', 'getExitCodeText', 'isOutputDisabled', 'getWorkingDirectory'),
             array($cmd)
         );
         $process->expects($this->once())
@@ -81,27 +82,32 @@ class ProcessFailedExceptionTest extends \PHPUnit_Framework_TestCase
             ->method('isOutputDisabled')
             ->will($this->returnValue(false));
 
+        $process->expects($this->once())
+            ->method('getWorkingDirectory')
+            ->will($this->returnValue($workingDirectory));
+
         $exception = new ProcessFailedException($process);
 
         $this->assertEquals(
-            "The command \"$cmd\" failed.\nExit Code: $exitCode($exitText)\n\nOutput:\n================\n{$output}\n\nError Output:\n================\n{$errorOutput}",
+            "The command \"$cmd\" failed.\n\nExit Code: $exitCode($exitText)\n\nWorking directory: {$workingDirectory}\n\nOutput:\n================\n{$output}\n\nError Output:\n================\n{$errorOutput}",
             $exception->getMessage()
         );
     }
 
     /**
      * Tests that ProcessFailedException does not extract information from
-     * process output if it was previously disabled
+     * process output if it was previously disabled.
      */
     public function testDisabledOutputInFailedExceptionDoesNotPopulateOutput()
     {
         $cmd = 'php';
         $exitCode = 1;
         $exitText = 'General error';
+        $workingDirectory = getcwd();
 
         $process = $this->getMock(
             'Symfony\Component\Process\Process',
-            array('isSuccessful', 'isOutputDisabled', 'getExitCode', 'getExitCodeText', 'getOutput', 'getErrorOutput'),
+            array('isSuccessful', 'isOutputDisabled', 'getExitCode', 'getExitCodeText', 'getOutput', 'getErrorOutput', 'getWorkingDirectory'),
             array($cmd)
         );
         $process->expects($this->once())
@@ -126,10 +132,14 @@ class ProcessFailedExceptionTest extends \PHPUnit_Framework_TestCase
             ->method('isOutputDisabled')
             ->will($this->returnValue(true));
 
+		$process->expects($this->once())
+            ->method('getWorkingDirectory')
+            ->will($this->returnValue($workingDirectory));
+
         $exception = new ProcessFailedException($process);
 
         $this->assertEquals(
-            "The command \"$cmd\" failed.\nExit Code: $exitCode($exitText)",
+            "The command \"$cmd\" failed.\n\nExit Code: $exitCode($exitText)\n\nWorking directory: {$workingDirectory}",
             $exception->getMessage()
         );
     }


### PR DESCRIPTION
... because quite often the Exception is a result of the `www-data` user not having the appropriate rights at that working path. Maybe @schmittjoh can confirm this?

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
