### PR TITLE
[property access] Fix issue for broken reference chain

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -25,6 +25,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 {
     const VALUE = 0;
     const IS_REF = 1;
+    const IS_REF_CHAINED = 2;
 
     /**
      * @var bool
@@ -75,6 +76,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         array_unshift($propertyValues, array(
             self::VALUE => &$objectOrArray,
             self::IS_REF => true,
+            self::IS_REF_CHAINED => true,
         ));
 
         for ($i = count($propertyValues) - 1; $i >= 0; --$i) {
@@ -82,14 +84,34 @@ class PropertyAccessor implements PropertyAccessorInterface
 
             $property = $propertyPath->getElement($i);
 
-            if ($propertyPath->isIndex($i)) {
-                $this->writeIndex($objectOrArray, $property, $value);
-            } else {
-                $this->writeProperty($objectOrArray, $property, $value);
-            }
+            // We only need set value for current element if:
+            // 1. it's the parent of the last index element
+            // OR
+            // 2. it's child is not passed by reference
+            //
+            // This may avoid uncessary value setting process for array elements.
+            // For example:
+            // '[a][b][c]' => 'old-value'
+            // If we want to change its value to 'new-value', 
+            // we only need set value for '[a][b][c]' and it's safe to ignore '[a][b]' and '[a]'
+            //
+            if ($i === count($propertyValues) - 1 || !$propertyValues[$i + 1][self::IS_REF]) {
 
-            if ($propertyValues[$i][self::IS_REF]) {
-                return;
+                if ($propertyPath->isIndex($i)) {
+                    $this->writeIndex($objectOrArray, $property, $value);
+                } else {
+                    $this->writeProperty($objectOrArray, $property, $value);
+                }
+
+                // if current element is an object
+                // OR
+                // if current element's reference chain is not broken - current element 
+                // as well as all its ancients in the property path are all passed by reference, 
+                // then there is no need to continue the value setting process
+                if (is_object($propertyValues[$i][self::VALUE]) || $propertyValues[$i][self::IS_REF_CHAINED]) {
+                    return;
+                }
+
             }
 
             $value = &$objectOrArray;
@@ -132,6 +154,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             array_unshift($propertyValues, array(
                 self::VALUE => $objectOrArray,
                 self::IS_REF => true,
+                self::IS_REF_CHAINED => true,
             ));
 
             for ($i = count($propertyValues) - 1; $i >= 0; --$i) {
@@ -149,7 +172,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                     }
                 }
 
-                if ($propertyValues[$i][self::IS_REF]) {
+                if (is_object($propertyValues[$i][self::VALUE]) || $propertyValues[$i][self::IS_REF_CHAINED]) {
                     return true;
                 }
             }
@@ -232,7 +255,10 @@ class PropertyAccessor implements PropertyAccessorInterface
                 throw new UnexpectedTypeException($objectOrArray, 'object or array');
             }
 
+            $propertyValue[self::IS_REF_CHAINED] = $propertyValue[self::IS_REF] && ($i == 0 || $propertyValues[$i - 1][self::IS_REF_CHAINED]);
+
             $propertyValues[] = &$propertyValue;
+
         }
 
         return $propertyValues;

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassIsWritable.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassIsWritable.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class TestClassIsWritable
+{
+	protected $value;
+
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+	public function __construct($value)
+	{
+		$this->value = $value;
+	}
+
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassSetValue.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassSetValue.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class TestClassSetValue
+{
+	protected $value;
+
+    public function getValue()
+	{
+	    return $this->value;
+	}
+
+	public function setValue($value)
+	{
+	    $this->value = $value;
+	}
+
+	public function __construct($value)
+	{
+	    $this->value = $value;
+	}
+
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicGet;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Ticket5775Object;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassSetValue;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassIsWritable;
 
 class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
 {
@@ -446,4 +448,45 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->propertyAccessor->setValue($obj, 'publicProperty[foo][bar]', 'Updated');
         $this->assertSame('Updated', $obj->publicProperty['foo']['bar']);
     }
+
+    public function getReferenceChainObjectsForSetValue()
+    {
+        return array(
+            array(array('a' => array('b' => array('c' => 'old-value'))), '[a][b][c]', 'new-value'),
+            array(new TestClassSetValue(new TestClassSetValue('old-value')), 'value.value', 'new-value'),
+            array(new TestClassSetValue(array('a' => array('b' => array('c' => new TestClassSetValue('old-value'))))), 'value[a][b][c].value', 'new-value'),
+            array(new TestClassSetValue(array('a' => array('b' => 'old-value'))), 'value[a][b]', 'new-value'),
+            array(new \ArrayIterator(array('a' => array('b' => array('c' => 'old-value')))), '[a][b][c]', 'new-value'),
+        );
+
+    }
+
+    /**
+     * @dataProvider getReferenceChainObjectsForSetValue
+     */
+    public function testSetValueForReferenceChainIssue($object, $path, $value)
+    {
+        $this->propertyAccessor->setValue($object, $path, $value);
+
+        $this->assertEquals($value, $this->propertyAccessor->getValue($object, $path));
+    }
+
+    public function getReferenceChainObjectsForIsWritable()
+    {
+        return array(
+            array(new TestClassIsWritable(array('a' => array('b' => 'old-value'))), 'value[a][b]', false),
+            array(new TestClassIsWritable(new \ArrayIterator(array('a' => array('b' => 'old-value')))), 'value[a][b]', true),
+            array(new TestClassIsWritable(array('a' => array('b' => array('c' => new TestClassSetValue('old-value'))))), 'value[a][b][c].value', true),
+        );
+
+    }
+
+    /**
+     * @dataProvider getReferenceChainObjectsForIsWritable
+     */
+    public function testIsWritableForReferenceChainIssue($object, $path, $value)
+    {
+        $this->assertEquals($value, $this->propertyAccessor->isWritable($object, $path));
+    }
+
 }


### PR DESCRIPTION
For the 'property values' that corresponds to a property path in PropertyAccessor::readPropertiesUntil() method, if current element's 'IS_REF' flag is true, it means and only means that it is passed as a reference to its immediate parent in the property path.

It does not guarantee that current element's reference will be automatically escalated to the top, because if there is an element, which is passed by value, stands in its way of going back to the top, the reference chain will be broken.

However, a broken reference chain does NOT necessarily break the reference itself.

There are actually two scenarios:
1. Current element is an object: this won't break the object's reference, because object is always passed as reference, even if the array that holds it is copied, the object is still copied as reference.
2. Current element is an array element: this will also break the reference, because when copying an array, the array elements are copied as values instead of references. This means, at this point, the top element is referring to a different "current element". In order to escalate current element back to the top, its values must be copied explicitly.

The original code of PropertyAccessor does not recognize the 2nd senario, so it will raise issues in method setValue() and isWritable().

Let's explain this issue with some examples:

``` php
// example 1

class Foo
{
    protected $value;

    public function getValue()
    {
        return $this->value;
    }

    public function setValue($value)
    {
        $this->value = $value;
    }

    public function __construct($value)
    {
       $this->value = $value;
    }
}

$pa = new PropertyAccessor();

$b = new Foo('old-value');
$a = new Foo(
    array(
       'a' => array(
           'b' => array(
               'c' => $b
           )
       )
    )
)

$pa->setValue($a, 'value[a][b][c].value', 'new-value');
// The reference chain is broken at $a.value, because array is
// passed as value. But since $a.value[a][b][c].value is an object,
// which is always passed as reference, the refernce itself is not broken,
// the original code base works and the value of $a.value[a][b][c].value
// will be changed to 'new-value'
```

``` php
// example 2.

class Foo
{
    protected $value;

    public function getValue()
    {
        return $this->value;
    }

    public function setValue($value)
    {
        $this->value = $value;
    }

    public function __construct($value)
    {
       $this->value = $value;
    }
}

$a = new Foo(
    array(
        'a' => array(
            'b' => 'old-value'
        )
    )
);

$pa = new PropertyAccessor();

$pa->setValue($a, 'value[a][b]', 'new-value');

// The reference chain is broken at $a.value, because array is
// passed as value and the reference of $a.value[a][b] is broken as
// well, because when $a.value is copied, $a.value[a][b] is passed by
// value as well.
// But the original code base does not recognize this scenario and will
// terminate the process earlier, which will fail to update the value of
// $a.value[a][b]

```

This issue is caused by the incorrect use of 'IS_REF' flag: the original
code base only use the 'IS_REF' flag to identify reference element, but
it does not care if it's an object or array element. For object, it's
safe to terminate the process earlier, but for array element, we should
not terminate the process unless we can confirm that its reference chain
is not broken - all of its ancient elements in the property path are
passed by reference.

This issue affects both the setValue() and the isWritable() methods.

So we need introduce a new flag, 'IS_REF_CHAINED', to identify an
element that is passed as reference and all its ancient elements in
the property path are also passed as reference.

And we can terminate the process as follows:
1. If current element is an object, then it's safe to terminate the value setting process here because object is always passed as reference.
2. If current element is not an object and its 'IS_REF_CHAINED' flag is true, then it's safe to terminate the value setting process, because all the acient elements in the property path are referring
   to this object as reference, so there is no need to copy values.
3. Otherwise, we should not terminate the value setting process here,
   so that the element value can be copied explicitly later.
   
   | Q | A |
   | --- | --- |
   | Bug fix? | yes |
   | New feature? | no |
   | BC breaks? | no |
   | Deprecations? | no |
   | Tests pass? | yes |
   | Fixed tickets | n/a |
   | License | MIT |
   | Doc PR | n/a |
