### PR TITLE
add X_ORIGINAL_URL empty filter

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1746,7 +1746,7 @@ class Request
     {
         $requestUri = '';
 
-        if ($this->headers->has('X_ORIGINAL_URL')) {
+        if ($this->headers->has('X_ORIGINAL_URL') && !empty($this->headers->get('X_ORIGINAL_URL'))) {
             // IIS with Microsoft Rewrite Module
             $requestUri = $this->headers->get('X_ORIGINAL_URL');
             $this->headers->remove('X_ORIGINAL_URL');


### PR DESCRIPTION
In some Nokia WAP Gateway, the REQUEST_URI is not empty, but it contain empty string HTTP_X_ORIGINAL_URL headers.

so, it is better to add empty check.

the header like that :

```
    'REQUEST_URI' => '/api1.2/util/getversion/?lng=0',
    'DOCUMENT_URI' => '/index.php',
    'DOCUMENT_ROOT' => '/test',
    'SERVER_PROTOCOL' => 'HTTP/1.0',
    'GATEWAY_INTERFACE' => 'CGI/1.1',
    'SERVER_SOFTWARE' => 'nginx/1.0.15',
    'REMOTE_ADDR' => '100.97.181.26',
    'REMOTE_PORT' => '52575',
    'SERVER_ADDR' => 'xxxxx',
    'SERVER_PORT' => '80',
    'SERVER_NAME' => 'xxxx',
    'REDIRECT_STATUS' => '200',
    'HTTP_REMOTEIP' => 'xxxx',
    'HTTP_HOST' => 'xxxx',
    'HTTP_X_FORWARDED_FOR' => 'xxxx, xxxxx',
    'HTTP_CONNECTION' => 'close',
    'HTTP_CONTENT_LENGTH' => '0',
    'HTTP_ACCEPT_ENCODING' => 'gzip',
    'HTTP_HTTP' => '1.1',
    'HTTP_VIA' => 'WTP/1.1 GDSZ-PS-WAP4-GW12. (Nokia WAP Gateway 4.1 CD1/ECD13_F/4.1.06)',
    'HTTP_X_SOURCE_ID' => '117.142.2.86',
    'HTTP_X_UP_BEARER_TYPE' => 'GPRS',
    'HTTP_X_NOKIA_GATEWAY_ID' => 'NWG/4.1/Build4.1.06',
    'HTTP_X_UP_BEAR_TYPE' => 'TD-SCDMA',
    'HTTP_X_ORIGINAL_URL' => '',
    'HTTP_ACCEPT' => '*/*',
    'PHP_SELF' => '/index.php',
```
