### PR TITLE
[bugfix][MonologBridge] WebProcessor: passing $extraFields to BaseWebProcessor

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
@@ -22,10 +22,13 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class WebProcessor extends BaseWebProcessor
 {
-    public function __construct()
+    /**
+     * @param array|null $extraFields
+     */
+    public function __construct(array $extraFields = null)
     {
         // Pass an empty array as the default null value would access $_SERVER
-        parent::__construct(array());
+        parent::__construct(array(), $extraFields);
     }
 
     public function onKernelRequest(GetResponseEvent $event)

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -26,10 +26,24 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
         $processor->onKernelRequest($event);
         $record = $processor($this->getRecord());
 
+        $this->assertCount(5, $record['extra']);
         $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
         $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
         $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
         $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
+        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
+    }
+
+    public function testCanBeConstructedWithExtraFields()
+    {
+        list($event, $server) = $this->createRequestEvent();
+
+        $processor = new WebProcessor(array('url', 'referrer'));
+        $processor->onKernelRequest($event);
+        $record = $processor($this->getRecord());
+
+        $this->assertCount(2, $record['extra']);
+        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
         $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
     }
 

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -20,6 +20,24 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
 {
     public function testUsesRequestServerData()
     {
+        list($event, $server) = $this->createRequestEvent();
+
+        $processor = new WebProcessor();
+        $processor->onKernelRequest($event);
+        $record = $processor($this->getRecord());
+
+        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
+        $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
+        $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
+        $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
+        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
+    }
+
+    /**
+     * @return array
+     */
+    protected function createRequestEvent()
+    {
         $server = array(
             'REQUEST_URI' => 'A',
             'REMOTE_ADDR' => 'B',
@@ -41,15 +59,7 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
             ->method('getRequest')
             ->will($this->returnValue($request));
 
-        $processor = new WebProcessor();
-        $processor->onKernelRequest($event);
-        $record = $processor($this->getRecord());
-
-        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
-        $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
-        $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
-        $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
-        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
+        return array($event, $server);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14962 |
| License | MIT |
| Doc PR | ~ |
