### PR TITLE
[Intl] fix IntlDataFormatter default pattern

### DIFF
--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -604,7 +604,7 @@ class IntlDateFormatter
         if (self::NONE !== $this->timetype) {
             $patternParts[] = $this->defaultTimeFormats[$this->timetype];
         }
-        $pattern = implode(' ', $patternParts);
+        $pattern = implode(', ', $patternParts);
 
         return $pattern;
     }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -30,6 +30,21 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         new IntlDateFormatter('pt_BR', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
     }
 
+    public function testEqualWithNative()
+    {
+        $native = \IntlDateFormatter::create('en', \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT);
+
+        if ($native instanceof IntlDateFormatter) {
+            $this->markTestSkipped('No intl extension installed');
+        }
+
+        $replacement = IntlDateFormatter::create('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
+
+        $time = time();
+
+        $this->assertSame($native->format($time), $replacement->format($time));
+    }
+
     public function testStaticCreate()
     {
         $formatter = IntlDateFormatter::create('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Without installed Intl extension tests failed, because seems IntlDataFormatter replacement have bug.
In this PR proof-test for this case and fix.
Not sure about "BC breaks"
