### PR TITLE
[2.8] Make service not shared when prototype scope is set

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -649,6 +649,10 @@ class Definition
             @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
         }
 
+        if (ContainerInterface::SCOPE_PROTOTYPE === $scope) {
+            $this->setShared(false);
+        }
+
         $this->scope = $scope;
 
         return $this;

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class DefinitionTest extends \PHPUnit_Framework_TestCase
 {
@@ -137,6 +138,18 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($def->isShared(), '->isShared() returns true by default');
         $this->assertSame($def, $def->setShared(false), '->setShared() implements a fluent interface');
         $this->assertFalse($def->isShared(), '->isShared() returns false if the instance must not be shared');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testPrototypeScopedDefinitionAreNotShared()
+    {
+        $def = new Definition('stdClass');
+        $def->setScope(ContainerInterface::SCOPE_PROTOTYPE);
+
+        $this->assertFalse($def->isShared());
+        $this->assertEquals(ContainerInterface::SCOPE_PROTOTYPE, $def->getScope());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy-services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy-services9.xml
@@ -33,6 +33,6 @@
       <configurator class="%baz_class%" method="configureStatic1"/>
     </service>
     <service id="factory_service" class="Bar" factory-method="getInstance" factory-service="foo.baz"/>
-    <service id="foo_bar" class="%foo_class%" scope="prototype"/>
+    <service id="foo_bar" class="%foo_class%" shared="false" scope="prototype"/>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy-services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy-services9.yml
@@ -29,4 +29,5 @@ services:
         factory_service: foo.baz
     foo_bar:
         class: %foo_class%
+        shared: false
         scope: prototype


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Deprecating the scopes was introducing a BC break in Symfony 2.8 when using the prototype scope. As `$shared` wasn't updated if the scope was set to `prototype`, people will always get an error because of [the `CheckDefinitionValidityPass`](https://github.com/symfony/DependencyInjection/blob/04d5d925a987f35854f51b1c468c0ca81e1d61b9/Compiler/CheckDefinitionValidityPass.php#L54-L57).
