### PR TITLE
[FrameworkBundle] Reuse PropertyAccessor service for ObjectNormalizer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -55,8 +55,10 @@
         </service>
 
         <!-- CoreExtension -->
+        <service id="form.property_accessor" alias="property_accessor" public="false" />
+
         <service id="form.type.form" class="Symfony\Component\Form\Extension\Core\Type\FormType">
-            <argument type="service" id="property_accessor"/>
+            <argument type="service" id="form.property_accessor" />
             <tag name="form.type" alias="form" />
         </service>
         <service id="form.type.birthday" class="Symfony\Component\Form\Extension\Core\Type\BirthdayType">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -23,7 +23,7 @@
         <service id="serializer.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument>null</argument>
-            <argument type="service" id="serializer.property_accessor" on-invalid="ignore" />
+            <argument type="service" id="serializer.property_accessor" />
 
             <!-- Run after all custom serializers -->
             <tag name="serializer.normalizer" priority="-1000" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -20,6 +20,8 @@
         <!-- Normalizer -->
         <service id="serializer.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
+            <argument>null</argument>
+            <argument type="service" id="property_accessor" on-invalid="ignore" />
 
             <!-- Run after all custom serializers -->
             <tag name="serializer.normalizer" priority="-1000" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -17,11 +17,13 @@
             <argument type="collection" />
         </service>
 
+        <service id="serializer.property_accessor" alias="property_accessor" public="false" />
+
         <!-- Normalizer -->
         <service id="serializer.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument>null</argument>
-            <argument type="service" id="property_accessor" on-invalid="ignore" />
+            <argument type="service" id="serializer.property_accessor" on-invalid="ignore" />
 
             <!-- Run after all custom serializers -->
             <tag name="serializer.normalizer" priority="-1000" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Inject the `property_accessor` service if available in the `ObjectNormalize` instead of creating a new instance.
