### PR TITLE
[Form] Add option widget to ChoiceType

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -35,7 +35,11 @@
 {%- endblock textarea_widget -%}
 
 {%- block choice_widget -%}
-    {% if expanded %}
+    {% if 'hidden' == widget %}
+        {{- block('hidden_widget') -}}
+    {% elseif 'text' == widget %}
+        {{- block('form_widget_simple') -}}
+    {% elseif expanded %}
         {{- block('choice_widget_expanded') -}}
     {% else %}
         {{- block('choice_widget_collapsed') -}}

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValuesToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValuesToStringTransformer.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * Converts an array of values to a string with multiple values separated by a delimiter.
+ *
+ * @author Bilal Amarni <bilal.amarni@gmail.com>
+ */
+class ValuesToStringTransformer implements DataTransformerInterface
+{
+    /**
+     * @var string
+     */
+    private $delimiter;
+
+    /**
+     * @var bool
+     */
+    private $trim;
+
+    /**
+     * @param string $delimiter
+     * @param bool   $trim
+     */
+    public function __construct($delimiter, $trim)
+    {
+        $this->delimiter = $delimiter;
+        $this->trim = $trim;
+    }
+
+    /**
+     * @param array $array
+     *
+     * @return string
+     *
+     * @throws UnexpectedTypeException if the given value is not an array
+     */
+    public function transform($array)
+    {
+        if (null === $array) {
+            return '';
+        }
+
+        if (!is_array($array)) {
+            throw new TransformationFailedException('Expected an array');
+        }
+
+        return implode($this->delimiter, $array);
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return array
+     *
+     * @throws UnexpectedTypeException if the given value is not a string
+     */
+    public function reverseTransform($string)
+    {
+        if (empty($string)) {
+            return array();
+        }
+
+        if (!is_string($string)) {
+            throw new TransformationFailedException('Expected a string');
+        }
+
+        $values = explode($this->delimiter, $string);
+
+        if ($this->trim) {
+            $values = array_map('trim', $values);
+        }
+
+        return $values;
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -32,6 +32,7 @@ use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface as Lega
 use Symfony\Component\Form\Extension\Core\EventListener\MergeCollectionListener;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToValueTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToValuesTransformer;
+use Symfony\Component\Form\Extension\Core\DataTransformer\ValuesToStringTransformer;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -54,7 +55,7 @@ class ChoiceType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if ($options['expanded']) {
+        if ($options['expanded'] && !in_array($options['widget'], array('text', 'hidden'))) {
             $builder->setDataMapper($options['multiple']
                 ? new CheckboxListMapper($options['choice_list'])
                 : new RadioListMapper($options['choice_list']));
@@ -140,10 +141,15 @@ class ChoiceType extends AbstractType
                 });
             }
         } elseif ($options['multiple']) {
-            // <select> tag with "multiple" option
+            // "select", "text" or "hidden" widget with "multiple" option
             $builder->addViewTransformer(new ChoicesToValuesTransformer($options['choice_list']));
+
+            // for "text" / "hidden" widget, view data uses a delimiter
+            if (in_array($options['widget'], array('text', 'hidden'))) {
+                $builder->addViewTransformer(new ValuesToStringTransformer($options['delimiter'], $options['trim']));
+            }
         } else {
-            // <select> tag without "multiple" option
+            // "select", "text" or "hidden" tag without "multiple" option
             $builder->addViewTransformer(new ChoiceToValueTransformer($options['choice_list']));
         }
 
@@ -170,14 +176,19 @@ class ChoiceType extends AbstractType
             : $this->createChoiceListView($options['choice_list'], $options);
 
         $view->vars = array_replace($view->vars, array(
+            'widget' => $options['widget'],
             'multiple' => $options['multiple'],
-            'expanded' => $options['expanded'],
+            'expanded' => $options['expanded'], // BC
             'preferred_choices' => $choiceListView->preferredChoices,
             'choices' => $choiceListView->choices,
             'separator' => '-------------------',
             'placeholder' => null,
             'choice_translation_domain' => $choiceTranslationDomain,
         ));
+
+        if (in_array($options['widget'], array('text', 'hidden'))) {
+            return;
+        }
 
         // The decision, whether a choice is selected, is potentially done
         // thousand of times during the rendering of a template. Provide a
@@ -218,6 +229,10 @@ class ChoiceType extends AbstractType
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
+        if (in_array($options['widget'], array('text', 'hidden'))) {
+            return;
+        }
+
         if ($options['expanded']) {
             // Radio buttons should have the same name as the parent
             $childName = $view->vars['full_name'];
@@ -292,6 +307,18 @@ class ChoiceType extends AbstractType
             return;
         };
 
+        $multipleNormalizer = function (Options $options, $multiple) {
+            if (in_array($options['widget'], array('radio', 'checkbox'))) {
+                return 'checkbox' == $options['widget'];
+            }
+
+            return $multiple;
+        };
+
+        $expandedNomalizer = function (Options $options, $expanded) {
+            return in_array($options['widget'], array('radio', 'checkbox')) ?: $expanded;
+        };
+
         $choiceListNormalizer = function (Options $options, $choiceList) use ($choiceListFactory) {
             if ($choiceList) {
                 @trigger_error('The "choice_list" option is deprecated since version 2.7 and will be removed in 3.0. Use "choice_loader" instead.', E_USER_DEPRECATED);
@@ -364,8 +391,10 @@ class ChoiceType extends AbstractType
         };
 
         $resolver->setDefaults(array(
+            'widget' => null,
             'multiple' => false,
-            'expanded' => false,
+            'delimiter' => ',',
+            'expanded' => false, // deprecated
             'choice_list' => null, // deprecated
             'choices' => array(),
             'choices_as_values' => false,
@@ -388,6 +417,8 @@ class ChoiceType extends AbstractType
             'choice_translation_domain' => true,
         ));
 
+        $resolver->setNormalizer('expanded', $expandedNomalizer);
+        $resolver->setNormalizer('multiple', $multipleNormalizer);
         $resolver->setNormalizer('choices', $choicesNormalizer);
         $resolver->setNormalizer('choice_list', $choiceListNormalizer);
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValuesToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValuesToStringTransformerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
+
+use Symfony\Component\Form\Extension\Core\DataTransformer\ValuesToStringTransformer;
+
+class ValuesToStringTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    private $transformer;
+
+    protected function setUp()
+    {
+        $this->transformer = new ValuesToStringTransformer(',', true);
+    }
+
+    protected function tearDown()
+    {
+        $this->transformer = null;
+    }
+
+    public function testTransform()
+    {
+        $output = 'a,b,c';
+
+        $this->assertSame($output, $this->transformer->transform(array('a', 'b', 'c')));
+    }
+
+    public function testTransformNull()
+    {
+        $this->assertSame('', $this->transformer->transform(null));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformRequiresAnArray()
+    {
+        $this->transformer->transform('a, b, c');
+    }
+
+    public function testReverseTransform()
+    {
+        $input = 'a, b  ,c ';
+
+        $this->assertSame(array('a', 'b', 'c'), $this->transformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformEmpty()
+    {
+        $input = '';
+
+        $this->assertSame(array(), $this->transformer->reverseTransform($input));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformRequiresAString()
+    {
+        $this->transformer->reverseTransform(array('a', 'b', 'c'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1887,4 +1887,68 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         // Trigger data initialization
         $form->getViewData();
     }
+
+    /**
+     * @dataProvider simpleWidgetsProvider
+     */
+    public function testSubmitChoicesWithSimpleWidgets($widget)
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'widget' => $widget,
+            'multiple' => false,
+            'choices' => $this->choices,
+            'choices_as_values' => true,
+        ));
+
+        $form->submit('b');
+
+        $this->assertEquals('b', $form->getData());
+        $this->assertEquals('b', $form->getViewData());
+    }
+
+    /**
+     * @dataProvider simpleWidgetsProvider
+     */
+    public function testSubmitMultipleChoicesWithSimpleWidgets($widget)
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'widget' => $widget,
+            'multiple' => true,
+            'choices' => $this->choices,
+            'choices_as_values' => true,
+        ));
+
+        $form->submit('a,b');
+
+        $this->assertEquals(array('a', 'b'), $form->getData());
+        $this->assertEquals('a,b', $form->getViewData());
+    }
+
+    /**
+     * @dataProvider simpleWidgetsProvider
+     */
+    public function testSubmitMultipleChoicesDelimiterAndTrimWithSimpleWidgets($widget)
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'widget' => $widget,
+            'multiple' => true,
+            'delimiter' => '|',
+            'trim' => true,
+            'choices' => $this->choices,
+            'choices_as_values' => true,
+        ));
+
+        $form->submit('a| b ');
+
+        $this->assertEquals(array('a', 'b'), $form->getData());
+        $this->assertEquals('a|b', $form->getViewData());
+    }
+
+    public function simpleWidgetsProvider()
+    {
+        return array(
+            array('text'),
+            array('hidden'),
+        );
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [yes] |
| Tests pass? | [yes] |
| Fixed tickets | #6602 |
| License | MIT |

Adding the behavior described here #6602, with another approach regarding radios and checkboxes though. When trying to implement it I noticed that the "multiple" option was kinda conflicting with the radio and checkbox widgets, because its value is implicit with them. So I think it would be better to stick to a more generic widget called "expanded", and the multiple option will decide whether it's a radio or a checkbox, it's similar to what we have currently and easier to implement. What do you think @webmozart?

Then I'll only need to rebase the old changes in #8112 about the entity type and it should be ok :)
