### PR TITLE
[3.0][FrameworkBundle] Add assets helper

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -354,7 +354,7 @@ UPGRADE FROM 2.x to 3.0
    service instead.
 
  * The `templating.helper.assets` was moved to `templating_php.xml`. You can
-   use the `assets.package` service instead.
+   use the `assets.packages` service instead.
 
    Before:
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -34,8 +34,7 @@
 
         <service id="templating.helper.assets" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper">
             <tag name="templating.helper" alias="assets" />
-            <argument /> <!-- default package -->
-            <argument type="collection" /> <!-- named packages -->
+            <argument /> <!-- packages -->
         </service>
 
         <service id="templating.helper.actions" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper">

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Templating\Helper;
+
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Templating\Helper\Helper;
+
+/**
+ * AssetsHelper helps manage asset URLs.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AssetsHelper extends Helper
+{
+    private $packages;
+
+    public function __construct(Packages $packages)
+    {
+        $this->packages = $packages;
+    }
+
+    /**
+     * Returns the public url/path of an asset.
+     *
+     * If the package used to generate the path is an instance of
+     * UrlPackage, you will always get a URL and not a path.
+     *
+     * @param string $path        A public path
+     * @param string $packageName The name of the asset package to use
+     *
+     * @return string The public path of the asset
+     */
+    public function getUrl($path, $packageName = null)
+    {
+        return $this->packages->getUrl($path, $packageName);
+    }
+
+    /**
+     * Returns the version of an asset.
+     *
+     * @param string $path        A public path
+     * @param string $packageName The name of the asset package to use
+     *
+     * @return string The asset version
+     */
+    public function getVersion($path, $packageName = null)
+    {
+        return $this->packages->getVersion($path, $packageName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'assets';
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper;
+
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
+use Symfony\Component\Asset\Package;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
+
+class AssetsHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetUrl()
+    {
+        $package = new Package(new StaticVersionStrategy('22', '%s?version=%s'));
+        $packages = new Packages($package);
+        $helper = new AssetsHelper($packages);
+
+        $this->assertEquals('me.png?version=22', $helper->getUrl('me.png'));
+    }
+
+    public function testGetVersion()
+    {
+        $package = new Package(new StaticVersionStrategy('22'));
+        $imagePackage = new Package(new StaticVersionStrategy('42'));
+        $packages = new Packages($package, array('images' => $imagePackage));
+        $helper = new AssetsHelper($packages);
+
+        $this->assertEquals('22', $helper->getVersion('/foo'));
+        $this->assertEquals('42', $helper->getVersion('/foo', 'images'));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This PR adds again the `AssetsHelper` removed in #13666 but without the BC layer. Without this helper we can't use the Asset component in a PHP template.
If all of us agree with this, we should fix the UPGRADE-2.7.md file updated in #14940
