### PR TITLE
[Form] Fixed compatibility with FormTypeInterface implementations that don't extend AbstractType

### DIFF
--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -200,27 +200,35 @@ class ResolvedFormType implements ResolvedFormTypeInterface
 
             $this->innerType->setDefaultOptions($this->optionsResolver);
 
-            $reflector = new \ReflectionMethod($this->innerType, 'setDefaultOptions');
-            $isOldOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType';
+            if (method_exists($this->innerType, 'configureOptions')) {
+                $reflector = new \ReflectionMethod($this->innerType, 'setDefaultOptions');
+                $isOldOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType';
 
-            $reflector = new \ReflectionMethod($this->innerType, 'configureOptions');
-            $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType';
+                $reflector = new \ReflectionMethod($this->innerType, 'configureOptions');
+                $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractType';
 
-            if ($isOldOverwritten && !$isNewOverwritten) {
-                @trigger_error(get_class($this->innerType).': The FormTypeInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeInterface with Symfony 3.0.', E_USER_DEPRECATED);
+                if ($isOldOverwritten && !$isNewOverwritten) {
+                    @trigger_error(get_class($this->innerType).': The FormTypeInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeInterface with Symfony 3.0.', E_USER_DEPRECATED);
+                }
+            } else {
+                @trigger_error(get_class($this->innerType).': The FormTypeInterface::configureOptions() method will be added in Symfony 3.0. You should extend AbstractType or implement it in your classes.', E_USER_DEPRECATED);
             }
 
             foreach ($this->typeExtensions as $extension) {
                 $extension->setDefaultOptions($this->optionsResolver);
 
-                $reflector = new \ReflectionMethod($extension, 'setDefaultOptions');
-                $isOldOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension';
+                if (method_exists($extension, 'configureOptions')) {
+                    $reflector = new \ReflectionMethod($extension, 'setDefaultOptions');
+                    $isOldOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension';
 
-                $reflector = new \ReflectionMethod($extension, 'configureOptions');
-                $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension';
+                    $reflector = new \ReflectionMethod($extension, 'configureOptions');
+                    $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Symfony\Component\Form\AbstractTypeExtension';
 
-                if ($isOldOverwritten && !$isNewOverwritten) {
-                    @trigger_error(get_class($extension).': The FormTypeExtensionInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeExtensionInterface with Symfony 3.0.', E_USER_DEPRECATED);
+                    if ($isOldOverwritten && !$isNewOverwritten) {
+                        @trigger_error(get_class($extension).': The FormTypeExtensionInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeExtensionInterface with Symfony 3.0.', E_USER_DEPRECATED);
+                    }
+                } else {
+                    @trigger_error(get_class($this->innerType).': The FormTypeExtensionInterface::configureOptions() method will be added in Symfony 3.0. You should extend AbstractTypeExtension or implement it in your classes.', E_USER_DEPRECATED);
                 }
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
