### PR TITLE
[DependencyInjection] Allow anonymous DefinitionDecorator resolving

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -21,12 +21,13 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  * merged Definition instance.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
  */
 class ResolveDefinitionTemplatesPass implements CompilerPassInterface
 {
-    private $container;
     private $compiler;
     private $formatter;
+    private $currentId;
 
     /**
      * Process the ContainerBuilder to replace DefinitionDecorator instances with their real Definition instances.
@@ -35,44 +36,80 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $this->container = $container;
         $this->compiler = $container->getCompiler();
         $this->formatter = $this->compiler->getLoggingFormatter();
 
-        foreach ($container->getDefinitions() as $id => $definition) {
-            // yes, we are specifically fetching the definition from the
-            // container to ensure we are not operating on stale data
-            $definition = $container->getDefinition($id);
-            if (!$definition instanceof DefinitionDecorator || $definition->isAbstract()) {
-                continue;
-            }
+        $container->setDefinitions($this->resolveArguments($container, $container->getDefinitions(), true));
+    }
 
-            $this->resolveDefinition($id, $definition);
+    /**
+     * Resolves definition decorator arguments.
+     *
+     * @param ContainerBuilder $container The ContainerBuilder
+     * @param array            $arguments An array of arguments
+     * @param bool             $isRoot    If we are processing the root definitions or not
+     *
+     * @return array
+     */
+    private function resolveArguments(ContainerBuilder $container, array $arguments, $isRoot = false)
+    {
+        foreach ($arguments as $k => $argument) {
+            if ($isRoot) {
+                // yes, we are specifically fetching the definition from the
+                // container to ensure we are not operating on stale data
+                $arguments[$k] = $argument = $container->getDefinition($k);
+                $this->currentId = $k;
+            }
+            if (is_array($argument)) {
+                $arguments[$k] = $this->resolveArguments($container, $argument);
+            } elseif ($argument instanceof Definition) {
+                if ($argument instanceof DefinitionDecorator) {
+                    $arguments[$k] = $argument = $this->resolveDefinition($container, $argument);
+                    if ($isRoot) {
+                        $container->setDefinition($k, $argument);
+                    }
+                }
+                $argument->setArguments($this->resolveArguments($container, $argument->getArguments()));
+                $argument->setMethodCalls($this->resolveArguments($container, $argument->getMethodCalls()));
+                $argument->setProperties($this->resolveArguments($container, $argument->getProperties()));
+
+                $configurator = $this->resolveArguments($container, array($argument->getConfigurator()));
+                $argument->setConfigurator($configurator[0]);
+
+                $factory = $this->resolveArguments($container, array($argument->getFactory()));
+                $argument->setFactory($factory[0]);
+            }
         }
+
+        return $arguments;
     }
 
     /**
      * Resolves the definition.
      *
-     * @param string              $id         The definition identifier
+     * @param ContainerBuilder    $container  The ContainerBuilder
      * @param DefinitionDecorator $definition
      *
      * @return Definition
      *
      * @throws \RuntimeException When the definition is invalid
      */
-    private function resolveDefinition($id, DefinitionDecorator $definition)
+    private function resolveDefinition(ContainerBuilder $container, DefinitionDecorator $definition)
     {
-        if (!$this->container->hasDefinition($parent = $definition->getParent())) {
-            throw new RuntimeException(sprintf('The parent definition "%s" defined for definition "%s" does not exist.', $parent, $id));
+        if (!$container->hasDefinition($parent = $definition->getParent())) {
+            throw new RuntimeException(sprintf('The parent definition "%s" defined for definition "%s" does not exist.', $parent, $this->currentId));
         }
 
-        $parentDef = $this->container->getDefinition($parent);
+        $parentDef = $container->getDefinition($parent);
         if ($parentDef instanceof DefinitionDecorator) {
-            $parentDef = $this->resolveDefinition($parent, $parentDef);
+            $id = $this->currentId;
+            $this->currentId = $parent;
+            $parentDef = $this->resolveDefinition($container, $parentDef);
+            $container->setDefinition($parent, $parentDef);
+            $this->currentId = $id;
         }
 
-        $this->compiler->addLogMessage($this->formatter->formatResolveInheritance($this, $id, $parent));
+        $this->compiler->addLogMessage($this->formatter->formatResolveInheritance($this, $this->currentId, $parent));
         $def = new Definition();
 
         // merge in parent definition
@@ -155,9 +192,6 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $def->setAbstract($definition->isAbstract());
         $def->setScope($definition->getScope(false), false);
         $def->setTags($definition->getTags());
-
-        // set new definition on container
-        $this->container->setDefinition($id, $def);
 
         return $def;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR allows injecting anonymous DefinitionDecorator into services' arguments/properties, such as:

``` php
$container->register('foo_service_name', 'FooClass')
    ->setProperty('bar', new DefinitionDecorator('definition_decorated_service'))
; 
```
