### PR TITLE
[2.8][HttpKernel] Added support for registering Bundle dependencies

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/BundleDependenciesInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleDependenciesInterface.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Bundle;
+
+/**
+ * Class BundleDependenciesInterface.
+ *
+ * Adds capability to let Bundles specify other bundles they need to load (before this one), both required and optional
+ * dependencies.
+ *
+ * This allows you to define only the bundle you want to use in registerBundles(), but don't need to take care about
+ * registering the dependencies it uses, and you won't need to make any changes in your kernel if those dependencies
+ * change.
+ *
+ * NOTE: In this interface bundle dependencies are returned as FQN strings because several bundles (and root) might
+ * register the same bundle. This means dependencies can not have arguments in its constructor, reflecting best practice
+ * in Symfony of not having any logic in Bundle constructors given it is executed on every Kernel boot.
+ *
+ * NOTE2: This functionality is not a bundle plugin system, but rather a way to set your upstream dependencies,
+ *        or in the case of a distribution bundle, all bundles they are to be used with.
+ *
+ * @author André Roemcke <andre.romcke@ez.no>
+ *
+ * @since 2.8
+ *
+ * @api
+ */
+interface BundleDependenciesInterface
+{
+    /**
+     * @const Flag a Bundle Dependency as required, if missing throw exception
+     *
+     * @link \Symfony\Component\HttpKernel\Exception\DependencyMismatchException
+     */
+    const DEP_REQUIRED = true;
+
+    /**
+     * @const Flag a Bundle Dependency as optional, if missing silently ignore it
+     */
+    const DEP_OPTIONAL = false;
+
+    /**
+     * Returns an array of bundle dependencies Kernel should register on boot.
+     *
+     * Dependencies will be registered before current bundle, implying current bundle *MUST* be loaded after as it
+     * for instance extends it.
+     *
+     * Example of use:
+     * ```php
+     * class AcmeBundle extends Bundle implements BundleDependenciesInterface
+     * {
+     *     public function getBundleDependencies($environment, $debug)
+     *     {
+     *         $dependencies = array();
+     *
+     *         // If you need to load some bundles only in dev using $environment (or in $debug)
+     *         if ($environment === 'dev') {
+     *              $dependencies['Egulias\SecurityDebugCommandBundle\EguliasSecurityDebugCommandBundle'] = self::DEP_REQUIRED;
+     *         }
+     *
+     *         return $dependencies + array(
+     *             // Keys must be Fully Qualified Name (FQN) for the class to avoid bundles being loaded several times
+     *             // Note: Currently, use of DEP_OPTIONAL causes a *uncached* file system call on boot (every request)
+     *             //       if dependency is missing, in a future versions this information might be cached.
+     *             'FOS\HttpCacheBundle\FOSHttpCacheBundle' => self::DEP_OPTIONAL,
+     *
+     *             // If you require PHP 5.5+ it is possible to use `::class` constant for required dependencies:
+     *             Oneup\FlysystemBundle\OneupFlysystemBundle::class => self::DEP_REQUIRED,
+     *         );
+     *     }
+     * }
+     * ```
+     *
+     * @param string $environment The current environment
+     * @param bool   $debug       Whether to debugging is enabled or not
+     *
+     * @return mixed[string] An array where key is bundle class (FQN) names as strings, and value DEP_* constants
+     *
+     * @api
+     */
+    public function getBundleDependencies($environment, $debug);
+}

--- a/src/Symfony/Component/HttpKernel/Exception/DependencyMismatchException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/DependencyMismatchException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * DependencyMismatchException.
+ *
+ * For exceptions related to dependency issues, like missing required dependency or recursive dependencies.
+ *
+ * @author André Roemcke <andre.romcke@ez.no>
+ *
+ * @since 2.8
+ */
+class DependencyMismatchException extends \RuntimeException
+{
+    /**
+     * Constructor.
+     *
+     * @param string     $msg      The message; for recursion issues, missing required dependency, ..
+     * @param array      $stack    The Bundle dependency stack trace up until the mismatch using bundle name or FQN
+     * @param \Exception $previous The previous exception if there was one
+     */
+    public function __construct($msg, array $stack, \Exception $previous = null)
+    {
+        parent::__construct(
+            sprintf("%s, bundle dependencies stack trace: '%s'", $msg, var_export($stack, true)),
+            0,
+            $previous
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleADependenciesNon.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleADependenciesNon.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies;
+
+use Symfony\Component\HttpKernel\Bundle\BundleDependenciesInterface;
+
+class BundleADependenciesNon implements BundleDependenciesInterface
+{
+    public function getBundleDependencies($environment, $debug)
+    {
+        return array();
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleBDependenciesA.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleBDependenciesA.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies;
+
+use Symfony\Component\HttpKernel\Bundle\BundleDependenciesInterface;
+
+class BundleBDependenciesA implements BundleDependenciesInterface
+{
+    public function getBundleDependencies($environment, $debug)
+    {
+        return array('Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies\BundleADependenciesNon' => self::DEP_REQUIRED);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleCDependenciesBA.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleCDependenciesBA.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies;
+
+use Symfony\Component\HttpKernel\Bundle\BundleDependenciesInterface;
+
+class BundleCDependenciesBA implements BundleDependenciesInterface
+{
+    public function getBundleDependencies($environment, $debug)
+    {
+        if ('prod_test' === $environment) {
+            return array();
+        } elseif ($debug) {
+            return array('Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies\BundleADependenciesNon' => self::DEP_REQUIRED);
+        }
+
+        return array(
+            'Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies\BundleBDependenciesA' => self::DEP_REQUIRED,
+            'Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies\BundleADependenciesNon' => self::DEP_OPTIONAL,
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleDDependenciesE.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleDDependenciesE.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies;
+
+use Symfony\Component\HttpKernel\Bundle\BundleDependenciesInterface;
+
+class BundleDDependenciesE implements BundleDependenciesInterface
+{
+    public function getBundleDependencies($environment, $debug)
+    {
+        return array('Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies\BundleEDependenciesD' => self::DEP_REQUIRED);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleEDependenciesD.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleEDependenciesD.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies;
+
+use Symfony\Component\HttpKernel\Bundle\BundleDependenciesInterface;
+
+class BundleEDependenciesD implements BundleDependenciesInterface
+{
+    public function getBundleDependencies($environment, $debug)
+    {
+        return array('Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies\BundleDDependenciesE' => self::DEP_REQUIRED);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleFDependenciesMissing.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleFDependenciesMissing.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies;
+
+use Symfony\Component\HttpKernel\Bundle\BundleDependenciesInterface;
+
+class BundleFDependenciesMissing implements BundleDependenciesInterface
+{
+    public function getBundleDependencies($environment, $debug)
+    {
+        return array('Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies\BundleMissing' => self::DEP_REQUIRED);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleGDependenciesMissingOptional.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleDependencies/BundleGDependenciesMissingOptional.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies;
+
+use Symfony\Component\HttpKernel\Bundle\BundleDependenciesInterface;
+
+class BundleGDependenciesMissingOptional implements BundleDependenciesInterface
+{
+    public function getBundleDependencies($environment, $debug)
+    {
+        return array('Symfony\Component\HttpKernel\Tests\Fixtures\BundleDependencies\BundleMissing' => self::DEP_OPTIONAL);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -34,4 +34,9 @@ class KernelForTest extends Kernel
     {
         return $this->booted;
     }
+
+    public function registeredDependencies()
+    {
+        return parent::registeredDependencies();
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13505 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/5610 |

As there are ongoing discussions in both in eZ and [Symfony CMF](https://github.com/symfony-cmf/symfony-cmf/issues/216) on this topic _(and in Sylius)_, agreed with @lsmith77 to open PR to discuss this potential light weight native approach. Alternative if native feature is not wanted is [OroPlatform](https://github.com/orocrm/platform/blob/master/src/Oro/Bundle/DistributionBundle/OroKernel.php), a custom, still somewhat project specific and heavier approach involving bundles.yml files and caching needs.
## What?

Adds possibility for a Bundle to specify other bundles it depends on. This allows root/meta projects to not have to specify dependencies of dependencies, and no need for user to perform manual upgrade work in Kernel file when they change.

_This could potentially allow "distribution bundles" for larger solutions like Sylius, CMF and eZ to be more easily installed in same Symfony installation, assuming there is no package or other conflicts._

A dependency implies two things for the Kernel:
- make sure it is loaded, unless dependency is marked as _optional_
- order it before "current" bundle

The last point is because we assume a dependency is something we might extend so we _always_ load it before "self".
## How

A optional interface is added that bundles can implement, while the method could have been added
to the main interface like getParent(), this approach allows the code to check using instanceof,
keeps full BC, and allows a clear contract on use of this feature.

The approach further explicitly avoids giving bundle writers any control over priority of load ordering other
then "before self", as otherwise it would 1. potential lead to conflicts, and 2. complicate the implementation.

For further info on the new function and why it returns FQN class names, see BundleDependenciesInterface.
## Todo
- [x] CS fixes
- [x] Testing, incl recursion testing and fixes in implementation for this
- [x] Update Doc when discussion with core team have been made on selecting approach for dealing with optional dependencies _(the approach suggested here is to handle it in doc, see BundleDependenciesInterface)_

For earlier discussions see #13945 _(was targeted at 2.7)_
