### PR TITLE
[2.3] [PropertyAccess] Updated StringUtil::singularify()

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -276,6 +276,34 @@ class FormTypeTest extends BaseTypeTest
         $this->assertEquals('Bernhard', $author->firstName);
     }
 
+    public function testPropertiesSingularization()
+    {
+        $author = new Author();
+
+        $builder = $this->factory->createBuilder('form', null, array(
+            'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
+            'empty_data' => $author,
+        ));
+        $builder->add('career', 'collection', array(
+            'by_reference' => false,
+            'allow_add' => true,
+        ));
+        $builder->add('feedbackReport', 'collection', array(
+            'by_reference' => false,
+            'allow_add' => true,
+        ));
+        $form = $builder->getForm();
+
+        $form->submit(array(
+            'career' => array('some career'),
+            'feedbackReport' => array('something'),
+        ));
+
+        $this->assertSame($author, $form->getData());
+        $this->assertContains('some career', $author->getCareer());
+        $this->assertContains('something', $author->getFeedbackReport());
+    }
+
     public function provideZeros()
     {
         return array(

--- a/src/Symfony/Component/Form/Tests/Fixtures/Author.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Author.php
@@ -21,6 +21,10 @@ class Author
 
     private $privateProperty;
 
+    private $career = array();
+
+    private $feedbackReport = array();
+
     public function setLastName($lastName)
     {
         $this->lastName = $lastName;
@@ -67,5 +71,39 @@ class Author
 
     private function setPrivateSetter($data)
     {
+    }
+
+    public function addCareer($career)
+    {
+        $this->career[] = $career;
+    }
+
+    public function removeCareer($career)
+    {
+        if ($key = array_search($career, $this->career, true)) {
+            unset($this->career[$key]);
+        }
+    }
+
+    public function getCareer()
+    {
+        return $this->career;
+    }
+
+    public function addFeedbackReport($feedbackReport)
+    {
+        $this->feedbackReport[] = $feedbackReport;
+    }
+
+    public function removeFeedbackReport($feedbackReport)
+    {
+        if ($key = array_search($feedbackReport, $this->feedbackReport, true)) {
+            unset($this->career[$key]);
+        }
+    }
+
+    public function getFeedbackReport()
+    {
+        return $this->feedbackReport;
     }
 }

--- a/src/Symfony/Component/PropertyAccess/StringUtil.php
+++ b/src/Symfony/Component/PropertyAccess/StringUtil.php
@@ -203,7 +203,7 @@ class StringUtil
         }
 
         // Convert teeth to tooth, feet to foot
-        if (false !== ($pos = strpos($plural, 'ee')) && strlen($plural) > 3 && 'feedback' !== $plural) {
+        if (false !== ($pos = strpos($plural, 'ee')) && strlen($plural) > 3 && !preg_match('{feedback|Feedback|career|Career}', $plural)) {
             return substr_replace($plural, 'oo', $pos, 2);
         }
 

--- a/src/Symfony/Component/PropertyAccess/Tests/StringUtilTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/StringUtilTest.php
@@ -45,6 +45,7 @@ class StringUtilTest extends \PHPUnit_Framework_TestCase
             array('buses', array('bus', 'buse', 'busis')),
             array('bushes', array('bush', 'bushe')),
             array('calves', array('calf', 'calve', 'calff')),
+            array('careers', 'career'),
             array('cars', 'car'),
             array('cassettes', array('cassett', 'cassette')),
             array('caves', array('caf', 'cave', 'caff')),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
- Added "career" word to list of false positive plurals.
- Updated `StringUtil::singularify()` in order to detect occurences of false
  positive plurals.

By instance, this change resolves following situation:

```
Neither the property "careerSubject" nor one of the methods
"addCaroorSubject()"/"removeCaroorSubject()", "setCareerSubject()", "careerSubject()",
"__set()" or "__call()" exist and have public access in class "AppBundle\Entity\Career".
```
