### PR TITLE
[Console] respect multi-character shortcuts

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -40,7 +40,7 @@ class TextDescriptor extends Descriptor
         $totalWidth = isset($options['total_width']) ? $options['total_width'] : strlen($argument->getName());
         $spacingWidth = $totalWidth - strlen($argument->getName()) + 2;
 
-        $this->writeText(sprintf("  <info>%s</info>%s%s%s",
+        $this->writeText(sprintf('  <info>%s</info>%s%s%s',
             $argument->getName(),
             str_repeat(' ', $spacingWidth),
             // + 17 = 2 spaces + <info> + </info> + 2 spaces
@@ -77,7 +77,7 @@ class TextDescriptor extends Descriptor
 
         $spacingWidth = $totalWidth - strlen($synopsis) + 2;
 
-        $this->writeText(sprintf("  <info>%s</info>%s%s%s%s",
+        $this->writeText(sprintf('  <info>%s</info>%s%s%s%s',
             $synopsis,
             str_repeat(' ', $spacingWidth),
             // + 17 = 2 spaces + <info> + </info> + 2 spaces
@@ -207,7 +207,7 @@ class TextDescriptor extends Descriptor
                 foreach ($namespace['commands'] as $name) {
                     $this->writeText("\n");
                     $spacingWidth = $width - strlen($name);
-                    $this->writeText(sprintf("  <info>%s</info>%s%s", $name, str_repeat(' ', $spacingWidth), $description->getCommand($name)->getDescription()), $options);
+                    $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $description->getCommand($name)->getDescription()), $options);
                 }
             }
 
@@ -266,7 +266,8 @@ class TextDescriptor extends Descriptor
     {
         $totalWidth = 0;
         foreach ($options as $option) {
-            $nameLength = 4 + strlen($option->getName()) + 2; // - + shortcut + , + whitespace + name + --
+            // "-" + shortcut + ", --" + name
+            $nameLength = 1 + max(strlen($option->getShortcut()), 1) + 4 + strlen($option->getName());
 
             if ($option->acceptValue()) {
                 $valueLength = 1 + strlen($option->getName()); // = + value

--- a/src/Symfony/Component/Console/Tests/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/ObjectsProvider.php
@@ -42,6 +42,7 @@ class ObjectsProvider
             'input_option_3' => new InputOption('option_name', 'o', InputOption::VALUE_REQUIRED, 'option description'),
             'input_option_4' => new InputOption('option_name', 'o', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'option description', array()),
             'input_option_5' => new InputOption('option_name', 'o', InputOption::VALUE_REQUIRED, "multiline\noption description"),
+            'input_option_6' => new InputOption('option_name', array('o', 'O'), InputOption::VALUE_REQUIRED, 'option with multiple shortcuts'),
         );
     }
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.json
@@ -1,0 +1,1 @@
+{"name":"--option_name","shortcut":"-o|-O","accept_value":true,"is_value_required":true,"is_multiple":false,"description":"option with multiple shortcuts","default":null}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.md
@@ -1,0 +1,9 @@
+**option_name:**
+
+* Name: `--option_name`
+* Shortcut: `-o|-O`
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Description: option with multiple shortcuts
+* Default: `NULL`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.txt
@@ -1,0 +1,1 @@
+  <info>-o|O, --option_name=OPTION_NAME</info>  option with multiple shortcuts

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<option name="--option_name" shortcut="-o" shortcuts="-o|-O" accept_value="1" is_value_required="1" is_multiple="0">
+  <description>option with multiple shortcuts</description>
+  <defaults/>
+</option>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15105 |
| License | MIT |
| Doc PR |  |

The `TextDescriptor` assumed that shortcuts will only consume one space
when calculating the maximum width needed to display the option's
synopsis.
