### PR TITLE
[Form] bool2string strict comparison

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -4,6 +4,42 @@
 Form
 ----
 
+ * The "checkbox" form-type now interprets '0' and '' values as unchecked unless you 
+   explicitly specified one of those as checked-value (the "value"-option). 
+   Any other value will transform to NULL.
+   
+   Before:
+   ```
+   true  <---> '1' (default checked-value)
+   false <---> null
+   (any other value were true as well)
+   true  <--- ''
+   true  <--- '0'
+   true  <--- 'foobar'
+   ```
+   
+   After:
+   ```
+   true  <---> '1' (default checked-value)
+   false <---> null
+   true  <---> true
+   false <---> false
+   false <--- ''
+   false <--- '0'
+   false <--- 'false'
+   true  <---  '1'
+   true  <---  'true'
+   (any other value will cause an TransformationFailedException and results in the form-value being null)
+   null  <--- 'foobar'
+   ```
+   
+   The new behaviour is due to changes of the `BooleanToStringTransformer` where any other value
+   than `trueValue`, '0' and '' will now cause a `TransformationFailedException`.
+   It should ease Javascript form-submissions where a serialized form with a checkbox-type
+   were interpreted as checked in the backend even if the submitted value wasn't '1' but '0', 
+   which may cause confusion when checkbox is mapped to boolean-type property in the 
+   JS model.
+   
  * The "cascade_validation" option was deprecated. Use the "constraints"
    option together with the `Valid` constraint instead. Contrary to
    "cascade_validation", "constraints" must be set on the respective child forms,

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -30,6 +30,20 @@ class BooleanToStringTransformer implements DataTransformerInterface
     private $trueValue;
 
     /**
+     * Other values recognised as TRUE.
+     *
+     * @var array
+     */
+    private $defaultTrueValues = array('true', '1');
+
+    /**
+     * Values recognised as FALSE.
+     *
+     * @var array
+     */
+    private $defaultFalseValues = array('false', '0', '');
+
+    /**
      * Sets the value emitted upon transform if the input is true.
      *
      * @param string $trueValue
@@ -80,6 +94,19 @@ class BooleanToStringTransformer implements DataTransformerInterface
             throw new TransformationFailedException('Expected a string.');
         }
 
-        return true;
+        if (in_array($value, array_merge($this->defaultTrueValues, array($this->trueValue)), true)) {
+            return true;
+        }
+
+        if (in_array($value, $this->defaultFalseValues, true)) {
+            return false;
+        }
+
+        throw new TransformationFailedException(
+            sprintf(
+                'Unexpected value "%s"!',
+                $value
+            )
+        );
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -60,11 +60,19 @@ class BooleanToStringTransformerTest extends \PHPUnit_Framework_TestCase
         $this->transformer->reverseTransform(1);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformFailsIfUnexspectedValue()
+    {
+        $this->transformer->reverseTransform('foobar');
+    }
+
     public function testReverseTransform()
     {
         $this->assertTrue($this->transformer->reverseTransform(self::TRUE_VALUE));
-        $this->assertTrue($this->transformer->reverseTransform('foobar'));
-        $this->assertTrue($this->transformer->reverseTransform(''));
+        $this->assertFalse($this->transformer->reverseTransform('0'));
+        $this->assertFalse($this->transformer->reverseTransform(''));
         $this->assertFalse($this->transformer->reverseTransform(null));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -70,15 +70,15 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertEquals('foobar', $form->getViewData());
     }
 
-    public function testSubmitWithRandomValueChecked()
+    public function testSubmitWithRandomValueUnchecked()
     {
         $form = $this->factory->create('checkbox', null, array(
             'value' => 'foobar',
         ));
         $form->submit('krixikraxi');
 
-        $this->assertTrue($form->getData());
-        $this->assertEquals('foobar', $form->getViewData());
+        $this->assertNull($form->getData());
+        $this->assertEquals('krixikraxi', $form->getViewData());
     }
 
     public function testSubmitWithValueUnchecked()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The current behavior of the `BooleanToStringTransformer` perfectly fits the need of the `CheckBoxType`and how browsers handle form submissions of checkbox-values.
The downside is that any value e.g. "0" will transform to `true` even if the `trueValue`is set to "1". Due to this it may cause trouble when you want to handle form-submission by Javascript. For a JS-Dev is may not be 100% clear that "0" will transform to `true`in the backend. 
This PR makes it possible to uncheck values without omitting the form-field in the post-data by submitting "0" or "" as value.
