### PR TITLE
Bug #14712 [Form] Verify that $modelData is not a boolean before casting it to a string

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -344,7 +344,7 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         // Treat data as strings unless a value transformer exists
-        if (!$this->config->getViewTransformers() && !$this->config->getModelTransformers() && is_scalar($modelData)) {
+        if (!$this->config->getViewTransformers() && !$this->config->getModelTransformers() && !is_bool($modelData) && is_scalar($modelData)) {
             $modelData = (string) $modelData;
         }
 

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Tests;
 
-use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -463,6 +464,34 @@ class SimpleFormTest extends AbstractFormTest
 
         $this->assertSame('1', $form->getData());
         $this->assertSame('1', $form->getNormData());
+        $this->assertSame('1', $form->getViewData());
+    }
+
+    /*
+     * When there is no data transformer and the data is a boolean, it should not be converted to a string
+     */
+    public function testSetDataIsIgnoredIfDataIsBooleanFalse()
+    {
+        $form = $this->getBuilder()->getForm();
+
+        $form->setData(false);
+
+        $this->assertFalse($form->getData());
+        $this->assertFalse($form->getNormData());
+        $this->assertSame('', $form->getViewData());
+    }
+
+    /*
+     * When there is no data transformer and the data is a boolean, it should not be converted to a string
+     */
+    public function testSetDataIsIgnoredIfDataIsBooleanTrue()
+    {
+        $form = $this->getBuilder()->getForm();
+
+        $form->setData(true);
+
+        $this->assertTrue($form->getData());
+        $this->assertTrue($form->getNormData());
         $this->assertSame('1', $form->getViewData());
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14712 |
| License | MIT |
| Doc PR |  |

Verifies that $modelData is not a boolean before casting it to a string. Also added two unit tests to verify that booleans are working as intended.
Thanks to @manuelj555 fix [here](https://github.com/symfony/symfony/issues/14712#issuecomment-108454657)
