### PR TITLE
[Config] Remove extra argument from method call

### DIFF
--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -108,7 +108,7 @@ class ConfigCache implements ConfigCacheInterface
         $mode = 0666;
         $umask = umask();
         $filesystem = new Filesystem();
-        $filesystem->dumpFile($this->file, $content, null);
+        $filesystem->dumpFile($this->file, $content);
         try {
             $filesystem->chmod($this->file, $mode, $umask);
         } catch (IOException $e) {
@@ -116,7 +116,7 @@ class ConfigCache implements ConfigCacheInterface
         }
 
         if (null !== $metadata && true === $this->debug) {
-            $filesystem->dumpFile($this->getMetaFile(), serialize($metadata), null);
+            $filesystem->dumpFile($this->getMetaFile(), serialize($metadata));
             try {
                 $filesystem->chmod($this->getMetaFile(), $mode, $umask);
             } catch (IOException $e) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

The `$mode` argument of `Filesystem::dumpFile()` is removed in 3.0.
