### PR TITLE
Added a small Upgrade note regarding security.context

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -643,3 +643,25 @@ FrameworkBundle
        }
    }
    ```
+
+Security
+---------------
+
+ * Injection of the `security.context` service has been reduced to a bare minimum. This means
+   that arguments that once hinted `SecurityContext` or `SecurityContextInterface` will have
+   to be updated accordingly to either the `TokenStorageInterface` or `AuthorizationCheckerInterface`.
+   The following classes now require the `security.token_storage` service instead of the `security.context`,
+   please update your extending implementations accordingly.
+
+    * `AbstractAuthenticationListener`
+    * `AnonymousAuthenticationListener`
+    * `ContextListener`
+    * `SimplePreAuthenticationListener`
+    * `X509AuthenticationListener`
+    * `RemoteUserAuthenticationListener`
+    * `BasicAuthenticationListener`
+    * `DigestAuthenticationListener`
+    * `ExceptionListener`
+    * `SwitchUserListener`
+    * `AccessListener`
+    * `RememberMeListener`

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Templating;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\SecurityContext;
 
 /**

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -101,7 +101,7 @@ class ContextListener implements ListenerInterface
     }
 
     /**
-     * Writes the SecurityContext to the session.
+     * Writes the security token into the session.
      *
      * @param FilterResponseEvent $event A FilterResponseEvent instance
      */
@@ -120,10 +120,6 @@ class ContextListener implements ListenerInterface
 
         $request = $event->getRequest();
         $session = $request->getSession();
-
-        if (null === $session) {
-            return;
-        }
 
         if ((null === $token = $this->tokenStorage->getToken()) || ($token instanceof AnonymousToken)) {
             if ($request->hasPreviousSession()) {

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeServicesInterface.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeServicesInterface.php
@@ -36,8 +36,8 @@ interface RememberMeServicesInterface
     const COOKIE_ATTR_NAME = '_security_remember_me_cookie';
 
     /**
-     * This method will be called whenever the SecurityContext does not contain
-     * an TokenInterface object and the framework wishes to provide an implementation
+     * This method will be called whenever the TokenStorage does not contain
+     * a TokenInterface object and the framework wishes to provide an implementation
      * with an opportunity to authenticate the request using remember-me capabilities.
      *
      * No attempt whatsoever is made to determine whether the browser has requested

--- a/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategyInterface.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategyInterface.php
@@ -27,7 +27,7 @@ interface SessionAuthenticationStrategyInterface
     /**
      * This performs any necessary changes to the session.
      *
-     * This method is called before the SecurityContext is populated with a
+     * This method is called before the TokenStorage is populated with a
      * Token, and only by classes inheriting from AbstractAuthenticationListener.
      *
      * @param Request        $request


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | ~ |
| Fixed tickets | #14889 |
| License | MIT |
| Doc PR | ~ |

I've added a note in the 2.7 upgrade file on which extending implementations should be updated when using 2.7. Along with it, I've removed an unused use statement, fixed some typos and removed a redundant session check as this check is already done at the start of the method.

For #14889 I have also done a search through the docs (2.7), but I couldn't find any remaining examples encouraging the usage of the `SecurityContext(Interface)` anywhere. 
