### PR TITLE
Add a way to reset the singleton

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
@@ -68,6 +68,13 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
     }
 
     /**
+     * Resets the singleton instance.
+     */
+    public static function reset() {
+        self::$instance = null;
+    }
+
+    /**
      * Registers all natively provided mime type guessers.
      */
     private function __construct()

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -45,6 +45,18 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('gif', $file->guessExtension());
     }
 
+    public function testGuessExtensionWithReset() {
+        $file = new File(__DIR__.'/Fixtures/other-file.example');
+        $guesser = $this->createMockGuesser($file->getPathname(), 'image/gif');
+        MimeTypeGuesser::getInstance()->register($guesser);
+
+        $this->assertEquals('gif', $file->guessExtension());
+
+        MimeTypeGuesser::reset();
+
+        $this->assertNull($file->guessExtension());
+    }
+
     public function testConstructWhenFileNotExists()
     {
         $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException');


### PR DESCRIPTION
## Problem

The mime type guesser is a singleton, which as we know, causes all kind of problems.
One problem Drupal ran into is the problem that for tests we continuesly registered more and more mimetype guessers,
once everytime we rebuild the container as part of your testing.

Once that we had that, with enough test functions + made one of the mimetype guessers as proxy, we ran into a memory leak
of storing the container as part of the mime type singleton.

See https://www.drupal.org/node/2408371
## Solution

Allow to reset the singleton.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
