### PR TITLE
[2.6][Validator] Fix BC for Validator's validate method

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
@@ -75,6 +75,12 @@ abstract class Abstract2Dot5ApiTest extends AbstractValidatorTest
         $this->assertCount(1, $violations);
     }
 
+    public function testValidateWithEmptyArrayAsConstraint()
+    {
+        $violations = $this->validator->validate('value', array());
+        $this->assertCount(0, $violations);
+    }
+
     public function testGroupSequenceAbortsAfterFailedGroup()
     {
         $entity = new Entity();

--- a/src/Symfony/Component/Validator/Validator/LegacyValidator.php
+++ b/src/Symfony/Component/Validator/Validator/LegacyValidator.php
@@ -69,7 +69,7 @@ class LegacyValidator extends RecursiveValidator implements LegacyValidatorInter
 
     private static function testConstraints($constraints)
     {
-        return null === $constraints || $constraints instanceof Constraint || (is_array($constraints) && current($constraints) instanceof Constraint);
+        return null === $constraints || $constraints instanceof Constraint || (is_array($constraints) && (0 === count($constraints) || current($constraints) instanceof Constraint));
     }
 
     private static function testGroups($groups)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This fix makes method call `$validator->validate($value, array());` backward compatible and does not throw

```
[Symfony\Component\Validator\Exception\NoSuchMetadataException]

The class or interface "XXX" does not exist.
```

when the `$value` is a scalar type.
