### PR TITLE
Documented minor BC break introduced in AssetHelper

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -592,3 +592,54 @@ TwigBundle
        background: {{ brand_color|raw }};
    }
    ```
+
+FrameworkBundle
+---------------
+
+ * The `templating.helper.assets` was refactored and returns now an object of the type
+   `Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper` instead of
+   `Symfony\Component\Templating\Helper\CoreAssetsHelper`. You can update your class definition
+   or use the `assets.package` service instead. Using the `assets.package` service is the recommended 
+   way. The `templating.helper.assets` service will be removed in Symfony 3.0.
+
+   Before:
+
+   ```php
+   use Symfony\Component\Templating\Helper\CoreAssetsHelper;
+
+   class DemoService
+   {
+       private $assetsHelper;
+
+       public function __construct(CoreAssetsHelper $assetsHelper)
+       {
+           $this->assetsHelper = $assetsHelper;
+       }
+
+       public function testMethod()
+       {
+           return $this->assetsHelper->getUrl('thumbnail.png', null, $this->assetsHelper->getVersion());
+       }
+   }
+   ```
+
+   After:
+
+   ```php
+   use Symfony\Component\Asset\Packages;
+
+   class DemoService
+   {
+       private $assetPackages;
+
+       public function __construct(Packages $assetPackages)
+       {
+           $this->assetPackages = $assetPackages;
+       }
+
+       public function testMethod()
+       {
+           return $this->assetPackages->getUrl('thumbnail.png').$this->assetPackages->getVersion();
+       }
+   }
+   ```

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -349,7 +349,7 @@ UPGRADE FROM 2.x to 3.0
  * The `request` service was removed. You must inject the `request_stack`
    service instead.
 
- * The `templating.helper.assets` was moved to `templating_php.xml`. You can
+ * The `templating.helper.assets` was removed in Symfony 3.0. You should
    use the `assets.package` service instead.
 
    Before:

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
@@ -13,14 +13,14 @@ namespace Symfony\Bundle\FrameworkBundle\Templating\Helper;
 
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
-use Symfony\Component\Templating\Helper\Helper;
+use Symfony\Component\Templating\Helper\CoreAssetsHelper;
 
 /**
  * AssetsHelper helps manage asset URLs.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class AssetsHelper extends Helper
+class AssetsHelper extends CoreAssetsHelper
 {
     private $packages;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
@@ -13,14 +13,14 @@ namespace Symfony\Bundle\FrameworkBundle\Templating\Helper;
 
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
-use Symfony\Component\Templating\Helper\CoreAssetsHelper;
+use Symfony\Component\Templating\Helper\Helper;
 
 /**
  * AssetsHelper helps manage asset URLs.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class AssetsHelper extends CoreAssetsHelper
+class AssetsHelper extends Helper
 {
     private $packages;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14898 |
| License | MIT |
| Doc PR | - |

This should be an easy fix. As this AssetHelper is removed in 3.0 I think no correction for 3.0 would be needed. 
