### PR TITLE
DbalLogger: Small nonutf8 array fix

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
+++ b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
@@ -82,6 +82,12 @@ class DbalLogger implements SQLLogger
     private function normalizeParams(array $params)
     {
         foreach ($params as $index => $param) {
+            // normalize recursively
+            if (is_array($param)) {
+                $params[$index] = $this->normalizeParams($param);
+                continue;
+            }
+
             if (!is_string($params[$index])) {
                 continue;
             }

--- a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
+++ b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
@@ -50,30 +50,7 @@ class DbalLogger implements SQLLogger
         }
 
         if (is_array($params)) {
-            foreach ($params as $index => $param) {
-                if (!is_string($params[$index])) {
-                    continue;
-                }
-
-                // non utf-8 strings break json encoding
-                if (!preg_match('//u', $params[$index])) {
-                    $params[$index] = self::BINARY_DATA_VALUE;
-                    continue;
-                }
-
-                // detect if the too long string must be shorten
-                if (function_exists('mb_strlen')) {
-                    if (self::MAX_STRING_LENGTH < mb_strlen($params[$index], 'UTF-8')) {
-                        $params[$index] = mb_substr($params[$index], 0, self::MAX_STRING_LENGTH - 6, 'UTF-8').' [...]';
-                        continue;
-                    }
-                } else {
-                    if (self::MAX_STRING_LENGTH < strlen($params[$index])) {
-                        $params[$index] = substr($params[$index], 0, self::MAX_STRING_LENGTH - 6).' [...]';
-                        continue;
-                    }
-                }
-            }
+            $params = $this->normalizeParams($params);
         }
 
         if (null !== $this->logger) {
@@ -100,5 +77,35 @@ class DbalLogger implements SQLLogger
     protected function log($message, array $params)
     {
         $this->logger->debug($message, $params);
+    }
+
+    private function normalizeParams(array $params)
+    {
+        foreach ($params as $index => $param) {
+            if (!is_string($params[$index])) {
+                continue;
+            }
+
+            // non utf-8 strings break json encoding
+            if (!preg_match('//u', $params[$index])) {
+                $params[$index] = self::BINARY_DATA_VALUE;
+                continue;
+            }
+
+            // detect if the too long string must be shorten
+            if (function_exists('mb_strlen')) {
+                if (self::MAX_STRING_LENGTH < mb_strlen($params[$index], 'UTF-8')) {
+                    $params[$index] = mb_substr($params[$index], 0, self::MAX_STRING_LENGTH - 6, 'UTF-8').' [...]';
+                    continue;
+                }
+            } else {
+                if (self::MAX_STRING_LENGTH < strlen($params[$index])) {
+                    $params[$index] = substr($params[$index], 0, self::MAX_STRING_LENGTH - 6).' [...]';
+                    continue;
+                }
+            }
+        }
+
+        return $params;
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
@@ -73,6 +73,37 @@ class DbalLoggerTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testLogNonUtf8Array()
+    {
+        $logger = $this->getMock('Psr\\Log\\LoggerInterface');
+
+        $dbalLogger = $this
+            ->getMockBuilder('Symfony\\Bridge\\Doctrine\\Logger\\DbalLogger')
+            ->setConstructorArgs(array($logger, null))
+            ->setMethods(array('log'))
+            ->getMock()
+        ;
+
+        $dbalLogger
+            ->expects($this->once())
+            ->method('log')
+            ->with('SQL', array(
+                    'utf8' => 'foo',
+                    array(
+                        'nonutf8' => DbalLogger::BINARY_DATA_VALUE,
+                    )
+                )
+            )
+        ;
+
+        $dbalLogger->startQuery('SQL', array(
+            'utf8' => 'foo',
+            array(
+                'nonutf8' => "\x7F\xFF",
+            )
+        ));
+    }
+
     public function testLogLongString()
     {
         $logger = $this->getMock('Symfony\\Component\\HttpKernel\\Log\\LoggerInterface');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9096 |
| License | MIT |
| Doc PR | n/a |

Hi guys!

Just a small triage of #9096. Actually, @vpetrovych did all the work, and I was able to rebase and keep his original commit for authorship :).

This is obviously a very minor, edge issue - but the patch is simple. The new `normalizeParams` function is an exact copy-and-paste except for the changes in sha: 1882a2ae472a4fcdf846756f63460ef720c8df61

Thanks!
