### PR TITLE
[DEBUG] Update ErrorHandler to also process Fatal-Errors on HHVM

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -151,7 +151,6 @@ class FrameworkExtension extends Extension
             $container->setAlias('event_dispatcher', 'debug.event_dispatcher');
         } else {
             $levels = E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR;
-
             if (defined('FATAL_ERROR')) {
                 $levels |= FATAL_ERROR;
             }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -150,7 +150,12 @@ class FrameworkExtension extends Extension
             $container->setDefinition('debug.event_dispatcher.parent', $definition);
             $container->setAlias('event_dispatcher', 'debug.event_dispatcher');
         } else {
-            $definition->replaceArgument(2, E_COMPILE_ERROR | E_PARSE | E_ERROR | E_CORE_ERROR);
+            $levels = E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR;
+
+            if (defined('FATAL_ERROR')) {
+                $levels |= FATAL_ERROR;
+            }
+            $definition->replaceArgument(2, $levels);
         }
 
         $this->addClassesToCompile(array(

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -151,7 +151,7 @@ class FrameworkExtension extends Extension
             $container->setAlias('event_dispatcher', 'debug.event_dispatcher');
         } else {
             $levels = E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR;
-            if (defined('FATAL_ERROR')) {
+            if (defined('HHVM_VERSION')) {
                 $levels |= FATAL_ERROR;
             }
             $definition->replaceArgument(2, $levels);

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -109,6 +109,21 @@ class ErrorHandler
     private $displayErrors = 0x1FFF;
 
     /**
+     * wether we should also listen to FATAL_ERROR levels (hhvm only).
+     *
+     * @var bool
+     */
+    private static $fatalErrors = false;
+
+    public function __construct()
+    {
+        if (defined('FATAL_ERROR')) {
+            $this->loggers[FATAL_ERROR] = array(null, LogLevel::CRITICAL);
+            self::$fatalErrors = true;
+        }
+    }
+
+    /**
      * Registers the error handler.
      *
      * @param self|null|int $handler The handler to register, or @deprecated (since version 2.6, to be removed in 3.0) bit field of thrown levels
@@ -160,10 +175,6 @@ class ErrorHandler
      */
     public function setDefaultLogger(LoggerInterface $logger, $levels = null, $replace = false)
     {
-        if (defined('FATAL_ERROR')) {
-            $this->loggers[FATAL_ERROR] = array(null, LogLevel::CRITICAL);
-        }
-
         $loggers = array();
 
         if (is_array($levels)) {
@@ -531,7 +542,7 @@ class ErrorHandler
 
         $levels = E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR;
 
-        if (defined('FATAL_ERROR')) {
+        if (self::$fatalErrors) {
             $levels |= FATAL_ERROR;
         }
 
@@ -570,7 +581,7 @@ class ErrorHandler
     {
         $levels = E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR;
 
-        if (defined('FATAL_ERROR')) {
+        if (self::$fatalErrors) {
             $levels |= FATAL_ERROR;
         }
 
@@ -588,7 +599,7 @@ class ErrorHandler
             $e = error_reporting($level);
             $levels = E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR;
 
-            if (defined('FATAL_ERROR')) {
+            if (self::$fatalErrors) {
                 $levels |= FATAL_ERROR;
             }
 

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -689,6 +689,7 @@ class ErrorHandler
             if (defined('FATAL_ERROR')) {
                 $levels = $levels | FATAL_ERROR;
             }
+
             $handler->setDefaultLogger($logger, $levels, true);
             $handler->screamAt($levels);
         }

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -156,7 +156,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                 E_CORE_ERROR => array(null, LogLevel::CRITICAL),
             );
 
-            if (defined('FATAL_ERROR')) {
+            if (defined('HHVM_VERSION')) {
                 $loggers[FATAL_ERROR] = array(null, LogLevel::CRITICAL);
             }
             $this->assertSame($loggers, $handler->setLoggers(array()));
@@ -365,7 +365,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleFatalErrorOnHHVM()
     {
-        if (!defined('FATAL_ERROR')) {
+        if (!defined('HHVM_VERSION')) {
             $this->markTestSkipped('Should be executed in HHVM context.');
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | no] |
| Tests pass? | [yes] |
| Fixed tickets | [?] |
| License | MIT |
| Doc PR | [-] |

HHVM handles Fatal-Errors a bit different.

this PR allows to catch those Errors as well. Inspiration from https://github.com/laravel/framework/issues/8744
