### PR TITLE
[HttpFoundation] Use convention to allow throwing from __toString()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -480,7 +480,7 @@ class Request
         try {
             $content = $this->getContent();
         } catch (\LogicException $e) {
-            trigger_error($e->getMessage(), E_USER_ERROR);
+            return trigger_error($e, E_USER_ERROR);
         }
 
         return


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Corollary to #15076, works without it.
