### PR TITLE
[bugfix][MonologBridge] WebProcessor: passing $extraFields to BaseWebProcessor

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
@@ -22,9 +22,6 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class WebProcessor extends BaseWebProcessor
 {
-    /**
-     * @param array|null $extraFields
-     */
     public function __construct(array $extraFields = null)
     {
         // Pass an empty array as the default null value would access $_SERVER

--- a/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
@@ -22,10 +22,13 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class WebProcessor extends BaseWebProcessor
 {
-    public function __construct()
+    /**
+     * @param array|null $extraFields
+     */
+    public function __construct(array $extraFields = null)
     {
         // Pass an empty array as the default null value would access $_SERVER
-        parent::__construct(array());
+        parent::__construct(array(), $extraFields);
     }
 
     public function onKernelRequest(GetResponseEvent $event)

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -26,10 +26,24 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
         $processor->onKernelRequest($event);
         $record = $processor($this->getRecord());
 
+        $this->assertCount(5, $record['extra']);
         $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
         $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
         $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
         $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
+        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
+    }
+
+    public function testCanBeConstructedWithExtraFields()
+    {
+        list($event, $server) = $this->createRequestEvent();
+
+        $processor = new WebProcessor(array('url', 'referrer'));
+        $processor->onKernelRequest($event);
+        $record = $processor($this->getRecord());
+
+        $this->assertCount(2, $record['extra']);
+        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
         $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
     }
 

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -50,7 +50,7 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    protected function createRequestEvent()
+    private function createRequestEvent()
     {
         $server = array(
             'REQUEST_URI' => 'A',
@@ -82,7 +82,7 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
      *
      * @return array Record
      */
-    protected function getRecord($level = Logger::WARNING, $message = 'test')
+    private function getRecord($level = Logger::WARNING, $message = 'test')
     {
         return array(
             'message' => $message,

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -36,6 +36,10 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testCanBeConstructedWithExtraFields()
     {
+        if (!$this->isExtraFieldsSupported()) {
+            $this->markTestSkipped('WebProcessor of the installed Monolog version does not support $extraFields parameter');
+        }
+
         list($event, $server) = $this->createRequestEvent();
 
         $processor = new WebProcessor(array('url', 'referrer'));
@@ -93,5 +97,18 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
             'datetime' => new \DateTime(),
             'extra' => array(),
         );
+    }
+
+    private function isExtraFieldsSupported()
+    {
+        $monologWebProcessorClass = new \ReflectionClass('Monolog\Processor\WebProcessor');
+
+        foreach ($monologWebProcessorClass->getConstructor()->getParameters() as $parameter) {
+            if ('extraFields' === $parameter->getName()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -20,6 +20,24 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
 {
     public function testUsesRequestServerData()
     {
+        list($event, $server) = $this->createRequestEvent();
+
+        $processor = new WebProcessor();
+        $processor->onKernelRequest($event);
+        $record = $processor($this->getRecord());
+
+        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
+        $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
+        $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
+        $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
+        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
+    }
+
+    /**
+     * @return array
+     */
+    protected function createRequestEvent()
+    {
         $server = array(
             'REQUEST_URI' => 'A',
             'REMOTE_ADDR' => 'B',
@@ -41,15 +59,7 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
             ->method('getRequest')
             ->will($this->returnValue($request));
 
-        $processor = new WebProcessor();
-        $processor->onKernelRequest($event);
-        $record = $processor($this->getRecord());
-
-        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
-        $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
-        $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
-        $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
-        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
+        return array($event, $server);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #14962 |
| License | MIT |
| Doc PR | ~ |
