### PR TITLE
[HttpFoundation] Postpone setting the date header on a Response

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -202,9 +202,6 @@ class Response
         $this->setContent($content);
         $this->setStatusCode($status);
         $this->setProtocolVersion('1.0');
-        if (!$this->headers->has('Date')) {
-            $this->setDate(new \DateTime(null, new \DateTimeZone('UTC')));
-        }
     }
 
     /**
@@ -331,6 +328,10 @@ class Response
         // headers have already been sent by the developer
         if (headers_sent()) {
             return $this;
+        }
+
+        if (!$this->headers->has('Date')) {
+            $this->setDate(new \DateTime());
         }
 
         // status
@@ -644,7 +645,11 @@ class Response
      */
     public function getDate()
     {
-        return $this->headers->getDate('Date', new \DateTime());
+        if (!$this->headers->has('Date')) {
+            $this->setDate(new \DateTime());
+        }
+
+        return $this->headers->getDate('Date');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14906 |
| License | MIT |
| Doc PR | - |

The only risk of doing this is if someone called `getDate()` and the date header was not present, the date might be slightly different than the one sent with the headers.

`getDate()` could also set the date header first time it's requested (do a lazy initialisation).
