### PR TITLE
[Form] fixed sending non array data on submit to ResizeListener

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -101,7 +101,7 @@ class ResizeFormListener implements EventSubscriberInterface
         }
 
         if (!is_array($data) && !($data instanceof \Traversable && $data instanceof \ArrayAccess)) {
-            throw new UnexpectedTypeException($data, 'array or (\Traversable and \ArrayAccess)');
+            $data = array();
         }
 
         // Remove all empty rows

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -167,15 +167,14 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->form->has('2'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
-    public function testPreSubmitRequiresArrayOrTraversable()
+    public function testPreSubmitDealsWithNoArrayOrTraversable()
     {
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preSubmit($event);
+
+        $this->assertFalse($this->form->has('1'));
     }
 
     public function testPreSubmitDealsWithNullData()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13804, #13851 |
| License | MIT |
| Doc PR |  |

I agree with @Tobion that #13851 is a bug fix and therefore should be applied on the `2.3` branch too.
