### PR TITLE
fix Merge branch '2.7' into 2.8 JsonFileLoader

### DIFF
--- a/src/Symfony/Component/Translation/Loader/JsonFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/JsonFileLoader.php
@@ -25,14 +25,6 @@ class JsonFileLoader extends FileLoader
      */
     protected function loadResource($resource)
     {
-        if (!stream_is_local($resource)) {
-            throw new InvalidResourceException(sprintf('This is not a local file "%s".', $resource));
-        }
-
-        if (!file_exists($resource)) {
-            throw new NotFoundResourceException(sprintf('File "%s" not found.', $resource));
-        }
-
         $messages = array();
         if ($data = file_get_contents($resource)) {
             $messages = json_decode($data, true);


### PR DESCRIPTION
This fix a merge commit see https://github.com/symfony/symfony/commit/5593bdd56e5146693ac0437edb0175d897c2f9bd. The `stream_is_local` and `file_exists` checks are all ready done in the parent `FileLoader` class.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |
