### PR TITLE
[Security] Initialize SwitchUserEvent::targetUser on attemptExitUser

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -162,7 +162,8 @@ class SwitchUserListener implements ListenerInterface
         }
 
         if (null !== $this->dispatcher) {
-            $switchEvent = new SwitchUserEvent($request, $original->getUser());
+            $user = $this->provider->refreshUser($original->getUser());
+            $switchEvent = new SwitchUserEvent($request, $user);
             $this->dispatcher->dispatch(SecurityEvents::SWITCH_USER, $switchEvent);
         }
 


### PR DESCRIPTION
The `SwitchUserEvent` is triggered in case an account is switched. This works okay while switching to the user, but on exit the `SwitchUserEvent` is triggered again with the original User. That User was not initialized by the provider yet.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
