### PR TITLE
[Form] Fixed: Filter non-integers when selecting entities by int ID

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -99,6 +99,12 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
         $metadata = $qb->getEntityManager()->getClassMetadata($entity);
         if (in_array($metadata->getTypeOfField($identifier), array('integer', 'bigint', 'smallint'))) {
             $parameterType = Connection::PARAM_INT_ARRAY;
+
+            // Filter out non-integer values (e.g. ""). If we don't, some
+            // databases such as PostgreSQL fail.
+            $values = array_values(array_filter($values, function ($v) {
+                return (string) $v === (string) (int) $v;
+            }));
         } else {
             $parameterType = Connection::PARAM_STR_ARRAY;
         }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Doctrine\DBAL\Connection;
 
-class ORMQueryBuilderLoaderTest extends DoctrineTestHelper
+class ORMQueryBuilderLoaderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
@@ -27,6 +27,7 @@ class ORMQueryBuilderLoaderTest extends DoctrineTestHelper
 
     /**
      * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
+     * @group legacy
      */
     public function testClosureRequiresTheEntityManager()
     {
@@ -47,7 +48,7 @@ class ORMQueryBuilderLoaderTest extends DoctrineTestHelper
 
     protected function checkIdentifierType($classname, $expectedType)
     {
-        $em = $this->createTestEntityManager();
+        $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
             ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
@@ -56,7 +57,7 @@ class ORMQueryBuilderLoaderTest extends DoctrineTestHelper
         $query->expects($this->once())
             ->method('setParameter')
             ->with('ORMQueryBuilderLoader_getEntitiesByIds_id', array(), $expectedType)
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
@@ -65,12 +66,41 @@ class ORMQueryBuilderLoaderTest extends DoctrineTestHelper
 
         $qb->expects($this->once())
             ->method('getQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $qb->select('e')
             ->from($classname, 'e');
 
         $loader = new ORMQueryBuilderLoader($qb);
         $loader->getEntitiesByIds('id', array());
+    }
+
+    public function testFilterNonIntegerValues()
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+
+        $query = $this->getMockBuilder('QueryMock')
+            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
+            ->getMock();
+
+        $query->expects($this->once())
+            ->method('setParameter')
+            ->with('ORMQueryBuilderLoader_getEntitiesByIds_id', array(1, 2, 3), Connection::PARAM_INT_ARRAY)
+            ->willReturn($query);
+
+        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+            ->setConstructorArgs(array($em))
+            ->setMethods(array('getQuery'))
+            ->getMock();
+
+        $qb->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $qb->select('e')
+            ->from('Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity', 'e');
+
+        $loader = new ORMQueryBuilderLoader($qb);
+        $loader->getEntitiesByIds('id', array(1, '', 2, 3, 'foo'));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14583 (for Doctrine, not Propel) |
| License | MIT |
| Doc PR | - |

This PR fixes #14583 for Doctrine. Non-integer values (like `""`) are not passed to the database anymore when selecting entities by integer PK, which causes an error on some DBMSs (like PostgreSQL).
