### PR TITLE
[HttpFoundation] Fix baseUrl when SCRIPT_NAME is not starting with a slash

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1656,7 +1656,9 @@ class Request
             return $prefix;
         }
 
-        if ($baseUrl && false !== $prefix = $this->getUrlencodedPrefix($requestUri, rtrim(dirname($baseUrl), '/'.DIRECTORY_SEPARATOR).'/')) {
+        // Make sure the directory of the base url starts and ends with a slash for this check
+        $baseUrlDirectory = rtrim(dirname('/'.ltrim($baseUrl, '/'.DIRECTORY_SEPARATOR)), '/'.DIRECTORY_SEPARATOR).'/';
+        if ($baseUrl && false !== $prefix = $this->getUrlencodedPrefix($requestUri, $baseUrlDirectory)) {
             // directory portion of $baseUrl matches
             return rtrim($prefix, '/'.DIRECTORY_SEPARATOR);
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1346,9 +1346,29 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array(
                 '/fruit/strawberry/1234index.php/blah',
                 array(
+                    'SCRIPT_FILENAME' => '/var/www/htdocs/fruit/index.php',
+                    'SCRIPT_NAME' => 'fruit/index.php',
+                    'PHP_SELF' => 'fruit/index.php',
+                ),
+                '/fruit',
+                '/strawberry/1234index.php/blah',
+            ),
+            array(
+                '/fruit/strawberry/1234index.php/blah',
+                array(
                     'SCRIPT_FILENAME' => 'E:/Sites/cc-new/public_html/index.php',
                     'SCRIPT_NAME' => '/index.php',
                     'PHP_SELF' => '/index.php',
+                ),
+                '',
+                '/fruit/strawberry/1234index.php/blah',
+            ),
+            array(
+                '/fruit/strawberry/1234index.php/blah',
+                array(
+                    'SCRIPT_FILENAME' => '/var/www/htdocs/index.php',
+                    'SCRIPT_NAME' => 'index.php',
+                    'PHP_SELF' => 'index.php',
                 ),
                 '',
                 '/fruit/strawberry/1234index.php/blah',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The current implementation of prepareBaseUrl() in the Request class assumes that the base url, which comes from `SCRIPT_NAME`, `PHP_SELF`, ... starts with a /.
Although the default configs of common webservers add a slash at the beginning, I just came across a project that is setting the fastcgi value of `SCRIPT_NAME` to 'index.php' (without a starting slash), which then breaks all urls that contain the string 'index.php' somewhere in the pathinfo.

The problem is that `dirname('index.php')` returns `.` which does not match in getUrlencodedPrefix(). So what I did is ensuring that there is a slash at the beginning of this string, just for this check.
