### PR TITLE
[Form] Added chainable request handler

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.8.0
 -----
 
+ * added ability to chain request handlers
  * deprecated option "read_only" in favor of "attr['readonly']"
 
 2.7.0

--- a/src/Symfony/Component/Form/ChainRequestHandler.php
+++ b/src/Symfony/Component/Form/ChainRequestHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+use Symfony\Component\Form\Exception\LogicException;
+
+/**
+ * A request handler that chains over multiple request handlers,
+ * until it finds one that can handle the request.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class ChainRequestHandler implements RequestHandlerInterface
+{
+    /**
+     * @var ChainableRequestHandlerInterface[]
+     */
+    private $requestHandlers;
+
+    public function __construct(array $requestHandlers = array())
+    {
+        $this->requestHandlers = $requestHandlers;
+    }
+
+    /**
+     * Adds a new request handler to the chain.
+     *
+     * @param ChainableRequestHandlerInterface $requestHandler
+     */
+    public function add(ChainableRequestHandlerInterface $requestHandler)
+    {
+        $this->requestHandlers[] = $requestHandler;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws LogicException When the request could not be handled by the registered request handlers
+     */
+    public function handleRequest(FormInterface $form, $request = null)
+    {
+        foreach ($this->requestHandlers as $requestHandler) {
+            if ($requestHandler->supports($request)) {
+                $requestHandler->handleRequest($form, $request);
+
+                return;
+            }
+        }
+
+        throw new LogicException('None of the registered request handlers were able to handle the request.');
+    }
+}

--- a/src/Symfony/Component/Form/ChainableRequestHandlerInterface.php
+++ b/src/Symfony/Component/Form/ChainableRequestHandlerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+/**
+ * An interface that has to be implemented by request
+ * handlers that can be chained.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+interface ChainableRequestHandlerInterface extends RequestHandlerInterface
+{
+    /**
+     * Returns whether this request handler is able to handle the request.
+     *
+     * @param mixed $request
+     *
+     * @return bool
+     */
+    public function supports($request = null);
+}

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Form\Extension\HttpFoundation;
 
+use Symfony\Component\Form\ChainableRequestHandlerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\RequestHandlerInterface;
 use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class HttpFoundationRequestHandler implements RequestHandlerInterface
+class HttpFoundationRequestHandler implements ChainableRequestHandlerInterface
 {
     /**
      * @var ServerParams
@@ -37,6 +37,14 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
     public function __construct(ServerParams $serverParams = null)
     {
         $this->serverParams = $serverParams ?: new ServerParams();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($request = null)
+    {
+        return $request instanceof Request;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/Type/FormTypeHttpFoundationExtension.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/Type/FormTypeHttpFoundationExtension.php
@@ -47,7 +47,12 @@ class FormTypeHttpFoundationExtension extends AbstractTypeExtension
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addEventSubscriber($this->listener);
-        $builder->setRequestHandler($this->requestHandler);
+
+        if (!method_exists($builder, 'addRequestHandler')) {
+            $builder->setRequestHandler($this->requestHandler);
+        } else {
+            $builder->addRequestHandler($this->requestHandler);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -850,6 +850,28 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     }
 
     /**
+     * Adds a request handler to a chain of request handlers.
+     *
+     * @param ChainableRequestHandlerInterface $requestHandler
+     *
+     * @return self The configuration object
+     */
+    public function addRequestHandler(ChainableRequestHandlerInterface $requestHandler)
+    {
+        if ($this->locked) {
+            throw new BadMethodCallException('The config builder cannot be modified anymore.');
+        }
+
+        if (!$this->requestHandler instanceof ChainRequestHandler) {
+            $this->requestHandler = new ChainRequestHandler(array($this->getRequestHandler()));
+        }
+
+        $this->requestHandler->add($requestHandler);
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function setAutoInitialize($initialize)

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -266,6 +266,17 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     public function setRequestHandler(RequestHandlerInterface $requestHandler);
 
     /**
+     * Adds a request handler to a chain of request handlers.
+     *
+     * @param ChainableRequestHandlerInterface $requestHandler
+     *
+     * @return self The configuration object
+     *
+     * @todo Add to the interface in Symfony 3.
+     *
+    public function addRequestHandler(ChainableRequestHandlerInterface $requestHandler);*/
+
+    /**
      * Sets whether the form should be initialized automatically.
      *
      * Should be set to true only for root forms.

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\Util\ServerParams;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class NativeRequestHandler implements RequestHandlerInterface
+class NativeRequestHandler implements ChainableRequestHandlerInterface
 {
     /**
      * @var ServerParams
@@ -32,6 +32,14 @@ class NativeRequestHandler implements RequestHandlerInterface
     public function __construct(ServerParams $params = null)
     {
         $this->serverParams = $params ?: new ServerParams();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($request = null)
+    {
+        return null === $request;
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/ChainRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/ChainRequestHandlerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Symfony\Component\Form\Tests;
+
+use Symfony\Component\Form\ChainRequestHandler;
+
+class ChainRequestHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ChainRequestHandler
+     */
+    private $requestHandler;
+
+    public function setUp()
+    {
+        $this->requestHandler = new ChainRequestHandler();
+    }
+
+    public function testChainsOverRequestHandlerUntilOneSupportsTheRequest()
+    {
+        $handler1 = $this->createHandlerMock(false);
+        $handler1->expects($this->never())->method('handleRequest');
+
+        $handler2 = $this->createHandlerMock();
+        $handler2->expects($this->once())->method('handleRequest');
+
+        $handler3 = $this->createHandlerMock();
+        $handler3->expects($this->never())->method('handleRequest');
+
+        $this->requestHandler->add($handler1);
+        $this->requestHandler->add($handler2);
+        $this->requestHandler->add($handler3);
+
+        $this->requestHandler->handleRequest($this->createFormMock());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\LogicException
+     */
+    public function testFailsIfNoneOfTheHandlersSupportsTheRequest()
+    {
+        $this->requestHandler->handleRequest($this->createFormMock());
+    }
+
+    private function createFormMock()
+    {
+        return $this->getMock('Symfony\Component\Form\FormInterface');
+    }
+
+    private function createHandlerMock($support = true)
+    {
+        $handler = $this->getMock('Symfony\Component\Form\ChainableRequestHandlerInterface');
+        $handler->expects($this->any())->method('supports')->will($this->returnValue($support));
+
+        return $handler;
+    }
+}


### PR DESCRIPTION
## Description

This is a first step towards implementing PSR-7 support for the Symfony Form component. I don't have enough knowledge about PSR-7 to actually implement a PsrHttpMessage request handler. However, before being able to implement such request handler, there is a need to be able to chain multiple request handlers. That is what this PR is implementing.
## Pr Info Table

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14865 (partially) |
| License | MIT |
| Doc PR | tbd |
## Todo
- [ ] Write docs
- [x] Add tests
