### PR TITLE
[Config] Remove duplicated paths

### DIFF
--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -53,6 +53,7 @@ class FileLocator implements FileLocatorInterface
             array_unshift($paths, $currentPath);
         }
 
+        $paths = array_unique($paths);
         $filepaths = array();
 
         foreach ($paths as $path) {
@@ -68,7 +69,7 @@ class FileLocator implements FileLocatorInterface
             throw new \InvalidArgumentException(sprintf('The file "%s" does not exist (in: %s).', $name, implode(', ', $paths)));
         }
 
-        return array_values(array_unique($filepaths));
+        return $filepaths;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

If someone sets the same path twice, the file locator will search for the the same file twice. We should remove duplicated paths before locate a file.
