### PR TITLE
[Debug+VarDumper] Fix handling of PHP7 "Throwable" exceptions

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Debug;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Debug\Exception\ContextErrorException;
-use Symfony\Component\Debug\Exception\FatalBaseException;
 use Symfony\Component\Debug\Exception\FatalErrorException;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Symfony\Component\Debug\Exception\OutOfMemoryException;
 use Symfony\Component\Debug\FatalErrorHandler\UndefinedFunctionFatalErrorHandler;
 use Symfony\Component\Debug\FatalErrorHandler\UndefinedMethodFatalErrorHandler;
@@ -431,15 +431,15 @@ class ErrorHandler
     /**
      * Handles an exception by logging then forwarding it to an other handler.
      *
-     * @param \Exception|\BaseException $exception An exception to handle
-     * @param array                     $error     An array as returned by error_get_last()
+     * @param \Exception|\Throwable $exception An exception to handle
+     * @param array                 $error     An array as returned by error_get_last()
      *
      * @internal
      */
     public function handleException($exception, array $error = null)
     {
         if (!$exception instanceof \Exception) {
-            $exception = new FatalBaseException($exception);
+            $exception = new FatalThrowableError($exception);
         }
         $type = $exception instanceof FatalErrorException ? $exception->getSeverity() : E_ERROR;
 
@@ -451,15 +451,17 @@ class ErrorHandler
                 'level' => error_reporting(),
                 'stack' => $exception->getTrace(),
             );
-            if ($exception instanceof FatalBaseException) {
-                $error = array(
-                    'type' => $type,
-                    'message' => $message = $exception->getMessage(),
-                    'file' => $e['file'],
-                    'line' => $e['line'],
-                );
-            } elseif ($exception instanceof FatalErrorException) {
-                $message = 'Fatal '.$exception->getMessage();
+            if ($exception instanceof FatalErrorException) {
+                if ($exception instanceof FatalThrowableError) {
+                    $error = array(
+                        'type' => $type,
+                        'message' => $message = $exception->getMessage(),
+                        'file' => $e['file'],
+                        'line' => $e['line'],
+                    );
+                } else {
+                    $message = 'Fatal '.$exception->getMessage();
+                }
             } elseif ($exception instanceof \ErrorException) {
                 $message = 'Uncaught '.$exception->getMessage();
                 if ($exception instanceof ContextErrorException) {
@@ -486,9 +488,9 @@ class ErrorHandler
         try {
             call_user_func($this->exceptionHandler, $exception);
         } catch (\Exception $handlerException) {
-            $this->exceptionHandler = null;
-            $this->handleException($handlerException);
-        } catch (\BaseException $handlerException) {
+        } catch (\Throwable $handlerException) {
+        }
+        if (isset($handlerException)) {
             $this->exceptionHandler = null;
             $this->handleException($handlerException);
         }

--- a/src/Symfony/Component/Debug/Exception/FatalThrowableError.php
+++ b/src/Symfony/Component/Debug/Exception/FatalThrowableError.php
@@ -12,18 +12,18 @@
 namespace Symfony\Component\Debug\Exception;
 
 /**
- * Base Fatal Error Exception.
+ * Fatal Throwable Error.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class FatalBaseException extends FatalErrorException
+class FatalThrowableError extends FatalErrorException
 {
-    public function __construct(\BaseException $e)
+    public function __construct(\Throwable $e)
     {
-        if ($e instanceof \ParseException) {
+        if ($e instanceof \ParseError) {
             $message = 'Parse error: '.$e->getMessage();
             $severity = E_PARSE;
-        } elseif ($e instanceof \TypeException) {
+        } elseif ($e instanceof \TypeError) {
             $message = 'Type error: '.$e->getMessage();
             $severity = E_RECOVERABLE_ERROR;
         } else {

--- a/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
@@ -63,8 +63,9 @@ class DOMCaster
 
     public static function castException(\DOMException $e, array $a, Stub $stub, $isNested)
     {
-        if (isset($a["\0*\0code"], self::$errorCodes[$a["\0*\0code"]])) {
-            $a["\0*\0code"] = new ConstStub(self::$errorCodes[$a["\0*\0code"]], $a["\0*\0code"]);
+        $k = "\0*\0code";
+        if (isset($a[$k], self::$errorCodes[$a[$k]])) {
+            $a[$k] = new ConstStub(self::$errorCodes[$a[$k]], $a[$k]);
         }
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Caster/DoctrineCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DoctrineCaster.php
@@ -25,34 +25,35 @@ class DoctrineCaster
 {
     public static function castCommonProxy(CommonProxy $proxy, array $a, Stub $stub, $isNested)
     {
-        unset(
-            $a['__cloner__'],
-            $a['__initializer__']
-        );
-        $stub->cut += 2;
+        foreach (array('__cloner__', '__initializer__') as $k) {
+            if (array_key_exists($k, $a)) {
+                unset($a[$k]);
+                ++$stub->cut;
+            }
+        }
 
         return $a;
     }
 
     public static function castOrmProxy(OrmProxy $proxy, array $a, Stub $stub, $isNested)
     {
-        $prefix = "\0Doctrine\\ORM\\Proxy\\Proxy\0";
-        unset(
-            $a[$prefix.'_entityPersister'],
-            $a[$prefix.'_identifier']
-        );
-        $stub->cut += 2;
+        foreach (array('_entityPersister', '_identifier') as $k) {
+            if (array_key_exists($k = "\0Doctrine\\ORM\\Proxy\\Proxy\0".$k, $a)) {
+                unset($a[$k]);
+                ++$stub->cut;
+            }
+        }
 
         return $a;
     }
 
     public static function castPersistentCollection(PersistentCollection $coll, array $a, Stub $stub, $isNested)
     {
-        $prefix = "\0Doctrine\\ORM\\PersistentCollection\0";
-
-        $a[$prefix.'snapshot'] = new CutStub($a[$prefix.'snapshot']);
-        $a[$prefix.'association'] = new CutStub($a[$prefix.'association']);
-        $a[$prefix.'typeClass'] = new CutStub($a[$prefix.'typeClass']);
+        foreach (array('snapshot', 'association', 'typeClass') as $k) {
+            if (array_key_exists($k = "\0Doctrine\\ORM\\PersistentCollection\0".$k, $a)) {
+                $a[$k] = new CutStub($a[$k]);
+            }
+        }
 
         return $a;
     }

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -40,27 +40,14 @@ class ExceptionCaster
         E_STRICT => 'E_STRICT',
     );
 
+    public static function castError(\Error $e, array $a, Stub $stub, $isNested)
+    {
+        return $e instanceof \Exception ? $a : self::filterExceptionArray($a, "\0Error\0");
+    }
+
     public static function castException(\Exception $e, array $a, Stub $stub, $isNested)
     {
-        $xPrefix = PHP_VERSION_ID >= 70000 ? "\0BaseException\0" : "\0Exception\0";
-        if (isset($a[$xPrefix.'trace'])) {
-            $trace = $a[$xPrefix.'trace'];
-            unset($a[$xPrefix.'trace']); // Ensures the trace is always last
-        } else {
-            $trace = array();
-        }
-
-        static::filterTrace($trace, static::$traceArgs);
-
-        if (null !== $trace) {
-            $a[$xPrefix.'trace'] = $trace;
-        }
-        if (empty($a[$xPrefix.'previous'])) {
-            unset($a[$xPrefix.'previous']);
-        }
-        unset($a[$xPrefix.'string'], $a["\0+\0xdebug_message"], $a["\0+\0__destructorException"]);
-
-        return $a;
+        return self::filterExceptionArray($a, "\0Exception\0");
     }
 
     public static function castErrorException(\ErrorException $e, array $a, Stub $stub, $isNested)
@@ -75,7 +62,7 @@ class ExceptionCaster
     public static function castThrowingCasterException(ThrowingCasterException $e, array $a, Stub $stub, $isNested)
     {
         $prefix = "\0*\0";
-        $xPrefix = PHP_VERSION_ID >= 70000 ? "\0BaseException\0" : "\0Exception\0";
+        $xPrefix = "\0Exception\0";
 
         if (isset($a[$xPrefix.'previous'], $a[$xPrefix.'trace'][0])) {
             $b = (array) $a[$xPrefix.'previous'];
@@ -122,5 +109,27 @@ class ExceptionCaster
                 unset($t['args']);
             }
         }
+    }
+
+    private static function filterExceptionArray(array $a, $xPrefix)
+    {
+        if (isset($a[$xPrefix.'trace'])) {
+            $trace = $a[$xPrefix.'trace'];
+            unset($a[$xPrefix.'trace']); // Ensures the trace is always last
+        } else {
+            $trace = array();
+        }
+
+        static::filterTrace($trace, static::$traceArgs);
+
+        if (null !== $trace) {
+            $a[$xPrefix.'trace'] = $trace;
+        }
+        if (empty($a[$xPrefix.'previous'])) {
+            unset($a[$xPrefix.'previous']);
+        }
+        unset($a[$xPrefix.'string'], $a["\0+\0xdebug_message"], $a["\0+\0__destructorException"]);
+
+        return $a;
     }
 }

--- a/src/Symfony/Component/VarDumper/Caster/PdoCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/PdoCaster.php
@@ -78,21 +78,21 @@ class PdoCaster
             }
         }
 
-        $m = "\0~\0";
+        $prefix = "\0~\0";
         $a += array(
-            $m.'inTransaction' => method_exists($c, 'inTransaction'),
-            $m.'errorInfo' => $c->errorInfo(),
-            $m.'attributes' => $attr,
+            $prefix.'inTransaction' => method_exists($c, 'inTransaction'),
+            $prefix.'errorInfo' => $c->errorInfo(),
+            $prefix.'attributes' => $attr,
         );
 
-        if ($a[$m.'inTransaction']) {
-            $a[$m.'inTransaction'] = $c->inTransaction();
+        if ($a[$prefix.'inTransaction']) {
+            $a[$prefix.'inTransaction'] = $c->inTransaction();
         } else {
-            unset($a[$m.'inTransaction']);
+            unset($a[$prefix.'inTransaction']);
         }
 
-        if (!isset($a[$m.'errorInfo'][1], $a[$m.'errorInfo'][2])) {
-            unset($a[$m.'errorInfo']);
+        if (!isset($a[$prefix.'errorInfo'][1], $a[$prefix.'errorInfo'][2])) {
+            unset($a[$prefix.'errorInfo']);
         }
 
         $c->setAttribute(\PDO::ATTR_ERRMODE, $errmode);
@@ -102,11 +102,11 @@ class PdoCaster
 
     public static function castPdoStatement(\PDOStatement $c, array $a, Stub $stub, $isNested)
     {
-        $m = "\0~\0";
-        $a[$m.'errorInfo'] = $c->errorInfo();
+        $prefix = "\0~\0";
+        $a[$prefix.'errorInfo'] = $c->errorInfo();
 
-        if (!isset($a[$m.'errorInfo'][1], $a[$m.'errorInfo'][2])) {
-            unset($a[$m.'errorInfo']);
+        if (!isset($a[$prefix.'errorInfo'][1], $a[$prefix.'errorInfo'][2])) {
+            unset($a[$prefix.'errorInfo']);
         }
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -22,14 +22,15 @@ class SplCaster
 {
     public static function castArrayObject(\ArrayObject $c, array $a, Stub $stub, $isNested)
     {
+        $prefix = "\0~\0";
         $class = $stub->class;
         $flags = $c->getFlags();
 
         $b = array(
-            "\0~\0flag::STD_PROP_LIST" => (bool) ($flags & \ArrayObject::STD_PROP_LIST),
-            "\0~\0flag::ARRAY_AS_PROPS" => (bool) ($flags & \ArrayObject::ARRAY_AS_PROPS),
-            "\0~\0iteratorClass" => $c->getIteratorClass(),
-            "\0~\0storage" => $c->getArrayCopy(),
+            $prefix.'flag::STD_PROP_LIST' => (bool) ($flags & \ArrayObject::STD_PROP_LIST),
+            $prefix.'flag::ARRAY_AS_PROPS' => (bool) ($flags & \ArrayObject::ARRAY_AS_PROPS),
+            $prefix.'iteratorClass' => $c->getIteratorClass(),
+            $prefix.'storage' => $c->getArrayCopy(),
         );
 
         if ($class === 'ArrayObject') {
@@ -68,12 +69,13 @@ class SplCaster
 
     public static function castDoublyLinkedList(\SplDoublyLinkedList $c, array $a, Stub $stub, $isNested)
     {
+        $prefix = "\0~\0";
         $mode = $c->getIteratorMode();
         $c->setIteratorMode(\SplDoublyLinkedList::IT_MODE_KEEP | $mode & ~\SplDoublyLinkedList::IT_MODE_DELETE);
 
         $a += array(
-            "\0~\0mode" => new ConstStub((($mode & \SplDoublyLinkedList::IT_MODE_LIFO) ? 'IT_MODE_LIFO' : 'IT_MODE_FIFO').' | '.(($mode & \SplDoublyLinkedList::IT_MODE_KEEP) ? 'IT_MODE_KEEP' : 'IT_MODE_DELETE'), $mode),
-            "\0~\0dllist" => iterator_to_array($c),
+            $prefix.'mode' => new ConstStub((($mode & \SplDoublyLinkedList::IT_MODE_LIFO) ? 'IT_MODE_LIFO' : 'IT_MODE_FIFO').' | '.(($mode & \SplDoublyLinkedList::IT_MODE_KEEP) ? 'IT_MODE_KEEP' : 'IT_MODE_DELETE'), $mode),
+            $prefix.'dllist' => iterator_to_array($c),
         );
         $c->setIteratorMode($mode);
 

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -57,6 +57,7 @@ abstract class AbstractCloner implements ClonerInterface
 
         'ErrorException' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castErrorException',
         'Exception' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castException',
+        'Error' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castError',
         'Symfony\Component\DependencyInjection\ContainerInterface' => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
         'Symfony\Component\VarDumper\Exception\ThrowingCasterException' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castThrowingCasterException',
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

PHP7 may introduce the Throwable interface if the corresponding RFC is accepted (see https://wiki.php.net/rfc/throwable-interface)
This PR adds support for it. We should wait for final approval of the RFC before merging it.
