### PR TITLE
[2.8] [Form] Rename CollectionType options for entries

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -27,17 +27,17 @@ class CollectionType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['allow_add'] && $options['prototype']) {
-            $prototype = $builder->create($options['prototype_name'], $options['type'], array_replace(array(
+            $prototype = $builder->create($options['prototype_name'], $options['entry_type'], array_replace(array(
                 'label' => $options['prototype_name'].'label__',
-            ), $options['options'], array(
+            ), $options['entry_options'], array(
                 'data' => $options['prototype_data'],
             )));
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 
         $resizeListener = new ResizeFormListener(
-            $options['type'],
-            $options['options'],
+            $options['entry_type'],
+            $options['entry_options'],
             $options['allow_add'],
             $options['allow_delete'],
             $options['delete_empty']
@@ -76,10 +76,36 @@ class CollectionType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $optionsNormalizer = function (Options $options, $value) {
+        $entryOptionsNormalizer = function (Options $options, $value) {
             $value['block_name'] = 'entry';
 
             return $value;
+        };
+        $optionsNormalizer = function (Options $options, $value) use ($entryOptionsNormalizer) {
+            if (null !== $value) {
+                @trigger_error('The form option "options" is deprecated since version 2.8 and will be removed in 3.0. Use "entry_options" instead.', E_USER_DEPRECATED);
+            }
+
+            return $entryOptionsNormalizer($options, $value);
+        };
+        $typeNormalizer = function (Options $options, $value) {
+            if (null !== $value) {
+                @trigger_error('The form option "type" is deprecated since version 2.8 and will be removed in 3.0. Use "entry_type" instead.', E_USER_DEPRECATED);
+            }
+        };
+        $entryType = function (Options $options) {
+            if (null !== $options['type']) {
+                return $options['type'];
+            }
+
+            return __NAMESPACE__.'\TextType';
+        };
+        $entryOptions = function (Options $options) {
+            if (1 === count($options['options']) && isset($options['block_name'])) {
+                return array();
+            }
+
+            return $options['options'];
         };
 
         $resolver->setDefaults(array(
@@ -88,12 +114,17 @@ class CollectionType extends AbstractType
             'prototype' => true,
             'prototype_data' => null,
             'prototype_name' => '__name__',
-            'type' => __NAMESPACE__.'\TextType',
-            'options' => array(),
+            // deprecated as of Symfony 2.8, to be removed in Symfony 3.0. Use entry_type instead
+            'type' => null,
+            // deprecated as of Symfony 2.8, to be removed in Symfony 3.0. Use entry_options instead
+            'options' => null,
+            'entry_type' => $entryType,
+            'entry_options' => $entryOptions,
             'delete_empty' => false,
         ));
 
         $resolver->setNormalizer('options', $optionsNormalizer);
+        $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -284,7 +284,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testCollection()
     {
         $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array('a', 'b'), array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -306,7 +306,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             array('title' => 'b'),
         );
         $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', $data, array(
-            'type' => 'Symfony\Component\Form\Tests\Fixtures\AlternatingRowType',
+            'entry_type' => 'Symfony\Component\Form\Tests\Fixtures\AlternatingRowType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -324,7 +324,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testEmptyCollection()
     {
         $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -341,7 +341,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             'collection',
             'Symfony\Component\Form\Extension\Core\Type\CollectionType',
             array('a', 'b'),
-            array('type' => 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            array('entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType')
         );
 
         $form = $this->factory->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType')

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -22,7 +22,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testLegacyName()
     {
         $form = $this->factory->create('collection', array(
-            'type' => 'text',
+            'entry_type' => 'text',
         ));
 
         $this->assertSame('collection', $form->getConfig()->getType()->getName());
@@ -40,8 +40,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testSetDataAdjustsSize()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-            'options' => array(
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_options' => array(
                 'attr' => array('maxlength' => 20),
             ),
         ));
@@ -69,7 +69,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testThrowsExceptionIfObjectIsNotTraversable()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $form->setData(new \stdClass());
@@ -78,7 +78,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testNotResizedIfSubmittedWithMissingData()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
         $form->submit(array('foo@bar.com'));
@@ -92,7 +92,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testResizedDownIfSubmittedWithMissingDataAndAllowDelete()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_delete' => true,
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
@@ -107,7 +107,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testResizedDownIfSubmittedWithEmptyDataAndDeleteEmpty()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_delete' => true,
             'delete_empty' => true,
         ));
@@ -124,7 +124,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testDontAddEmptyDataIfDeleteEmpty()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_add' => true,
             'delete_empty' => true,
         ));
@@ -141,7 +141,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testNoDeleteEmptyIfDeleteNotAllowed()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_delete' => false,
             'delete_empty' => true,
         ));
@@ -156,10 +156,10 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testResizedDownIfSubmittedWithCompoundEmptyDataAndDeleteEmpty()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Tests\Fixtures\AuthorType',
+            'entry_type' => 'Symfony\Component\Form\Tests\Fixtures\AuthorType',
             // If the field is not required, no new Author will be created if the
             // form is completely empty
-            'options' => array('required' => false),
+            'entry_options' => array('required' => false),
             'allow_add' => true,
             'delete_empty' => true,
         ));
@@ -179,7 +179,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testNotResizedIfSubmittedWithExtraData()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
         $form->setData(array('foo@bar.com'));
         $form->submit(array('foo@foo.com', 'bar@bar.com'));
@@ -192,7 +192,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testResizedUpIfSubmittedWithExtraDataAndAllowAdd()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_add' => true,
         ));
         $form->setData(array('foo@bar.com'));
@@ -208,7 +208,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testAllowAddButNoPrototype()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
             'allow_add' => true,
             'prototype' => false,
         ));
@@ -220,7 +220,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $form = $this->factory
             ->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-                'type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
+                'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
                 'allow_add' => true,
                 'prototype' => true,
             ))
@@ -232,7 +232,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testGetDataDoesNotContainsPrototypeNameBeforeDataAreSet()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
             'prototype' => true,
             'allow_add' => true,
         ));
@@ -244,7 +244,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testGetDataDoesNotContainsPrototypeNameAfterDataAreSet()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
             'allow_add' => true,
             'prototype' => true,
         ));
@@ -257,7 +257,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPrototypeNameOption()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
             'prototype' => true,
             'allow_add' => true,
         ));
@@ -265,7 +265,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('__name__', $form->getConfig()->getAttribute('prototype')->getName(), '__name__ is the default');
 
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
             'prototype' => true,
             'allow_add' => true,
             'prototype_name' => '__test__',
@@ -274,10 +274,26 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('__test__', $form->getConfig()->getAttribute('prototype')->getName());
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyEntryOptions()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\NumberType',
+            'options' => array('attr' => array('maxlength' => '10')),
+        ));
+
+        $resolvedOptions = $form->getConfig()->getOptions();
+
+        $this->assertEquals('Symfony\Component\Form\Extension\Core\Type\NumberType', $resolvedOptions['entry_type']);
+        $this->assertEquals(array('attr' => array('maxlength' => '10'), 'block_name' => 'entry'), $resolvedOptions['entry_options']);
+    }
+
     public function testPrototypeDefaultLabel()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
             'allow_add' => true,
             'prototype' => true,
             'prototype_name' => '__test__',
@@ -293,7 +309,7 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'allow_add' => true,
             'prototype' => true,
             'prototype_data' => 'foo',
-            'options' => array(
+            'entry_options' => array(
                 'data' => 'bar',
             ),
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -347,8 +347,8 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     {
         $prototypeView = $this->factory
             ->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
-                'type' => __CLASS__.'_ChildType',
-                'options' => array(
+                'entry_type' => __CLASS__.'_ChildType',
+                'entry_options' => array(
                     'csrf_field_name' => 'csrf',
                 ),
                 'prototype' => true,


### PR DESCRIPTION
## Description

Replaces #13820 for the 2.8 branch.

Original description:

> `type` and `options` are extremely generic. Prefixing them with `entry_` makes it clear what they are configuring.
> 
> About the property deprecation it is the same story as https://github.com/symfony/symfony/pull/13717 and I don't know which direction you want me to go.

I've tried to apply the comments in the previous PR, but got a bit lost in the normalizers/default closure stuff. I hope I did everything correctly, but please review :)
## PR Info Table

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #7831 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/5051 |
