### PR TITLE
Bug #14836 [HttpFoundation] Moves default JSON encoding assignment fr…

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -26,7 +26,10 @@ class JsonResponse extends Response
 {
     protected $data;
     protected $callback;
-    protected $encodingOptions;
+
+    // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
+    // 15 === JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT
+    protected $encodingOptions = 15;
 
     /**
      * Constructor.
@@ -42,9 +45,6 @@ class JsonResponse extends Response
         if (null === $data) {
             $data = new \ArrayObject();
         }
-
-        // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
-        $this->encodingOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
 
         $this->setData($data);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #14918, #14836 |
| License | MIT |
| Doc PR | no |

Moves the assignment of the encoding flags to a property so the class can be extended without needing to re-write the constructor and perform the encoding of data twice.

For more information please see https://github.com/symfony/symfony/issues/14836
