### PR TITLE
[HttpKernel] render_esi should behave in dev as it does in prod

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -64,6 +64,8 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
     public function render($uri, Request $request, array $options = array())
     {
         if (!$this->surrogate || !$this->surrogate->hasSurrogateCapability($request)) {
+            $options['is_fallback'] = true;
+
             return $this->inlineStrategy->render($uri, $request, $options);
         }
 

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -59,8 +59,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
             // want that as we want to preserve objects (so we manually set Request attributes
             // below instead)
             $attributes = $reference->attributes;
-            if (isset($options['is_fallback']) && $options['is_fallback'] )
-            {
+            if (isset($options['is_fallback']) && $options['is_fallback']) {
                 $this->checkNonScalar($attributes);
                 unset($options['is_fallback']);
             }

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -59,6 +59,11 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
             // want that as we want to preserve objects (so we manually set Request attributes
             // below instead)
             $attributes = $reference->attributes;
+            if (isset($options['is_fallback']) && $options['is_fallback'] )
+            {
+                $this->checkNonScalar($attributes);
+                unset($options['is_fallback']);
+            }
             $reference->attributes = array();
 
             // The request format and locale might have been overridden by the user

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -77,7 +77,7 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
         return $request->getBaseUrl().$path;
     }
 
-    private function checkNonScalar($values)
+    protected function checkNonScalar($values)
     {
         foreach ($values as $key => $value) {
             if (is_array($value)) {

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
@@ -28,7 +28,6 @@ class LazyLoadingFragmentHandlerTest extends \PHPUnit_Framework_TestCase
 
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())->method('get')->will($this->returnValue($renderer));
-
         $handler = new LazyLoadingFragmentHandler($container, false, $requestStack);
         $handler->addRendererService('foo', 'foo');
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -95,12 +95,10 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $inline = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer')->disableOriginalConstructor()->getMock();
 
         if ($called) {
-            if ($options)
-            {
+            if ($options) {
                 $inline->expects($this->once())->method('render')->with($this->anything(), $this->anything(), $options);
             }
-            else
-            {
+            else {
                 $inline->expects($this->once())->method('render');
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -21,13 +21,13 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
 {
     public function testRenderFallbackToInlineStrategyIfNoRequest()
     {
-        $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true));
+        $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true, array('is_fallback' => true)));
         $strategy->render('/', Request::create('/'));
     }
 
     public function testRenderFallbackToInlineStrategyIfEsiNotSupported()
     {
-        $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true));
+        $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true, array('is_fallback' => true)));
         $strategy->render('/', Request::create('/'));
     }
 
@@ -90,12 +90,19 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $strategy->render('/', $request, array('alt' => new ControllerReference('alt_controller')));
     }
 
-    private function getInlineStrategy($called = false)
+    private function getInlineStrategy($called = false, $options = false)
     {
         $inline = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer')->disableOriginalConstructor()->getMock();
 
         if ($called) {
-            $inline->expects($this->once())->method('render');
+            if ($options)
+            {
+                $inline->expects($this->once())->method('render')->with($this->anything(), $this->anything(), $options);
+            }
+            else
+            {
+                $inline->expects($this->once())->method('render');
+            }
         }
 
         return $inline;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | todo |
- [ ] gather feedback
- [ ] submit changes to the documentation

Hello,

If an object can't be turned into a string for the URL, then calling render_esi would throw an exception. 
But in dev env, render_esi silently falls back on using a InlineFragmentRenderer and everything seems to work.

I add a parameter (_framework.fragments.strict_) to make the fallback throw the same exception, to detect the logic error in dev mode, before deploying on an env with cache enabled.
