### PR TITLE
[2.8] Move argument resolving from ControllerResolver

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -153,6 +153,10 @@ class FrameworkExtension extends Extension
             $definition->replaceArgument(2, E_COMPILE_ERROR | E_PARSE | E_ERROR | E_CORE_ERROR);
         }
 
+        if (interface_exists('Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface')) {
+            $loader->load('psr-http-message.xml');
+        }
+
         $this->addClassesToCompile(array(
             'Symfony\\Component\\Config\\FileLocator',
 

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -36,6 +36,7 @@ use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\DependencyInjection\RegisterArgumentResolversPass;
 
 /**
  * Bundle.
@@ -88,6 +89,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new TranslationDumperPass());
         $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new SerializerPass());
+        $container->addCompilerPass(new RegisterArgumentResolversPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/psr-http-message.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/psr-http-message.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="argument_resolver.psr_message" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\PsrServerRequestArgumentResolver">
+            <tag name="kernel.argument_resolver" />
+        </service>
+
+    </services>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -25,6 +25,7 @@
             <argument type="service" id="service_container" />
             <argument type="service" id="controller_resolver" />
             <argument type="service" id="request_stack" />
+            <argument type="service" id="argument_resolver.manager" />
             <argument>false</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -25,6 +25,16 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
+        <service id="argument_resolver.manager" class="Symfony\Component\HttpKernel\Controller\ArgumentResolverManager" />
+
+        <service id="argument_resolver.request" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestArgumentResolver">
+            <tag name="kernel.argument_resolver" />
+        </service>
+
+        <service id="argument_resolver.request_attributes" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributesArgumentResolver">
+            <tag name="kernel.argument_resolver" />
+        </service>
+
         <service id="response_listener" class="%response_listener.class%">
             <tag name="kernel.event_subscriber" />
             <argument>%kernel.charset%</argument>

--- a/src/Symfony/Bundle/SecurityBundle/ArgumentResolver/UserArgumentResolver.php
+++ b/src/Symfony/Bundle/SecurityBundle/ArgumentResolver/UserArgumentResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class UserArgumentResolver implements ArgumentResolverInterface
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, \ReflectionParameter $parameter)
+    {
+        $class = $parameter->getClass();
+        $userInterface = 'Symfony\Component\Security\Core\User\UserInterface';
+
+        return null !== $class && ($userInterface === $class || $class->implementsInterface($userInterface));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter)
+    {
+        if (null === $token = $this->tokenStorage->getToken()) {
+            return;
+        }
+
+        if (!is_object($user = $token->getUser())) {
+            // e.g. anonymous authentication
+            return;
+        }
+
+        return $user;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/ArgumentResolver/UserArgumentResolver.php
+++ b/src/Symfony/Bundle/SecurityBundle/ArgumentResolver/UserArgumentResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bundle\SecurityBundle\ArgumentResolver;
 
 use Symfony\Component\HttpFoundation\Request;
@@ -7,6 +16,8 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInt
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
+ * Resolves a typehint for UserInterface in a controller to the current user.
+ *
  * @author Wouter J <wouter@wouterj.nl>
  */
 class UserArgumentResolver implements ArgumentResolverInterface
@@ -28,8 +39,9 @@ class UserArgumentResolver implements ArgumentResolverInterface
     {
         $class = $parameter->getClass();
         $userInterface = 'Symfony\Component\Security\Core\User\UserInterface';
+        $userImplementation = 'Symfony\Component\Security\Core\User\User';
 
-        return null !== $class && ($userInterface === $class || $class->implementsInterface($userInterface));
+        return null !== $class && ($userInterface === $class->getName() || $userImplementation === $class->getName());
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -50,6 +50,11 @@
     </parameters>
 
     <services>
+
+        <service id="security.argument_resolver.user" class="Symfony\Bundle\SecurityBundle\ArgumentResolver\UserArgumentResolver">
+            <tag name="kernel.argument_resolver" />
+        </service>
+
         <service id="security.context" class="%security.context.class%">
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authorization_checker" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -51,7 +51,7 @@
 
     <services>
 
-        <service id="security.argument_resolver.user" class="Symfony\Bundle\SecurityBundle\ArgumentResolver\UserArgumentResolver">
+        <service id="security.argument_resolver.user"Controller class="Symfony\Bundle\SecurityBundle\ArgumentResolver\UserArgumentResolver">
             <tag name="kernel.argument_resolver" />
         </service>
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -51,7 +51,8 @@
 
     <services>
 
-        <service id="security.argument_resolver.user"Controller class="Symfony\Bundle\SecurityBundle\ArgumentResolver\UserArgumentResolver">
+        <service id="security.argument_resolver.user" class="Symfony\Bundle\SecurityBundle\ArgumentResolver\UserArgumentResolver">
+            <argument type="service" id="security.token_storage" />
             <tag name="kernel.argument_resolver" />
         </service>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/ArgumentResolver/UserArgumentResolverTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/ArgumentResolver/UserArgumentResolverTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\ArgumentResolver;
+
+use Symfony\Bundle\SecurityBundle\ArgumentResolver\UserArgumentResolver;
+use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class UserArgumentResolverTest extends \PHPUnit_Framework_TestCase
+{
+    private $resolver;
+    private $tokenStorage;
+
+    protected function setUp()
+    {
+        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $this->resolver = new UserArgumentResolver($this->tokenStorage);
+    }
+
+    /**
+     * @dataProvider provideClasses
+     */
+    public function testSupports($class, $supported = true)
+    {
+        $this->assertEquals($supported, $this->resolver->supports($this->getRequestMock(), $this->getReflectionParameterMock($class)));
+    }
+
+    public function provideClasses()
+    {
+        return array(
+            array('Symfony\Component\Security\Core\User\UserInterface'),
+            array('Symfony\Component\Security\Core\User\User'),
+            array('Symfony\Bundle\SecurityBundle\Tests\ArgumentResolver\UserFixture', false),
+            array('\stdClass', false),
+        );
+    }
+
+    public function testResolvesToNullWhenNoUserIsAvailable()
+    {
+        $this->tokenStorage->expects($this->any())->method('getToken')->willReturn(null);
+
+        $this->assertNull($this->resolver->resolve($this->getRequestMock(), $this->getReflectionParameterMock()));
+    }
+
+    public function testResolvesToNullWhenUserIsAnonymous()
+    {
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token->expects($this->any())->method('getUser')->willReturn('anon.');
+
+        $this->tokenStorage->expects($this->any())->method('getToken')->willReturn($token);
+
+        $this->assertNull($this->resolver->resolve($this->getRequestMock(), $this->getReflectionParameterMock()));
+    }
+
+    public function testResolvesToUser()
+    {
+        $user = $this->getMock('Symfony\component\Security\Core\User\User');
+
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token->expects($this->any())->method('getUser')->willReturn($user);
+
+        $this->tokenStorage->expects($this->any())->method('getToken')->willReturn($token);
+
+        $this->assertEquals($user, $this->resolver->resolve($this->getRequestMock(), $this->getReflectionParameterMock()));
+    }
+
+    private function getRequestMock()
+    {
+        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+    }
+
+    private function getReflectionParameterMock($class = null)
+    {
+        $reflectionParameter = $this->getMockBuilder('\ReflectionParameter')->disableOriginalConstructor()->getMock();
+
+        if (null !== $class) {
+            $reflectionClass = $this->getMockBuilder('\ReflectionClass')->disableOriginalConstructor()->getMock();
+            $reflectionClass->expects($this->any())->method('getName')->willReturn($class);
+            $reflectionParameter->expects($this->any())->method('getClass')->willReturn($reflectionClass);
+        }
+
+        return $reflectionParameter;
+    }
+}
+
+class UserFixture implements UserInterface
+{
+    public function getRoles() {}
+    public function getPassword() {}
+    public function getSalt() {}
+    public function getUsername() {}
+    public function eraseCredentials() {}
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * added argument resolvers
+ * deprecated `Symfony\Component\HttpKernel\Controller\ControllerResolver::getArguments()` and `doGetArguments()` in favor of argument resolvers
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ArgumentResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ArgumentResolverInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * An ArgumentResolverInterface implementation resolves the arguments of
+ * controllers.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+interface ArgumentResolverInterface
+{
+    /**
+     * Checks if the current pameter can be esolved by this argument
+     * resolver.
+     *
+     * @param Request              $request
+     * @param \ReflectionParameter $parameter
+     *
+     * @return bool
+     */
+    public function supports(Request $request, \ReflectionParameter $parameter);
+
+    /**
+     * Resolves the current parameter into an argument.
+     *
+     * @param Request              $request
+     * @param \ReflectionParameter $parameter
+     *
+     * @return mixed The resolved argument
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter);
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/PsrServerRequestArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/PsrServerRequestArgumentResolver.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Converts HttpFoundation Request to PSR-7 ServerRequest using the bridge.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class PsrServerRequestArgumentResolver implements ArgumentResolverInterface
+{
+    /**
+     * @var array
+     */
+    private static $supportedTypes = array(
+        'Psr\Http\Message\ServerRequestInterface' => true,
+        'Psr\Http\Message\RequestInterface' => true,
+        'Psr\Http\Message\MessageInterface' => true,
+    );
+
+    /**
+     * @var HttpMessageFactoryInterface
+     */
+    private $httpMessageFactory;
+
+    public function __construct(HttpMessageFactoryInterface $httpMessageFactory)
+    {
+        $this->httpMessageFactory = $httpMessageFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, \ReflectionParameter $parameter)
+    {
+        $class = $parameter->getClass();
+
+        return null !== $class && isset(self::$supportedTypes[$class->name]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter)
+    {
+        return $this->httpMessageFactory->createRequest($request);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/PsrServerRequestArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/PsrServerRequestArgumentResolver.php
@@ -39,7 +39,7 @@ class PsrServerRequestArgumentResolver implements ArgumentResolverInterface
     {
         $class = $parameter->getClass();
 
-        return null !== $class && isset(self::$supportedTypes[$class->name]);
+        return null !== $class && isset(self::$supportedTypes[$class->getName()]);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestArgumentResolver.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Resolves arguments typehinting for the HttpFoundation Request object.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RequestArgumentResolver implements ArgumentResolverInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, \ReflectionParameter $parameter)
+    {
+        $class = $parameter->getClass();
+
+        return $class && $class->isInstance($request);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter)
+    {
+        return $request;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Resolves arguments which names are equal to the name of a request attribute.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RequestAttributesArgumentResolver implements ArgumentResolverInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, \ReflectionParameter $parameter)
+    {
+        return $request->attributes->has($parameter->name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter)
+    {
+        return $request->attributes->get($parameter->name);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributesArgumentResolver.php
@@ -25,7 +25,7 @@ class RequestAttributesArgumentResolver implements ArgumentResolverInterface
      */
     public function supports(Request $request, \ReflectionParameter $parameter)
     {
-        return $request->attributes->has($parameter->name);
+        return $request->attributes->has($parameter->getName());
     }
 
     /**
@@ -33,6 +33,6 @@ class RequestAttributesArgumentResolver implements ArgumentResolverInterface
      */
     public function resolve(Request $request, \ReflectionParameter $parameter)
     {
-        return $request->attributes->get($parameter->name);
+        return $request->attributes->get($parameter->getName());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverManager.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverManager.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface;
+
+/**
+ * The ArgumentResolverManager chains over the registered argument resolvers to
+ * resolve all controller arguments.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class ArgumentResolverManager
+{
+    /**
+     * @var ArgumentResolverInterface[]
+     */
+    private $resolvers = array();
+
+    /**
+     * Adds an argument resolver.
+     *
+     * @param ArgumentResolverInterface $resolver
+     */
+    public function add(ArgumentResolverInterface $resolver)
+    {
+        $this->resolvers[] = $resolver;
+    }
+
+    public function getArguments(Request $request, $controller)
+    {
+        if (!is_callable($controller)) {
+            throw new \InvalidArgumentException(sprintf('Expected a callable as second parameter, got "%s".', is_object($controller) ? get_class($controller) : gettype($controller)));
+        }
+
+        if (is_array($controller)) {
+            $controllerReflection = new \ReflectionMethod($controller[0], $controller[1]);
+        } elseif (is_object($controller) && !$controller instanceof \Closure) {
+            $controllerReflection = new \ReflectionObject($controller);
+            $controllerReflection = $controllerReflection->getMethod('__invoke');
+        } else {
+            $controllerReflection = new \ReflectionFunction($controller);
+        }
+
+        $parameters = $controllerReflection->getParameters();
+        $arguments = array();
+
+        foreach ($parameters as $parameter) {
+            foreach ($this->resolvers as $argumentResolver) {
+                if ($argumentResolver->supports($request, $parameter)) {
+                    $arguments[] = $argumentResolver->resolve($request, $parameter);
+                    continue 2;
+                }
+            }
+
+            if ($parameter->isDefaultValueAvailable()) {
+                $arguments[] = $parameter->getDefaultValue();
+            } else {
+                if (is_array($controller)) {
+                    $repr = sprintf('%s::%s()', get_class($controller[0]), $controller[1]);
+                } elseif (is_object($controller)) {
+                    $repr = get_class($controller);
+                } else {
+                    $repr = $controller;
+                }
+
+                throw new \RuntimeException(sprintf('Controller "%s" requires that you provide a value for the "$%s" argument (because there is no default value and none of the argument resolvers could resolve its value).', $repr, $parameter->name));
+            }
+        }
+
+        return $arguments;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverManager.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverManager.php
@@ -25,7 +25,15 @@ class ArgumentResolverManager
     /**
      * @var ArgumentResolverInterface[]
      */
-    private $resolvers = array();
+    private $resolvers;
+
+    /**
+     * @param ArgumentResolverInterface[] $resolvers
+     */
+    public function __construct(array $resolvers = array())
+    {
+        $this->resolvers = $resolvers;
+    }
 
     /**
      * Adds an argument resolver.

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -172,9 +172,10 @@ class ControllerResolver implements ControllerResolverInterface
     private function getArgumentResolverManager()
     {
         if (null === $this->argumentResolverManager) {
-            $this->argumentResolverManager = new ArgumentResolverManager();
-            $this->argumentResolverManager->add(new RequestArgumentResolver());
-            $this->argumentResolverManager->add(new RequestAttributesArgumentResolver());
+            $this->argumentResolverManager = new ArgumentResolverManager(array(
+                new RequestArgumentResolver(),
+                new RequestAttributesArgumentResolver(),
+            ));
         }
 
         return $this->argumentResolverManager;

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -33,7 +33,6 @@ class ControllerResolver implements ControllerResolverInterface
 
     /**
      * @var ArgumentResolverManager
-     * @internal
      */
     private $argumentResolverManager;
 
@@ -120,7 +119,7 @@ class ControllerResolver implements ControllerResolverInterface
 
         $reflector = new \ReflectionMethod($this, 'doGetArguments');
         if ($reflector->getDeclaringClass()->getName() !== __CLASS__) {
-            trigger_error('The ControllerResolverInterface::doGetArguments() method is deprecated since version 2.7 and will be removed in 3.0. Use the ArgumentResolverManager and custom ArgumentResolverInterface implementations instead.', E_USER_DEPRECATED);
+            @trigger_error('The ControllerResolverInterface::doGetArguments() method is deprecated since version 2.8 and will be removed in 3.0. Use the ArgumentResolverManager and custom ArgumentResolverInterface implementations instead.', E_USER_DEPRECATED);
         }
 
         return $this->doGetArguments($request, $controller, $r->getParameters());
@@ -173,9 +172,10 @@ class ControllerResolver implements ControllerResolverInterface
     private function getArgumentResolverManager()
     {
         if (null === $this->argumentResolverManager) {
-            $this->argumentResolverManager = new ArgumentResolverManager();
-            $this->argumentResolverManager->add(new RequestArgumentResolver());
-            $this->argumentResolverManager->add(new RequestAttributesArgumentResolver());
+            $this->argumentResolverManager = new ArgumentResolverManager(array(
+                new RequestArgumentResolver(),
+                new RequestAttributesArgumentResolver(),
+            ));
         }
 
         return $this->argumentResolverManager;

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -158,7 +158,7 @@ class ControllerResolver implements ControllerResolverInterface
     }
 
     /**
-     * Returns an instantiated controller
+     * Returns an instantiated controller.
      *
      * @param string $class A class name
      *

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -172,10 +172,9 @@ class ControllerResolver implements ControllerResolverInterface
     private function getArgumentResolverManager()
     {
         if (null === $this->argumentResolverManager) {
-            $this->argumentResolverManager = new ArgumentResolverManager(array(
-                new RequestArgumentResolver(),
-                new RequestAttributesArgumentResolver(),
-            ));
+            $this->argumentResolverManager = new ArgumentResolverManager();
+            $this->argumentResolverManager->add(new RequestArgumentResolver());
+            $this->argumentResolverManager->add(new RequestAttributesArgumentResolver());
         }
 
         return $this->argumentResolverManager;

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
@@ -57,6 +57,8 @@ interface ControllerResolverInterface
      *
      * @throws \RuntimeException When value for argument given is not provided
      *
+     * @deprecated As of Symfony 2.8, to be removed in Symfony 3.0. Use the ArgumentResolverManager instead.
+     *
      * @api
      */
     public function getArguments(Request $request, $controller);

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\DependencyInjection;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverManager;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
@@ -35,15 +36,16 @@ class ContainerAwareHttpKernel extends HttpKernel
     /**
      * Constructor.
      *
-     * @param EventDispatcherInterface    $dispatcher         An EventDispatcherInterface instance
-     * @param ContainerInterface          $container          A ContainerInterface instance
-     * @param ControllerResolverInterface $controllerResolver A ControllerResolverInterface instance
-     * @param RequestStack                $requestStack       A stack for master/sub requests
-     * @param bool                        $triggerDeprecation Whether or not to trigger the deprecation warning for the ContainerAwareHttpKernel
+     * @param EventDispatcherInterface    $dispatcher              An EventDispatcherInterface instance
+     * @param ContainerInterface          $container               A ContainerInterface instance
+     * @param ControllerResolverInterface $controllerResolver      A ControllerResolverInterface instance
+     * @param RequestStack                $requestStack            A stack for master/sub requests
+     * @param ArgumentResolverManager     $argumentResolverManager A manager to resolve arguments
+     * @param bool                        $triggerDeprecation      Whether or not to trigger the deprecation warning for the ContainerAwareHttpKernel
      */
-    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver, RequestStack $requestStack = null, $triggerDeprecation = true)
+    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver, RequestStack $requestStack = null, ArgumentResolverManager $argumentResolverManager = null, $triggerDeprecation = true)
     {
-        parent::__construct($dispatcher, $controllerResolver, $requestStack);
+        parent::__construct($dispatcher, $controllerResolver, $requestStack, $argumentResolverManager);
 
         if ($triggerDeprecation) {
             trigger_error('The '.__CLASS__.' class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\HttpKernel class instead.', E_USER_DEPRECATED);

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
@@ -30,9 +30,16 @@ class RegisterArgumentResolversPass implements CompilerPassInterface
         }
 
         $definition = $container->findDefinition($this->managerService);
+        $resolvers = array();
 
-        foreach ($container->findTaggedServiceIds($this->resolverTag) as $id => $resolver) {
-            $definition->addMethodCall('add', array(new Reference($id)));
+        foreach ($container->findTaggedServiceIds($this->resolverTag) as $id => $tags) {
+            $priority = isset($tags[0]['priority']) ? $tags[0]['priority'] : 0;
+            $resolvers[$priority][] = new Reference($id);
         }
+
+        ksort($resolvers);
+        $resolvers = call_user_func_array('array_merge', $resolvers);
+
+        $definition->replaceArgument(1, $resolvers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterArgumentResolversPass.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RegisterArgumentResolversPass implements CompilerPassInterface
+{
+    private $managerService;
+    private $resolverTag;
+
+    public function __construct($managerService = 'argument_resolver.manager', $resolverTag = 'kernel.argument_resolver')
+    {
+        $this->managerService = $managerService;
+        $this->resolverTag = $resolverTag;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition($this->managerService) && !$container->hasAlias($this->managerService)) {
+            return;
+        }
+
+        $definition = $container->findDefinition($this->managerService);
+
+        foreach ($container->findTaggedServiceIds($this->resolverTag) as $id => $resolver) {
+            $definition->addMethodCall('add', array(new Reference($id)));
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -59,10 +59,9 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         $this->requestStack = $requestStack ?: new RequestStack();
 
         if (null === $argumentResolverManager) {
-            $argumentResolverManager = new ArgumentResolverManager(array(
-                new RequestArgumentResolver(),
-                new RequestAttributesArgumentResolver(),
-            ));
+            $argumentResolverManager = new ArgumentResolverManager();
+            $argumentResolverManager->add(new RequestArgumentResolver());
+            $argumentResolverManager->add(new RequestAttributesArgumentResolver());
         }
 
         if (method_exists($resolver, 'setArgumentResolverManager')) {

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -157,7 +157,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
 
         // controller arguments
         $reflector = new \ReflectionMethod($this->resolver, 'getArguments');
-        if ($reflector->getDeclaringClass()->getName() !== 'Symfony\Component\HttpKernel\Controller\ControllerResolver') {
+        if (0 !== strpos($reflector->getDeclaringClass()->getName(), 'Symfony\Component\HttpKernel\Controller\\')) {
             @trigger_error('The ControllerResolverInterface::getArguments() method is deprecated since version 2.8 and will be removed in 3.0. Use the ArgumentResolverManager and custom ArgumentResolverInterface implementations instead.', E_USER_DEPRECATED);
         }
 

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\HttpKernel;
 
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributesArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverManager;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -42,17 +45,28 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     /**
      * Constructor.
      *
-     * @param EventDispatcherInterface    $dispatcher   An EventDispatcherInterface instance
-     * @param ControllerResolverInterface $resolver     A ControllerResolverInterface instance
-     * @param RequestStack                $requestStack A stack for master/sub requests
+     * @param EventDispatcherInterface    $dispatcher              An EventDispatcherInterface instance
+     * @param ControllerResolverInterface $resolver                A ControllerResolverInterface instance
+     * @param RequestStack                $requestStack            A stack for master/sub requests
+     * @param ArgumentResolverManager     $argumentResolverManager A manager to resolve the controller arguments
      *
      * @api
      */
-    public function __construct(EventDispatcherInterface $dispatcher, ControllerResolverInterface $resolver, RequestStack $requestStack = null)
+    public function __construct(EventDispatcherInterface $dispatcher, ControllerResolverInterface $resolver, RequestStack $requestStack = null, ArgumentResolverManager $argumentResolverManager = null)
     {
         $this->dispatcher = $dispatcher;
         $this->resolver = $resolver;
         $this->requestStack = $requestStack ?: new RequestStack();
+
+        if (null === $argumentResolverManager) {
+            $argumentResolverManager = new ArgumentResolverManager();
+            $argumentResolverManager->add(new RequestArgumentResolver());
+            $argumentResolverManager->add(new RequestAttributesArgumentResolver());
+        }
+
+        if (method_exists($resolver, 'setArgumentResolverManager')) {
+            $resolver->setArgumentResolverManager($argumentResolverManager);
+        }
     }
 
     /**
@@ -141,6 +155,11 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         $controller = $event->getController();
 
         // controller arguments
+        $reflector = new \ReflectionMethod($this->resolver, 'getArguments');
+        if ($reflector->getDeclaringClass()->getName() !== 'Symfony\Component\HttpKernel\Controller\ControllerResolver') {
+            trigger_error('['.$reflector->getDeclaringClass()->getName().'] The ControllerResolverInterface::getArguments() method is deprecated since version 2.8 and will be removed in 3.0. Use the ArgumentResolverManager and custom ArgumentResolverInterface implementations instead.', E_USER_DEPRECATED);
+        }
+
         $arguments = $this->resolver->getArguments($request, $controller);
 
         // call controller

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -59,9 +59,10 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         $this->requestStack = $requestStack ?: new RequestStack();
 
         if (null === $argumentResolverManager) {
-            $argumentResolverManager = new ArgumentResolverManager();
-            $argumentResolverManager->add(new RequestArgumentResolver());
-            $argumentResolverManager->add(new RequestAttributesArgumentResolver());
+            $argumentResolverManager = new ArgumentResolverManager(array(
+                new RequestArgumentResolver(),
+                new RequestAttributesArgumentResolver(),
+            ));
         }
 
         if (method_exists($resolver, 'setArgumentResolverManager')) {
@@ -157,7 +158,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         // controller arguments
         $reflector = new \ReflectionMethod($this->resolver, 'getArguments');
         if ($reflector->getDeclaringClass()->getName() !== 'Symfony\Component\HttpKernel\Controller\ControllerResolver') {
-            trigger_error('['.$reflector->getDeclaringClass()->getName().'] The ControllerResolverInterface::getArguments() method is deprecated since version 2.8 and will be removed in 3.0. Use the ArgumentResolverManager and custom ArgumentResolverInterface implementations instead.', E_USER_DEPRECATED);
+            @trigger_error('The ControllerResolverInterface::getArguments() method is deprecated since version 2.8 and will be removed in 3.0. Use the ArgumentResolverManager and custom ArgumentResolverInterface implementations instead.', E_USER_DEPRECATED);
         }
 
         $arguments = $this->resolver->getArguments($request, $controller);

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -59,9 +59,10 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         $this->requestStack = $requestStack ?: new RequestStack();
 
         if (null === $argumentResolverManager) {
-            $argumentResolverManager = new ArgumentResolverManager();
-            $argumentResolverManager->add(new RequestArgumentResolver());
-            $argumentResolverManager->add(new RequestAttributesArgumentResolver());
+            $argumentResolverManager = new ArgumentResolverManager(array(
+                new RequestArgumentResolver(),
+                new RequestAttributesArgumentResolver(),
+            ));
         }
 
         if (method_exists($resolver, 'setArgumentResolverManager')) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/PsrServerRequestArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/PsrServerRequestArgumentResolverTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\PsrServerRequestArgumentResolver;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class PsrServerRequestArgumentResolverTest extends \PHPUnit_Framework_TestCase
+{
+    private $httpMessageFactory;
+    private $resolver;
+
+    protected function setUp()
+    {
+        $this->httpMessageFactory = $this->getMock('Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface', array('createRequest'));
+        $this->resolver = new PsrServerRequestArgumentResolver($this->httpMessageFactory);
+    }
+
+    /**
+     * @dataProvider provideClasses
+     */
+    public function testSupports($class, $supported = true)
+    {
+        $this->assertEquals($supported, $this->resolver->supports($this->getRequestMock(), $this->getReflectionParameterMock($class)));
+    }
+
+    public function provideClasses()
+    {
+        return array(
+            array('Psr\Http\Message\ServerRequestInterface'),
+            array('Psr\Http\Message\RequestInterface'),
+            array('Psr\Http\Message\MessageInterface'),
+            array('\stdClass', false),
+            array('Symfony\Component\HttpFoundation\Request', false),
+        );
+    }
+
+    public function testResolvesUsingHttpMessageFactory()
+    {
+        $request = $this->getRequestMock();
+
+        $this->httpMessageFactory->expects($this->once())->method('createRequest')->with($request);
+
+        $this->resolver->resolve($request, $this->getReflectionParameterMock());
+    }
+
+    private function getRequestMock()
+    {
+        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+    }
+
+    private function getReflectionParameterMock($class = null)
+    {
+        $reflectionParameter = $this->getMockBuilder('ReflectionParameter')->disableOriginalConstructor()->getMock();
+
+        if (null !== $class) {
+            $reflectionClass = $this->getMockBuilder('ReflectionClass')->disableOriginalConstructor()->getMock();
+            $reflectionClass->expects($this->any())->method('getName')->willReturn($class);
+
+            $reflectionParameter->expects($this->any())->method('getClass')->will($this->returnValue($reflectionClass));
+        }
+
+        return $reflectionParameter;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestArgumentResolverTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestArgumentResolver;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RequestArgumentResolverTest extends \PHPUnit_Framework_TestCase
+{
+    private $resolver;
+
+    protected function setUp()
+    {
+        $this->resolver = new RequestArgumentResolver();
+    }
+
+    /**
+     * @dataProvider provideClasses
+     */
+    public function testSupports($class, $supported = true)
+    {
+        $this->assertEquals($supported, $this->resolver->supports($this->getRequestMock(), $this->getReflectionParameterMock($class)));
+    }
+
+    public function provideClasses()
+    {
+        return array(
+            array('Symfony\Component\HttpFoundation\Request'),
+            array('Symfony\Component\BrowerKit\Request', false),
+            array('\stdClass', false),
+        );
+    }
+
+    public function testResolvesToRequest()
+    {
+        $request = $this->getRequestMock();
+
+        $this->assertEquals($request, $this->resolver->resolve($request, $this->getReflectionParameterMock()));
+    }
+
+    private function getRequestMock()
+    {
+        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+    }
+
+    private function getReflectionParameterMock($class = null)
+    {
+        $reflectionParameter = $this->getMockBuilder('ReflectionParameter')->disableOriginalConstructor()->getMock();
+
+        if (null !== $class) {
+            $reflectionClass = $this->getMockBuilder('ReflectionClass')->disableOriginalConstructor()->getMock();
+            $reflectionClass->expects($this->any())->method('isInstance')->will($this->returnCallback(function ($obj) use ($class) {
+                return is_a($obj, $class);
+            }));
+
+            $reflectionParameter->expects($this->any())->method('getClass')->will($this->returnValue($reflectionClass));
+        }
+
+        return $reflectionParameter;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestAttributesArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestAttributesArgumentResolverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributesArgumentResolver;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RequestAttributesArgumentResolverTest extends \PHPUnit_Framework_TestCase
+{
+    private $resolver;
+
+    public function setUp()
+    {
+        $this->resolver = new RequestAttributesArgumentResolver();
+    }
+
+    /**
+     * @dataProvider provideParameters
+     */
+    public function testSupports($parameterName, $supported = true)
+    {
+        $this->assertEquals($supported, $this->resolver->supports($this->getRequestMock(), $this->getReflectionParameterMock($parameterName)));
+    }
+
+    public function provideParameters()
+    {
+        return array(
+            array('exists'),
+            array('not_exists', false),
+        );
+    }
+
+    public function testResolvesToRequestAttributeValues()
+    {
+        $this->assertEquals('value_of_exists', $this->resolver->resolve($this->getRequestMock(), $this->getReflectionParameterMock('exists')));
+    }
+
+    private function getRequestMock()
+    {
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $request->attributes->expects($this->any())->method('has')->will($this->returnValueMap(array(
+            array('exists', true),
+            array('not_exists', false),
+        )));
+        $request->attributes->expects($this->any())->method('get')->with('exists')->willReturn('value_of_exists');
+
+        return $request;
+    }
+
+    private function getReflectionParameterMock($name)
+    {
+        $reflectionParameter = $this->getMockBuilder('ReflectionParameter')->disableOriginalConstructor()->getMock();
+        $reflectionParameter->expects($this->any())->method('getName')->willReturn($name);
+
+        return $reflectionParameter;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
@@ -15,19 +15,20 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolverManager;
 
 class ArgumentResolverManagerTest extends \PHPUnit_Framework_TestCase
 {
-    protected $manager;
-    protected $resolver1;
-    protected $resolver2;
-    protected $request;
+    private $manager;
+    private $resolver1;
+    private $resolver2;
+    private $request;
 
     public function setUp()
     {
         $this->resolver1 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface');
         $this->resolver2 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface');
 
-        $this->manager = new ArgumentResolverManager();
-        $this->manager->add($this->resolver1);
-        $this->manager->add($this->resolver2);
+        $this->manager = new ArgumentResolverManager(array(
+            $this->resolver1,
+            $this->resolver2,
+        ));
 
         $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
     }
@@ -107,20 +108,6 @@ class ArgumentResolverManagerTest extends \PHPUnit_Framework_TestCase
         $this->promiseResolverToNotMatch($this->resolver2);
 
         $this->assertArguments(array(null), function ($a = null) { });
-    }
-
-    public function testPriority()
-    {
-        $this->promiseResolverToNotMatch($this->resolver1);
-        $this->resolver1->expects($this->never())->method('resolve');
-
-        $this->promiseResolverToMatch($this->resolver2, 'resolved by 2');
-
-        $this->manager = new ArgumentResolverManager();
-        $this->manager->add($this->resolver1);
-        $this->manager->add($this->resolver2, 100);
-
-        $this->assertArguments(array('resolved by 2'), function ($a) { });
     }
 
     private function assertArguments(array $expected, $controller)

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverManager;
+
+class ArgumentResolverManagerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $manager;
+    protected $resolver1;
+    protected $resolver2;
+    protected $request;
+
+    public function setUp()
+    {
+        $this->resolver1 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface');
+        $this->resolver2 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface');
+
+        $this->manager = new ArgumentResolverManager();
+        $this->manager->add($this->resolver1);
+        $this->manager->add($this->resolver2);
+
+        $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+    }
+
+    public function testGetArgumentsWithoutControllerParameters()
+    {
+        $this->assertArguments(array(), function () { });
+    }
+
+    public function testGetArgumentsFirstResolverAccepts()
+    {
+        $this->promiseResolverToMatch($this->resolver1, 'resolved_value');
+
+        $this->assertArguments(array('resolved_value'), $this->getControllerWithOneParameter());
+    }
+
+    public function testGetArgumentsSecondResolverAccepts()
+    {
+        $this->promiseResolverToNotMatch($this->resolver1);
+        $this->promiseResolverToMatch($this->resolver2, 'resolved_value');
+
+        $this->assertArguments(array('resolved_value'), $this->getControllerWithOneParameter());
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGetArgumentsFailsIfNoResolverAccepts()
+    {
+        $this->promiseResolverToNotMatch($this->resolver1);
+        $this->promiseResolverToNotMatch($this->resolver2);
+
+        $this->manager->getArguments($this->request, $this->getControllerWithOneParameter());
+    }
+
+    public function testGetArgumentResolvingMultipleParameters()
+    {
+        $this->resolver1->expects($this->any())
+            ->method('supports')
+            ->will($this->onConsecutiveCalls(false, true, true));
+        $this->resolver1->expects($this->any())
+            ->method('resolve')
+            ->will($this->onConsecutiveCalls('1st resolved by 1', '2nd resolved by 1'));
+
+        $this->resolver2->expects($this->any())
+            ->method('supports')
+            ->will($this->onConsecutiveCalls(true, false, true));
+        $this->resolver2->expects($this->any())
+            ->method('resolve')
+            ->will($this->onConsecutiveCalls('1st resolved by 2', '2nd resolved by 2'));
+
+        $this->assertArguments(
+            array('1st resolved by 2', '1st resolved by 1', '2nd resolved by 1'),
+            function ($a, $b, $c) { }
+        );
+    }
+
+    public function testControllerWithOneOptionalParameterWhichDoesNotMatch()
+    {
+        $this->promiseResolverToNotMatch($this->resolver1);
+        $this->promiseResolverToNotMatch($this->resolver2);
+
+        $this->assertArguments(array('default'), function ($a = 'default') { });
+    }
+
+    public function testControllerWithOneOptionalParameterWhichDoesMatch()
+    {
+        $this->promiseResolverToMatch($this->resolver1, 'resolved by 1');
+        $this->promiseResolverToNotMatch($this->resolver2);
+
+        $this->assertArguments(array('resolved by 1'), function ($a = 'default') { });
+    }
+
+    public function testControllerWithOneParameterWithNullDefault()
+    {
+        $this->promiseResolverToNotMatch($this->resolver1);
+        $this->promiseResolverToNotMatch($this->resolver2);
+
+        $this->assertArguments(array(null), function ($a = null) { });
+    }
+
+    private function assertArguments(array $expected, $controller)
+    {
+        $this->assertEquals($expected, $this->manager->getArguments($this->request, $controller));
+    }
+
+    private function promiseResolverToMatch($resolver, $return)
+    {
+        $resolver->expects($this->any())->method('supports')->will($this->returnValue(true));
+        $resolver->expects($this->any())->method('resolve')->will($this->returnValue($return));
+    }
+
+    private function promiseResolverToNotMatch($resolver)
+    {
+        $resolver->expects($this->any())->method('supports')->will($this->returnValue(false));
+    }
+
+    private function getControllerWithOneParameter()
+    {
+        return function ($a) { };
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
@@ -25,7 +25,9 @@ class ArgumentResolverManagerTest extends \PHPUnit_Framework_TestCase
         $this->resolver1 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface');
         $this->resolver2 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface');
 
-        $this->manager = new ArgumentResolverManager(array($this->resolver1, $this->resolver2));
+        $this->manager = new ArgumentResolverManager();
+        $this->manager->add($this->resolver1);
+        $this->manager->add($this->resolver2);
 
         $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
     }
@@ -105,6 +107,20 @@ class ArgumentResolverManagerTest extends \PHPUnit_Framework_TestCase
         $this->promiseResolverToNotMatch($this->resolver2);
 
         $this->assertArguments(array(null), function ($a = null) { });
+    }
+
+    public function testPriority()
+    {
+        $this->promiseResolverToNotMatch($this->resolver1);
+        $this->resolver1->expects($this->never())->method('resolve');
+
+        $this->promiseResolverToMatch($this->resolver2, 'resolved by 2');
+
+        $this->manager = new ArgumentResolverManager();
+        $this->manager->add($this->resolver1);
+        $this->manager->add($this->resolver2, 100);
+
+        $this->assertArguments(array('resolved by 2'), function ($a) { });
     }
 
     private function assertArguments(array $expected, $controller)

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverManagerTest.php
@@ -25,9 +25,7 @@ class ArgumentResolverManagerTest extends \PHPUnit_Framework_TestCase
         $this->resolver1 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface');
         $this->resolver2 = $this->getMock('Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface');
 
-        $this->manager = new ArgumentResolverManager();
-        $this->manager->add($this->resolver1);
-        $this->manager->add($this->resolver2);
+        $this->manager = new ArgumentResolverManager(array($this->resolver1, $this->resolver2));
 
         $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -220,19 +220,19 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
     {
     }
 
-    protected function controllerMethod2($foo, $bar = null)
+    public function controllerMethod2($foo, $bar = null)
     {
     }
 
-    protected function controllerMethod3($foo, $bar = null, $foobar)
+    public function controllerMethod3($foo, $bar = null, $foobar)
     {
     }
 
-    protected static function controllerMethod4()
+    public static function controllerMethod4()
     {
     }
 
-    protected function controllerMethod5(Request $request)
+    public function controllerMethod5(Request $request)
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -20,6 +20,11 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
 class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Tagged as legacy because of the usage of the deprecated ControllerResolver#getArguments().
+     *
+     * @group legacy
+     */
     public function testStopwatchSections()
     {
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch = new Stopwatch());
@@ -39,6 +44,11 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         ), array_keys($events));
     }
 
+    /**
+     * Tagged as legacy because of the usage of the deprecated ControllerResolver#getArguments().
+     *
+     * @group legacy
+     */
     public function testStopwatchCheckControllerOnRequestEvent()
     {
         $stopwatch = $this->getMockBuilder('Symfony\Component\Stopwatch\Stopwatch')
@@ -55,6 +65,11 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $kernel->handle($request);
     }
 
+    /**
+     * Tagged as legacy because of the usage of the deprecated ControllerResolver#getArguments().
+     *
+     * @group legacy
+     */
     public function testStopwatchStopControllerOnRequestEvent()
     {
         $stopwatch = $this->getMockBuilder('Symfony\Component\Stopwatch\Stopwatch')

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -140,6 +140,11 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
         return $kernel;
     }
 
+    /**
+     * Tagged as legacy because of the usage of the deprecated ControllerResolver#getArguments().
+     *
+     * @group legacy
+     */
     public function testExceptionInSubRequestsDoesNotMangleOutputBuffers()
     {
         $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -17,8 +17,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\Tests\TestArgumentResolverManager;
+use Symfony\Component\HttpKernel\Tests\TestControllerResolver;
 
-class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
+class TestHttpKernel extends HttpKernel
 {
     protected $body;
     protected $status;
@@ -35,7 +37,7 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
         $this->headers = $headers;
         $this->customizer = $customizer;
 
-        parent::__construct(new EventDispatcher(), $this);
+        parent::__construct(new EventDispatcher(), new TestControllerResolver($this), null, new TestArgumentResolverManager());
     }
 
     public function getBackendRequest()
@@ -54,16 +56,6 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
     public function isCatchingExceptions()
     {
         return $this->catch;
-    }
-
-    public function getController(Request $request)
-    {
-        return array($this, 'callController');
-    }
-
-    public function getArguments(Request $request, $controller)
-    {
-        return array($request);
     }
 
     public function callController(Request $request)

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\Tests\TestArgumentResolverManager;
 use Symfony\Component\HttpKernel\Tests\TestControllerResolver;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
@@ -17,8 +17,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\Tests\TestArgumentResolverManager;
+use Symfony\Component\HttpKernel\Tests\TestControllerResolver;
 
-class TestMultipleHttpKernel extends HttpKernel implements ControllerResolverInterface
+class TestMultipleHttpKernel extends HttpKernel
 {
     protected $bodies = array();
     protected $statuses = array();
@@ -34,7 +36,7 @@ class TestMultipleHttpKernel extends HttpKernel implements ControllerResolverInt
             $this->headers[] = $response['headers'];
         }
 
-        parent::__construct(new EventDispatcher(), $this);
+        parent::__construct(new EventDispatcher(), new TestControllerResolver($this), null, new TestArgumentResolverManager());
     }
 
     public function getBackendRequest()
@@ -47,16 +49,6 @@ class TestMultipleHttpKernel extends HttpKernel implements ControllerResolverInt
         $this->backendRequest = $request;
 
         return parent::handle($request, $type, $catch);
-    }
-
-    public function getController(Request $request)
-    {
-        return array($this, 'callController');
-    }
-
-    public function getArguments(Request $request, $controller)
-    {
-        return array($request);
     }
 
     public function callController(Request $request)

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\Tests\TestArgumentResolverManager;
 use Symfony\Component\HttpKernel\Tests\TestControllerResolver;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -21,6 +21,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+/**
+ * Tagged as legacy because of the usage of the deprecated ControllerResolver#getArguments().
+ *
+ * @group legacy
+ */
 class HttpKernelTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/TestArgumentResolverManager.php
+++ b/src/Symfony/Component/HttpKernel/Tests/TestArgumentResolverManager.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverManager;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class TestArgumentResolverManager extends ArgumentResolverManager
+{
+    public function getArguments(Request $request, $controller)
+    {
+        return array($request);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/TestControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Tests/TestControllerResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class TestControllerResolver extends ControllerResolver
+{
+    private $controller;
+
+    public function __construct($controller, LoggerInterface $logger = null)
+    {
+        parent::__construct($logger);
+        $this->controller = $controller;
+    }
+
+    public function getController(Request $request)
+    {
+        return array($this->controller, 'callController');
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
@@ -17,21 +17,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
+class TestHttpKernel extends HttpKernel
 {
     public function __construct()
     {
-        parent::__construct(new EventDispatcher(), $this);
-    }
-
-    public function getController(Request $request)
-    {
-        return array($this, 'callController');
-    }
-
-    public function getArguments(Request $request, $controller)
-    {
-        return array($request);
+        parent::__construct(new EventDispatcher(), new TestControllerResolver($this), null, new TestArgumentResolverManager());
     }
 
     public function callController(Request $request)

--- a/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\HttpKernel\Tests;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class TestHttpKernel extends HttpKernel


### PR DESCRIPTION
## Description

This closes #11457. Changes since that PR:
- The ControllerResolver has a new method `setArgumentResolver`, too keep BC with people overriding `ControllerResolver#doGetArguments`
- Deprecations instead of removal, so it can be merged into 2.8
- Added 2 new argument resolvers: A Security user resolver (which was the original problem to create this PR) and a PSR Request resolver
## PR Info Table

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #1547, #10710 |
| License | MIT |
| Doc PR | tbd |
## Todo
- [x] Add priority (is this actually needed?)
- [x] Make tests pass
- [ ] Update docs
