### PR TITLE
[VarDumper] Fix dump output for better readability

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -55,10 +55,10 @@ array:25 [
   4 => INF
   5 => -INF
   6 => {$intMax}
-  "str" => "déjà"
-  7 => b"é@"
+  "str" => "déjà\\n"
+  7 => b"é\\x00"
   "[]" => []
-  "res" => :stream {@{$res1}
+  "res" => stream resource {@{$res1}
     wrapper_type: "plainfile"
     stream_type: "STDIO"
     mode: "r"
@@ -69,21 +69,21 @@ array:25 [
     eof: false
     options: []
   }
-  8 => :Unknown {@{$res2}}
+  8 => Unknown resource @{$res2}
   "obj" => Symfony\Component\VarDumper\Tests\Fixture\DumbFoo {#%d
     +foo: "foo"
     +"bar": "bar"
   }
   "closure" => Closure {#%d
     reflection: """
-      Closure [ <user%S> %s Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {
-        @@ {$var['file']} {$var['line']} - {$var['line']}
-
-        - Parameters [2] {
-          Parameter #0 [ <required> \$a ]
-          Parameter #1 [ <optional> PDO or NULL &\$b = NULL ]
-        }
-      }
+      Closure [ <user%S> %s Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {\\n
+        @@ {$var['file']} {$var['line']} - {$var['line']}\\n
+      \\n
+        - Parameters [2] {\\n
+          Parameter #0 [ <required> \$a ]\\n
+          Parameter #1 [ <optional> PDO or NULL &\$b = NULL ]\\n
+        }\\n
+      }\\n
       """
   }
   "line" => {$var['line']}
@@ -130,7 +130,7 @@ EOTXT
 
         $this->assertStringMatchesFormat(
             <<<EOTXT
-:stream {@{$ref}
+stream resource {@{$ref}
   wrapper_type: "PHP"
   stream_type: "MEMORY"
   mode: "w+b"
@@ -161,7 +161,7 @@ EOTXT
     public function testRefsInProperties()
     {
         $var = (object) array('foo' => 'foo');
-        $var->bar =& $var->foo;
+        $var->bar = &$var->foo;
 
         $dumper = new CliDumper();
         $dumper->setColors(false);
@@ -325,7 +325,7 @@ EOTXT
 
         $var = function &() {
             $var = array();
-            $var[] =& $var;
+            $var[] = &$var;
 
             return $var;
         };

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/dumb-var.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/dumb-var.php
@@ -19,7 +19,7 @@ fclose($h);
 $var = array(
     'number' => 1, null,
     'const' => 1.1, true, false, NAN, INF, -INF, PHP_INT_MAX,
-    'str' => "déjà", "\xE9\x00",
+    'str' => "déjà\n", "\xE9\x00",
     '[]' => array(),
     'res' => $g,
     $h,
@@ -30,14 +30,14 @@ $var = array(
 );
 
 $r = array();
-$r[] =& $r;
+$r[] = &$r;
 
-$var['recurs'] =& $r;
-$var[] =& $var[0];
+$var['recurs'] = &$r;
+$var[] = &$var[0];
 $var['sobj'] = $var['obj'];
-$var['snobj'] =& $var['nobj'][0];
+$var['snobj'] = &$var['nobj'][0];
 $var['snobj2'] = $var['nobj'][0];
 $var['file'] = __FILE__;
-$var["bin-key-\xE9"] = "";
+$var["bin-key-\xE9"] = '';
 
 unset($g, $h, $r);

--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -59,10 +59,10 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   <span class=sf-dump-key>4</span> => <span class=sf-dump-num>INF</span>
   <span class=sf-dump-key>5</span> => <span class=sf-dump-num>-INF</span>
   <span class=sf-dump-key>6</span> => <span class=sf-dump-num>{$intMax}</span>
-  "<span class=sf-dump-key>str</span>" => "<span class=sf-dump-str title="4 characters">d&#233;j&#224;</span>"
-  <span class=sf-dump-key>7</span> => b"<span class=sf-dump-str title="2 binary or non-UTF-8 characters">&#233;<span class=sf-dump-cchr title=\\x00>&#9216;</span></span>"
+  "<span class=sf-dump-key>str</span>" => "<span class=sf-dump-str title="5 characters">d&#233;j&#224;</span>\\n"
+  <span class=sf-dump-key>7</span> => b"<span class=sf-dump-str title="2 binary or non-UTF-8 characters">&#233;</span>\\x00"
   "<span class=sf-dump-key>[]</span>" => []
-  "<span class=sf-dump-key>res</span>" => <abbr title="`stream` resource" class=sf-dump-note>:stream</abbr> {<a class=sf-dump-ref>@{$res1}</a><samp>
+  "<span class=sf-dump-key>res</span>" => <span class=sf-dump-note>stream resource</span> <a class=sf-dump-ref>@{$res1}</a><samp>
     <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str title="9 characters">plainfile</span>"
     <span class=sf-dump-meta>stream_type</span>: "<span class=sf-dump-str title="5 characters">STDIO</span>"
     <span class=sf-dump-meta>mode</span>: "<span class=sf-dump-str>r</span>"
@@ -73,21 +73,21 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
     <span class=sf-dump-meta>eof</span>: <span class=sf-dump-const>false</span>
     <span class=sf-dump-meta>options</span>: []
   </samp>}
-  <span class=sf-dump-key>8</span> => <abbr title="`Unknown` resource" class=sf-dump-note>:Unknown</abbr> {<a class=sf-dump-ref>@{$res2}</a>}
+  <span class=sf-dump-key>8</span> => <span class=sf-dump-note>Unknown resource</span> <a class=sf-dump-ref>@{$res2}</a>
   "<span class=sf-dump-key>obj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="2 occurrences">#%d</a><samp id={$dumpId}-ref2%d>
     +<span class=sf-dump-public title="Public property">foo</span>: "<span class=sf-dump-str title="3 characters">foo</span>"
     +"<span class=sf-dump-public title="Runtime added dynamic property">bar</span>": "<span class=sf-dump-str title="3 characters">bar</span>"
   </samp>}
   "<span class=sf-dump-key>closure</span>" => <span class=sf-dump-note>Closure</span> {<a class=sf-dump-ref>#%d</a><samp>
     <span class=sf-dump-meta>reflection</span>: """
-      <span class=sf-dump-str title="%d characters">Closure [ &lt;user%S&gt; %s Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {</span>
-      <span class=sf-dump-str title="%d characters">  @@ {$var['file']} {$var['line']} - {$var['line']}</span>
-
-      <span class=sf-dump-str title="%d characters">  - Parameters [2] {</span>
-      <span class=sf-dump-str title="%d characters">    Parameter #0 [ &lt;required&gt; \$a ]</span>
-      <span class=sf-dump-str title="%d characters">    Parameter #1 [ &lt;optional&gt; PDO or NULL &amp;\$b = NULL ]</span>
-      <span class=sf-dump-str title="%d characters">  }</span>
-      <span class=sf-dump-str title="%d characters">}</span>
+      <span class=sf-dump-str title="%d characters">Closure [ &lt;user%S&gt; %s Symfony\Component\VarDumper\Tests\Fixture\{closure} ] {</span>\\n
+      <span class=sf-dump-str title="%d characters">  @@ {$var['file']} {$var['line']} - {$var['line']}</span>\\n
+      \\n
+      <span class=sf-dump-str title="%d characters">  - Parameters [2] {</span>\\n
+      <span class=sf-dump-str title="%d characters">    Parameter #0 [ &lt;required&gt; \$a ]</span>\\n
+      <span class=sf-dump-str title="%d characters">    Parameter #1 [ &lt;optional&gt; PDO or NULL &amp;\$b = NULL ]</span>\\n
+      <span class=sf-dump-str title="%d characters">  }</span>\\n
+      <span class=sf-dump-str title="%d characters">}</span>\\n
       """
   </samp>}
   "<span class=sf-dump-key>line</span>" => <span class=sf-dump-num>{$var['line']}</span>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR is a follow up of the feedback provided by @bobthecow while proposing var-dumper on bobthecow/psysh#184

It tweaks the output of dumps to (hopefully) make it more readable. The updated test cases in the attached patch should be enough to understand the differences, which are mainly:
- change the displaying of control chars (`\x00` instead of `@`)
- show the `\n` character at end of lines (and display `"foo\n"` on a single line)
- label resources as `foo resource` instead of `:foo` and remove their empty brackets (`{}`) when they have no meta-data
- add a missing hook when reaching end of values
