### PR TITLE
[Form] Fixed: remove quoted strings from Intl date formats (e.g. es_ES full pattern)

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -145,6 +145,10 @@ class DateType extends AbstractType
 
             // remove special characters unless the format was explicitly specified
             if (!is_string($options['format'])) {
+                // remove quoted strings first
+                $pattern = preg_replace('/\'[^\']+\'/', '', $pattern);
+
+                // remove remaining special chars
                 $pattern = preg_replace('/[^yMd]+/', '', $pattern);
             }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -614,6 +614,20 @@ class DateTypeTest extends TestCase
         $this->assertFalse(isset($view->vars['date_pattern']));
     }
 
+    public function testDatePatternFormatWithQuotedStrings()
+    {
+        \Locale::setDefault('es_ES');
+
+        $form = $this->factory->create('date', null, array(
+            // EEEE, d 'de' MMMM 'de' y
+            'format' => \IntlDateFormatter::FULL,
+        ));
+
+        $view = $form->createView();
+
+        $this->assertEquals('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
+    }
+
     public function testPassWidgetToView()
     {
         $form = $this->factory->create('date', null, array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15042 |
| License | MIT |
| Doc PR | - |
