### PR TITLE
[Form] Deprecated FormTypeInterface::getName() and passing of type instances

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -12,7 +12,7 @@ Form
    Before:
    
    ```php
-   $form = $this->createForm('form', $article, array('cascade_validation' => true))
+   $form = $this->createFormBuilder($article, array('cascade_validation' => true))
        ->add('author', new AuthorType())
        ->getForm();
    ```
@@ -22,7 +22,7 @@ Form
    ```php
    use Symfony\Component\Validator\Constraints\Valid;
    
-   $form = $this->createForm('form', $article)
+   $form = $this->createFormBuilder($article)
        ->add('author', new AuthorType(), array(
            'constraints' => new Valid(),
        ))
@@ -41,6 +41,194 @@ Form
         */
        private $author;
    }
+   ```
+   
+ * Type names were deprecated and will be removed in Symfony 3.0. Instead of
+   referencing types by name, you should reference them by their
+   fully-qualified class name (FQCN) instead. With PHP 5.5 or later, you can
+   use the "class" constant for that:
+   
+   Before:
+   
+   ```php
+   $form = $this->createFormBuilder()
+       ->add('name', 'text')
+       ->add('age', 'integer')
+       ->getForm();
+   ```
+   
+   After:
+   
+   ```php
+   use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+   use Symfony\Component\Form\Extension\Core\Type\TextType;
+   
+   $form = $this->createFormBuilder()
+       ->add('name', TextType::class)
+       ->add('age', IntegerType::class)
+       ->getForm();
+   ```
+   
+   As a further consequence, the method `FormTypeInterface::getName()` was
+   deprecated and will be removed in Symfony 3.0. You should remove this method
+   from your form types.
+   
+   If you want to customize the block prefix of a type in Twig, you should now
+   implement `FormTypeInterface::getBlockPrefix()` instead:
+   
+   Before:
+   
+   ```php
+   class UserProfileType extends AbstractType
+   {
+       public function getName()
+       {
+           return 'profile';
+       }
+   }
+   ```
+   
+   After:
+   
+   ```php
+   class UserProfileType extends AbstractType
+   {
+       public function getBlockPrefix()
+       {
+           return 'profile';
+       }
+   }
+   ```
+   
+   If you don't customize `getBlockPrefix()`, it defaults to the class name
+   without "Type" suffix in underscore notation (here: "user_profile").
+   
+   If you want to create types that are compatible with Symfony 2.3 up to 2.8
+   and don't trigger deprecation errors, implement *both* `getName()` and
+   `getBlockPrefix()`:
+   
+   ```php
+   class ProfileType extends AbstractType
+   {
+       public function getName()
+       {
+           return $this->getBlockPrefix();
+       }
+       
+       public function getBlockPrefix()
+       {
+           return 'profile';
+       }
+   }
+   ```
+   
+   If you define your form types in the Dependency Injection configuration, you
+   should further remove the "alias" attribute:
+   
+   Before:
+   
+   ```xml
+   <service id="my.type" class="Vendor\Type\MyType">
+       <tag name="form.type" alias="mytype" />
+   </service>
+   ```
+   
+   After:
+   
+   ```xml
+   <service id="my.type" class="Vendor\Type\MyType">
+       <tag name="form.type" />
+   </service>
+   ```
+   
+   Type extension should return the fully-qualified class name of the extended
+   type from `FormTypeExtensionInterface::getExtendedType()` now.
+   
+   Before:
+   
+   ```php
+   class MyTypeExtension extends AbstractTypeExtension
+   {
+       public function getExtendedType()
+       {
+           return 'form';
+       }
+   }
+   ```
+   
+   After:
+   
+   ```php
+   use Symfony\Component\Form\Extension\Core\Type\FormType;
+   
+   class MyTypeExtension extends AbstractTypeExtension
+   {
+       public function getExtendedType()
+       {
+           return FormType::class;
+       }
+   }
+   ```
+   
+   If your extension has to be compatible with Symfony 2.3-2.8, use the 
+   following statement:
+   
+   ```php
+   use Symfony\Component\Form\AbstractType;
+   use Symfony\Component\Form\Extension\Core\Type\FormType;
+   
+   class MyTypeExtension extends AbstractTypeExtension
+   {
+       public function getExtendedType()
+       {
+           method_exists(AbstractType::class, 'getBlockPrefix') ? FormType::class : 'form';
+       }
+   }
+   ```
+   
+ * Returning type instances from `FormTypeInterface::getParent()` is deprecated
+   and will not be supported anymore in Symfony 3.0. Return the fully-qualified
+   class name of the parent type class instead.
+   
+   Before:
+   
+   ```php
+   class MyType
+   {
+       public function getParent()
+       {
+           return new ParentType();
+       }
+   }
+   ```
+   
+   After:
+   
+   ```php
+   class MyType
+   {
+       public function getParent()
+       {
+           return ParentType::class;
+       }
+   }
+   ```
+   
+ * Passing type instances to `Form::add()`, `FormBuilder::add()` and the
+   `FormFactory::create*()` methods is deprecated and will not be supported
+   anymore in Symfony 3.0. Pass the fully-qualified class name of the type
+   instead.
+   
+   Before:
+   
+   ```php
+   $form = $this->createForm(new MyType());
+   ```
+   
+   After:
+   
+   ```php
+   $form = $this->createForm(MyType::class);
    ```
 
 Translator

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -94,12 +94,12 @@ abstract class DoctrineType extends AbstractType
      * Gets important parts from QueryBuilder that will allow to cache its results.
      * For instance in ORM two query builders with an equal SQL string and
      * equal parameters are considered to be equal.
-     * 
+     *
      * @param object $queryBuilder
-     * 
+     *
      * @return array|false Array with important QueryBuilder parts or false if
      *                     they can't be determined
-     * 
+     *
      * @internal This method is public to be usable as callback. It should not
      *           be used in user code.
      */
@@ -335,6 +335,6 @@ abstract class DoctrineType extends AbstractType
 
     public function getParent()
     {
-        return 'choice';
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -56,7 +56,18 @@ class EntityType extends DoctrineType
         return new ORMQueryBuilderLoader($queryBuilder, $manager, $class);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'entity';
     }
@@ -64,11 +75,11 @@ class EntityType extends DoctrineType
     /**
      * We consider two query builders with an equal SQL string and
      * equal parameters to be equal.
-     * 
+     *
      * @param QueryBuilder $queryBuilder
-     * 
+     *
      * @return array
-     * 
+     *
      * @internal This method is public to be usable as callback. It should not
      *           be used in user code.
      */

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -102,12 +102,22 @@ class EntityTypeTest extends TypeTestCase
         // be managed!
     }
 
+    public function testLegacyName()
+    {
+        $field = $this->factory->createNamed('name', 'entity', null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ));
+
+        $this->assertSame('entity', $field->getConfig()->getType()->getName());
+    }
+
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
      */
     public function testClassOptionIsRequired()
     {
-        $this->factory->createNamed('name', 'entity');
+        $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType');
     }
 
     /**
@@ -115,7 +125,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testInvalidClassOption()
     {
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'class' => 'foo',
         ));
     }
@@ -127,7 +137,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -144,7 +154,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -161,7 +171,7 @@ class EntityTypeTest extends TypeTestCase
         $this->persist(array($entity1, $entity2));
         $qb = $this->em->createQueryBuilder()->select('e')->from(self::SINGLE_IDENT_CLASS, 'e');
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -177,7 +187,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testConfigureQueryBuilderWithNonQueryBuilderAndNonClosure()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => new \stdClass(),
@@ -189,7 +199,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testConfigureQueryBuilderWithClosureReturningNonQueryBuilder()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function () {
@@ -202,7 +212,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataSingleNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => false,
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
@@ -215,7 +225,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataMultipleExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => true,
             'expanded' => true,
             'em' => 'default',
@@ -229,7 +239,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataMultipleNonExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -243,7 +253,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => false,
             'expanded' => true,
             'em' => 'default',
@@ -257,7 +267,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSubmitSingleNonExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -271,7 +281,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSubmitMultipleNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => true,
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
@@ -289,7 +299,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -311,7 +321,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -335,7 +345,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -360,7 +370,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -391,7 +401,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -417,7 +427,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -447,7 +457,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => false,
             'expanded' => true,
             'em' => 'default',
@@ -473,7 +483,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => true,
             'expanded' => true,
             'em' => 'default',
@@ -503,7 +513,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             // not all persisted entities should be displayed
@@ -528,7 +538,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($item1, $item2, $item3, $item4));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::ITEM_GROUP_CLASS,
             'choices' => array($item1, $item2, $item3, $item4),
@@ -559,7 +569,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'preferred_choices' => array($entity3, $entity2),
@@ -578,7 +588,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choices' => array($entity2, $entity3),
@@ -598,7 +608,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -619,7 +629,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::COMPOSITE_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -642,7 +652,7 @@ class EntityTypeTest extends TypeTestCase
 
         $repository = $this->em->getRepository(self::SINGLE_IDENT_CLASS);
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => $repository->createQueryBuilder('e')
@@ -664,7 +674,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function ($repository) {
@@ -688,7 +698,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::COMPOSITE_IDENT_CLASS,
             'query_builder' => function ($repository) {
@@ -710,7 +720,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -731,7 +741,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -757,7 +767,7 @@ class EntityTypeTest extends TypeTestCase
             ->with(self::SINGLE_IDENT_CLASS)
             ->will($this->returnValue($this->em));
 
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'choice_label' => 'name',
@@ -772,7 +782,7 @@ class EntityTypeTest extends TypeTestCase
         $this->emRegistry->expects($this->never())
             ->method('getManagerForClass');
 
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'choice_label' => 'name',
@@ -801,15 +811,15 @@ class EntityTypeTest extends TypeTestCase
             ->addTypeGuesser($entityTypeGuesser)
             ->getFormFactory();
 
-        $formBuilder = $factory->createNamedBuilder('form', 'form');
+        $formBuilder = $factory->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType');
 
-        $formBuilder->add('property1', 'entity', array(
+        $formBuilder->add('property1', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => $repo->createQueryBuilder('e')->where('e.id IN (1, 2)'),
         ));
 
-        $formBuilder->add('property2', 'entity', array(
+        $formBuilder->add('property2', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function (EntityRepository $repo) {
@@ -817,7 +827,7 @@ class EntityTypeTest extends TypeTestCase
             },
         ));
 
-        $formBuilder->add('property3', 'entity', array(
+        $formBuilder->add('property3', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function (EntityRepository $repo) {
@@ -848,14 +858,14 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field1 = $this->factory->createNamed('name', 'entity', null, array(
+        $field1 = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'choice_label' => 'name',
         ));
 
-        $field2 = $this->factory->createNamed('name', 'entity', null, array(
+        $field2 = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -876,7 +886,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -23,7 +23,7 @@
         "symfony/phpunit-bridge": "~2.7|~3.0.0",
         "symfony/stopwatch": "~2.2|~3.0.0",
         "symfony/dependency-injection": "~2.2|~3.0.0",
-        "symfony/form": "~2.7,>=2.7.1|~3.0.0",
+        "symfony/form": "~2.8|~3.0.0",
         "symfony/http-kernel": "~2.2|~3.0.0",
         "symfony/property-access": "~2.3|~3.0.0",
         "symfony/security": "~2.2|~3.0.0",

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -69,7 +69,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testThemeBlockInheritanceUsingUse()
     {
         $view = $this->factory
-            ->createNamed('name', 'email')
+            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType')
             ->createView()
         ;
 
@@ -84,7 +84,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testThemeBlockInheritanceUsingExtend()
     {
         $view = $this->factory
-            ->createNamed('name', 'email')
+            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType')
             ->createView()
         ;
 
@@ -99,7 +99,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testThemeBlockInheritanceUsingDynamicExtend()
     {
         $view = $this->factory
-            ->createNamed('name', 'email')
+            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType')
             ->createView()
         ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -46,6 +46,8 @@
             <argument type="collection" />
             <!-- All services with tag "form.type_guesser" are inserted here by FormPass -->
             <argument type="collection" />
+            <!-- The deprecated type names are inserted here by FormPass -->
+            <argument type="collection" />
         </service>
 
         <!-- ValidatorTypeGuesser -->

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Form\AbstractType;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class FormPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDoNothingIfFormExtensionNotLoaded()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new FormPass());
+
+        $container->compile();
+
+        $this->assertFalse($container->hasDefinition('form.extension'));
+    }
+
+    public function testAddTaggedTypes()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new FormPass());
+
+        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
+        $extDefinition->setArguments(array(
+            new Reference('service_container'),
+            array(),
+            array(),
+            array(),
+            array(),
+        ));
+
+        $definition1 = new Definition(__CLASS__.'_Type1');
+        $definition1->addTag('form.type');
+        $definition2 = new Definition(__CLASS__.'_Type2');
+        $definition2->addTag('form.type');
+
+        $container->setDefinition('form.extension', $extDefinition);
+        $container->setDefinition('my.type1', $definition1);
+        $container->setDefinition('my.type2', $definition2);
+
+        $container->compile();
+
+        $extDefinition = $container->getDefinition('form.extension');
+
+        $this->assertEquals(array(
+            // As of Symfony 2.8, the class is used to look up types
+            __CLASS__.'_Type1' => 'my.type1',
+            __CLASS__.'_Type2' => 'my.type2',
+            // Before Symfony 2.8, the service ID was used as default alias
+            'my.type1' => 'my.type1',
+            'my.type2' => 'my.type2',
+        ), $extDefinition->getArgument(1));
+    }
+
+    public function testUseCustomAliasIfSet()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new FormPass());
+
+        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
+        $extDefinition->setArguments(array(
+            new Reference('service_container'),
+            array(),
+            array(),
+            array(),
+            array(),
+        ));
+
+        $definition1 = new Definition(__CLASS__.'_Type1');
+        $definition1->addTag('form.type', array('alias' => 'mytype1'));
+        $definition2 = new Definition(__CLASS__.'_Type2');
+        $definition2->addTag('form.type', array('alias' => 'mytype2'));
+
+        $container->setDefinition('form.extension', $extDefinition);
+        $container->setDefinition('my.type1', $definition1);
+        $container->setDefinition('my.type2', $definition2);
+
+        $container->compile();
+
+        $extDefinition = $container->getDefinition('form.extension');
+
+        $this->assertEquals(array(
+            __CLASS__.'_Type1' => 'my.type1',
+            __CLASS__.'_Type2' => 'my.type2',
+            'mytype1' => 'my.type1',
+            'mytype2' => 'my.type2',
+        ), $extDefinition->getArgument(1));
+    }
+
+    public function testPassLegacyNames()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new FormPass());
+
+        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
+        $extDefinition->setArguments(array(
+            new Reference('service_container'),
+            array(),
+            array(),
+            array(),
+            array(),
+        ));
+
+        $definition1 = new Definition(__CLASS__.'_Type1');
+        $definition1->addTag('form.type');
+        $definition2 = new Definition(__CLASS__.'_Type2');
+        $definition2->addTag('form.type', array('alias' => 'mytype2'));
+
+        $container->setDefinition('form.extension', $extDefinition);
+        $container->setDefinition('my.type1', $definition1);
+        $container->setDefinition('my.type2', $definition2);
+
+        $container->compile();
+
+        $extDefinition = $container->getDefinition('form.extension');
+
+        $this->assertEquals(array(
+            // Service ID if no alias is set
+            'my.type1' => true,
+            // Alias if set
+            'mytype2' => true,
+        ), $extDefinition->getArgument(4));
+    }
+
+    public function testAddTaggedTypeExtensions()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new FormPass());
+
+        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
+        $extDefinition->setArguments(array(
+            new Reference('service_container'),
+            array(),
+            array(),
+            array(),
+            array(),
+        ));
+
+        $definition1 = new Definition('stdClass');
+        $definition1->addTag('form.type_extension', array('alias' => 'type1'));
+        $definition2 = new Definition('stdClass');
+        $definition2->addTag('form.type_extension', array('alias' => 'type1'));
+        $definition3 = new Definition('stdClass');
+        $definition3->addTag('form.type_extension', array('alias' => 'type2'));
+
+        $container->setDefinition('form.extension', $extDefinition);
+        $container->setDefinition('my.type_extension1', $definition1);
+        $container->setDefinition('my.type_extension2', $definition2);
+        $container->setDefinition('my.type_extension3', $definition3);
+
+        $container->compile();
+
+        $extDefinition = $container->getDefinition('form.extension');
+
+        $this->assertSame(array(
+            'type1' => array(
+                'my.type_extension1',
+                'my.type_extension2',
+            ),
+            'type2' => array(
+                'my.type_extension3',
+            ),
+        ), $extDefinition->getArgument(2));
+    }
+
+    public function testAddTaggedGuessers()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new FormPass());
+
+        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
+        $extDefinition->setArguments(array(
+            new Reference('service_container'),
+            array(),
+            array(),
+            array(),
+            array(),
+        ));
+
+        $definition1 = new Definition('stdClass');
+        $definition1->addTag('form.type_guesser');
+        $definition2 = new Definition('stdClass');
+        $definition2->addTag('form.type_guesser');
+
+        $container->setDefinition('form.extension', $extDefinition);
+        $container->setDefinition('my.guesser1', $definition1);
+        $container->setDefinition('my.guesser2', $definition2);
+
+        $container->compile();
+
+        $extDefinition = $container->getDefinition('form.extension');
+
+        $this->assertSame(array(
+            'my.guesser1',
+            'my.guesser2',
+        ), $extDefinition->getArgument(3));
+    }
+}
+
+class FormPassTest_Type1 extends AbstractType
+{
+}
+
+class FormPassTest_Type2 extends AbstractType
+{
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Controller/LoginController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Controller/LoginController.php
@@ -19,7 +19,7 @@ class LoginController extends ContainerAware
 {
     public function loginAction()
     {
-        $form = $this->container->get('form.factory')->create('user_login');
+        $form = $this->container->get('form.factory')->create('Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfFormLoginBundle\Form\UserLoginType');
 
         return $this->container->get('templating')->renderResponse('CsrfFormLoginBundle:Login:login.html.twig', array(
             'form' => $form->createView(),

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Form/UserLoginType.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Form/UserLoginType.php
@@ -27,7 +27,7 @@ use Symfony\Component\Security\Core\Security;
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
  * @author Jeremy Mikola <jmikola@gmail.com>
  */
-class UserLoginFormType extends AbstractType
+class UserLoginType extends AbstractType
 {
     private $requestStack;
 
@@ -45,9 +45,9 @@ class UserLoginFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('username', 'text')
-            ->add('password', 'password')
-            ->add('_target_path', 'hidden')
+            ->add('username', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\PasswordType')
+            ->add('_target_path', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
         ;
 
         $request = $this->requestStack->getCurrentRequest();
@@ -86,13 +86,5 @@ class UserLoginFormType extends AbstractType
         $resolver->setDefaults(array(
             'intention' => 'authenticate',
         ));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'user_login';
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
@@ -3,11 +3,11 @@ imports:
 
 services:
     csrf_form_login.form.type:
-        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfFormLoginBundle\Form\UserLoginFormType
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfFormLoginBundle\Form\UserLoginType
         arguments:
             - @request_stack
         tags:
-            - { name: form.type, alias: user_login }
+            - { name: form.type }
 
 security:
     encoders:

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -156,7 +156,15 @@ abstract class AbstractExtension implements FormExtensionInterface
                 throw new UnexpectedTypeException($type, 'Symfony\Component\Form\FormTypeInterface');
             }
 
-            $this->types[$type->getName()] = $type;
+            // Since Symfony 3.0 types are identified by their FQCN
+            $fqcn = get_class($type);
+            $legacyName = $type->getName();
+
+            $this->types[$fqcn] = $type;
+
+            if ($legacyName) {
+                $this->types[$legacyName] = $type;
+            }
         }
     }
 

--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\Util\StringUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -64,8 +65,34 @@ abstract class AbstractType implements FormTypeInterface
     /**
      * {@inheritdoc}
      */
+    public function getName()
+    {
+        // As of Symfony 2.8, the name defaults to the fully-qualified class name
+        return get_class($this);
+    }
+
+    /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefixes defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        $fqcn = get_class($this);
+        $name = $this->getName();
+
+        // For BC: Use the name as block prefix if one is set
+        return $name !== $fqcn ? $name : StringUtil::fqcnToBlockPrefix($fqcn);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getParent()
     {
-        return 'form';
+        return 'Symfony\Component\Form\Extension\Core\Type\FormType';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Util\StringUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -77,7 +78,17 @@ abstract class BaseType extends AbstractType
 
         $blockPrefixes = array();
         for ($type = $form->getConfig()->getType(); null !== $type; $type = $type->getParent()) {
-            array_unshift($blockPrefixes, $type->getName());
+            if (method_exists($type, 'getBlockPrefix')) {
+                array_unshift($blockPrefixes, $type->getBlockPrefix());
+            } else {
+                @trigger_error(get_class($type).': The ResolvedFormTypeInterface::getBlockPrefix() method will be added in version 3.0. You should add it to your implementation.', E_USER_DEPRECATED);
+
+                $fqcn = get_class($type->getInnerType());
+                $name = $type->getName();
+                $hasCustomName = $name !== $fqcn;
+
+                array_unshift($blockPrefixes, $hasCustomName ? $name : StringUtil::fqcnToBlockPrefix($fqcn));
+            }
         }
         $blockPrefixes[] = $uniqueBlockPrefix;
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
@@ -31,13 +31,21 @@ class BirthdayType extends AbstractType
      */
     public function getParent()
     {
-        return 'date';
+        return __NAMESPACE__.'\DateType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'birthday';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/ButtonType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ButtonType.php
@@ -33,6 +33,14 @@ class ButtonType extends BaseType implements ButtonTypeInterface
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'button';
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -67,6 +67,14 @@ class CheckboxType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'checkbox';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -362,6 +362,14 @@ class ChoiceType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'choice';
     }
 
@@ -424,12 +432,12 @@ class ChoiceType extends AbstractType
         );
 
         if ($options['multiple']) {
-            $choiceType = 'checkbox';
+            $choiceType = __NAMESPACE__.'\CheckboxType';
             // The user can check 0 or more checkboxes. If required
             // is true, he is required to check all of them.
             $choiceOpts['required'] = false;
         } else {
-            $choiceType = 'radio';
+            $choiceType = __NAMESPACE__.'\RadioType';
         }
 
         $builder->add($name, $choiceType, $choiceOpts);

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -88,7 +88,7 @@ class CollectionType extends AbstractType
             'prototype' => true,
             'prototype_data' => null,
             'prototype_name' => '__name__',
-            'type' => 'text',
+            'type' => __NAMESPACE__.'\TextType',
             'options' => array(),
             'delete_empty' => false,
         ));
@@ -100,6 +100,14 @@ class CollectionType extends AbstractType
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'collection';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -33,13 +33,21 @@ class CountryType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return __NAMESPACE__.'\ChoiceType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'country';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -33,13 +33,21 @@ class CurrencyType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return __NAMESPACE__.'\ChoiceType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'currency';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -161,8 +161,8 @@ class DateTimeType extends AbstractType
                         'time' => $timeParts,
                     )),
                 )))
-                ->add('date', 'date', $dateOptions)
-                ->add('time', 'time', $timeOptions)
+                ->add('date', __NAMESPACE__.'\DateType', $dateOptions)
+                ->add('time', __NAMESPACE__.'\TimeType', $timeOptions)
             ;
         }
 
@@ -284,6 +284,14 @@ class DateTimeType extends AbstractType
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'datetime';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -37,6 +37,11 @@ class DateType extends AbstractType
         \IntlDateFormatter::SHORT,
     );
 
+    private static $widgets = array(
+        'text' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+        'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+    );
+
     /**
      * {@inheritdoc}
      */
@@ -101,9 +106,9 @@ class DateType extends AbstractType
             }
 
             $builder
-                ->add('year', $options['widget'], $yearOptions)
-                ->add('month', $options['widget'], $monthOptions)
-                ->add('day', $options['widget'], $dayOptions)
+                ->add('year', self::$widgets[$options['widget']], $yearOptions)
+                ->add('month', self::$widgets[$options['widget']], $monthOptions)
+                ->add('day', self::$widgets[$options['widget']], $dayOptions)
                 ->addViewTransformer(new DateTimeToArrayTransformer(
                     $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day')
                 ))
@@ -253,6 +258,14 @@ class DateType extends AbstractType
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'date';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
@@ -20,13 +20,21 @@ class EmailType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        return __NAMESPACE__.'\TextType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'email';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -62,6 +62,14 @@ class FileType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'file';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -245,6 +245,14 @@ class FormType extends BaseType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'form';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/HiddenType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/HiddenType.php
@@ -35,6 +35,14 @@ class HiddenType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'hidden';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
@@ -74,6 +74,14 @@ class IntegerType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'integer';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -33,13 +33,21 @@ class LanguageType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return __NAMESPACE__.'\ChoiceType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'language';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
@@ -33,13 +33,21 @@ class LocaleType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return __NAMESPACE__.'\ChoiceType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'locale';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -79,6 +79,14 @@ class MoneyType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'money';
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
@@ -72,6 +72,14 @@ class NumberType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'number';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -44,13 +44,21 @@ class PasswordType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        return __NAMESPACE__.'\TextType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'password';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
@@ -63,6 +63,14 @@ class PercentType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'percent';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
@@ -20,13 +20,21 @@ class RadioType extends AbstractType
      */
     public function getParent()
     {
-        return 'checkbox';
+        return __NAMESPACE__.'\CheckboxType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'radio';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -20,13 +20,21 @@ class RangeType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        return __NAMESPACE__.'\TextType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'range';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -47,7 +47,7 @@ class RepeatedType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'type' => 'text',
+            'type' => __NAMESPACE__.'\TextType',
             'options' => array(),
             'first_options' => array(),
             'second_options' => array(),
@@ -65,6 +65,14 @@ class RepeatedType extends AbstractType
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'repeated';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/ResetType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ResetType.php
@@ -26,13 +26,21 @@ class ResetType extends AbstractType implements ButtonTypeInterface
      */
     public function getParent()
     {
-        return 'button';
+        return __NAMESPACE__.'\ButtonType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'reset';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
@@ -20,13 +20,21 @@ class SearchType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        return __NAMESPACE__.'\TextType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'search';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/SubmitType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SubmitType.php
@@ -33,13 +33,21 @@ class SubmitType extends AbstractType implements SubmitButtonTypeInterface
      */
     public function getParent()
     {
-        return 'button';
+        return __NAMESPACE__.'\ButtonType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'submit';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -31,6 +31,14 @@ class TextType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'text';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -30,13 +30,21 @@ class TextareaType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        return __NAMESPACE__.'\TextType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'textarea';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -25,6 +25,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TimeType extends AbstractType
 {
+    private static $widgets = array(
+        'text' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+        'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+    );
+
     /**
      * {@inheritdoc}
      */
@@ -99,14 +104,14 @@ class TimeType extends AbstractType
                 }
             }
 
-            $builder->add('hour', $options['widget'], $hourOptions);
+            $builder->add('hour', self::$widgets[$options['widget']], $hourOptions);
 
             if ($options['with_minutes']) {
-                $builder->add('minute', $options['widget'], $minuteOptions);
+                $builder->add('minute', self::$widgets[$options['widget']], $minuteOptions);
             }
 
             if ($options['with_seconds']) {
-                $builder->add('second', $options['widget'], $secondOptions);
+                $builder->add('second', self::$widgets[$options['widget']], $secondOptions);
             }
 
             $builder->addViewTransformer(new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts, 'text' === $options['widget']));
@@ -238,6 +243,14 @@ class TimeType extends AbstractType
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'time';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -39,13 +39,21 @@ class TimezoneType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return __NAMESPACE__.'\ChoiceType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'timezone';
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -43,13 +43,21 @@ class UrlType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        return __NAMESPACE__.'\TextType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'url';
     }

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -108,7 +108,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             $tokenId = $options['csrf_token_id'] ?: ($form->getName() ?: get_class($form->getConfig()->getType()->getInnerType()));
             $data = (string) $options['csrf_token_manager']->getToken($tokenId);
 
-            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'hidden', $data, array(
+            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'Symfony\Component\Form\Extension\Core\Type\HiddenType', $data, array(
                 'mapped' => false,
             ));
 
@@ -153,6 +153,6 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'form';
+        return 'Symfony\Component\Form\Extension\Core\Type\FormType';
     }
 }

--- a/src/Symfony/Component/Form/Extension/DataCollector/Proxy/ResolvedTypeDataCollectorProxy.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/Proxy/ResolvedTypeDataCollectorProxy.php
@@ -53,6 +53,14 @@ class ResolvedTypeDataCollectorProxy implements ResolvedFormTypeInterface
     /**
      * {@inheritdoc}
      */
+    public function getBlockPrefix()
+    {
+        return method_exists($this->proxiedType, 'getBlockPrefix') ? $this->proxiedType->getBlockPrefix() : $this->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getParent()
     {
         return $this->proxiedType->getParent();

--- a/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
+++ b/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
@@ -22,17 +22,19 @@ class DependencyInjectionExtension implements FormExtensionInterface
     private $typeServiceIds;
     private $typeExtensionServiceIds;
     private $guesserServiceIds;
+    private $legacyNames;
     private $guesser;
     private $guesserLoaded = false;
 
     public function __construct(ContainerInterface $container,
         array $typeServiceIds, array $typeExtensionServiceIds,
-        array $guesserServiceIds)
+        array $guesserServiceIds, array $legacyNames = array())
     {
         $this->container = $container;
         $this->typeServiceIds = $typeServiceIds;
         $this->typeExtensionServiceIds = $typeExtensionServiceIds;
         $this->guesserServiceIds = $guesserServiceIds;
+        $this->legacyNames = $legacyNames;
     }
 
     public function getType($name)
@@ -41,15 +43,21 @@ class DependencyInjectionExtension implements FormExtensionInterface
             throw new InvalidArgumentException(sprintf('The field type "%s" is not registered with the service container.', $name));
         }
 
+        if (isset($this->legacyNames[$name])) {
+            @trigger_error('Accessing form types by type name/service ID is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
+        }
+
         $type = $this->container->get($this->typeServiceIds[$name]);
 
-        if ($type->getName() !== $name) {
+        // BC: validate result of getName() for legacy names (non-FQCN)
+        if (isset($this->legacyNames[$name]) && $type->getName() !== $name) {
             throw new InvalidArgumentException(
                 sprintf('The type name specified for the service "%s" does not match the actual name. Expected "%s", given "%s"',
                     $this->typeServiceIds[$name],
                     $name,
                     $type->getName()
-                ));
+                )
+            );
         }
 
         return $type;
@@ -57,11 +65,23 @@ class DependencyInjectionExtension implements FormExtensionInterface
 
     public function hasType($name)
     {
-        return isset($this->typeServiceIds[$name]);
+        if (isset($this->typeServiceIds[$name])) {
+            if (isset($this->legacyNames[$name])) {
+                @trigger_error('Accessing form types by type name/service ID is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     public function getTypeExtensions($name)
     {
+        if (isset($this->legacyNames[$name])) {
+            @trigger_error('Accessing form types by type name/service ID is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
+        }
+
         $extensions = array();
 
         if (isset($this->typeExtensionServiceIds[$name])) {
@@ -75,6 +95,10 @@ class DependencyInjectionExtension implements FormExtensionInterface
 
     public function hasTypeExtensions($name)
     {
+        if (isset($this->legacyNames[$name])) {
+            @trigger_error('Accessing form types by type name/service ID is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
+        }
+
         return isset($this->typeExtensionServiceIds[$name]);
     }
 

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -94,6 +94,6 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
      */
     public function getExtendedType()
     {
-        return 'form';
+        return 'Symfony\Component\Form\Extension\Core\Type\FormType';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Type/RepeatedTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/RepeatedTypeValidatorExtension.php
@@ -40,6 +40,6 @@ class RepeatedTypeValidatorExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'repeated';
+        return 'Symfony\Component\Form\Extension\Core\Type\RepeatedType';
     }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Type/SubmitTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/SubmitTypeValidatorExtension.php
@@ -21,6 +21,6 @@ class SubmitTypeValidatorExtension extends BaseValidatorExtension
      */
     public function getExtendedType()
     {
-        return 'submit';
+        return 'Symfony\Component\Form\Extension\Core\Type\SubmitType';
     }
 }

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -99,7 +99,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
         }
 
         if (null === $type && null === $this->getDataClass()) {
-            $type = 'text';
+            $type = 'Symfony\Component\Form\Extension\Core\Type\TextType';
         }
 
         if (null !== $type) {

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Util\StringUtil;
 
 class FormFactory implements FormFactoryInterface
 {
@@ -34,7 +35,7 @@ class FormFactory implements FormFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create($type = 'form', $data = null, array $options = array())
+    public function create($type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = array())
     {
         return $this->createBuilder($type, $data, $options)->getForm();
     }
@@ -42,7 +43,7 @@ class FormFactory implements FormFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createNamed($name, $type = 'form', $data = null, array $options = array())
+    public function createNamed($name, $type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = array())
     {
         return $this->createNamedBuilder($name, $type, $data, $options)->getForm();
     }
@@ -58,11 +59,37 @@ class FormFactory implements FormFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createBuilder($type = 'form', $data = null, array $options = array())
+    public function createBuilder($type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = array())
     {
-        $name = $type instanceof FormTypeInterface || $type instanceof ResolvedFormTypeInterface
-            ? $type->getName()
-            : $type;
+        $name = null;
+        $typeName = null;
+
+        if ($type instanceof ResolvedFormTypeInterface) {
+            if (method_exists($type, 'getBlockPrefix')) {
+                // As of Symfony 3.0, the block prefix of the type is used as
+                // default name
+                $name = $type->getBlockPrefix();
+            } else {
+                // BC
+                $typeName = $type->getName();
+            }
+        } elseif ($type instanceof FormTypeInterface) {
+            // BC
+            $typeName = $type->getName();
+        } else {
+            // BC
+            $typeName = $type;
+        }
+
+        if (null === $name) {
+            if (false === strpos($typeName, '\\')) {
+                // No FQCN - leave unchanged for BC
+                $name = $typeName;
+            } else {
+                // FQCN
+                $name = StringUtil::fqcnToBlockPrefix($typeName);
+            }
+        }
 
         return $this->createNamedBuilder($name, $type, $data, $options);
     }
@@ -70,17 +97,20 @@ class FormFactory implements FormFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createNamedBuilder($name, $type = 'form', $data = null, array $options = array())
+    public function createNamedBuilder($name, $type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = array())
     {
         if (null !== $data && !array_key_exists('data', $options)) {
             $options['data'] = $data;
         }
 
         if ($type instanceof FormTypeInterface) {
+            @trigger_error('Passing type instances to FormBuilder::add(), Form::add() or the FormFactory is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
             $type = $this->resolveType($type);
         } elseif (is_string($type)) {
             $type = $this->registry->getType($type);
-        } elseif (!$type instanceof ResolvedFormTypeInterface) {
+        } elseif ($type instanceof ResolvedFormTypeInterface) {
+            @trigger_error('Passing type instances to FormBuilder::add(), Form::add() or the FormFactory is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
+        } else {
             throw new UnexpectedTypeException($type, 'string, Symfony\Component\Form\ResolvedFormTypeInterface or Symfony\Component\Form\FormTypeInterface');
         }
 
@@ -99,7 +129,7 @@ class FormFactory implements FormFactoryInterface
     public function createBuilderForProperty($class, $property, $data = null, array $options = array())
     {
         if (null === $guesser = $this->registry->getTypeGuesser()) {
-            return $this->createNamedBuilder($property, 'text', $data, $options);
+            return $this->createNamedBuilder($property, 'Symfony\Component\Form\Extension\Core\Type\TextType', $data, $options);
         }
 
         $typeGuess = $guesser->guessType($class, $property);
@@ -107,7 +137,7 @@ class FormFactory implements FormFactoryInterface
         $requiredGuess = $guesser->guessRequired($class, $property);
         $patternGuess = $guesser->guessPattern($class, $property);
 
-        $type = $typeGuess ? $typeGuess->getType() : 'text';
+        $type = $typeGuess ? $typeGuess->getType() : 'Symfony\Component\Form\Extension\Core\Type\TextType';
 
         $maxLength = $maxLengthGuess ? $maxLengthGuess->getValue() : null;
         $pattern = $patternGuess ? $patternGuess->getValue() : null;

--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -78,7 +78,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
      */
     public function addType(FormTypeInterface $type)
     {
-        $this->types[$type->getName()] = $type;
+        $this->types[] = $type;
 
         return $this;
     }
@@ -89,7 +89,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
     public function addTypes(array $types)
     {
         foreach ($types as $type) {
-            $this->types[$type->getName()] = $type;
+            $this->types[] = $type;
         }
 
         return $this;

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -29,7 +29,7 @@ interface FormFactoryInterface
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the given type
      */
-    public function create($type = 'form', $data = null, array $options = array());
+    public function create($type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = array());
 
     /**
      * Returns a form.
@@ -45,7 +45,7 @@ interface FormFactoryInterface
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the given type
      */
-    public function createNamed($name, $type = 'form', $data = null, array $options = array());
+    public function createNamed($name, $type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = array());
 
     /**
      * Returns a form for a property of a class.
@@ -74,7 +74,7 @@ interface FormFactoryInterface
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the given type
      */
-    public function createBuilder($type = 'form', $data = null, array $options = array());
+    public function createBuilder($type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = array());
 
     /**
      * Returns a form builder.
@@ -88,7 +88,7 @@ interface FormFactoryInterface
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException if any given option is not applicable to the given type
      */
-    public function createNamedBuilder($name, $type = 'form', $data = null, array $options = array());
+    public function createNamedBuilder($name, $type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = array());
 
     /**
      * Returns a form builder for a property of a class.

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -35,6 +35,11 @@ class FormRegistry implements FormRegistryInterface
     private $types = array();
 
     /**
+     * @var string[]
+     */
+    private $legacyNames = array();
+
+    /**
      * @var FormTypeGuesserInterface|false|null
      */
     private $guesser = false;
@@ -84,10 +89,19 @@ class FormRegistry implements FormRegistryInterface
             }
 
             if (!$type) {
-                throw new InvalidArgumentException(sprintf('Could not load type "%s"', $name));
+                // Support fully-qualified class names
+                if (class_exists($name) && in_array('Symfony\Component\Form\FormTypeInterface', class_implements($name))) {
+                    $type = new $name();
+                } else {
+                    throw new InvalidArgumentException(sprintf('Could not load type "%s"', $name));
+                }
             }
 
             $this->resolveAndAddType($type);
+        }
+
+        if (isset($this->legacyNames[$name])) {
+            @trigger_error('Accessing types by their string name is deprecated since version 2.8 and will be removed in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
         }
 
         return $this->types[$name];
@@ -103,27 +117,52 @@ class FormRegistry implements FormRegistryInterface
      */
     private function resolveAndAddType(FormTypeInterface $type)
     {
+        $typeExtensions = array();
         $parentType = $type->getParent();
+        $fqcn = get_class($type);
+        $name = $type->getName();
+        $hasCustomName = $name !== $fqcn;
 
         if ($parentType instanceof FormTypeInterface) {
+            @trigger_error('Returning a FormTypeInterface from FormTypeInterface::getParent() is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
             $this->resolveAndAddType($parentType);
             $parentType = $parentType->getName();
         }
 
-        $typeExtensions = array();
+        if ($hasCustomName) {
+            foreach ($this->extensions as $extension) {
+                $typeExtensions = array_merge(
+                    $typeExtensions,
+                    $extension->getTypeExtensions($name)
+                );
+            }
+
+            if ($typeExtensions) {
+                @trigger_error('Returning a type name from FormTypeExtensionInterface::getExtendedType() is deprecated since version 2.8 and will be removed in 3.0. Return the fully-qualified type class name instead.', E_USER_DEPRECATED);
+            }
+        }
 
         foreach ($this->extensions as $extension) {
             $typeExtensions = array_merge(
                 $typeExtensions,
-                $extension->getTypeExtensions($type->getName())
+                $extension->getTypeExtensions($fqcn)
             );
         }
 
-        $this->types[$type->getName()] = $this->resolvedTypeFactory->createResolvedType(
+        $resolvedType = $this->resolvedTypeFactory->createResolvedType(
             $type,
             $typeExtensions,
             $parentType ? $this->getType($parentType) : null
         );
+
+        $this->types[$fqcn] = $resolvedType;
+
+        if ($hasCustomName) {
+            // Enable access by the explicit type name until Symfony 3.0
+            $this->types[$name] = $resolvedType;
+            $this->legacyNames[$name] = true;
+        }
     }
 
     /**
@@ -131,6 +170,10 @@ class FormRegistry implements FormRegistryInterface
      */
     public function hasType($name)
     {
+        if (isset($this->legacyNames[$name])) {
+            @trigger_error('Accessing types by their string name is deprecated since version 2.8 and will be removed in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
+        }
+
         if (isset($this->types[$name])) {
             return true;
         }

--- a/src/Symfony/Component/Form/FormTypeInterface.php
+++ b/src/Symfony/Component/Form/FormTypeInterface.php
@@ -86,7 +86,12 @@ interface FormTypeInterface
      * is discouraged because it leads to a performance penalty. The support
      * for returning type instances may be dropped from future releases.
      *
-     * @return string|null|FormTypeInterface The name of the parent type if any, null otherwise.
+     * Returning a {@link FormTypeInterface} instance is deprecated since
+     * Symfony 2.8 and will be unsupported as of Symfony 3.0. Return the
+     * fully-qualified class name of the parent type instead.
+     *
+     * @return string|null|FormTypeInterface The name of the parent type if any,
+     *                                       null otherwise.
      */
     public function getParent();
 
@@ -94,6 +99,9 @@ interface FormTypeInterface
      * Returns the name of this type.
      *
      * @return string The name of this type
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed in Symfony 3.0.
+     *             Use the fully-qualified class name of the type instead.
      */
     public function getName();
 }

--- a/src/Symfony/Component/Form/PreloadedExtension.php
+++ b/src/Symfony/Component/Form/PreloadedExtension.php
@@ -38,15 +38,22 @@ class PreloadedExtension implements FormExtensionInterface
     /**
      * Creates a new preloaded extension.
      *
-     * @param FormTypeInterface[]           $types       The types that the extension should support.
-     * @param array[FormTypeExtensionInterface[]] typeExtensions The type extensions that the extension should support.
-     * @param FormTypeGuesserInterface|null $typeGuesser The guesser that the extension should support.
+     * @param FormTypeInterface[]            $types          The types that the extension should support.
+     * @param FormTypeExtensionInterface[][] $typeExtensions The type extensions that the extension should support.
+     * @param FormTypeGuesserInterface|null  $typeGuesser    The guesser that the extension should support.
      */
     public function __construct(array $types, array $typeExtensions, FormTypeGuesserInterface $typeGuesser = null)
     {
-        $this->types = $types;
         $this->typeExtensions = $typeExtensions;
         $this->typeGuesser = $typeGuesser;
+
+        foreach ($types as $type) {
+            // Up to Symfony 2.8, types were identified by their names
+            $this->types[$type->getName()] = $type;
+
+            // Since Symfony 2.8, types are identified by their FQCN
+            $this->types[get_class($type)] = $type;
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -17,7 +17,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 {
     public function testLabelOnForm()
     {
-        $form = $this->factory->createNamed('name', 'date');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType');
         $view = $form->createView();
         $this->renderWidget($view, array('label' => 'foo'));
         $html = $this->renderLabel($view);
@@ -32,7 +32,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), null, array(
             'attr' => array(
                 'class' => 'my&class',
@@ -49,7 +49,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), null, array(
             'label_attr' => array(
                 'class' => 'my&class',
@@ -66,7 +66,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), 'Custom label', array(
             'label_attr' => array(
                 'class' => 'my&class',
@@ -84,7 +84,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'label' => 'Custom label',
         ));
         $html = $this->renderLabel($form->createView(), null, array(
@@ -104,7 +104,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testErrors()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $form->addError(new FormError('[trans]Error 2[/trans]'));
         $view = $form->createView();
@@ -137,7 +137,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testOverrideWidgetBlock()
     {
         // see custom_widgets.html.twig
-        $form = $this->factory->createNamed('text_id', 'text');
+        $form = $this->factory->createNamed('text_id', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderWidget($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -155,7 +155,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCheckedCheckbox()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', true);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', true);
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -173,7 +173,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testUncheckedCheckbox()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', false);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', false);
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -191,7 +191,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCheckboxWithValue()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', false, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', false, array(
             'value' => 'foo&bar',
         ));
 
@@ -211,7 +211,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoice()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
@@ -256,7 +256,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => false,
@@ -281,7 +281,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceWithPreferred()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -305,7 +305,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceWithPreferredAndNoSeparator()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -328,7 +328,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -352,7 +352,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testChoiceWithOnlyPreferred()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&a', '&b'),
             'multiple' => false,
@@ -369,7 +369,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceNonRequired()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => false,
@@ -393,7 +393,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceNonRequiredNoneSelected()
     {
-        $form = $this->factory->createNamed('name', 'choice', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => false,
@@ -417,7 +417,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceNonRequiredWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
@@ -442,7 +442,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceRequiredWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
@@ -467,7 +467,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceRequiredWithPlaceholderViaView()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
@@ -491,7 +491,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceGrouped()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array(
                 'Group&1' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
                 'Group&2' => array('&c' => 'Choice&C'),
@@ -522,7 +522,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoice()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => true,
@@ -546,7 +546,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'required' => true,
@@ -573,7 +573,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceSkipsPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => true,
             'expanded' => false,
@@ -596,7 +596,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceNonRequired()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => true,
@@ -619,7 +619,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -690,7 +690,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceExpandedAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => false,
@@ -728,7 +728,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceExpandedWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -773,7 +773,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSingleChoiceExpandedWithBooleanValue()
     {
-        $form = $this->factory->createNamed('name', 'choice', true, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', true, array(
             'choices' => array('1' => 'Choice&A', '0' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -808,7 +808,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a', '&c'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
             'multiple' => true,
             'expanded' => true,
@@ -899,7 +899,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMultipleChoiceExpandedAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a', '&c'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => true,
@@ -947,7 +947,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCountry()
     {
-        $form = $this->factory->createNamed('name', 'country', 'AT');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CountryType', 'AT');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/select
@@ -961,7 +961,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCountryWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'country', 'AT', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CountryType', 'AT', array(
             'placeholder' => 'Select&Country',
             'required' => false,
         ));
@@ -979,7 +979,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTime()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1015,7 +1015,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'datetime', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
@@ -1055,7 +1055,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     {
         $data = array('year' => '2011', 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5');
 
-        $form = $this->factory->createNamed('name', 'datetime', $data, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', $data, array(
             'input' => 'array',
             'required' => false,
         ));
@@ -1092,7 +1092,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1133,7 +1133,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeSingleText()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'date_widget' => 'single_text',
             'time_widget' => 'single_text',
@@ -1162,7 +1162,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithWidgetSingleText()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'widget' => 'single_text',
             'model_timezone' => 'UTC',
@@ -1181,7 +1181,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithWidgetSingleTextIgnoreDateAndTimeWidgets()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
@@ -1202,7 +1202,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateChoice()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', '2011-02-03', array(
             'input' => 'string',
             'widget' => 'choice',
         ));
@@ -1231,7 +1231,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateChoiceWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'date', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'input' => 'string',
             'widget' => 'choice',
             'placeholder' => 'Change&Me',
@@ -1262,7 +1262,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateChoiceWithPlaceholderOnYear()
     {
-        $form = $this->factory->createNamed('name', 'date', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'input' => 'string',
             'widget' => 'choice',
             'required' => false,
@@ -1293,7 +1293,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateText()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', '2011-02-03', array(
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -1325,7 +1325,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateSingleText()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', '2011-02-03', array(
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -1342,7 +1342,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testBirthDay()
     {
-        $form = $this->factory->createNamed('name', 'birthday', '2000-02-03', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType', '2000-02-03', array(
             'input' => 'string',
         ));
 
@@ -1370,7 +1370,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testBirthDayWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'birthday', '1950-01-01', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType', '1950-01-01', array(
             'input' => 'string',
             'placeholder' => '',
             'required' => false,
@@ -1403,7 +1403,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testEmail()
     {
-        $form = $this->factory->createNamed('name', 'email', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1418,7 +1418,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testEmailWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'email', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar', array(
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1435,7 +1435,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testHidden()
     {
-        $form = $this->factory->createNamed('name', 'hidden', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\HiddenType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1452,7 +1452,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
      */
     public function testLegacyReadOnly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'read_only' => true,
         ));
 
@@ -1468,7 +1468,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDisabled()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'disabled' => true,
         ));
 
@@ -1484,7 +1484,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testInteger()
     {
-        $form = $this->factory->createNamed('name', 'integer', 123);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\IntegerType', 123);
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1498,7 +1498,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLanguage()
     {
-        $form = $this->factory->createNamed('name', 'language', 'de');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\LanguageType', 'de');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/select
@@ -1512,7 +1512,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLocale()
     {
-        $form = $this->factory->createNamed('name', 'locale', 'de_AT');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\LocaleType', 'de_AT');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/select
@@ -1526,7 +1526,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testMoney()
     {
-        $form = $this->factory->createNamed('name', 'money', 1234.56, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', 1234.56, array(
             'currency' => 'EUR',
         ));
 
@@ -1550,7 +1550,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testNumber()
     {
-        $form = $this->factory->createNamed('name', 'number', 1234.56);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\NumberType', 1234.56);
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1564,7 +1564,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPassword()
     {
-        $form = $this->factory->createNamed('name', 'password', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1577,7 +1577,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPasswordSubmittedWithNotAlwaysEmpty()
     {
-        $form = $this->factory->createNamed('name', 'password', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', null, array(
             'always_empty' => false,
         ));
         $form->submit('foo&bar');
@@ -1594,7 +1594,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPasswordWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'password', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar', array(
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1610,7 +1610,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPercent()
     {
-        $form = $this->factory->createNamed('name', 'percent', 0.1);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1);
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -1632,7 +1632,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testCheckedRadio()
     {
-        $form = $this->factory->createNamed('name', 'radio', true);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RadioType', true);
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -1656,7 +1656,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testUncheckedRadio()
     {
-        $form = $this->factory->createNamed('name', 'radio', false);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RadioType', false);
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
@@ -1679,7 +1679,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testRadioWithValue()
     {
-        $form = $this->factory->createNamed('name', 'radio', false, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RadioType', false, array(
             'value' => 'foo&bar',
         ));
 
@@ -1704,7 +1704,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testRange()
     {
-        $form = $this->factory->createNamed('name', 'range', 42, array('attr' => array('min' => 5)));
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, array('attr' => array('min' => 5)));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1719,7 +1719,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testRangeWithMinMaxValues()
     {
-        $form = $this->factory->createNamed('name', 'range', 42, array('attr' => array('min' => 5, 'max' => 57)));
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, array('attr' => array('min' => 5, 'max' => 57)));
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1735,7 +1735,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTextarea()
     {
-        $form = $this->factory->createNamed('name', 'textarea', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', 'foo&bar', array(
             'attr' => array('pattern' => 'foo'),
         ));
 
@@ -1751,7 +1751,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testText()
     {
-        $form = $this->factory->createNamed('name', 'text', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1766,7 +1766,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTextWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'text', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar', array(
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1783,7 +1783,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSearch()
     {
-        $form = $this->factory->createNamed('name', 'search', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -1798,7 +1798,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTime()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', array(
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1825,7 +1825,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', array(
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1860,7 +1860,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeText()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', array(
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -1893,7 +1893,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeSingleText()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', array(
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -1911,7 +1911,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'time', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
@@ -1938,7 +1938,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimeWithPlaceholderOnYear()
     {
-        $form = $this->factory->createNamed('name', 'time', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'input' => 'string',
             'required' => false,
             'placeholder' => array('hour' => 'Change&Me'),
@@ -1965,7 +1965,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimezone()
     {
-        $form = $this->factory->createNamed('name', 'timezone', 'Europe/Vienna');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimezoneType', 'Europe/Vienna');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/select
@@ -1984,7 +1984,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testTimezoneWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'timezone', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimezoneType', null, array(
             'placeholder' => 'Select&Timezone',
             'required' => false,
         ));
@@ -2002,7 +2002,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testUrl()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'url', $url);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url);
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
@@ -2016,7 +2016,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testButton()
     {
-        $form = $this->factory->createNamed('name', 'button');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ButtonType');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
             '/button[@type="button"][@name="name"][.="[trans]Name[/trans]"][@class="my&class btn"]'
@@ -2025,7 +2025,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSubmit()
     {
-        $form = $this->factory->createNamed('name', 'submit');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\SubmitType');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
             '/button[@type="submit"][@name="name"][@class="my&class btn"]'
@@ -2034,7 +2034,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testReset()
     {
-        $form = $this->factory->createNamed('name', 'reset');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ResetType');
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
             '/button[@type="reset"][@name="name"][@class="my&class btn"]'
@@ -2043,7 +2043,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testWidgetAttributes()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', array(
             'required' => true,
             'disabled' => true,
             'attr' => array('readonly' => true, 'maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
@@ -2057,7 +2057,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', array(
             'attr' => array('foo' => true),
         ));
 
@@ -2069,7 +2069,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testButtonAttributes()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', null, array(
             'disabled' => true,
             'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
         ));
@@ -2082,7 +2082,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testButtonAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', null, array(
             'attr' => array('foo' => true),
         ));
 

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -19,7 +19,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -39,7 +39,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRowOverrideVariables()
     {
-        $view = $this->factory->createNamed('name', 'text')->createView();
+        $view = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType')->createView();
         $html = $this->renderRow($view, array(
             'attr' => array('class' => 'my&class'),
             'label' => 'foo&bar',
@@ -58,7 +58,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRow()
     {
-        $form = $this->factory->createNamed('name', 'repeated');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType');
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -85,7 +85,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testButtonRow()
     {
-        $form = $this->factory->createNamed('name', 'button');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ButtonType');
         $view = $form->createView();
         $html = $this->renderRow($view);
 
@@ -101,11 +101,11 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRest()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('field1', 'text')
-            ->add('field2', 'repeated')
-            ->add('field3', 'text')
-            ->add('field4', 'text')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
+            ->add('field3', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field4', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm()
             ->createView();
 
@@ -142,15 +142,15 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRestWithChildrenForms()
     {
-        $child1 = $this->factory->createNamedBuilder('child1', 'form')
-            ->add('field1', 'text')
-            ->add('field2', 'text');
+        $child1 = $this->factory->createNamedBuilder('child1', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType');
 
-        $child2 = $this->factory->createNamedBuilder('child2', 'form')
-            ->add('field1', 'text')
-            ->add('field2', 'text');
+        $child2 = $this->factory->createNamedBuilder('child2', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType');
 
-        $view = $this->factory->createNamedBuilder('parent', 'form')
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($child1)
             ->add($child2)
             ->getForm()
@@ -200,9 +200,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRestAndRepeatedWithRow()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('first', 'text')
-            ->add('password', 'repeated')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
             ->getForm()
             ->createView();
 
@@ -226,9 +226,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRestAndRepeatedWithRowPerChild()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('first', 'text')
-            ->add('password', 'repeated')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
             ->getForm()
             ->createView();
 
@@ -254,9 +254,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRestAndRepeatedWithWidgetPerChild()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('first', 'text')
-            ->add('password', 'repeated')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
             ->getForm()
             ->createView();
 
@@ -284,8 +284,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testCollection()
     {
-        $form = $this->factory->createNamed('names', 'collection', array('a', 'b'), array(
-            'type' => 'text',
+        $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array('a', 'b'), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -306,8 +306,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             array('title' => 'a'),
             array('title' => 'b'),
         );
-        $form = $this->factory->createNamed('names', 'collection', $data, array(
-            'type' => new AlternatingRowType(),
+        $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', $data, array(
+            'type' => 'Symfony\Component\Form\Tests\Fixtures\AlternatingRowType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -324,8 +324,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testEmptyCollection()
     {
-        $form = $this->factory->createNamed('names', 'collection', array(), array(
-            'type' => 'text',
+        $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -340,12 +340,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     {
         $collection = $this->factory->createNamedBuilder(
             'collection',
-            'collection',
+            'Symfony\Component\Form\Extension\Core\Type\CollectionType',
             array('a', 'b'),
-            array('type' => 'text')
+            array('type' => 'Symfony\Component\Form\Extension\Core\Type\TextType')
         );
 
-        $form = $this->factory->createNamedBuilder('form', 'form')
+        $form = $this->factory->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType')
           ->add($collection)
           ->getForm();
 
@@ -378,11 +378,11 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testForm()
     {
-        $form = $this->factory->createNamedBuilder('name', 'form')
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->setMethod('PUT')
             ->setAction('http://example.com')
-            ->add('firstName', 'text')
-            ->add('lastName', 'text')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         // include ampersands everywhere to validate escaping
@@ -422,9 +422,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testFormWidget()
     {
-        $form = $this->factory->createNamedBuilder('name', 'form')
-            ->add('firstName', 'text')
-            ->add('lastName', 'text')
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -450,10 +450,10 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     // https://github.com/symfony/symfony/issues/2308
     public function testNestedFormError()
     {
-        $form = $this->factory->createNamedBuilder('name', 'form')
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($this->factory
-                ->createNamedBuilder('child', 'form', null, array('error_bubbling' => false))
-                ->add('grandChild', 'form')
+                ->createNamedBuilder('child', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array('error_bubbling' => false))
+                ->add('grandChild', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             )
             ->getForm();
 
@@ -476,11 +476,11 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             ->method('getToken')
             ->will($this->returnValue(new CsrfToken('token_id', 'foo&bar')));
 
-        $form = $this->factory->createNamedBuilder('name', 'form')
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($this->factory
                 // No CSRF protection on nested forms
-                ->createNamedBuilder('child', 'form')
-                ->add($this->factory->createNamedBuilder('grandchild', 'text'))
+                ->createNamedBuilder('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+                ->add($this->factory->createNamedBuilder('grandchild', 'Symfony\Component\Form\Extension\Core\Type\TextType'))
             )
             ->getForm();
 
@@ -497,8 +497,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRepeated()
     {
-        $form = $this->factory->createNamed('name', 'repeated', 'foobar', array(
-            'type' => 'text',
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', 'foobar', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -523,7 +523,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedWithCustomOptions()
     {
-        $form = $this->factory->createNamed('name', 'repeated', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
             // the global required value cannot be overridden
             'first_options' => array('label' => 'Test', 'required' => false),
             'second_options' => array('label' => 'Test2'),
@@ -551,8 +551,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testSearchInputName()
     {
-        $form = $this->factory->createNamedBuilder('full', 'form')
-            ->add('name', 'search')
+        $form = $this->factory->createNamedBuilder('full', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType')
             ->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -572,7 +572,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testLabelHasNoId()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderRow($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -587,7 +587,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testLabelIsNotRenderedWhenSetToFalse()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'label' => false,
         ));
         $html = $this->renderRow($form->createView());
@@ -608,7 +608,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testThemeBlockInheritance($theme)
     {
         $view = $this->factory
-            ->createNamed('name', 'email')
+            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType')
             ->createView()
         ;
 
@@ -625,11 +625,11 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
      */
     public function testThemeInheritance($parentTheme, $childTheme)
     {
-        $child = $this->factory->createNamedBuilder('child', 'form')
-            ->add('field', 'text');
+        $child = $this->factory->createNamedBuilder('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field', 'Symfony\Component\Form\Extension\Core\Type\TextType');
 
-        $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('field', 'text')
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->add($child)
             ->getForm()
             ->createView()
@@ -671,7 +671,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testCollectionRowWithCustomBlock()
     {
         $collection = array('one', 'two', 'three');
-        $form = $this->factory->createNamedBuilder('names', 'collection', $collection)
+        $form = $this->factory->createNamedBuilder('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', $collection)
             ->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -691,7 +691,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
      */
     public function testChoiceRowWithCustomBlock()
     {
-        $form = $this->factory->createNamedBuilder('name_c', 'choice', 'a', array(
+        $form = $this->factory->createNamedBuilder('name_c', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', 'a', array(
                 'choices' => array('a' => 'ChoiceA', 'b' => 'ChoiceB'),
                 'expanded' => true,
             ))
@@ -709,9 +709,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testFormEndWithRest()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('field1', 'text')
-            ->add('field2', 'text')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm()
             ->createView();
 
@@ -739,9 +739,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testFormEndWithoutRest()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('field1', 'text')
-            ->add('field2', 'text')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm()
             ->createView();
 
@@ -755,11 +755,11 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testWidgetContainerAttributes()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
         ));
 
-        $form->add('text', 'text');
+        $form->add('text', 'Symfony\Component\Form\Extension\Core\Type\TextType');
 
         $html = $this->renderWidget($form->createView());
 
@@ -769,7 +769,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testWidgetContainerAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'attr' => array('foo' => true),
         ));
 

--- a/src/Symfony/Component/Form/Tests/AbstractExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractExtensionTest.php
@@ -19,14 +19,14 @@ class AbstractExtensionTest extends \PHPUnit_Framework_TestCase
     public function testHasType()
     {
         $loader = new ConcreteExtension();
-        $this->assertTrue($loader->hasType('foo'));
-        $this->assertFalse($loader->hasType('bar'));
+        $this->assertTrue($loader->hasType('Symfony\Component\Form\Tests\Fixtures\FooType'));
+        $this->assertFalse($loader->hasType('foo'));
     }
 
     public function testGetType()
     {
         $loader = new ConcreteExtension();
-        $this->assertInstanceOf('Symfony\Component\Form\Tests\Fixtures\FooType', $loader->getType('foo'));
+        $this->assertInstanceOf('Symfony\Component\Form\Tests\Fixtures\FooType', $loader->getType('Symfony\Component\Form\Tests\Fixtures\FooType'));
     }
 
     /**
@@ -35,7 +35,7 @@ class AbstractExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testCustomOptionsResolver()
     {
-        $extension = new Fixtures\FooTypeBarExtension();
+        $extension = new Fixtures\LegacyFooTypeBarExtension();
         $resolver = new Fixtures\CustomOptionsResolver();
         $extension->setDefaultOptions($resolver);
     }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -134,8 +134,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
      */
     public function testEnctype()
     {
-        $form = $this->factory->createNamedBuilder('name', 'form')
-            ->add('file', 'file')
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType')
             ->getForm();
 
         $this->assertEquals('enctype="multipart/form-data"', $this->renderEnctype($form->createView()));
@@ -146,8 +146,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
      */
     public function testNoEnctype()
     {
-        $form = $this->factory->createNamedBuilder('name', 'form')
-            ->add('text', 'text')
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('text', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         $this->assertEquals('', $this->renderEnctype($form->createView()));
@@ -155,7 +155,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabel()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $view = $form->createView();
         $this->renderWidget($view, array('label' => 'foo'));
         $html = $this->renderLabel($view);
@@ -184,7 +184,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelOnForm()
     {
-        $form = $this->factory->createNamed('name', 'date');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType');
         $view = $form->createView();
         $this->renderWidget($view, array('label' => 'foo'));
         $html = $this->renderLabel($view);
@@ -199,7 +199,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelWithCustomTextPassedAsOption()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'label' => 'Custom label',
         ));
         $html = $this->renderLabel($form->createView());
@@ -214,7 +214,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelWithCustomTextPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), 'Custom label');
 
         $this->assertMatchesXpath($html,
@@ -227,7 +227,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelWithCustomTextPassedAsOptionAndDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'label' => 'Custom label',
         ));
         $html = $this->renderLabel($form->createView(), 'Overridden label');
@@ -242,7 +242,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), null, array(
             'attr' => array(
                 'class' => 'my&class',
@@ -259,7 +259,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), null, array(
             'label_attr' => array(
                 'class' => 'my&class',
@@ -276,7 +276,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), 'Custom label', array(
             'label_attr' => array(
                 'class' => 'my&class',
@@ -295,7 +295,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     // https://github.com/symfony/symfony/issues/5029
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'label' => 'Custom label',
         ));
         $html = $this->renderLabel($form->createView(), null, array(
@@ -316,7 +316,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testLabelFormatName()
     {
         $form = $this->factory->createNamedBuilder('myform')
-            ->add('myfield', 'text')
+            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
         $view = $form->get('myfield')->createView();
         $html = $this->renderLabel($view, null, array('label_format' => 'form.%name%'));
@@ -332,7 +332,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testLabelFormatId()
     {
         $form = $this->factory->createNamedBuilder('myform')
-            ->add('myfield', 'text')
+            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
         $view = $form->get('myfield')->createView();
         $html = $this->renderLabel($view, null, array('label_format' => 'form.%id%'));
@@ -349,8 +349,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $options = array('label_format' => 'form.%name%');
 
-        $form = $this->factory->createNamedBuilder('myform', 'form', null, $options)
-            ->add('myfield', 'text')
+        $form = $this->factory->createNamedBuilder('myform', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, $options)
+            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
         $view = $form->get('myfield')->createView();
         $html = $this->renderLabel($view);
@@ -367,8 +367,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $options = array('label_format' => 'form.%name%');
 
-        $form = $this->factory->createNamedBuilder('myform', 'form', null, $options)
-            ->add('myfield', 'text', array('label_format' => 'field.%name%'))
+        $form = $this->factory->createNamedBuilder('myform', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, $options)
+            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('label_format' => 'field.%name%'))
             ->getForm();
         $view = $form->get('myfield')->createView();
         $html = $this->renderLabel($view);
@@ -384,7 +384,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testLabelFormatOnButton()
     {
         $form = $this->factory->createNamedBuilder('myform')
-            ->add('mybutton', 'button')
+            ->add('mybutton', 'Symfony\Component\Form\Extension\Core\Type\ButtonType')
             ->getForm();
         $view = $form->get('mybutton')->createView();
         $html = $this->renderWidget($view, array('label_format' => 'form.%name%'));
@@ -401,7 +401,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testLabelFormatOnButtonId()
     {
         $form = $this->factory->createNamedBuilder('myform')
-            ->add('mybutton', 'button')
+            ->add('mybutton', 'Symfony\Component\Form\Extension\Core\Type\ButtonType')
             ->getForm();
         $view = $form->get('mybutton')->createView();
         $html = $this->renderWidget($view, array('label_format' => 'form.%id%'));
@@ -417,7 +417,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testErrors()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $form->addError(new FormError('[trans]Error 2[/trans]'));
         $view = $form->createView();
@@ -437,7 +437,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testOverrideWidgetBlock()
     {
         // see custom_widgets.html.twig
-        $form = $this->factory->createNamed('text_id', 'text');
+        $form = $this->factory->createNamed('text_id', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderWidget($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -454,7 +454,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCheckedCheckbox()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', true);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', true);
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -468,7 +468,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testUncheckedCheckbox()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', false);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', false);
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -481,7 +481,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCheckboxWithValue()
     {
-        $form = $this->factory->createNamed('name', 'checkbox', false, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', false, array(
             'value' => 'foo&bar',
         ));
 
@@ -496,7 +496,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoice()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
@@ -551,7 +551,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => false,
@@ -575,7 +575,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceWithPreferred()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -598,7 +598,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceWithPreferredAndNoSeparator()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -620,7 +620,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
             'multiple' => false,
@@ -643,7 +643,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testChoiceWithOnlyPreferred()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&a', '&b'),
             'multiple' => false,
@@ -659,7 +659,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceNonRequired()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => false,
@@ -682,7 +682,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceNonRequiredNoneSelected()
     {
-        $form = $this->factory->createNamed('name', 'choice', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => false,
@@ -705,7 +705,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceNonRequiredWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => false,
@@ -729,7 +729,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceRequiredWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
@@ -756,7 +756,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceRequiredWithPlaceholderViaView()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => false,
@@ -782,7 +782,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceGrouped()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array(
                 'Group&1' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
                 'Group&2' => array('&c' => 'Choice&C'),
@@ -812,7 +812,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoice()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => true,
             'multiple' => true,
@@ -835,7 +835,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'required' => true,
@@ -861,7 +861,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceSkipsPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => true,
             'expanded' => false,
@@ -883,7 +883,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceNonRequired()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
             'multiple' => true,
@@ -905,7 +905,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -950,7 +950,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceExpandedAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => false,
@@ -975,7 +975,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceExpandedWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'choice', '&a', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -1000,7 +1000,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSingleChoiceExpandedWithBooleanValue()
     {
-        $form = $this->factory->createNamed('name', 'choice', true, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', true, array(
             'choices' => array('1' => 'Choice&A', '0' => 'Choice&B'),
             'multiple' => false,
             'expanded' => true,
@@ -1022,7 +1022,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a', '&c'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
             'multiple' => true,
             'expanded' => true,
@@ -1073,7 +1073,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMultipleChoiceExpandedAttributes()
     {
-        $form = $this->factory->createNamed('name', 'choice', array('&a', '&c'), array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('&a', '&c'), array(
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
             'choice_attr' => array('Choice&B' => array('class' => 'foo&bar')),
             'multiple' => true,
@@ -1101,7 +1101,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCountry()
     {
-        $form = $this->factory->createNamed('name', 'country', 'AT');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CountryType', 'AT');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
@@ -1114,7 +1114,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCountryWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'country', 'AT', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CountryType', 'AT', array(
             'placeholder' => 'Select&Country',
             'required' => false,
         ));
@@ -1131,7 +1131,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTime()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1170,7 +1170,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'datetime', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
@@ -1212,7 +1212,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     {
         $data = array('year' => '2011', 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5');
 
-        $form = $this->factory->createNamed('name', 'datetime', $data, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', $data, array(
             'input' => 'array',
             'required' => false,
         ));
@@ -1251,7 +1251,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1293,7 +1293,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeSingleText()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'date_widget' => 'single_text',
             'time_widget' => 'single_text',
@@ -1319,7 +1319,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithWidgetSingleText()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'widget' => 'single_text',
             'model_timezone' => 'UTC',
@@ -1337,7 +1337,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithWidgetSingleTextIgnoreDateAndTimeWidgets()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
@@ -1357,7 +1357,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateChoice()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', '2011-02-03', array(
             'input' => 'string',
             'widget' => 'choice',
         ));
@@ -1382,7 +1382,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateChoiceWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'date', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'input' => 'string',
             'widget' => 'choice',
             'placeholder' => 'Change&Me',
@@ -1409,7 +1409,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateChoiceWithPlaceholderOnYear()
     {
-        $form = $this->factory->createNamed('name', 'date', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'input' => 'string',
             'widget' => 'choice',
             'required' => false,
@@ -1436,7 +1436,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateText()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', '2011-02-03', array(
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -1464,7 +1464,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateSingleText()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType', '2011-02-03', array(
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -1480,8 +1480,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateErrorBubbling()
     {
-        $form = $this->factory->createNamedBuilder('form', 'form')
-            ->add('date', 'date')
+        $form = $this->factory->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('date', 'Symfony\Component\Form\Extension\Core\Type\DateType')
             ->getForm();
         $form->get('date')->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
@@ -1492,7 +1492,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testBirthDay()
     {
-        $form = $this->factory->createNamed('name', 'birthday', '2000-02-03', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType', '2000-02-03', array(
             'input' => 'string',
         ));
 
@@ -1516,7 +1516,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testBirthDayWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'birthday', '1950-01-01', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType', '1950-01-01', array(
             'input' => 'string',
             'placeholder' => '',
             'required' => false,
@@ -1545,7 +1545,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testEmail()
     {
-        $form = $this->factory->createNamed('name', 'email', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1559,7 +1559,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testEmailWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'email', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar', array(
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1575,7 +1575,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testFile()
     {
-        $form = $this->factory->createNamed('name', 'file');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\FileType');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1586,7 +1586,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testHidden()
     {
-        $form = $this->factory->createNamed('name', 'hidden', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\HiddenType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1602,7 +1602,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
      */
     public function testLegacyReadOnly()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'read_only' => true,
         ));
 
@@ -1617,7 +1617,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDisabled()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'disabled' => true,
         ));
 
@@ -1632,7 +1632,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testInteger()
     {
-        $form = $this->factory->createNamed('name', 'integer', 123);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\IntegerType', 123);
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1645,7 +1645,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLanguage()
     {
-        $form = $this->factory->createNamed('name', 'language', 'de');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\LanguageType', 'de');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
@@ -1658,7 +1658,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testLocale()
     {
-        $form = $this->factory->createNamed('name', 'locale', 'de_AT');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\LocaleType', 'de_AT');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
@@ -1671,7 +1671,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testMoney()
     {
-        $form = $this->factory->createNamed('name', 'money', 1234.56, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', 1234.56, array(
             'currency' => 'EUR',
         ));
 
@@ -1687,7 +1687,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testNumber()
     {
-        $form = $this->factory->createNamed('name', 'number', 1234.56);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\NumberType', 1234.56);
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1700,7 +1700,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testPassword()
     {
-        $form = $this->factory->createNamed('name', 'password', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1712,7 +1712,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testPasswordSubmittedWithNotAlwaysEmpty()
     {
-        $form = $this->factory->createNamed('name', 'password', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', null, array(
             'always_empty' => false,
         ));
         $form->submit('foo&bar');
@@ -1728,7 +1728,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testPasswordWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'password', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar', array(
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1743,7 +1743,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testPercent()
     {
-        $form = $this->factory->createNamed('name', 'percent', 0.1);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1);
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1757,7 +1757,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCheckedRadio()
     {
-        $form = $this->factory->createNamed('name', 'radio', true);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RadioType', true);
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1771,7 +1771,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testUncheckedRadio()
     {
-        $form = $this->factory->createNamed('name', 'radio', false);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RadioType', false);
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1784,7 +1784,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testRadioWithValue()
     {
-        $form = $this->factory->createNamed('name', 'radio', false, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RadioType', false, array(
             'value' => 'foo&bar',
         ));
 
@@ -1799,7 +1799,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testRange()
     {
-        $form = $this->factory->createNamed('name', 'range', 42, array('attr' => array('min' => 5)));
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, array('attr' => array('min' => 5)));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1813,7 +1813,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testRangeWithMinMaxValues()
     {
-        $form = $this->factory->createNamed('name', 'range', 42, array('attr' => array('min' => 5, 'max' => 57)));
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, array('attr' => array('min' => 5, 'max' => 57)));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1828,7 +1828,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTextarea()
     {
-        $form = $this->factory->createNamed('name', 'textarea', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', 'foo&bar', array(
             'attr' => array('pattern' => 'foo'),
         ));
 
@@ -1843,7 +1843,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testText()
     {
-        $form = $this->factory->createNamed('name', 'text', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1857,7 +1857,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTextWithMaxLength()
     {
-        $form = $this->factory->createNamed('name', 'text', 'foo&bar', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar', array(
             'attr' => array('maxlength' => 123),
         ));
 
@@ -1873,7 +1873,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testSearch()
     {
-        $form = $this->factory->createNamed('name', 'search', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType', 'foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -1887,7 +1887,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTime()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', array(
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1911,7 +1911,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', array(
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1942,7 +1942,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeText()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', array(
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -1972,7 +1972,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeSingleText()
     {
-        $form = $this->factory->createNamed('name', 'time', '04:05:06', array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', '04:05:06', array(
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -1989,7 +1989,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeWithPlaceholderGlobal()
     {
-        $form = $this->factory->createNamed('name', 'time', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'input' => 'string',
             'placeholder' => 'Change&Me',
             'required' => false,
@@ -2014,7 +2014,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeWithPlaceholderOnYear()
     {
-        $form = $this->factory->createNamed('name', 'time', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'input' => 'string',
             'required' => false,
             'placeholder' => array('hour' => 'Change&Me'),
@@ -2039,8 +2039,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimeErrorBubbling()
     {
-        $form = $this->factory->createNamedBuilder('form', 'form')
-            ->add('time', 'time')
+        $form = $this->factory->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('time', 'Symfony\Component\Form\Extension\Core\Type\TimeType')
             ->getForm();
         $form->get('time')->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
@@ -2051,7 +2051,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimezone()
     {
-        $form = $this->factory->createNamed('name', 'timezone', 'Europe/Vienna');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimezoneType', 'Europe/Vienna');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
@@ -2069,7 +2069,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTimezoneWithPlaceholder()
     {
-        $form = $this->factory->createNamed('name', 'timezone', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TimezoneType', null, array(
             'placeholder' => 'Select&Timezone',
             'required' => false,
         ));
@@ -2086,7 +2086,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
     public function testUrl()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'url', $url);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url);
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -2099,8 +2099,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testCollectionPrototype()
     {
-        $form = $this->factory->createNamedBuilder('name', 'form', array('items' => array('one', 'two', 'three')))
-            ->add('items', 'collection', array('allow_add' => true))
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType', array('items' => array('one', 'two', 'three')))
+            ->add('items', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array('allow_add' => true))
             ->getForm()
             ->createView();
 
@@ -2115,8 +2115,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testEmptyRootFormName()
     {
-        $form = $this->factory->createNamedBuilder('', 'form')
-            ->add('child', 'text')
+        $form = $this->factory->createNamedBuilder('', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         $this->assertMatchesXpath($this->renderWidget($form->createView()),
@@ -2127,7 +2127,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testButton()
     {
-        $form = $this->factory->createNamed('name', 'button');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ButtonType');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
             '/button[@type="button"][@name="name"][.="[trans]Name[/trans]"]'
@@ -2136,14 +2136,14 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testButtonLabelIsEmpty()
     {
-        $form = $this->factory->createNamed('name', 'button');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ButtonType');
 
         $this->assertSame('', $this->renderLabel($form->createView()));
     }
 
     public function testSubmit()
     {
-        $form = $this->factory->createNamed('name', 'submit');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\SubmitType');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
             '/button[@type="submit"][@name="name"]'
@@ -2152,7 +2152,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testReset()
     {
-        $form = $this->factory->createNamed('name', 'reset');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ResetType');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
             '/button[@type="reset"][@name="name"]'
@@ -2161,7 +2161,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTag()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'method' => 'get',
             'action' => 'http://example.com/directory',
         ));
@@ -2173,7 +2173,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTagForPutRequest()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'method' => 'put',
             'action' => 'http://example.com/directory',
         ));
@@ -2190,7 +2190,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTagWithOverriddenVars()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'method' => 'put',
             'action' => 'http://example.com/directory',
         ));
@@ -2205,11 +2205,11 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTagForMultipartForm()
     {
-        $form = $this->factory->createBuilder('form', null, array(
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'method' => 'get',
                 'action' => 'http://example.com/directory',
             ))
-            ->add('file', 'file')
+            ->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType')
             ->getForm();
 
         $html = $this->renderStart($form->createView());
@@ -2219,7 +2219,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testStartTagWithExtraAttributes()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'method' => 'get',
             'action' => 'http://example.com/directory',
         ));
@@ -2233,7 +2233,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testWidgetAttributes()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', array(
             'required' => true,
             'disabled' => true,
             'attr' => array('readonly' => true, 'maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'),
@@ -2247,7 +2247,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', array(
             'attr' => array('foo' => true),
         ));
 
@@ -2259,7 +2259,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testWidgetAttributeHiddenIfFalse()
     {
-        $form = $this->factory->createNamed('text', 'text', 'value', array(
+        $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', array(
             'attr' => array('foo' => false),
         ));
 
@@ -2270,7 +2270,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testButtonAttributes()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', null, array(
             'disabled' => true,
             'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
         ));
@@ -2283,7 +2283,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testButtonAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', null, array(
             'attr' => array('foo' => true),
         ));
 
@@ -2295,7 +2295,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testButtonAttributeHiddenIfFalse()
     {
-        $form = $this->factory->createNamed('button', 'button', null, array(
+        $form = $this->factory->createNamed('button', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', null, array(
             'attr' => array('foo' => false),
         ));
 
@@ -2306,7 +2306,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTextareaWithWhitespaceOnlyContentRetainsValue()
     {
-        $form = $this->factory->createNamed('textarea', 'textarea', '  ');
+        $form = $this->factory->createNamed('textarea', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', '  ');
 
         $html = $this->renderWidget($form->createView());
 
@@ -2315,8 +2315,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTextareaWithWhitespaceOnlyContentRetainsValueWhenRenderingForm()
     {
-        $form = $this->factory->createBuilder('form', array('textarea' => '  '))
-            ->add('textarea', 'textarea')
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', array('textarea' => '  '))
+            ->add('textarea', 'Symfony\Component\Form\Extension\Core\Type\TextareaType')
             ->getForm();
 
         $html = $this->renderForm($form->createView());
@@ -2326,7 +2326,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testWidgetContainerAttributeHiddenIfFalse()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'attr' => array('foo' => false),
         ));
 
@@ -2338,9 +2338,9 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testTranslatedAttributes()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('firstName', 'text', array('attr' => array('title' => 'Foo')))
-            ->add('lastName', 'text', array('attr' => array('placeholder' => 'Bar')))
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('attr' => array('title' => 'Foo')))
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('attr' => array('placeholder' => 'Bar')))
             ->getForm()
             ->createView();
 

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -323,7 +323,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($iniMax));
 
         $options = array('post_max_size_message' => 'Max {{ max }}!');
-        $form = $this->factory->createNamed('name', 'text', null, $options);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, $options);
         $this->setRequestData('POST', array(), array());
 
         $this->requestHandler->handleRequest($form, $this->request);

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -18,7 +18,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', 'text');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -42,7 +42,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testLabelIsNotRenderedWhenSetToFalse()
     {
-        $form = $this->factory->createNamed('name', 'text', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'label' => false,
         ));
         $html = $this->renderRow($form->createView());
@@ -61,7 +61,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRow()
     {
-        $form = $this->factory->createNamed('name', 'repeated');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType');
         $html = $this->renderRow($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -91,7 +91,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRowWithErrors()
     {
-        $form = $this->factory->createNamed('name', 'repeated');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType');
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -128,7 +128,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testButtonRow()
     {
-        $form = $this->factory->createNamed('name', 'button');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ButtonType');
         $view = $form->createView();
         $html = $this->renderRow($view);
 
@@ -147,11 +147,11 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRest()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('field1', 'text')
-            ->add('field2', 'repeated')
-            ->add('field3', 'text')
-            ->add('field4', 'text')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
+            ->add('field3', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field4', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm()
             ->createView();
 
@@ -194,8 +194,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testCollection()
     {
-        $form = $this->factory->createNamed('names', 'collection', array('a', 'b'), array(
-            'type' => 'text',
+        $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array('a', 'b'), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -212,8 +212,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testEmptyCollection()
     {
-        $form = $this->factory->createNamed('names', 'collection', array(), array(
-            'type' => 'text',
+        $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -226,11 +226,11 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testForm()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->setMethod('PUT')
             ->setAction('http://example.com')
-            ->add('firstName', 'text')
-            ->add('lastName', 'text')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm()
             ->createView();
 
@@ -278,9 +278,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testFormWidget()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('firstName', 'text')
-            ->add('lastName', 'text')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm()
             ->createView();
 
@@ -315,10 +315,10 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     // https://github.com/symfony/symfony/issues/2308
     public function testNestedFormError()
     {
-        $form = $this->factory->createNamedBuilder('name', 'form')
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($this->factory
-                ->createNamedBuilder('child', 'form', null, array('error_bubbling' => false))
-                ->add('grandChild', 'form')
+                ->createNamedBuilder('child', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array('error_bubbling' => false))
+                ->add('grandChild', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             )
             ->getForm();
 
@@ -341,11 +341,11 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
             ->method('getToken')
             ->will($this->returnValue(new CsrfToken('token_id', 'foo&bar')));
 
-        $form = $this->factory->createNamedBuilder('name', 'form')
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($this->factory
                 // No CSRF protection on nested forms
-                ->createNamedBuilder('child', 'form')
-                ->add($this->factory->createNamedBuilder('grandchild', 'text'))
+                ->createNamedBuilder('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+                ->add($this->factory->createNamedBuilder('grandchild', 'Symfony\Component\Form\Extension\Core\Type\TextType'))
             )
             ->getForm();
 
@@ -365,8 +365,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeated()
     {
-        $form = $this->factory->createNamed('name', 'repeated', 'foobar', array(
-            'type' => 'text',
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', 'foobar', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -399,8 +399,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedWithCustomOptions()
     {
-        $form = $this->factory->createNamed('name', 'repeated', 'foobar', array(
-            'type' => 'password',
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', 'foobar', array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\PasswordType',
             'first_options' => array('label' => 'Test', 'required' => false),
             'second_options' => array('label' => 'Test2'),
         ));
@@ -440,7 +440,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     public function testCollectionRowWithCustomBlock()
     {
         $collection = array('one', 'two', 'three');
-        $form = $this->factory->createNamedBuilder('names', 'collection', $collection)
+        $form = $this->factory->createNamedBuilder('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', $collection)
             ->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -456,9 +456,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testFormEndWithRest()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('field1', 'text')
-            ->add('field2', 'text')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm()
             ->createView();
 
@@ -494,9 +494,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testFormEndWithoutRest()
     {
-        $view = $this->factory->createNamedBuilder('name', 'form')
-            ->add('field1', 'text')
-            ->add('field2', 'text')
+        $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm()
             ->createView();
 
@@ -510,11 +510,11 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testWidgetContainerAttributes()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'attr' => array('class' => 'foobar', 'data-foo' => 'bar'),
         ));
 
-        $form->add('text', 'text');
+        $form->add('text', 'Symfony\Component\Form\Extension\Core\Type\TextType');
 
         $html = $this->renderWidget($form->createView());
 
@@ -524,7 +524,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testWidgetContainerAttributeNameRepeatedIfTrue()
     {
-        $form = $this->factory->createNamed('form', 'form', null, array(
+        $form = $this->factory->createNamed('form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'attr' => array('foo' => true),
         ));
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
@@ -26,16 +26,16 @@ class CompoundFormPerformanceTest extends \Symfony\Component\Form\Test\FormPerfo
         $this->setMaxRunningTime(1);
 
         for ($i = 0; $i < 40; ++$i) {
-            $form = $this->factory->createBuilder('form')
-                ->add('firstName', 'text')
-                ->add('lastName', 'text')
-                ->add('gender', 'choice', array(
+            $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
+                ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+                ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+                ->add('gender', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'choices' => array('male' => 'Male', 'female' => 'Female'),
                     'required' => false,
                 ))
-                ->add('age', 'number')
-                ->add('birthDate', 'birthday')
-                ->add('city', 'choice', array(
+                ->add('age', 'Symfony\Component\Form\Extension\Core\Type\NumberType')
+                ->add('birthDate', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType')
+                ->add('city', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     // simulate 300 different cities
                     'choices' => range(1, 300),
                 ))

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -110,7 +110,7 @@ class CompoundFormTest extends AbstractFormTest
         $factory = Forms::createFormFactoryBuilder()
             ->getFormFactory();
 
-        $child = $factory->create('file', null, array('auto_initialize' => false));
+        $child = $factory->createNamed('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', null, array('auto_initialize' => false));
 
         $this->form->add($child);
         $this->form->submit(array('file' => null), false);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -45,7 +45,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassIdAndNameToViewWithParent()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add('child', $this->getTestedType())
             ->getForm()
             ->createView();
@@ -57,8 +57,8 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassIdAndNameToViewWithGrandParent()
     {
-        $builder = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form');
+        $builder = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\FormType');
         $builder->get('child')->add('grand_child', $this->getTestedType());
         $view = $builder->getForm()->createView();
 
@@ -80,7 +80,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testInheritTranslationDomainFromParent()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'translation_domain' => 'domain',
             ))
             ->add('child', $this->getTestedType())
@@ -93,7 +93,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPreferOwnTranslationDomain()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'translation_domain' => 'parent_domain',
             ))
             ->add('child', $this->getTestedType(), array(
@@ -107,7 +107,7 @@ abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testDefaultTranslationDomain()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add('child', $this->getTestedType())
             ->getForm()
             ->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -16,18 +16,25 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
  */
 class BirthdayTypeTest extends BaseTypeTest
 {
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('birthday');
+
+        $this->assertSame('birthday', $form->getConfig()->getType()->getName());
+    }
+
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testSetInvalidYearsOption()
     {
-        $this->factory->create('birthday', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\BirthdayType', null, array(
             'years' => 'bad value',
         ));
     }
 
     protected function getTestedType()
     {
-        return 'birthday';
+        return 'Symfony\Component\Form\Extension\Core\Type\BirthdayType';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -16,13 +16,20 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
  */
 class ButtonTypeTest extends BaseTypeTest
 {
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('button');
+
+        $this->assertSame('button', $form->getConfig()->getType()->getName());
+    }
+
     public function testCreateButtonInstances()
     {
-        $this->assertInstanceOf('Symfony\Component\Form\Button', $this->factory->create('button'));
+        $this->assertInstanceOf('Symfony\Component\Form\Button', $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ButtonType'));
     }
 
     protected function getTestedType()
     {
-        return 'button';
+        return 'Symfony\Component\Form\Extension\Core\Type\ButtonType';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -15,9 +15,16 @@ use Symfony\Component\Form\CallbackTransformer;
 
 class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
-    public function testDataIsFalseByDefault()
+    public function testLegacyName()
     {
         $form = $this->factory->create('checkbox');
+
+        $this->assertSame('checkbox', $form->getConfig()->getType()->getName());
+    }
+
+    public function testDataIsFalseByDefault()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType');
 
         $this->assertFalse($form->getData());
         $this->assertFalse($form->getNormData());
@@ -26,7 +33,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassValueToView()
     {
-        $form = $this->factory->create('checkbox', null, array('value' => 'foobar'));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array('value' => 'foobar'));
         $view = $form->createView();
 
         $this->assertEquals('foobar', $view->vars['value']);
@@ -34,7 +41,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testCheckedIfDataTrue()
     {
-        $form = $this->factory->create('checkbox');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType');
         $form->setData(true);
         $view = $form->createView();
 
@@ -43,7 +50,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testCheckedIfDataTrueWithEmptyValue()
     {
-        $form = $this->factory->create('checkbox', null, array('value' => ''));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array('value' => ''));
         $form->setData(true);
         $view = $form->createView();
 
@@ -52,7 +59,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotCheckedIfDataFalse()
     {
-        $form = $this->factory->create('checkbox');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType');
         $form->setData(false);
         $view = $form->createView();
 
@@ -61,7 +68,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array(
             'value' => 'foobar',
         ));
         $form->submit('foobar');
@@ -72,7 +79,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithRandomValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array(
             'value' => 'foobar',
         ));
         $form->submit('krixikraxi');
@@ -83,7 +90,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithValueUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array(
             'value' => 'foobar',
         ));
         $form->submit(null);
@@ -94,7 +101,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithEmptyValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array(
             'value' => '',
         ));
         $form->submit('');
@@ -105,7 +112,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithEmptyValueUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array(
             'value' => '',
         ));
         $form->submit(null);
@@ -116,7 +123,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithEmptyValueAndFalseUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array(
             'value' => '',
         ));
         $form->submit(false);
@@ -127,7 +134,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitWithEmptyValueAndTrueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CheckboxType', null, array(
             'value' => '',
         ));
         $form->submit(true);
@@ -151,7 +158,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             }
         );
 
-        $form = $this->factory->createBuilder('checkbox')
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\CheckboxType')
             ->addModelTransformer($transformer)
             ->getForm();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
@@ -30,7 +30,7 @@ class ChoiceTypePerformanceTest extends FormPerformanceTestCase
         $choices = range(1, 300);
 
         for ($i = 0; $i < 100; ++$i) {
-            $this->factory->create('choice', mt_rand(1, 400), array(
+            $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', mt_rand(1, 400), array(
                 'choices' => $choices,
             ));
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -67,12 +67,19 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->objectChoices = null;
     }
 
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('choice');
+
+        $this->assertSame('choice', $form->getConfig()->getType()->getName());
+    }
+
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testChoicesOptionExpectsArrayOrTraversable()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => new \stdClass(),
         ));
     }
@@ -82,7 +89,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testChoiceListOptionExpectsChoiceListInterface()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choice_list' => array('foo' => 'foo'),
         ));
     }
@@ -92,19 +99,19 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testChoiceLoaderOptionExpectsChoiceLoaderInterface()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choice_loader' => new \stdClass(),
         ));
     }
 
     public function testChoiceListAndChoicesCanBeEmpty()
     {
-        $this->factory->create('choice');
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType');
     }
 
     public function testExpandedChoicesOptionsTurnIntoChildren()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'expanded' => true,
             'choices' => $this->choices,
         ));
@@ -114,7 +121,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderPresentOnNonRequiredExpandedSingleChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -127,7 +134,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderNotPresentIfRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -140,7 +147,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderNotPresentIfMultiple()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'required' => false,
@@ -153,7 +160,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderNotPresentIfEmptyChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -169,7 +176,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedChoicesOptionsAreFlattened()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'expanded' => true,
             'choices' => $this->groupedChoices,
         ));
@@ -194,7 +201,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $obj4 = (object) array('id' => 4, 'name' => 'Jon');
         $obj5 = (object) array('id' => 5, 'name' => 'Roman');
 
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'expanded' => true,
             'choices' => array(
                 'Symfony' => array($obj1, $obj2, $obj3),
@@ -214,7 +221,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedCheckboxesAreNeverRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'required' => true,
@@ -228,7 +235,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedRadiosAreRequiredIfChoiceChildIsRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -242,7 +249,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedRadiosAreNotRequiredIfChoiceChildIsNotRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -256,7 +263,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -271,7 +278,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -286,7 +293,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -304,7 +311,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleNonExpandedNullNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -319,7 +326,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -334,7 +341,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedEmptyExplicitEmptyChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(
@@ -357,7 +364,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleNonExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -372,7 +379,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -390,7 +397,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleNonExpandedFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -405,7 +412,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->objectChoices,
@@ -427,7 +434,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testLegacySubmitSingleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choice_list' => new ObjectChoiceList(
@@ -451,7 +458,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -466,7 +473,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -484,7 +491,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitMultipleNonExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => array(),
@@ -499,7 +506,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpandedInvalidScalarChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -514,7 +521,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpandedInvalidArrayChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -529,7 +536,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->objectChoices,
@@ -550,7 +557,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testLegacySubmitMultipleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choice_list' => new ObjectChoiceList(
@@ -573,7 +580,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -601,7 +608,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequiredInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -629,7 +636,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -659,7 +666,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -687,7 +694,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequiredNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -718,7 +725,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredNullNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -735,7 +742,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequiredEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -766,7 +773,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -783,7 +790,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedRequiredFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -814,7 +821,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -831,7 +838,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -864,7 +871,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredNullNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -881,7 +888,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -914,7 +921,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -931,7 +938,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -964,7 +971,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -981,7 +988,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedWithEmptyChild()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => array(
@@ -1003,7 +1010,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => $this->objectChoices,
@@ -1034,7 +1041,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testLegacySubmitSingleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'choice_list' => new ObjectChoiceList(
@@ -1067,7 +1074,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitSingleExpandedNumericChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => $this->numericChoices,
@@ -1092,7 +1099,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1119,7 +1126,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedInvalidScalarChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1146,7 +1153,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedInvalidArrayChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1173,7 +1180,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1201,7 +1208,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // choices are available.
     public function testSubmitMultipleExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => array(),
@@ -1215,7 +1222,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedWithEmptyChild()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => array(
@@ -1240,7 +1247,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->objectChoices,
@@ -1271,7 +1278,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testLegacySubmitMultipleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choice_list' => new ObjectChoiceList(
@@ -1304,7 +1311,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultipleExpandedNumericChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->numericChoices,
@@ -1333,7 +1340,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testSetDataSingleNonExpandedAcceptsBoolean()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->numericChoices,
@@ -1348,7 +1355,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetDataMultipleNonExpandedAcceptsBoolean()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->numericChoices,
@@ -1363,7 +1370,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassRequiredToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->choices,
         ));
         $view = $form->createView();
@@ -1373,7 +1380,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassNonRequiredToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'required' => false,
             'choices' => $this->choices,
         ));
@@ -1384,7 +1391,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassMultipleToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'choices' => $this->choices,
         ));
@@ -1395,7 +1402,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassExpandedToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'expanded' => true,
             'choices' => $this->choices,
         ));
@@ -1406,7 +1413,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassChoiceTranslationDomainToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->choices,
         ));
         $view = $form->createView();
@@ -1416,7 +1423,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testChoiceTranslationDomainWithTrueValueToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->choices,
             'choice_translation_domain' => true,
         ));
@@ -1427,7 +1434,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testDefaultChoiceTranslationDomainIsSameAsTranslationDomainToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->choices,
             'translation_domain' => 'foo',
         ));
@@ -1439,10 +1446,10 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testInheritChoiceTranslationDomainFromParent()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'translation_domain' => 'domain',
             ))
-            ->add('child', 'choice')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType')
             ->getForm()
             ->createView();
 
@@ -1451,7 +1458,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderIsNullByDefaultIfRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'required' => true,
             'choices' => $this->choices,
@@ -1463,7 +1470,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderIsEmptyStringByDefaultIfNotRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'required' => false,
             'choices' => $this->choices,
@@ -1478,7 +1485,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testPassPlaceholderToView($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
@@ -1496,7 +1503,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testPassEmptyValueBC($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
@@ -1516,7 +1523,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testDontPassPlaceholderIfContainedInChoices($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
@@ -1576,7 +1583,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPassChoicesToView()
     {
         $choices = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D');
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $choices,
         ));
         $view = $form->createView();
@@ -1592,7 +1599,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPassPreferredChoicesToView()
     {
         $choices = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D');
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $choices,
             'preferred_choices' => array('b', 'd'),
         ));
@@ -1610,7 +1617,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPassHierarchicalChoicesToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->groupedChoices,
             'preferred_choices' => array('b', 'd'),
         ));
@@ -1641,7 +1648,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $obj2 = (object) array('value' => 'b', 'label' => 'B');
         $obj3 = (object) array('value' => 'c', 'label' => 'C');
         $obj4 = (object) array('value' => 'd', 'label' => 'D');
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => array($obj1, $obj2, $obj3, $obj4),
             'choices_as_values' => true,
             'choice_label' => 'label',
@@ -1659,7 +1666,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testAdjustFullNameForMultipleNonExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -1672,7 +1679,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // https://github.com/symfony/symfony/issues/3298
     public function testInitializeWithEmptyChoices()
     {
-        $this->factory->createNamed('name', 'choice', null, array(
+        $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => array(),
         ));
     }
@@ -1684,7 +1691,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $obj3 = (object) array('value' => 'c', 'label' => 'C');
         $obj4 = (object) array('value' => 'd', 'label' => 'D');
 
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => array($obj1, $obj2, $obj3, $obj4),
             'choices_as_values' => true,
             'choice_label' => 'label',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -17,10 +17,19 @@ use Symfony\Component\Form\Tests\Fixtures\AuthorType;
 
 class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('collection', array(
+            'type' => 'text',
+        ));
+
+        $this->assertSame('collection', $form->getConfig()->getType()->getName());
+    }
+
     public function testContainsNoChildByDefault()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertCount(0, $form);
@@ -28,8 +37,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetDataAdjustsSize()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => array(
                 'attr' => array('maxlength' => 20),
             ),
@@ -57,8 +66,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testThrowsExceptionIfObjectIsNotTraversable()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $form->setData(new \stdClass());
@@ -66,8 +75,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotResizedIfSubmittedWithMissingData()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
         $form->submit(array('foo@bar.com'));
@@ -80,8 +89,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testResizedDownIfSubmittedWithMissingDataAndAllowDelete()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_delete' => true,
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
@@ -95,8 +104,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testResizedDownIfSubmittedWithEmptyDataAndDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_delete' => true,
             'delete_empty' => true,
         ));
@@ -112,8 +121,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testDontAddEmptyDataIfDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_add' => true,
             'delete_empty' => true,
         ));
@@ -129,8 +138,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNoDeleteEmptyIfDeleteNotAllowed()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_delete' => false,
             'delete_empty' => true,
         ));
@@ -144,8 +153,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testResizedDownIfSubmittedWithCompoundEmptyDataAndDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => new AuthorType(),
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Tests\Fixtures\AuthorType',
             // If the field is not required, no new Author will be created if the
             // form is completely empty
             'options' => array('required' => false),
@@ -167,8 +176,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotResizedIfSubmittedWithExtraData()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
         $form->setData(array('foo@bar.com'));
         $form->submit(array('foo@foo.com', 'bar@bar.com'));
@@ -180,8 +189,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testResizedUpIfSubmittedWithExtraDataAndAllowAdd()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_add' => true,
         ));
         $form->setData(array('foo@bar.com'));
@@ -196,8 +205,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testAllowAddButNoPrototype()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
             'allow_add' => true,
             'prototype' => false,
         ));
@@ -208,8 +217,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testPrototypeMultipartPropagation()
     {
         $form = $this->factory
-            ->create('collection', null, array(
-                'type' => 'file',
+            ->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+                'type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
                 'allow_add' => true,
                 'prototype' => true,
             ))
@@ -220,8 +229,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testGetDataDoesNotContainsPrototypeNameBeforeDataAreSet()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
             'prototype' => true,
             'allow_add' => true,
         ));
@@ -232,8 +241,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testGetDataDoesNotContainsPrototypeNameAfterDataAreSet()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
             'allow_add' => true,
             'prototype' => true,
         ));
@@ -245,16 +254,16 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPrototypeNameOption()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
             'prototype' => true,
             'allow_add' => true,
         ));
 
         $this->assertSame('__name__', $form->getConfig()->getAttribute('prototype')->getName(), '__name__ is the default');
 
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
             'prototype' => true,
             'allow_add' => true,
             'prototype_name' => '__test__',
@@ -265,8 +274,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPrototypeDefaultLabel()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
             'allow_add' => true,
             'prototype' => true,
             'prototype_name' => '__test__',
@@ -277,8 +286,8 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPrototypeData()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'allow_add' => true,
             'prototype' => true,
             'prototype_data' => 'foo',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -24,9 +24,16 @@ class CountryTypeTest extends TestCase
         parent::setUp();
     }
 
-    public function testCountriesAreSelectable()
+    public function testLegacyName()
     {
         $form = $this->factory->create('country');
+
+        $this->assertSame('country', $form->getConfig()->getType()->getName());
+    }
+
+    public function testCountriesAreSelectable()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CountryType');
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
@@ -40,7 +47,7 @@ class CountryTypeTest extends TestCase
 
     public function testUnknownCountryIsNotIncluded()
     {
-        $form = $this->factory->create('country', 'country');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CountryType', 'Symfony\Component\Form\Extension\Core\Type\CountryType');
         $view = $form->createView();
         $choices = $view->vars['choices'];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -24,9 +24,16 @@ class CurrencyTypeTest extends TestCase
         parent::setUp();
     }
 
-    public function testCurrenciesAreSelectable()
+    public function testLegacyName()
     {
         $form = $this->factory->create('currency');
+
+        $this->assertSame('currency', $form->getConfig()->getType()->getName());
+    }
+
+    public function testCurrenciesAreSelectable()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CurrencyType');
         $view = $form->createView();
         $choices = $view->vars['choices'];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -24,9 +24,16 @@ class DateTimeTypeTest extends TestCase
         parent::setUp();
     }
 
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('datetime');
+
+        $this->assertSame('datetime', $form->getConfig()->getType()->getName());
+    }
+
     public function testSubmitDateTime()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -53,7 +60,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitString()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -78,7 +85,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitTimestamp()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -105,7 +112,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitWithoutMinutes()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -134,7 +141,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitWithSeconds()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -165,7 +172,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentTimezones()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'date_widget' => 'choice',
@@ -196,7 +203,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentTimezonesDateTime()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'widget' => 'single_text',
@@ -215,7 +222,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitStringSingleText()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -230,7 +237,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitStringSingleTextWithSeconds()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -246,7 +253,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentPattern()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'date_format' => 'MM*yyyy*dd',
             'date_widget' => 'single_text',
             'time_widget' => 'single_text',
@@ -268,12 +275,12 @@ class DateTimeTypeTest extends TestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->factory->create('datetime', new \DateTime());
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', new \DateTime());
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'widget' => 'single_text',
         ));
 
@@ -283,7 +290,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'required' => false,
             'with_seconds' => true,
         ));
@@ -299,7 +306,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'required' => true,
             'with_seconds' => true,
         ));
@@ -315,7 +322,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'placeholder' => 'Empty',
             'with_seconds' => true,
         ));
@@ -331,7 +338,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'empty_value' => 'Empty',
             'with_seconds' => true,
         ));
@@ -353,7 +360,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
@@ -376,7 +383,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'required' => false,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -398,7 +405,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'required' => true,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -420,7 +427,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'widget' => 'single_text',
         ));
 
@@ -430,7 +437,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'widget' => 'single_text',
             'html5' => false,
         ));
@@ -441,7 +448,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'widget' => 'single_text',
             'format' => 'yyyy-MM-dd HH:mm',
         ));
@@ -452,7 +459,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfNotSingleText()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'widget' => 'text',
         ));
 
@@ -463,7 +470,7 @@ class DateTimeTypeTest extends TestCase
     public function testDateTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null);
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null);
 
         $form['date']->addError($error);
 
@@ -474,7 +481,7 @@ class DateTimeTypeTest extends TestCase
     public function testDateTypeSingleTextErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'date_widget' => 'single_text',
         ));
 
@@ -487,7 +494,7 @@ class DateTimeTypeTest extends TestCase
     public function testTimeTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null);
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null);
 
         $form['time']->addError($error);
 
@@ -498,7 +505,7 @@ class DateTimeTypeTest extends TestCase
     public function testTimeTypeSingleTextErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateTimeType', null, array(
             'time_widget' => 'single_text',
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -37,12 +37,19 @@ class DateTypeTest extends TestCase
         date_default_timezone_set($this->defaultTimezone);
     }
 
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('date');
+
+        $this->assertSame('date', $form->getConfig()->getType()->getName());
+    }
+
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testInvalidWidgetOption()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => 'fake_widget',
         ));
     }
@@ -52,14 +59,14 @@ class DateTypeTest extends TestCase
      */
     public function testInvalidInputOption()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'input' => 'fake_input',
         ));
     }
 
     public function testSubmitFromSingleTextDateTimeWithDefaultFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -74,7 +81,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextDateTime()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -90,7 +97,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextString()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -106,7 +113,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextTimestamp()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -124,7 +131,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextRaw()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -146,7 +153,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromText()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'text',
@@ -168,7 +175,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromChoice()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -190,7 +197,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromChoiceEmpty()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -211,7 +218,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputDateTimeDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -227,7 +234,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputStringDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -243,7 +250,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputTimestampDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -261,7 +268,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputRawDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -286,7 +293,7 @@ class DateTypeTest extends TestCase
      */
     public function testDatePatternWithFormatOption($format, $pattern)
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => $format,
         ));
 
@@ -312,7 +319,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsNoPattern()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => '0',
             'widget' => 'single_text',
             'input' => 'string',
@@ -324,7 +331,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatDoesNotContainYearMonthAndDay()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'months' => array(6, 7),
             'format' => 'yy',
         ));
@@ -335,7 +342,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsNoConstant()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => 105,
         ));
     }
@@ -345,7 +352,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => array(),
         ));
     }
@@ -355,7 +362,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfYearsIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'years' => 'bad value',
         ));
     }
@@ -365,7 +372,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfMonthsIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'months' => 'bad value',
         ));
     }
@@ -375,14 +382,14 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfDaysIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'days' => 'bad value',
         ));
     }
 
     public function testSetDataWithNegativeTimezoneOffsetStringInput()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'America/New_York',
@@ -399,7 +406,7 @@ class DateTypeTest extends TestCase
 
     public function testSetDataWithNegativeTimezoneOffsetDateTimeInput()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'America/New_York',
@@ -419,7 +426,7 @@ class DateTypeTest extends TestCase
 
     public function testYearsOption()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'years' => array(2010, 2011),
         ));
 
@@ -433,7 +440,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOption()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'months' => array(6, 7),
         ));
 
@@ -447,7 +454,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOptionShortFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMM.yy',
         ));
@@ -462,7 +469,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOptionLongFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMMM.yy',
         ));
@@ -477,7 +484,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOptionLongFormatWithDifferentTimezone()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMMM.yy',
         ));
@@ -492,7 +499,7 @@ class DateTypeTest extends TestCase
 
     public function testIsDayWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'days' => array(6, 7),
         ));
 
@@ -508,7 +515,7 @@ class DateTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -523,7 +530,7 @@ class DateTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -542,7 +549,7 @@ class DateTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -561,7 +568,7 @@ class DateTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -578,7 +585,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToView()
     {
-        $form = $this->factory->create('date');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType');
         $view = $form->createView();
 
         $this->assertSame('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
@@ -586,7 +593,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToViewDifferentFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => \IntlDateFormatter::LONG,
         ));
 
@@ -597,7 +604,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToViewDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => 'MMyyyydd',
         ));
 
@@ -608,7 +615,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToViewDifferentPatternWithSeparators()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'format' => 'MM*yyyy*dd',
         ));
 
@@ -619,7 +626,7 @@ class DateTypeTest extends TestCase
 
     public function testDontPassDatePatternIfText()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => 'single_text',
         ));
         $view = $form->createView();
@@ -631,7 +638,7 @@ class DateTypeTest extends TestCase
     {
         \Locale::setDefault('es_ES');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             // EEEE, d 'de' MMMM 'de' y
             'format' => \IntlDateFormatter::FULL,
         ));
@@ -643,7 +650,7 @@ class DateTypeTest extends TestCase
 
     public function testPassWidgetToView()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => 'single_text',
         ));
         $view = $form->createView();
@@ -656,12 +663,12 @@ class DateTypeTest extends TestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->factory->create('date', new \DateTime());
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', new \DateTime());
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => 'single_text',
         ));
 
@@ -671,7 +678,7 @@ class DateTypeTest extends TestCase
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'required' => false,
         ));
 
@@ -683,7 +690,7 @@ class DateTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'required' => true,
         ));
 
@@ -695,7 +702,7 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'placeholder' => 'Empty',
         ));
 
@@ -707,7 +714,7 @@ class DateTypeTest extends TestCase
 
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'empty_value' => 'Empty',
         ));
 
@@ -722,7 +729,7 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
@@ -738,7 +745,7 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'required' => false,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -754,7 +761,7 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'required' => true,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -770,7 +777,7 @@ class DateTypeTest extends TestCase
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => 'single_text',
         ));
 
@@ -780,7 +787,7 @@ class DateTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => 'single_text',
             'html5' => false,
         ));
@@ -791,7 +798,7 @@ class DateTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => 'single_text',
             'format' => \IntlDateFormatter::MEDIUM,
         ));
@@ -802,7 +809,7 @@ class DateTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfNotSingleText()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => 'text',
         ));
 
@@ -824,7 +831,7 @@ class DateTypeTest extends TestCase
     public function testYearErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => $widget,
         ));
         $form['year']->addError($error);
@@ -839,7 +846,7 @@ class DateTypeTest extends TestCase
     public function testMonthErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => $widget,
         ));
         $form['month']->addError($error);
@@ -854,7 +861,7 @@ class DateTypeTest extends TestCase
     public function testDayErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'widget' => $widget,
         ));
         $form['day']->addError($error);
@@ -870,7 +877,7 @@ class DateTypeTest extends TestCase
                 'PHP must be compiled in 32 bit mode to run this test');
         }
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'years' => range(1900, 2040),
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -13,10 +13,17 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('file');
+
+        $this->assertSame('file', $form->getConfig()->getType()->getName());
+    }
+
     // https://github.com/symfony/symfony/pull/5028
     public function testSetData()
     {
-        $form = $this->factory->createBuilder('file')->getForm();
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FileType')->getForm();
         $data = $this->createUploadedFileMock('abcdef', 'original.jpg', true);
 
         $form->setData($data);
@@ -26,7 +33,7 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmit()
     {
-        $form = $this->factory->createBuilder('file')->getForm();
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FileType')->getForm();
         $data = $this->createUploadedFileMock('abcdef', 'original.jpg', true);
 
         $form->submit($data);
@@ -37,7 +44,7 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     // https://github.com/symfony/symfony/issues/6134
     public function testSubmitEmpty()
     {
-        $form = $this->factory->createBuilder('file')->getForm();
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FileType')->getForm();
 
         $form->submit(null);
 
@@ -46,7 +53,7 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSubmitMultiple()
     {
-        $form = $this->factory->createBuilder('file', null, array(
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FileType', null, array(
             'multiple' => true,
         ))->getForm();
 
@@ -65,9 +72,9 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testDontPassValueToView()
     {
-        $form = $this->factory->create('file');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FileType');
         $form->submit(array(
-            'file' => $this->createUploadedFileMock('abcdef', 'original.jpg', true),
+            'Symfony\Component\Form\Extension\Core\Type\FileType' => $this->createUploadedFileMock('abcdef', 'original.jpg', true),
         ));
         $view = $form->createView();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -51,25 +51,32 @@ class FormTest_AuthorWithoutRefSetter
 
 class FormTypeTest extends BaseTypeTest
 {
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('form');
+
+        $this->assertSame('form', $form->getConfig()->getType()->getName());
+    }
+
     public function testCreateFormInstances()
     {
-        $this->assertInstanceOf('Symfony\Component\Form\Form', $this->factory->create('form'));
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType'));
     }
 
     public function testPassRequiredAsOption()
     {
-        $form = $this->factory->create('form', null, array('required' => false));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array('required' => false));
 
         $this->assertFalse($form->isRequired());
 
-        $form = $this->factory->create('form', null, array('required' => true));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array('required' => true));
 
         $this->assertTrue($form->isRequired());
     }
 
     public function testSubmittedDataIsTrimmedBeforeTransforming()
     {
-        $form = $this->factory->createBuilder('form')
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
             ->addViewTransformer(new FixedDataTransformer(array(
                 null => '',
                 'reverse[a]' => 'a',
@@ -85,7 +92,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmittedDataIsNotTrimmedBeforeTransformingIfNoTrimming()
     {
-        $form = $this->factory->createBuilder('form', null, array('trim' => false))
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array('trim' => false))
             ->addViewTransformer(new FixedDataTransformer(array(
                 null => '',
                 'reverse[ a ]' => ' a ',
@@ -104,8 +111,8 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testLegacyNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('read_only' => true))
-            ->add('child', 'form')
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array('read_only' => true))
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->getForm()
             ->createView();
 
@@ -114,8 +121,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('attr' => array('readonly' => true)))
-            ->add('child', 'form')
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array('attr' => array('readonly' => true)))
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->getForm()
             ->createView();
 
@@ -127,8 +134,8 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testLegacyReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form', array('read_only' => true))
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\FormType', array('read_only' => true))
             ->getForm()
             ->createView();
 
@@ -137,8 +144,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form', array('attr' => array('readonly' => true)))
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\FormType', array('attr' => array('readonly' => true)))
             ->getForm()
             ->createView();
 
@@ -150,8 +157,8 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testLegacyNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
-                ->add('child', 'form')
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+                ->add('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
                 ->getForm()
                 ->createView();
 
@@ -160,8 +167,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form')
+        $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->getForm()
             ->createView();
 
@@ -170,7 +177,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMaxLengthToView()
     {
-        $form = $this->factory->create('form', null, array('attr' => array('maxlength' => 10)));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array('attr' => array('maxlength' => 10)));
         $view = $form->createView();
 
         $this->assertSame(10, $view->vars['attr']['maxlength']);
@@ -178,7 +185,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMaxLengthBCToView()
     {
-        $form = $this->factory->create('form', null, array('max_length' => 10));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array('max_length' => 10));
         $view = $form->createView();
 
         $this->assertSame(10, $view->vars['attr']['maxlength']);
@@ -186,21 +193,21 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataClassMayBeNull()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => null,
         ));
     }
 
     public function testDataClassMayBeAbstractClass()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\AbstractAuthor',
         ));
     }
 
     public function testDataClassMayBeInterface()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\AuthorInterface',
         ));
     }
@@ -210,19 +217,19 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testDataClassMustBeValidClassOrInterface()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => 'foobar',
         ));
     }
 
     public function testSubmitWithEmptyDataCreatesObjectIfClassAvailable()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ));
-        $builder->add('firstName', 'text');
-        $builder->add('lastName', 'text');
+        $builder->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $builder->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form->setData(null);
@@ -238,13 +245,13 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataCreatesObjectIfInitiallySubmittedWithObject()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             // data class is inferred from the passed object
             'data' => new Author(),
             'required' => false,
         ));
-        $builder->add('firstName', 'text');
-        $builder->add('lastName', 'text');
+        $builder->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $builder->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form->setData(null);
@@ -260,11 +267,11 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataCreatesArrayIfDataClassIsNull()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => null,
             'required' => false,
         ));
-        $builder->add('firstName', 'text');
+        $builder->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form->setData(null);
@@ -275,12 +282,12 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitEmptyWithEmptyDataCreatesNoObjectIfNotRequired()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ));
-        $builder->add('firstName', 'text');
-        $builder->add('lastName', 'text');
+        $builder->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $builder->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form->setData(null);
@@ -291,12 +298,12 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitEmptyWithEmptyDataCreatesObjectIfRequired()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => true,
         ));
-        $builder->add('firstName', 'text');
-        $builder->add('lastName', 'text');
+        $builder->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $builder->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form->setData(null);
@@ -310,8 +317,8 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testSubmitWithEmptyDataStoresArrayIfNoClassAvailable()
     {
-        $form = $this->factory->createBuilder('form')
-            ->add('firstName', 'text')
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         $form->setData(null);
@@ -322,7 +329,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataPassesEmptyStringToTransformerIfNotCompound()
     {
-        $form = $this->factory->createBuilder('form')
+        $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
             ->addViewTransformer(new FixedDataTransformer(array(
                 // required for the initial, internal setData(null)
                 null => 'null',
@@ -341,11 +348,11 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new Author();
 
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'empty_data' => $author,
         ));
-        $builder->add('firstName', 'text');
+        $builder->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form->submit(array('firstName' => 'Bernhard'));
@@ -370,7 +377,7 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testSetDataThroughParamsWithZero($data, $dataAsString)
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data' => $data,
             'compound' => false,
         ));
@@ -387,12 +394,12 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testAttributesException()
     {
-        $this->factory->create('form', null, array('attr' => ''));
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array('attr' => ''));
     }
 
     public function testNameCanBeEmptyString()
     {
-        $form = $this->factory->createNamed('', 'form');
+        $form = $this->factory->createNamed('', 'Symfony\Component\Form\Extension\Core\Type\FormType');
 
         $this->assertEquals('', $form->getName());
     }
@@ -401,11 +408,11 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder('form', $author);
-        $builder->add('reference', 'form', array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', $author);
+        $builder->add('reference', 'Symfony\Component\Form\Extension\Core\Type\FormType', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
         ));
-        $builder->get('reference')->add('firstName', 'text');
+        $builder->get('reference')->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form->submit(array(
@@ -424,11 +431,11 @@ class FormTypeTest extends BaseTypeTest
         $author = new FormTest_AuthorWithoutRefSetter(null);
         $newReference = new Author();
 
-        $builder = $this->factory->createBuilder('form', $author);
-        $builder->add('referenceCopy', 'form', array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', $author);
+        $builder->add('referenceCopy', 'Symfony\Component\Form\Extension\Core\Type\FormType', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
         ));
-        $builder->get('referenceCopy')->add('firstName', 'text');
+        $builder->get('referenceCopy')->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form['referenceCopy']->setData($newReference); // new author object
@@ -447,12 +454,12 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder('form', $author);
-        $builder->add('referenceCopy', 'form', array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', $author);
+        $builder->add('referenceCopy', 'Symfony\Component\Form\Extension\Core\Type\FormType', array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'by_reference' => false,
         ));
-        $builder->get('referenceCopy')->add('firstName', 'text');
+        $builder->get('referenceCopy')->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $form = $builder->getForm();
 
         $form->submit(array(
@@ -470,8 +477,8 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter('scalar');
 
-        $builder = $this->factory->createBuilder('form', $author);
-        $builder->add('referenceCopy', 'form');
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', $author);
+        $builder->add('referenceCopy', 'Symfony\Component\Form\Extension\Core\Type\FormType');
         $builder->get('referenceCopy')->addViewTransformer(new CallbackTransformer(
             function () {},
             function ($value) { // reverseTransform
@@ -495,9 +502,9 @@ class FormTypeTest extends BaseTypeTest
         $ref2 = new Author();
         $author = array('referenceCopy' => $ref1);
 
-        $builder = $this->factory->createBuilder('form');
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType');
         $builder->setData($author);
-        $builder->add('referenceCopy', 'form');
+        $builder->add('referenceCopy', 'Symfony\Component\Form\Extension\Core\Type\FormType');
         $builder->get('referenceCopy')->addViewTransformer(new CallbackTransformer(
             function () {},
             function ($value) use ($ref2) { // reverseTransform
@@ -518,9 +525,9 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMultipartTrueIfAnyChildIsMultipartToView()
     {
-        $view = $this->factory->createBuilder('form')
-            ->add('foo', 'text')
-            ->add('bar', 'file')
+        $view = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('bar', 'Symfony\Component\Form\Extension\Core\Type\FileType')
             ->getForm()
             ->createView();
 
@@ -529,8 +536,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewIsNotRenderedByDefault()
     {
-        $view = $this->factory->createBuilder('form')
-                ->add('foo', 'form')
+        $view = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
+                ->add('foo', 'Symfony\Component\Form\Extension\Core\Type\FormType')
                 ->getForm()
                 ->createView();
 
@@ -539,7 +546,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testErrorBubblingIfCompound()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'compound' => true,
         ));
 
@@ -548,7 +555,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNoErrorBubblingIfNotCompound()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'compound' => false,
         ));
 
@@ -557,7 +564,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testOverrideErrorBubbling()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'compound' => false,
             'error_bubbling' => true,
         ));
@@ -567,7 +574,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPropertyPath()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'property_path' => 'foo',
         ));
 
@@ -577,7 +584,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPropertyPathNullImpliesDefault()
     {
-        $form = $this->factory->createNamed('name', 'form', null, array(
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'property_path' => null,
         ));
 
@@ -587,7 +594,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNotMapped()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'property_path' => 'foo',
             'mapped' => false,
         ));
@@ -598,14 +605,14 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewValidNotSubmitted()
     {
-        $form = $this->factory->create('form');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType');
         $view = $form->createView();
         $this->assertTrue($view->vars['valid']);
     }
 
     public function testViewNotValidSubmitted()
     {
-        $form = $this->factory->create('form');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType');
         $form->submit(array());
         $form->addError(new FormError('An error'));
         $view = $form->createView();
@@ -614,14 +621,14 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewSubmittedNotSubmitted()
     {
-        $form = $this->factory->create('form');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType');
         $view = $form->createView();
         $this->assertFalse($view->vars['submitted']);
     }
 
     public function testViewSubmittedSubmitted()
     {
-        $form = $this->factory->create('form');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType');
         $form->submit(array());
         $view = $form->createView();
         $this->assertTrue($view->vars['submitted']);
@@ -629,7 +636,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataOptionSupersedesSetDataCalls()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data' => 'default',
             'compound' => false,
         ));
@@ -641,7 +648,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataOptionSupersedesSetDataCallsIfNull()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data' => null,
             'compound' => false,
         ));
@@ -653,7 +660,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNormDataIsPassedToView()
     {
-        $view = $this->factory->createBuilder('form')
+        $view = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
             ->addViewTransformer(new FixedDataTransformer(array(
                 'foo' => 'bar',
             )))
@@ -668,7 +675,7 @@ class FormTypeTest extends BaseTypeTest
     // https://github.com/symfony/symfony/issues/6862
     public function testPassZeroLabelToView()
     {
-        $view = $this->factory->create('form', null, array(
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'label' => '0',
             ))
             ->createView();
@@ -681,12 +688,12 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testCanGetErrorsWhenButtonInForm()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ));
-        $builder->add('foo', 'text');
-        $builder->add('submit', 'submit');
+        $builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $builder->add('submit', 'Symfony\Component\Form\Extension\Core\Type\SubmitType');
         $form = $builder->getForm();
 
         //This method should not throw a Fatal Error Exception.
@@ -695,6 +702,6 @@ class FormTypeTest extends BaseTypeTest
 
     protected function getTestedType()
     {
-        return 'form';
+        return 'Symfony\Component\Form\Extension\Core\Type\FormType';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -23,9 +23,16 @@ class IntegerTypeTest extends TestCase
         parent::setUp();
     }
 
-    public function testSubmitCastsToInteger()
+    public function testLegacyName()
     {
         $form = $this->factory->create('integer');
+
+        $this->assertSame('integer', $form->getConfig()->getType()->getName());
+    }
+
+    public function testSubmitCastsToInteger()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\IntegerType');
 
         $form->submit('1.678');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -24,9 +24,16 @@ class LanguageTypeTest extends TestCase
         parent::setUp();
     }
 
-    public function testCountriesAreSelectable()
+    public function testLegacyName()
     {
         $form = $this->factory->create('language');
+
+        $this->assertSame('language', $form->getConfig()->getType()->getName());
+    }
+
+    public function testCountriesAreSelectable()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\LanguageType');
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
@@ -39,7 +46,7 @@ class LanguageTypeTest extends TestCase
 
     public function testMultipleLanguagesIsNotIncluded()
     {
-        $form = $this->factory->create('language', 'language');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\LanguageType', 'Symfony\Component\Form\Extension\Core\Type\LanguageType');
         $view = $form->createView();
         $choices = $view->vars['choices'];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -24,9 +24,16 @@ class LocaleTypeTest extends TestCase
         parent::setUp();
     }
 
-    public function testLocalesAreSelectable()
+    public function testLegacyName()
     {
         $form = $this->factory->create('locale');
+
+        $this->assertSame('locale', $form->getConfig()->getType()->getName());
+    }
+
+    public function testLocalesAreSelectable()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\LocaleType');
         $view = $form->createView();
         $choices = $view->vars['choices'];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -25,11 +25,18 @@ class MoneyTypeTest extends TestCase
         parent::setUp();
     }
 
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('money');
+
+        $this->assertSame('money', $form->getConfig()->getType()->getName());
+    }
+
     public function testPassMoneyPatternToView()
     {
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create('money');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\MoneyType');
         $view = $form->createView();
 
         $this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
@@ -39,7 +46,7 @@ class MoneyTypeTest extends TestCase
     {
         \Locale::setDefault('en_US');
 
-        $form = $this->factory->create('money', null, array('currency' => 'JPY'));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\MoneyType', null, array('currency' => 'JPY'));
         $view = $form->createView();
         $this->assertTrue((bool) strstr($view->vars['money_pattern'], '¥'));
     }
@@ -49,8 +56,8 @@ class MoneyTypeTest extends TestCase
     {
         \Locale::setDefault('de_DE');
 
-        $form1 = $this->factory->create('money', null, array('currency' => 'GBP'));
-        $form2 = $this->factory->create('money', null, array('currency' => 'EUR'));
+        $form1 = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\MoneyType', null, array('currency' => 'GBP'));
+        $form2 = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\MoneyType', null, array('currency' => 'EUR'));
         $view1 = $form1->createView();
         $view2 = $form2->createView();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -26,9 +26,16 @@ class NumberTypeTest extends TestCase
         \Locale::setDefault('de_DE');
     }
 
-    public function testDefaultFormatting()
+    public function testLegacyName()
     {
         $form = $this->factory->create('number');
+
+        $this->assertSame('number', $form->getConfig()->getType()->getName());
+    }
+
+    public function testDefaultFormatting()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\NumberType');
         $form->setData('12345.67890');
         $view = $form->createView();
 
@@ -37,7 +44,7 @@ class NumberTypeTest extends TestCase
 
     public function testDefaultFormattingWithGrouping()
     {
-        $form = $this->factory->create('number', null, array('grouping' => true));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\NumberType', null, array('grouping' => true));
         $form->setData('12345.67890');
         $view = $form->createView();
 
@@ -46,7 +53,7 @@ class NumberTypeTest extends TestCase
 
     public function testDefaultFormattingWithScale()
     {
-        $form = $this->factory->create('number', null, array('scale' => 2));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\NumberType', null, array('scale' => 2));
         $form->setData('12345.67890');
         $view = $form->createView();
 
@@ -55,7 +62,7 @@ class NumberTypeTest extends TestCase
 
     public function testDefaultFormattingWithRounding()
     {
-        $form = $this->factory->create('number', null, array('scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\NumberType', null, array('scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP));
         $form->setData('12345.54321');
         $view = $form->createView();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -13,9 +13,16 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
-    public function testEmptyIfNotSubmitted()
+    public function testLegacyName()
     {
         $form = $this->factory->create('password');
+
+        $this->assertSame('password', $form->getConfig()->getType()->getName());
+    }
+
+    public function testEmptyIfNotSubmitted()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\PasswordType');
         $form->setData('pAs5w0rd');
         $view = $form->createView();
 
@@ -24,7 +31,7 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testEmptyIfSubmitted()
     {
-        $form = $this->factory->create('password');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\PasswordType');
         $form->submit('pAs5w0rd');
         $view = $form->createView();
 
@@ -33,7 +40,7 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotEmptyIfSubmittedAndNotAlwaysEmpty()
     {
-        $form = $this->factory->create('password', null, array('always_empty' => false));
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\PasswordType', null, array('always_empty' => false));
         $form->submit('pAs5w0rd');
         $view = $form->createView();
 
@@ -42,7 +49,7 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testNotTrimmed()
     {
-        $form = $this->factory->create('password', null);
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\PasswordType', null);
         $form->submit(' pAs5w0rd ');
         $data = $form->getData();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -19,10 +19,19 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         parent::setUp();
 
-        $this->form = $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $this->form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
         $this->form->setData(null);
+    }
+
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('repeated', array(
+            'type' => 'text',
+        ));
+
+        $this->assertSame('repeated', $form->getConfig()->getType()->getName());
     }
 
     public function testSetData()
@@ -35,8 +44,8 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetOptions()
     {
-        $form = $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => array('label' => 'Global'),
         ));
 
@@ -48,9 +57,9 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetOptionsPerChild()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
             // the global required value cannot be overridden
-            'type' => 'text',
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'first_options' => array('label' => 'Test', 'required' => false),
             'second_options' => array('label' => 'Test2'),
         ));
@@ -63,9 +72,9 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetRequired()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
             'required' => false,
-            'type' => 'text',
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
         $this->assertFalse($form['first']->isRequired());
@@ -77,8 +86,8 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testSetInvalidOptions()
     {
-        $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => 'bad value',
         ));
     }
@@ -88,8 +97,8 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testSetInvalidFirstOptions()
     {
-        $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'first_options' => 'bad value',
         ));
     }
@@ -99,15 +108,15 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
      */
     public function testSetInvalidSecondOptions()
     {
-        $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'second_options' => 'bad value',
         ));
     }
 
     public function testSetErrorBubblingToTrue()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
             'error_bubbling' => true,
         ));
 
@@ -118,7 +127,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetErrorBubblingToFalse()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
             'error_bubbling' => false,
         ));
 
@@ -129,7 +138,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetErrorBubblingIndividually()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
             'error_bubbling' => true,
             'options' => array('error_bubbling' => false),
             'second_options' => array('error_bubbling' => true),
@@ -142,8 +151,8 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testSetOptionsPerChildAndOverwrite()
     {
-        $form = $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => array('label' => 'Label'),
             'second_options' => array('label' => 'Second label'),
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
@@ -18,21 +18,28 @@ use Symfony\Component\Form\Test\TypeTestCase as TestCase;
  */
 class SubmitTypeTest extends TestCase
 {
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('submit');
+
+        $this->assertSame('submit', $form->getConfig()->getType()->getName());
+    }
+
     public function testCreateSubmitButtonInstances()
     {
-        $this->assertInstanceOf('Symfony\Component\Form\SubmitButton', $this->factory->create('submit'));
+        $this->assertInstanceOf('Symfony\Component\Form\SubmitButton', $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SubmitType'));
     }
 
     public function testNotClickedByDefault()
     {
-        $button = $this->factory->create('submit');
+        $button = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SubmitType');
 
         $this->assertFalse($button->isClicked());
     }
 
     public function testNotClickedIfSubmittedWithNull()
     {
-        $button = $this->factory->create('submit');
+        $button = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SubmitType');
         $button->submit(null);
 
         $this->assertFalse($button->isClicked());
@@ -40,7 +47,7 @@ class SubmitTypeTest extends TestCase
 
     public function testClickedIfSubmittedWithEmptyString()
     {
-        $button = $this->factory->create('submit');
+        $button = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SubmitType');
         $button->submit('');
 
         $this->assertTrue($button->isClicked());
@@ -48,7 +55,7 @@ class SubmitTypeTest extends TestCase
 
     public function testClickedIfSubmittedWithUnemptyString()
     {
-        $button = $this->factory->create('submit');
+        $button = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SubmitType');
         $button->submit('foo');
 
         $this->assertTrue($button->isClicked());
@@ -57,9 +64,9 @@ class SubmitTypeTest extends TestCase
     public function testSubmitCanBeAddedToForm()
     {
         $form = $this->factory
-            ->createBuilder('form')
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
             ->getForm();
 
-        $this->assertSame($form, $form->add('send', 'submit'));
+        $this->assertSame($form, $form->add('send', 'Symfony\Component\Form\Extension\Core\Type\SubmitType'));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -25,9 +25,16 @@ class TimeTypeTest extends TestCase
         parent::setUp();
     }
 
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('time');
+
+        $this->assertSame('time', $form->getConfig()->getType()->getName());
+    }
+
     public function testSubmitDateTime()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -48,7 +55,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitString()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -67,7 +74,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitTimestamp()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -88,7 +95,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArray()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -107,7 +114,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitDatetimeSingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -122,7 +129,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitDatetimeSingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -138,7 +145,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -158,7 +165,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -178,7 +185,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleTextWithSeconds()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -200,7 +207,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitStringSingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -215,7 +222,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitStringSingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -231,7 +238,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -245,7 +252,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataWithSeconds()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -259,7 +266,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataDifferentTimezones()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'string',
@@ -285,7 +292,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataDifferentTimezonesDateTime()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'datetime',
@@ -312,7 +319,7 @@ class TimeTypeTest extends TestCase
 
     public function testHoursOption()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'hours' => array(6, 7),
         ));
 
@@ -326,7 +333,7 @@ class TimeTypeTest extends TestCase
 
     public function testIsMinuteWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'minutes' => array(6, 7),
         ));
 
@@ -340,7 +347,7 @@ class TimeTypeTest extends TestCase
 
     public function testIsSecondWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'seconds' => array(6, 7),
             'with_seconds' => true,
         ));
@@ -357,7 +364,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'choice',
         ));
 
@@ -373,7 +380,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -391,7 +398,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'choice',
         ));
 
@@ -407,7 +414,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -425,7 +432,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -443,7 +450,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -461,7 +468,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -480,12 +487,12 @@ class TimeTypeTest extends TestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->factory->create('time', new \DateTime());
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', new \DateTime());
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'single_text',
         ));
 
@@ -495,7 +502,7 @@ class TimeTypeTest extends TestCase
 
     public function testSingleTextWidgetWithSecondsShouldHaveRightStepAttribute()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'single_text',
             'with_seconds' => true,
         ));
@@ -507,7 +514,7 @@ class TimeTypeTest extends TestCase
 
     public function testSingleTextWidgetWithSecondsShouldNotOverrideStepAttribute()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'single_text',
             'with_seconds' => true,
             'attr' => array(
@@ -522,7 +529,7 @@ class TimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => 'single_text',
             'html5' => false,
         ));
@@ -533,7 +540,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'required' => false,
             'with_seconds' => true,
         ));
@@ -546,7 +553,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'required' => true,
             'with_seconds' => true,
         ));
@@ -559,7 +566,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'placeholder' => 'Empty',
             'with_seconds' => true,
         ));
@@ -572,7 +579,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'empty_value' => 'Empty',
             'with_seconds' => true,
         ));
@@ -588,7 +595,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'placeholder' => array(
                 'hour' => 'Empty hour',
                 'minute' => 'Empty minute',
@@ -605,7 +612,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'required' => false,
             'placeholder' => array(
                 'hour' => 'Empty hour',
@@ -622,7 +629,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'required' => true,
             'placeholder' => array(
                 'hour' => 'Empty hour',
@@ -651,7 +658,7 @@ class TimeTypeTest extends TestCase
     public function testHourErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => $widget,
         ));
         $form['hour']->addError($error);
@@ -666,7 +673,7 @@ class TimeTypeTest extends TestCase
     public function testMinuteErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => $widget,
         ));
         $form['minute']->addError($error);
@@ -681,7 +688,7 @@ class TimeTypeTest extends TestCase
     public function testSecondErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'widget' => $widget,
             'with_seconds' => true,
         ));
@@ -696,7 +703,7 @@ class TimeTypeTest extends TestCase
      */
     public function testInitializeWithSecondsAndWithoutMinutes()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'with_minutes' => false,
             'with_seconds' => true,
         ));
@@ -707,7 +714,7 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfHoursIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'hours' => 'bad value',
         ));
     }
@@ -717,7 +724,7 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfMinutesIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'minutes' => 'bad value',
         ));
     }
@@ -727,7 +734,7 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfSecondsIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'seconds' => 'bad value',
         ));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -15,9 +15,16 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 
 class TimezoneTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
-    public function testTimezonesAreSelectable()
+    public function testLegacyName()
     {
         $form = $this->factory->create('timezone');
+
+        $this->assertSame('timezone', $form->getConfig()->getType()->getName());
+    }
+
+    public function testTimezonesAreSelectable()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimezoneType');
         $view = $form->createView();
         $choices = $view->vars['choices'];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -15,9 +15,16 @@ use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 
 class UrlTypeTest extends TestCase
 {
+    public function testLegacyName()
+    {
+        $form = $this->factory->create('url');
+
+        $this->assertSame('url', $form->getConfig()->getType()->getName());
+    }
+
     public function testSubmitAddsDefaultProtocolIfNoneIsIncluded()
     {
-        $form = $this->factory->create('url', 'name');
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\UrlType', 'name');
 
         $form->submit('www.domain.com');
 
@@ -27,7 +34,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfAlreadyIncluded()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\UrlType', null, array(
             'default_protocol' => 'http',
         ));
 
@@ -39,7 +46,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfEmpty()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\UrlType', null, array(
             'default_protocol' => 'http',
         ));
 
@@ -51,7 +58,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfNull()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\UrlType', null, array(
             'default_protocol' => 'http',
         ));
 
@@ -63,7 +70,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfSetToNull()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\UrlType', null, array(
             'default_protocol' => null,
         ));
 
@@ -78,7 +85,7 @@ class UrlTypeTest extends TestCase
      */
     public function testThrowExceptionIfDefaultProtocolIsInvalid()
     {
-        $this->factory->create('url', null, array(
+        $this->factory->create('Symfony\Component\Form\Extension\Core\Type\UrlType', null, array(
             'default_protocol' => array(),
         ));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -24,12 +24,7 @@ class FormTypeCsrfExtensionTest_ChildType extends AbstractType
     {
         // The form needs a child in order to trigger CSRF protection by
         // default
-        $builder->add('name', 'text');
-    }
-
-    public function getName()
-    {
-        return 'csrf_collection_test';
+        $builder->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
     }
 }
 
@@ -71,7 +66,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testCsrfProtectionByDefaultIfRootAndCompound()
     {
         $view = $this->factory
-            ->create('form', null, array(
+            ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'compound' => true,
             ))
@@ -83,9 +78,9 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testNoCsrfProtectionByDefaultIfCompoundButNotRoot()
     {
         $view = $this->factory
-            ->createNamedBuilder('root', 'form')
+            ->createNamedBuilder('root', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($this->factory
-                ->createNamedBuilder('form', 'form', null, array(
+                ->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                     'csrf_field_name' => 'csrf',
                     'compound' => true,
                 ))
@@ -100,7 +95,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testNoCsrfProtectionByDefaultIfRootButNotCompound()
     {
         $view = $this->factory
-            ->create('form', null, array(
+            ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'compound' => false,
             ))
@@ -112,7 +107,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testCsrfProtectionCanBeDisabled()
     {
         $view = $this->factory
-            ->create('form', null, array(
+            ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_protection' => false,
                 'compound' => true,
@@ -130,7 +125,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue(new CsrfToken('TOKEN_ID', 'token')));
 
         $view = $this->factory
-            ->create('form', null, array(
+            ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_token_id' => 'TOKEN_ID',
@@ -149,7 +144,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue('token'));
 
         $view = $this->factory
-            ->createNamed('FORM_NAME', 'form', null, array(
+            ->createNamed('FORM_NAME', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
@@ -167,7 +162,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue('token'));
 
         $view = $this->factory
-            ->createNamed('', 'form', null, array(
+            ->createNamed('', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
@@ -196,13 +191,13 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue($valid));
 
         $form = $this->factory
-            ->createBuilder('form', null, array(
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_token_id' => 'TOKEN_ID',
                 'compound' => true,
             ))
-            ->add('child', 'text')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         $form->submit(array(
@@ -228,12 +223,12 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue($valid));
 
         $form = $this->factory
-            ->createNamedBuilder('FORM_NAME', 'form', null, array(
+            ->createNamedBuilder('FORM_NAME', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
             ))
-            ->add('child', 'text')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         $form->submit(array(
@@ -259,12 +254,12 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue($valid));
 
         $form = $this->factory
-            ->createNamedBuilder('', 'form', null, array(
+            ->createNamedBuilder('', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
             ))
-            ->add('child', 'text')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         $form->submit(array(
@@ -285,13 +280,13 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->method('isTokenValid');
 
         $form = $this->factory
-            ->createBuilder('form', null, array(
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_token_id' => 'TOKEN_ID',
                 'compound' => true,
             ))
-            ->add('child', 'text')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->getForm();
 
         $form->submit(array(
@@ -312,9 +307,9 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->method('isTokenValid');
 
         $form = $this->factory
-            ->createNamedBuilder('root', 'form')
+            ->createNamedBuilder('root', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($this->factory
-                ->createNamedBuilder('form', 'form', null, array(
+                ->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                     'csrf_field_name' => 'csrf',
                     'csrf_token_manager' => $this->tokenManager,
                     'csrf_token_id' => 'TOKEN_ID',
@@ -336,7 +331,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->method('isTokenValid');
 
         $form = $this->factory
-            ->create('form', null, array(
+            ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_token_id' => 'TOKEN_ID',
@@ -351,8 +346,8 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     public function testNoCsrfProtectionOnPrototype()
     {
         $prototypeView = $this->factory
-            ->create('collection', null, array(
-                'type' => new FormTypeCsrfExtensionTest_ChildType(),
+            ->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, array(
+                'type' => __CLASS__.'_ChildType',
                 'options' => array(
                     'csrf_field_name' => 'csrf',
                 ),
@@ -379,7 +374,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
              ->will($this->returnValue('[trans]Foobar[/trans]'));
 
         $form = $this->factory
-            ->createBuilder('form', null, array(
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_token_manager' => $this->tokenManager,
                 'csrf_message' => 'Foobar',

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
@@ -36,10 +36,10 @@ class FormValidatorPerformanceTest extends FormPerformanceTestCase
     {
         $this->setMaxRunningTime(1);
 
-        $builder = $this->factory->createBuilder('form');
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType');
 
         for ($i = 0; $i < 40; ++$i) {
-            $builder->add($i, 'form');
+            $builder->add($i, 'Symfony\Component\Form\Extension\Core\Type\FormType');
 
             $builder->get($i)
                 ->add('a')

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -20,13 +20,13 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
     public function testSubmitValidatesData()
     {
         $builder = $this->factory->createBuilder(
-            'form',
+            'Symfony\Component\Form\Extension\Core\Type\FormType',
             null,
             array(
                 'validation_groups' => 'group',
             )
         );
-        $builder->add('firstName', 'form');
+        $builder->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\FormType');
         $form = $builder->getForm();
 
         $this->validator->expects($this->once())
@@ -93,6 +93,6 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = array())
     {
-        return $this->factory->create('form', null, $options);
+        return $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, $options);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
@@ -15,6 +15,6 @@ class SubmitTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 {
     protected function createForm(array $options = array())
     {
-        return $this->factory->create('submit', null, $options);
+        return $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SubmitType', null, $options);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/AlternatingRowType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AlternatingRowType.php
@@ -15,13 +15,10 @@ class AlternatingRowType extends AbstractType
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($formFactory) {
             $form = $event->getForm();
-            $type = $form->getName() % 2 === 0 ? 'text' : 'textarea';
+            $type = $form->getName() % 2 === 0
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
             $form->add('title', $type);
         });
-    }
-
-    public function getName()
-    {
-        return 'alternating_row';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/AuthorType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AuthorType.php
@@ -16,11 +16,6 @@ class AuthorType extends AbstractType
         ;
     }
 
-    public function getName()
-    {
-        return 'author';
-    }
-
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(

--- a/src/Symfony/Component/Form/Tests/Fixtures/FBooType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FBooType.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class FBooType extends AbstractType
+{
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Foo.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Foo.php
@@ -13,15 +13,6 @@ namespace Symfony\Component\Form\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
 
-class FooSubTypeWithParentInstance extends AbstractType
+class Foo extends AbstractType
 {
-    public function getName()
-    {
-        return 'foo_sub_type_parent_instance';
-    }
-
-    public function getParent()
-    {
-        return new FooType();
-    }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Foo1Bar2Type.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Foo1Bar2Type.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class Foo1Bar2Type extends AbstractType
+{
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooBarHTMLType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooBarHTMLType.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class FooBarHTMLType extends AbstractType
+{
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
@@ -15,13 +15,8 @@ use Symfony\Component\Form\AbstractType;
 
 class FooSubType extends AbstractType
 {
-    public function getName()
-    {
-        return 'foo_sub_type';
-    }
-
     public function getParent()
     {
-        return 'foo';
+        return __NAMESPACE__.'\FooType';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
@@ -15,11 +15,6 @@ use Symfony\Component\Form\AbstractType;
 
 class FooType extends AbstractType
 {
-    public function getName()
-    {
-        return 'foo';
-    }
-
     public function getParent()
     {
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBarExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBarExtension.php
@@ -30,6 +30,6 @@ class FooTypeBarExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return 'foo';
+        return __NAMESPACE__.'\FooType';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBazExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBazExtension.php
@@ -23,6 +23,6 @@ class FooTypeBazExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return 'foo';
+        return __NAMESPACE__.'\FooType';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooSubType.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class LegacyFooSubType extends AbstractType
+{
+    public function getName()
+    {
+        return 'foo_sub_type';
+    }
+
+    public function getParent()
+    {
+        return 'foo';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooSubTypeWithParentInstance.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooSubTypeWithParentInstance.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class LegacyFooSubTypeWithParentInstance extends AbstractType
+{
+    public function getName()
+    {
+        return 'foo_sub_type_parent_instance';
+    }
+
+    public function getParent()
+    {
+        return new LegacyFooType();
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooType.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class LegacyFooType extends AbstractType
+{
+    public function getName()
+    {
+        return 'foo';
+    }
+
+    public function getParent()
+    {
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooTypeBarExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooTypeBarExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class LegacyFooTypeBarExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->setAttribute('bar', 'x');
+    }
+
+    public function getAllowedOptionValues()
+    {
+        return array(
+            'a_or_b' => array('c'),
+        );
+    }
+
+    public function getExtendedType()
+    {
+        return 'foo';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooTypeBazExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/LegacyFooTypeBazExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class LegacyFooTypeBazExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->setAttribute('baz', 'x');
+    }
+
+    public function getExtendedType()
+    {
+        return 'foo';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
@@ -31,7 +31,7 @@ class TestExtension implements FormExtensionInterface
 
     public function addType(FormTypeInterface $type)
     {
-        $this->types[$type->getName()] = $type;
+        $this->types[$type->getName() ?: get_class($type)] = $type;
     }
 
     public function getType($name)

--- a/src/Symfony/Component/Form/Tests/Fixtures/Type.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Type.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class Type extends AbstractType
+{
+}

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -67,21 +67,21 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testAddIsFluent()
     {
-        $builder = $this->builder->add('foo', 'text', array('bar' => 'baz'));
+        $builder = $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', array('bar' => 'baz'));
         $this->assertSame($builder, $this->builder);
     }
 
     public function testAdd()
     {
         $this->assertFalse($this->builder->has('foo'));
-        $this->builder->add('foo', 'text');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $this->assertTrue($this->builder->has('foo'));
     }
 
     public function testAddIntegerName()
     {
         $this->assertFalse($this->builder->has(0));
-        $this->builder->add(0, 'text');
+        $this->builder->add(0, 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $this->assertTrue($this->builder->has(0));
     }
 
@@ -89,13 +89,13 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('foo', 'text')
+            ->with('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->will($this->returnValue(new FormBuilder('foo', null, $this->dispatcher, $this->factory)));
 
         $this->assertCount(0, $this->builder->all());
         $this->assertFalse($this->builder->has('foo'));
 
-        $this->builder->add('foo', 'text');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $children = $this->builder->all();
 
         $this->assertTrue($this->builder->has('foo'));
@@ -108,9 +108,9 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testMaintainOrderOfLazyAndExplicitChildren()
     {
-        $this->builder->add('foo', 'text');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $this->builder->add($this->getFormBuilder('bar'));
-        $this->builder->add('baz', 'text');
+        $this->builder->add('baz', 'Symfony\Component\Form\Extension\Core\Type\TextType');
 
         $children = $this->builder->all();
 
@@ -126,7 +126,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testRemove()
     {
-        $this->builder->add('foo', 'text');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $this->builder->remove('foo');
         $this->assertFalse($this->builder->has('foo'));
     }
@@ -140,7 +140,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
     // https://github.com/symfony/symfony/pull/4826
     public function testRemoveAndGetForm()
     {
-        $this->builder->add('foo', 'text');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $this->builder->remove('foo');
         $form = $this->builder->getForm();
         $this->assertInstanceOf('Symfony\Component\Form\Form', $form);
@@ -150,7 +150,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('foo', 'text', null, array())
+            ->with('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array())
         ;
 
         $this->builder->create('foo');
@@ -170,7 +170,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testGetExplicitType()
     {
-        $expectedType = 'text';
+        $expectedType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
         $expectedName = 'foo';
         $expectedOptions = array('bar' => 'baz');
 

--- a/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use Symfony\Component\Form\FormFactoryBuilder;
-use Symfony\Component\Form\Tests\Fixtures\FooType;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooType;
 
 class FormFactoryBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -27,7 +27,7 @@ class FormFactoryBuilderTest extends \PHPUnit_Framework_TestCase
         $this->registry->setAccessible(true);
 
         $this->guesser = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
-        $this->type = new FooType();
+        $this->type = new LegacyFooType();
     }
 
     public function testAddType()

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -16,9 +16,9 @@ use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Form\Guess\TypeGuess;
-use Symfony\Component\Form\Tests\Fixtures\FooType;
-use Symfony\Component\Form\Tests\Fixtures\FooSubType;
-use Symfony\Component\Form\Tests\Fixtures\FooSubTypeWithParentInstance;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooType;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooSubType;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooSubTypeWithParentInstance;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -99,11 +99,14 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', 'type', null, $options));
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateNamedBuilderWithTypeInstance()
     {
         $options = array('a' => '1', 'b' => '2');
         $resolvedOptions = array('a' => '2', 'b' => '3');
-        $type = new FooType();
+        $type = new LegacyFooType();
         $resolvedType = $this->getMockResolvedType();
 
         $this->resolvedTypeFactory->expects($this->once())
@@ -127,11 +130,14 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, null, $options));
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateNamedBuilderWithTypeInstanceWithParentType()
     {
         $options = array('a' => '1', 'b' => '2');
         $resolvedOptions = array('a' => '2', 'b' => '3');
-        $type = new FooSubType();
+        $type = new LegacyFooSubType();
         $resolvedType = $this->getMockResolvedType();
         $parentResolvedType = $this->getMockResolvedType();
 
@@ -161,11 +167,14 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, null, $options));
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateNamedBuilderWithTypeInstanceWithParentTypeInstance()
     {
         $options = array('a' => '1', 'b' => '2');
         $resolvedOptions = array('a' => '2', 'b' => '3');
-        $type = new FooSubTypeWithParentInstance();
+        $type = new LegacyFooSubTypeWithParentInstance();
         $resolvedType = $this->getMockResolvedType();
         $parentResolvedType = $this->getMockResolvedType();
 
@@ -195,6 +204,9 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', $type, null, $options));
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateNamedBuilderWithResolvedTypeInstance()
     {
         $options = array('a' => '1', 'b' => '2');
@@ -312,6 +324,164 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('FORM', $this->factory->create('TYPE', null, $options));
     }
 
+    public function testCreateStripsNamespaceOffTypeName()
+    {
+        $options = array('a' => '1', 'b' => '2');
+        $resolvedOptions = array('a' => '2', 'b' => '3');
+        $resolvedType = $this->getMockResolvedType();
+
+        $this->registry->expects($this->once())
+            ->method('getType')
+            ->with('Vendor\Name\Space\UserForm')
+            ->will($this->returnValue($resolvedType));
+
+        $resolvedType->expects($this->once())
+            ->method('createBuilder')
+            ->with($this->factory, 'user_form', $options)
+            ->will($this->returnValue($this->builder));
+
+        $this->builder->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue($resolvedOptions));
+
+        $resolvedType->expects($this->once())
+            ->method('buildForm')
+            ->with($this->builder, $resolvedOptions);
+
+        $this->builder->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue('FORM'));
+
+        $this->assertSame('FORM', $this->factory->create('Vendor\Name\Space\UserForm', null, $options));
+    }
+
+    public function testLegacyCreateStripsNamespaceOffTypeNameAccessByFQCN()
+    {
+        $options = array('a' => '1', 'b' => '2');
+        $resolvedOptions = array('a' => '2', 'b' => '3');
+        $resolvedType = $this->getMockResolvedType();
+
+        $this->registry->expects($this->once())
+            ->method('getType')
+            ->with('userform')
+            ->will($this->returnValue($resolvedType));
+
+        $resolvedType->expects($this->once())
+            ->method('createBuilder')
+            ->with($this->factory, 'userform', $options)
+            ->will($this->returnValue($this->builder));
+
+        $this->builder->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue($resolvedOptions));
+
+        $resolvedType->expects($this->once())
+            ->method('buildForm')
+            ->with($this->builder, $resolvedOptions);
+
+        $this->builder->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue('FORM'));
+
+        $this->assertSame('FORM', $this->factory->create('userform', null, $options));
+    }
+
+    public function testCreateStripsTypeSuffixOffTypeName()
+    {
+        $options = array('a' => '1', 'b' => '2');
+        $resolvedOptions = array('a' => '2', 'b' => '3');
+        $resolvedType = $this->getMockResolvedType();
+
+        $this->registry->expects($this->once())
+            ->method('getType')
+            ->with('Vendor\Name\Space\UserType')
+            ->will($this->returnValue($resolvedType));
+
+        $resolvedType->expects($this->once())
+            ->method('createBuilder')
+            ->with($this->factory, 'user', $options)
+            ->will($this->returnValue($this->builder));
+
+        $this->builder->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue($resolvedOptions));
+
+        $resolvedType->expects($this->once())
+            ->method('buildForm')
+            ->with($this->builder, $resolvedOptions);
+
+        $this->builder->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue('FORM'));
+
+        $this->assertSame('FORM', $this->factory->create('Vendor\Name\Space\UserType', null, $options));
+    }
+
+    public function testCreateDoesNotStripTypeSuffixIfResultEmpty()
+    {
+        $options = array('a' => '1', 'b' => '2');
+        $resolvedOptions = array('a' => '2', 'b' => '3');
+        $resolvedType = $this->getMockResolvedType();
+
+        $this->registry->expects($this->once())
+            ->method('getType')
+            ->with('Vendor\Name\Space\Type')
+            ->will($this->returnValue($resolvedType));
+
+        $resolvedType->expects($this->once())
+            ->method('createBuilder')
+            ->with($this->factory, 'type', $options)
+            ->will($this->returnValue($this->builder));
+
+        $this->builder->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue($resolvedOptions));
+
+        $resolvedType->expects($this->once())
+            ->method('buildForm')
+            ->with($this->builder, $resolvedOptions);
+
+        $this->builder->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue('FORM'));
+
+        $this->assertSame('FORM', $this->factory->create('Vendor\Name\Space\Type', null, $options));
+    }
+
+    public function testCreateConvertsTypeToUnderscoreSyntax()
+    {
+        $options = array('a' => '1', 'b' => '2');
+        $resolvedOptions = array('a' => '2', 'b' => '3');
+        $resolvedType = $this->getMockResolvedType();
+
+        $this->registry->expects($this->once())
+            ->method('getType')
+            ->with('Vendor\Name\Space\MyProfileHTMLType')
+            ->will($this->returnValue($resolvedType));
+
+        $resolvedType->expects($this->once())
+            ->method('createBuilder')
+            ->with($this->factory, 'my_profile_html', $options)
+            ->will($this->returnValue($this->builder));
+
+        $this->builder->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue($resolvedOptions));
+
+        $resolvedType->expects($this->once())
+            ->method('buildForm')
+            ->with($this->builder, $resolvedOptions);
+
+        $this->builder->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue('FORM'));
+
+        $this->assertSame('FORM', $this->factory->create('Vendor\Name\Space\MyProfileHTMLType', null, $options));
+    }
+
+    /**
+     * @group legacy
+     */
     public function testCreateUsesTypeNameIfTypeGivenAsObject()
     {
         $options = array('a' => '1', 'b' => '2');
@@ -383,7 +553,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array())
+            ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array())
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
@@ -397,7 +567,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('guessType')
             ->with('Application\Author', 'firstName')
             ->will($this->returnValue(new TypeGuess(
-                'text',
+                'Symfony\Component\Form\Extension\Core\Type\TextType',
                 array('attr' => array('maxlength' => 10)),
                 Guess::MEDIUM_CONFIDENCE
             )));
@@ -434,7 +604,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text')
+            ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
@@ -448,7 +618,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 ->method('guessType')
                 ->with('Application\Author', 'firstName')
                 ->will($this->returnValue(new TypeGuess(
-                    'text',
+                    'Symfony\Component\Form\Extension\Core\Type\TextType',
                     array('attr' => array('maxlength' => 10)),
                     Guess::MEDIUM_CONFIDENCE
                 )));
@@ -457,7 +627,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('attr' => array('maxlength' => 11)))
+            ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array('attr' => array('maxlength' => 11)))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
@@ -492,7 +662,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('attr' => array('maxlength' => 20)))
+            ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array('attr' => array('maxlength' => 20)))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
@@ -525,7 +695,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('attr' => array('maxlength' => 20, 'pattern' => '.{5,}', 'class' => 'tinymce')))
+            ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array('attr' => array('maxlength' => 20, 'pattern' => '.{5,}', 'class' => 'tinymce')))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
@@ -560,7 +730,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('required' => false))
+            ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array('required' => false))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(
@@ -593,7 +763,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('attr' => array('pattern' => '[a-zA-Z]')))
+            ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array('attr' => array('pattern' => '[a-zA-Z]')))
             ->will($this->returnValue('builderInstance'));
 
         $this->builder = $factory->createBuilderForProperty(

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Form\Tests;
 
 use Symfony\Component\Form\FormRegistry;
 use Symfony\Component\Form\FormTypeGuesserChain;
-use Symfony\Component\Form\Tests\Fixtures\TestExtension;
-use Symfony\Component\Form\Tests\Fixtures\FooSubTypeWithParentInstance;
+use Symfony\Component\Form\ResolvedFormType;
+use Symfony\Component\Form\ResolvedFormTypeFactoryInterface;
 use Symfony\Component\Form\Tests\Fixtures\FooSubType;
-use Symfony\Component\Form\Tests\Fixtures\FooTypeBazExtension;
-use Symfony\Component\Form\Tests\Fixtures\FooTypeBarExtension;
 use Symfony\Component\Form\Tests\Fixtures\FooType;
+use Symfony\Component\Form\Tests\Fixtures\FooTypeBarExtension;
+use Symfony\Component\Form\Tests\Fixtures\FooTypeBazExtension;
+use Symfony\Component\Form\Tests\Fixtures\TestExtension;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooSubTypeWithParentInstance;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooSubType;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooTypeBazExtension;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooTypeBarExtension;
+use Symfony\Component\Form\Tests\Fixtures\LegacyFooType;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -31,7 +37,7 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
     private $registry;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|ResolvedFormTypeFactoryInterface
      */
     private $resolvedTypeFactory;
 
@@ -71,22 +77,64 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
     public function testGetTypeFromExtension()
     {
         $type = new FooType();
-        $resolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+        $resolvedType = new ResolvedFormType($type);
 
         $this->extension2->addType($type);
 
         $this->resolvedTypeFactory->expects($this->once())
             ->method('createResolvedType')
             ->with($type)
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
-        $resolvedType->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('foo'));
+        $this->assertSame($resolvedType, $this->registry->getType(get_class($type)));
+    }
 
-        $resolvedType = $this->registry->getType('foo');
+    public function testLoadUnregisteredType()
+    {
+        $type = new FooType();
+        $resolvedType = new ResolvedFormType($type);
+
+        $this->resolvedTypeFactory->expects($this->once())
+            ->method('createResolvedType')
+            ->with($type)
+            ->willReturn($resolvedType);
+
+        $this->assertSame($resolvedType, $this->registry->getType('Symfony\Component\Form\Tests\Fixtures\FooType'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function testFailIfUnregisteredTypeNoClass()
+    {
+        $this->registry->getType('Symfony\Blubb');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function testFailIfUnregisteredTypeNoFormType()
+    {
+        $this->registry->getType('stdClass');
+    }
+
+    public function testLegacyGetTypeFromExtension()
+    {
+        $type = new LegacyFooType();
+        $resolvedType = new ResolvedFormType($type);
+
+        $this->extension2->addType($type);
+
+        $this->resolvedTypeFactory->expects($this->once())
+            ->method('createResolvedType')
+            ->with($type)
+            ->willReturn($resolvedType);
 
         $this->assertSame($resolvedType, $this->registry->getType('foo'));
+
+        // Even types with explicit getName() methods must support access by
+        // FQCN to support a smooth transition from 2.8 => 3.0
+        $this->assertSame($resolvedType, $this->registry->getType(get_class($type)));
     }
 
     public function testGetTypeWithTypeExtensions()
@@ -94,7 +142,7 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
         $type = new FooType();
         $ext1 = new FooTypeBarExtension();
         $ext2 = new FooTypeBazExtension();
-        $resolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+        $resolvedType = new ResolvedFormType($type, array($ext1, $ext2));
 
         $this->extension2->addType($type);
         $this->extension1->addTypeExtension($ext1);
@@ -103,11 +151,26 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
         $this->resolvedTypeFactory->expects($this->once())
             ->method('createResolvedType')
             ->with($type, array($ext1, $ext2))
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
-        $resolvedType->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('foo'));
+        $this->assertSame($resolvedType, $this->registry->getType(get_class($type)));
+    }
+
+    public function testLegacyGetTypeWithTypeExtensions()
+    {
+        $type = new LegacyFooType();
+        $ext1 = new LegacyFooTypeBarExtension();
+        $ext2 = new LegacyFooTypeBazExtension();
+        $resolvedType = new ResolvedFormType($type, array($ext1, $ext2));
+
+        $this->extension2->addType($type);
+        $this->extension1->addTypeExtension($ext1);
+        $this->extension2->addTypeExtension($ext2);
+
+        $this->resolvedTypeFactory->expects($this->once())
+            ->method('createResolvedType')
+            ->with($type, array($ext1, $ext2))
+            ->willReturn($resolvedType);
 
         $this->assertSame($resolvedType, $this->registry->getType('foo'));
     }
@@ -116,8 +179,8 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
     {
         $parentType = new FooType();
         $type = new FooSubType();
-        $parentResolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
-        $resolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type);
 
         $this->extension1->addType($parentType);
         $this->extension2->addType($type);
@@ -125,49 +188,59 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
         $this->resolvedTypeFactory->expects($this->at(0))
             ->method('createResolvedType')
             ->with($parentType)
-            ->will($this->returnValue($parentResolvedType));
+            ->willReturn($parentResolvedType);
 
         $this->resolvedTypeFactory->expects($this->at(1))
             ->method('createResolvedType')
             ->with($type, array(), $parentResolvedType)
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
-        $parentResolvedType->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('foo'));
+        $this->assertSame($resolvedType, $this->registry->getType(get_class($type)));
+    }
 
-        $resolvedType->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('foo_sub_type'));
+    public function testLegacyGetTypeConnectsParent()
+    {
+        $parentType = new LegacyFooType();
+        $type = new LegacyFooSubType();
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type);
+
+        $this->extension1->addType($parentType);
+        $this->extension2->addType($type);
+
+        $this->resolvedTypeFactory->expects($this->at(0))
+            ->method('createResolvedType')
+            ->with($parentType)
+            ->willReturn($parentResolvedType);
+
+        $this->resolvedTypeFactory->expects($this->at(1))
+            ->method('createResolvedType')
+            ->with($type, array(), $parentResolvedType)
+            ->willReturn($resolvedType);
 
         $this->assertSame($resolvedType, $this->registry->getType('foo_sub_type'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetTypeConnectsParentIfGetParentReturnsInstance()
     {
-        $type = new FooSubTypeWithParentInstance();
-        $parentResolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
-        $resolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+        $type = new LegacyFooSubTypeWithParentInstance();
+        $parentResolvedType = new ResolvedFormType($type->getParent());
+        $resolvedType = new ResolvedFormType($type);
 
         $this->extension1->addType($type);
 
         $this->resolvedTypeFactory->expects($this->at(0))
             ->method('createResolvedType')
-            ->with($this->isInstanceOf('Symfony\Component\Form\Tests\Fixtures\FooType'))
-            ->will($this->returnValue($parentResolvedType));
+            ->with($type->getParent())
+            ->willReturn($parentResolvedType);
 
         $this->resolvedTypeFactory->expects($this->at(1))
             ->method('createResolvedType')
             ->with($type, array(), $parentResolvedType)
-            ->will($this->returnValue($resolvedType));
-
-        $parentResolvedType->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('foo'));
-
-        $resolvedType->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('foo_sub_type_parent_instance'));
+            ->willReturn($resolvedType);
 
         $this->assertSame($resolvedType, $this->registry->getType('foo_sub_type_parent_instance'));
     }
@@ -178,6 +251,18 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
     public function testGetTypeThrowsExceptionIfParentNotFound()
     {
         $type = new FooSubType();
+
+        $this->extension1->addType($type);
+
+        $this->registry->getType($type);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testLegacyGetTypeThrowsExceptionIfParentNotFound()
+    {
+        $type = new LegacyFooSubType();
 
         $this->extension1->addType($type);
 
@@ -203,18 +288,42 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
     public function testHasTypeAfterLoadingFromExtension()
     {
         $type = new FooType();
-        $resolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+        $resolvedType = new ResolvedFormType($type);
 
         $this->resolvedTypeFactory->expects($this->once())
             ->method('createResolvedType')
             ->with($type)
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
-        $resolvedType->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('foo'));
+        $this->extension2->addType($type);
 
-        $this->assertFalse($this->registry->hasType('foo'));
+        $this->assertTrue($this->registry->hasType(get_class($type)));
+    }
+
+    public function testHasTypeIfFQCN()
+    {
+        $this->assertTrue($this->registry->hasType('Symfony\Component\Form\Tests\Fixtures\FooType'));
+    }
+
+    public function testDoesNotHaveTypeIfNonExistingClass()
+    {
+        $this->assertFalse($this->registry->hasType('Symfony\Blubb'));
+    }
+
+    public function testDoesNotHaveTypeIfNoFormType()
+    {
+        $this->assertFalse($this->registry->hasType('stdClass'));
+    }
+
+    public function testLegacyHasTypeAfterLoadingFromExtension()
+    {
+        $type = new LegacyFooType();
+        $resolvedType = new ResolvedFormType($type);
+
+        $this->resolvedTypeFactory->expects($this->once())
+            ->method('createResolvedType')
+            ->with($type)
+            ->willReturn($resolvedType);
 
         $this->extension2->addType($type);
 
@@ -229,7 +338,8 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
 
         $registry = new FormRegistry(
             array($this->getMock('Symfony\Component\Form\FormExtensionInterface')),
-            $this->resolvedTypeFactory);
+            $this->resolvedTypeFactory
+        );
 
         $this->assertNull($registry->getTypeGuesser());
     }

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Component\Form\FormTypeExtensionInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\ResolvedFormType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -34,11 +36,35 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $dataMapper;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|FormTypeInterface
+     */
     private $parentType;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|FormTypeInterface
+     */
     private $type;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|FormTypeExtensionInterface
+     */
     private $extension1;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|FormTypeExtensionInterface
+     */
     private $extension2;
+
+    /**
+     * @var ResolvedFormType
+     */
     private $parentResolvedType;
+
+    /**
+     * @var ResolvedFormType
+     */
     private $resolvedType;
 
     protected function setUp()
@@ -306,11 +332,106 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider provideValidNames
+     */
+    public function testGetName($name)
+    {
+        $this->type->expects($this->once())
+            ->method('getName')
+            ->willReturn($name);
+
+        $resolvedType = new ResolvedFormType($this->type);
+
+        $this->assertSame($name, $resolvedType->getName());
+    }
+
+    /**
+     * @dataProvider provideInvalidNames
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function testGetNameFailsIfInvalidChars($name)
+    {
+        $this->type->expects($this->once())
+            ->method('getName')
+            ->willReturn($name);
+
+        new ResolvedFormType($this->type);
+    }
+
+    public function provideValidNames()
+    {
+        return array(
+            array('text'),
+            array('type123'),
+            array('my_type123'),
+        );
+    }
+
+    public function provideInvalidNames()
+    {
+        return array(
+            array('my-type'),
+            array('my[type]'),
+            array('my{type}'),
+        );
+    }
+
+    public function testGetBlockPrefix()
+    {
+        $this->type->expects($this->once())
+            ->method('getBlockPrefix')
+            ->willReturn('my_prefix');
+
+        $resolvedType = new ResolvedFormType($this->type);
+
+        $this->assertSame('my_prefix', $resolvedType->getBlockPrefix());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testBlockPrefixDefaultsToNameIfSet()
+    {
+        // Type without getBlockPrefix() method
+        $type = $this->getMock('Symfony\Component\Form\FormTypeInterface');
+
+        $type->expects($this->once())
+            ->method('getName')
+            ->willReturn('my_prefix');
+
+        $resolvedType = new ResolvedFormType($type);
+
+        $this->assertSame('my_prefix', $resolvedType->getBlockPrefix());
+    }
+
+    /**
+     * @dataProvider provideTypeClassBlockPrefixTuples
+     */
+    public function testBlockPrefixDefaultsToFQCNIfNoName($typeClass, $blockPrefix)
+    {
+        $resolvedType = new ResolvedFormType(new $typeClass());
+
+        $this->assertSame($blockPrefix, $resolvedType->getBlockPrefix());
+    }
+
+    public function provideTypeClassBlockPrefixTuples()
+    {
+        return array(
+            array(__NAMESPACE__.'\Fixtures\FooType', 'foo'),
+            array(__NAMESPACE__.'\Fixtures\Foo', 'foo'),
+            array(__NAMESPACE__.'\Fixtures\Type', 'type'),
+            array(__NAMESPACE__.'\Fixtures\FooBarHTMLType', 'foo_bar_html'),
+            array(__NAMESPACE__.'\Fixtures\Foo1Bar2Type', 'foo1_bar2'),
+            array(__NAMESPACE__.'\Fixtures\FBooType', 'f_boo'),
+        );
+    }
+
+    /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getMockFormType()
+    private function getMockFormType($typeClass = 'Symfony\Component\Form\AbstractType')
     {
-        return $this->getMock('Symfony\Component\Form\AbstractType', array('getName', 'configureOptions', 'finishView', 'buildView', 'buildForm'));
+        return $this->getMock($typeClass, array('getName', 'getBlockPrefix', 'configureOptions', 'finishView', 'buildView', 'buildForm'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -1063,7 +1063,7 @@ class SimpleFormTest extends AbstractFormTest
      */
     public function testCustomOptionsResolver()
     {
-        $fooType = new Fixtures\FooType();
+        $fooType = new Fixtures\LegacyFooType();
         $resolver = new Fixtures\CustomOptionsResolver();
         $fooType->setDefaultOptions($resolver);
     }

--- a/src/Symfony/Component/Form/Util/StringUtil.php
+++ b/src/Symfony/Component/Form/Util/StringUtil.php
@@ -39,4 +39,19 @@ class StringUtil
 
         return trim($string);
     }
+
+    /**
+     * Converts a fully-qualified class name to a block prefix.
+     *
+     * @param string $fqcn The fully-qualified class name
+     *
+     * @return string|null The block prefix or null if not a valid FQCN
+     */
+    public static function fqcnToBlockPrefix($fqcn)
+    {
+        // Non-greedy ("+?") to match "type" suffix, if present
+        if (preg_match('~([^\\\\]+?)(type)?$~i', $fqcn, $matches)) {
+            return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), $matches[1]));
+        }
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #5321, #15008 |
| License | MIT |
| Doc PR | TODO |
#### Type Names

This PR deprecates the definition of the `getName()` method of form types. See #15008 for a more detailed description.

Before:

``` php
class MyType extends AbstractType
{
    public function getName()
    {
        return 'mytype';
    }

    // ...
}
```

After:

``` php
class MyType extends AbstractType
{
    // ...
}
```

You should always reference other types by their fully-qualified class names. Thanks to PHP 5.5, that's easy:

Before:

``` php
$form = $this->createFormBuilder()
    ->add('name', 'text')
    ->add('age', 'integer')
    ->getForm();
```

After:

``` php
$form = $this->createFormBuilder()
    ->add('name', TextType::class)
    ->add('age', IntegerType::class)
    ->getForm();
```
#### Type Instances

Furthermore, passing of type instances is deprecated.

Before:

``` php
$form = $this->createForm(new AuthorType());
```

After:

``` php
$form = $this->createForm(AuthorType::class);
```
#### DIC Aliases

When registering a type in the DIC, you should omit the "alias" attribute now.

Before:

``` xml
<service id="my.type" class="Vendor\Type\MyType">
    <tag name="form.type" alias="mytype" />
    <argument type="service" id="some.service.id" />
</service>
```

After:

``` xml
<service id="my.type" class="Vendor\Type\MyType">
    <tag name="form.type" />
    <argument type="service" id="some.service.id" />
</service>
```

Types without dependencies don't need to be registered in the DIC as they can be instantiated right away.
#### Template Block Prefixes

By default, the class name of the type in underscore notation minus "Type" suffix is used as Twig template block prefix (e.g. `UserProfileType` => `user_profile_*`). If you want to customize that, overwrite the new `getBlockPrefix()` method in your type:

``` php
class UserProfileType extends AbstractType
{
    public function getBlockPrefix()
    {
        return 'profile';
    }

    // ...
}
```
