### PR TITLE
Standardize the name of the exception variables

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -79,7 +79,7 @@ class TwigEngine extends BaseEngine implements EngineInterface
                 try {
                     // try to get the real file name of the template where the error occurred
                     $e->setTemplateFile(sprintf('%s', $this->locator->locate($this->parser->parse($e->getTemplateFile()))));
-                } catch (\Exception $ex) {
+                } catch (\Exception $e2) {
                 }
             }
 

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -256,7 +256,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
             try {
                 $value[$name] = $child->finalize($value[$name]);
-            } catch (UnsetKeyException $unset) {
+            } catch (UnsetKeyException $e) {
                 unset($value[$name]);
             }
         }

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -302,14 +302,10 @@ abstract class BaseNode implements NodeInterface
         foreach ($this->finalValidationClosures as $closure) {
             try {
                 $value = $closure($value);
-            } catch (Exception $correctEx) {
-                throw $correctEx;
-            } catch (\Exception $invalid) {
-                throw new InvalidConfigurationException(sprintf(
-                    'Invalid configuration for path "%s": %s',
-                    $this->getPath(),
-                    $invalid->getMessage()
-                ), $invalid->getCode(), $invalid);
+            } catch (Exception $e) {
+                throw $e;
+            } catch (\Exception $e) {
+                throw new InvalidConfigurationException(sprintf('Invalid configuration for path "%s": %s', $this->getPath(), $e->getMessage()), $e->getCode(), $e);
             }
         }
 

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -211,7 +211,7 @@ class PrototypedArrayNode extends ArrayNode
             $this->prototype->setName($k);
             try {
                 $value[$k] = $this->prototype->finalize($v);
-            } catch (UnsetKeyException $unset) {
+            } catch (UnsetKeyException $e) {
                 unset($value[$k]);
             }
         }

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -452,18 +452,18 @@ class DialogHelper extends Helper
      */
     private function validateAttempts($interviewer, OutputInterface $output, $validator, $attempts)
     {
-        $error = null;
+        $e = null;
         while (false === $attempts || $attempts--) {
-            if (null !== $error) {
-                $output->writeln($this->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+            if (null !== $e) {
+                $output->writeln($this->getHelperSet()->get('formatter')->formatBlock($e->getMessage(), 'error'));
             }
 
             try {
                 return call_user_func($validator, $interviewer());
-            } catch (\Exception $error) {
+            } catch (\Exception $e) {
             }
         }
 
-        throw $error;
+        throw $e;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -47,7 +47,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
             foreach ($definition->getMethodCalls() as $call) {
                 try {
                     $calls[] = array($call[0], $this->processArguments($call[1], true));
-                } catch (RuntimeException $ignore) {
+                } catch (RuntimeException $e) {
                     // this call is simply removed
                 }
             }
@@ -58,7 +58,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
                 try {
                     $value = $this->processArguments(array($value), true);
                     $properties[$name] = reset($value);
-                } catch (RuntimeException $ignore) {
+                } catch (RuntimeException $e) {
                     // ignore property
                 }
             }

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -125,7 +125,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                         'file' => $r->getFileName(),
                         'line' => $r->getStartLine(),
                     );
-                } catch (\ReflectionException $re) {
+                } catch (\ReflectionException $e) {
                     if (is_callable($controller)) {
                         // using __call or  __callStatic
                         $this->data['controller'] = array(

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -137,10 +137,10 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         try {
             $kernel->handle($request, $type);
             $this->fail('->handle() suppresses the controller exception');
-        } catch (\PHPUnit_Framework_Exception $exception) {
-            throw $exception;
-        } catch (\Exception $actual) {
-            $this->assertSame($expected, $actual, '->handle() throws the controller exception');
+        } catch (\PHPUnit_Framework_Exception $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            $this->assertSame($expected, $e, '->handle() throws the controller exception');
         }
     }
 

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -177,13 +177,13 @@ class AclProvider implements AclProviderInterface
             if ($currentBatchesCount > 0 && (self::MAX_BATCH_SIZE === $currentBatchesCount || ($i + 1) === $c)) {
                 try {
                     $loadedBatch = $this->lookupObjectIdentities($currentBatch, $sids, $oidLookup);
-                } catch (AclNotFoundException $aclNotFoundexception) {
+                } catch (AclNotFoundException $e) {
                     if ($result->count()) {
                         $partialResultException = new NotAllAclsFoundException('The provider could not find ACLs for all object identities.');
                         $partialResultException->setPartialResult($result);
                         throw $partialResultException;
                     } else {
-                        throw $aclNotFoundexception;
+                        throw $e;
                     }
                 }
                 foreach ($loadedBatch as $loadedOid) {

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -62,10 +62,10 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
             $this->connection->executeQuery($this->getInsertObjectIdentityRelationSql($pk, $pk));
 
             $this->connection->commit();
-        } catch (\Exception $failed) {
+        } catch (\Exception $e) {
             $this->connection->rollBack();
 
-            throw $failed;
+            throw $e;
         }
 
         // re-read the ACL from the database to ensure proper caching, etc.
@@ -90,10 +90,10 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
             $this->deleteObjectIdentity($oidPK);
 
             $this->connection->commit();
-        } catch (\Exception $failed) {
+        } catch (\Exception $e) {
             $this->connection->rollBack();
 
-            throw $failed;
+            throw $e;
         }
 
         // evict the ACL from the in-memory identity map
@@ -324,10 +324,10 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
             }
 
             $this->connection->commit();
-        } catch (\Exception $failed) {
+        } catch (\Exception $e) {
             $this->connection->rollBack();
 
-            throw $failed;
+            throw $e;
         }
 
         $this->propertyChanges->offsetSet($acl, array());

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -68,8 +68,8 @@ final class ObjectIdentity implements ObjectIdentityInterface
             } elseif (method_exists($domainObject, 'getId')) {
                 return new self((string) $domainObject->getId(), ClassUtils::getRealClass($domainObject));
             }
-        } catch (\InvalidArgumentException $invalid) {
-            throw new InvalidDomainObjectException($invalid->getMessage(), 0, $invalid);
+        } catch (\InvalidArgumentException $e) {
+            throw new InvalidDomainObjectException($e->getMessage(), 0, $e);
         }
 
         throw new InvalidDomainObjectException('$domainObject must either implement the DomainObjectInterface, or have a method named "getId".');

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentityRetrievalStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentityRetrievalStrategy.php
@@ -28,7 +28,7 @@ class ObjectIdentityRetrievalStrategy implements ObjectIdentityRetrievalStrategy
     {
         try {
             return ObjectIdentity::fromDomainObject($domainObject);
-        } catch (InvalidDomainObjectException $failed) {
+        } catch (InvalidDomainObjectException $e) {
             return;
         }
     }

--- a/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
@@ -55,21 +55,21 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
                 }
 
                 return $this->hasSufficientPermissions($acl, $aces, $masks, $sids, $administrativeMode);
-            } catch (NoAceFoundException $noObjectAce) {
+            } catch (NoAceFoundException $e) {
                 $aces = $acl->getClassAces();
 
                 if (!$aces) {
-                    throw $noObjectAce;
+                    throw $e;
                 }
 
                 return $this->hasSufficientPermissions($acl, $aces, $masks, $sids, $administrativeMode);
             }
-        } catch (NoAceFoundException $noClassAce) {
+        } catch (NoAceFoundException $e) {
             if ($acl->isEntriesInheriting() && null !== $parentAcl = $acl->getParentAcl()) {
                 return $parentAcl->isGranted($masks, $sids, $administrativeMode);
             }
 
-            throw $noClassAce;
+            throw $e;
         }
     }
 
@@ -86,20 +86,20 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
                 }
 
                 return $this->hasSufficientPermissions($acl, $aces, $masks, $sids, $administrativeMode);
-            } catch (NoAceFoundException $noObjectAces) {
+            } catch (NoAceFoundException $e) {
                 $aces = $acl->getClassFieldAces($field);
                 if (!$aces) {
-                    throw $noObjectAces;
+                    throw $e;
                 }
 
                 return $this->hasSufficientPermissions($acl, $aces, $masks, $sids, $administrativeMode);
             }
-        } catch (NoAceFoundException $noClassAces) {
+        } catch (NoAceFoundException $e) {
             if ($acl->isEntriesInheriting() && null !== $parentAcl = $acl->getParentAcl()) {
                 return $parentAcl->isFieldGranted($field, $masks, $sids, $administrativeMode);
             }
 
-            throw $noClassAces;
+            throw $e;
         }
     }
 

--- a/src/Symfony/Component/Security/Acl/Domain/SecurityIdentityRetrievalStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/SecurityIdentityRetrievalStrategy.php
@@ -51,7 +51,7 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
         if (!$token instanceof AnonymousToken) {
             try {
                 $sids[] = UserSecurityIdentity::fromToken($token);
-            } catch (\InvalidArgumentException $invalid) {
+            } catch (\InvalidArgumentException $e) {
                 // ignore, user has no user security identity
             }
         }

--- a/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
+++ b/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
@@ -132,7 +132,7 @@ class MaskBuilder
             if ('1' === $bitmask[$i]) {
                 try {
                     $pattern[$i] = self::getCode(1 << ($length - $i - 1));
-                } catch (\Exception $notPredefined) {
+                } catch (\Exception $e) {
                     $pattern[$i] = self::ON;
                 }
             }

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -113,13 +113,13 @@ class AclVoter implements VoterInterface
                 }
 
                 return self::ACCESS_DENIED;
-            } catch (AclNotFoundException $noAcl) {
+            } catch (AclNotFoundException $e) {
                 if (null !== $this->logger) {
                     $this->logger->debug('No ACL found for the object identity. Voting to deny access.');
                 }
 
                 return self::ACCESS_DENIED;
-            } catch (NoAceFoundException $noAce) {
+            } catch (NoAceFoundException $e) {
                 if (null !== $this->logger) {
                     $this->logger->debug('ACL found, no ACE applicable. Voting to deny access.');
                 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -87,13 +87,13 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
             }
 
             return $user;
-        } catch (UsernameNotFoundException $notFound) {
-            $notFound->setUsername($username);
-            throw $notFound;
-        } catch (\Exception $repositoryProblem) {
-            $ex = new AuthenticationServiceException($repositoryProblem->getMessage(), 0, $repositoryProblem);
-            $ex->setToken($token);
-            throw $ex;
+        } catch (UsernameNotFoundException $e) {
+            $e->setUsername($username);
+            throw $e;
+        } catch (\Exception $e) {
+            $e = new AuthenticationServiceException($e->getMessage(), 0, $e);
+            $e->setToken($token);
+            throw $e;
         }
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -68,13 +68,13 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
 
         try {
             $user = $this->retrieveUser($username, $token);
-        } catch (UsernameNotFoundException $notFound) {
+        } catch (UsernameNotFoundException $e) {
             if ($this->hideUserNotFoundExceptions) {
-                throw new BadCredentialsException('Bad credentials', 0, $notFound);
+                throw new BadCredentialsException('Bad credentials', 0, $e);
             }
-            $notFound->setUsername($username);
+            $e->setUsername($username);
 
-            throw $notFound;
+            throw $e;
         }
 
         if (!$user instanceof UserInterface) {

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -47,7 +47,7 @@ class ChainUserProvider implements UserProviderInterface
         foreach ($this->providers as $provider) {
             try {
                 return $provider->loadUserByUsername($username);
-            } catch (UsernameNotFoundException $notFound) {
+            } catch (UsernameNotFoundException $e) {
                 // try next one
             }
         }
@@ -67,18 +67,18 @@ class ChainUserProvider implements UserProviderInterface
         foreach ($this->providers as $provider) {
             try {
                 return $provider->refreshUser($user);
-            } catch (UnsupportedUserException $unsupported) {
+            } catch (UnsupportedUserException $e) {
                 // try next one
-            } catch (UsernameNotFoundException $notFound) {
+            } catch (UsernameNotFoundException $e) {
                 $supportedUserFound = true;
                 // try next one
             }
         }
 
         if ($supportedUserFound) {
-            $ex = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
-            $ex->setUsername($user->getUsername());
-            throw $ex;
+            $e = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
+            $e->setUsername($user->getUsername());
+            throw $e;
         } else {
             throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
         }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -62,8 +62,8 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
 
         try {
             list($user, $credentials) = $this->getPreAuthenticatedData($request);
-        } catch (BadCredentialsException $exception) {
-            $this->clearToken($exception);
+        } catch (BadCredentialsException $e) {
+            $this->clearToken($e);
 
             return;
         }
@@ -90,8 +90,8 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
                 $loginEvent = new InteractiveLoginEvent($request, $token);
                 $this->dispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN, $loginEvent);
             }
-        } catch (AuthenticationException $failed) {
-            $this->clearToken($failed);
+        } catch (AuthenticationException $e) {
+            $this->clearToken($e);
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -73,21 +73,21 @@ class BasicAuthenticationListener implements ListenerInterface
         try {
             $token = $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $request->headers->get('PHP_AUTH_PW'), $this->providerKey));
             $this->securityContext->setToken($token);
-        } catch (AuthenticationException $failed) {
+        } catch (AuthenticationException $e) {
             $token = $this->securityContext->getToken();
             if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey()) {
                 $this->securityContext->setToken(null);
             }
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Authentication request failed for user "%s": %s', $username, $failed->getMessage()));
+                $this->logger->info(sprintf('Authentication request failed for user "%s": %s', $username, $e->getMessage()));
             }
 
             if ($this->ignoreFailure) {
                 return;
             }
 
-            $event->setResponse($this->authenticationEntryPoint->start($request, $failed));
+            $event->setResponse($this->authenticationEntryPoint->start($request, $e));
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -167,11 +167,11 @@ class ContextListener implements ListenerInterface
                 }
 
                 return $token;
-            } catch (UnsupportedUserException $unsupported) {
+            } catch (UnsupportedUserException $e) {
                 // let's try the next user provider
-            } catch (UsernameNotFoundException $notFound) {
+            } catch (UsernameNotFoundException $e) {
                 if (null !== $this->logger) {
-                    $this->logger->warning(sprintf('Username "%s" could not be found.', $notFound->getUsername()));
+                    $this->logger->warning(sprintf('Username "%s" could not be found.', $e->getUsername()));
                 }
 
                 return;

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -93,7 +93,7 @@ class DigestAuthenticationListener implements ListenerInterface
             }
 
             $serverDigestMd5 = $digestAuth->calculateServerDigest($user->getPassword(), $request->getMethod());
-        } catch (UsernameNotFoundException $notFound) {
+        } catch (UsernameNotFoundException $e) {
             $this->fail($event, $request, new BadCredentialsException(sprintf('Username %s not found.', $digestAuth->getUsername())));
 
             return;

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -80,12 +80,12 @@ class RememberMeListener implements ListenerInterface
             if (null !== $this->logger) {
                 $this->logger->debug('SecurityContext populated with remember-me token.');
             }
-        } catch (AuthenticationException $failed) {
+        } catch (AuthenticationException $e) {
             if (null !== $this->logger) {
                 $this->logger->warning(
                     'SecurityContext not populated with remember-me token as the'
                    .' AuthenticationManager rejected the AuthenticationToken returned'
-                   .' by the RememberMeServices: '.$failed->getMessage()
+                   .' by the RememberMeServices: '.$e->getMessage()
                 );
             }
 

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -123,21 +123,21 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             }
 
             return new RememberMeToken($user, $this->providerKey, $this->key);
-        } catch (CookieTheftException $theft) {
+        } catch (CookieTheftException $e) {
             $this->cancelCookie($request);
 
-            throw $theft;
-        } catch (UsernameNotFoundException $notFound) {
+            throw $e;
+        } catch (UsernameNotFoundException $e) {
             if (null !== $this->logger) {
                 $this->logger->info('User for remember-me cookie not found.');
             }
-        } catch (UnsupportedUserException $unSupported) {
+        } catch (UnsupportedUserException $e) {
             if (null !== $this->logger) {
                 $this->logger->warning('User class for remember-me cookie not supported.');
             }
-        } catch (AuthenticationException $invalid) {
+        } catch (AuthenticationException $e) {
             if (null !== $this->logger) {
-                $this->logger->debug('Remember-Me authentication failed: '.$invalid->getMessage());
+                $this->logger->debug('Remember-Me authentication failed: '.$e->getMessage());
             }
         }
 

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -41,12 +41,12 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
         }
         try {
             $user = $this->getUserProvider($class)->loadUserByUsername($username);
-        } catch (\Exception $ex) {
-            if (!$ex instanceof AuthenticationException) {
-                $ex = new AuthenticationException($ex->getMessage(), $ex->getCode(), $ex);
+        } catch (\Exception $e) {
+            if (!$e instanceof AuthenticationException) {
+                $e = new AuthenticationException($e->getMessage(), $e->getCode(), $e);
             }
 
-            throw $ex;
+            throw $e;
         }
 
         if (!$user instanceof UserInterface) {

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderTest.php
@@ -45,11 +45,11 @@ class AclProviderTest extends \PHPUnit_Framework_TestCase
             $this->getProvider()->findAcls($oids);
 
             $this->fail('Provider did not throw an expected exception.');
-        } catch (\Exception $ex) {
-            $this->assertInstanceOf('Symfony\Component\Security\Acl\Exception\AclNotFoundException', $ex);
-            $this->assertInstanceOf('Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException', $ex);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Symfony\Component\Security\Acl\Exception\AclNotFoundException', $e);
+            $this->assertInstanceOf('Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException', $e);
 
-            $partialResult = $ex->getPartialResult();
+            $partialResult = $e->getPartialResult();
             $this->assertTrue($partialResult->contains($oids[0]));
             $this->assertFalse($partialResult->contains($oids[1]));
         }

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/MutableAclProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/MutableAclProviderTest.php
@@ -88,7 +88,7 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         try {
             $provider->findAcl($oid);
             $this->fail('ACL has not been properly deleted.');
-        } catch (AclNotFoundException $notFound) {
+        } catch (AclNotFoundException $e) {
         }
     }
 
@@ -104,7 +104,7 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         try {
             $provider->findAcl(new ObjectIdentity(1, 'Foo'));
             $this->fail('Child-ACLs have not been deleted.');
-        } catch (AclNotFoundException $notFound) {
+        } catch (AclNotFoundException $e) {
         }
     }
 
@@ -290,7 +290,7 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         try {
             $provider->updateAcl($acl1);
             $this->fail('Provider failed to detect a concurrent modification.');
-        } catch (ConcurrentModificationException $ex) {
+        } catch (ConcurrentModificationException $e) {
         }
     }
 

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/PermissionGrantingStrategyTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/PermissionGrantingStrategyTest.php
@@ -154,7 +154,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
             try {
                 $strategy->isGranted($acl, array($requiredMask), array($sid));
                 $this->fail('The ACE is not supposed to match.');
-            } catch (NoAceFoundException $noAce) {
+            } catch (NoAceFoundException $e) {
             }
         } else {
             $this->assertTrue($strategy->isGranted($acl, array($requiredMask), array($sid)));

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -115,7 +115,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
         try {
             $service->autoLogin($request);
             $this->fail('Expected CookieTheftException was not thrown.');
-        } catch (CookieTheftException $theft) {
+        } catch (CookieTheftException $e) {
         }
 
         $this->assertTrue($request->attributes->has(RememberMeServicesInterface::COOKIE_ATTR_NAME));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

See https://github.com/symfony/symfony-docs/pull/4491 for the context of this change.

In Symfony source code there are 410 `try ... catch` blocks. More than 95% of them use `$e` as the name of the exception variable. After applying these changes, 407 out of 410 variables are named `$e`.

These are the three cases where I didn't change the name of the `$e` variable:
- Nested exception in https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php#L40. It uses `$e2` as the name of the nested variable.
- Nested exception in https://github.com/symfony/symfony/blob/2.3/src/Symfony/Bundle/TwigBundle/TwigEngine.php#L82. I changed the name of the `$ex` variable to `$e2` to match the previous syntax.
- https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Console/Helper/DialogHelper.php#L463. I don't know if it's safe to change the name of the `$error` exception variable.
