### PR TITLE
[Security] Moved Simple{Form,Pre}AuthenticatorInterfaces to Security\Http

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * deprecated `getKey()` of the `AnonymousToken`, `RememberMeToken` and `AbstractRememberMeServices` classes
    in favor of `getSecret()`.
+ * deprecated `Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface`, use
+   `Symfony\Component\Security\Http\Authentication\SimpleFormAuthenticatorInterface` instead
 
 2.7.0
 -----

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * deprecated `getKey()` of the `AnonymousToken`, `RememberMeToken` and `AbstractRememberMeServices` classes
    in favor of `getSecret()`.
+ * deprecated `Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface`, use
+   `Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface` instead
  * deprecated `Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface`, use
    `Symfony\Component\Security\Http\Authentication\SimpleFormAuthenticatorInterface` instead
 

--- a/src/Symfony/Component/Security/Core/Authentication/SimpleFormAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/SimpleFormAuthenticatorInterface.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Security\Core\Authentication;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * @deprecated Deprecated since version 2.8, to be removed in 3.0. Use the same interface from Security\Http\Authentication instead.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 interface SimpleFormAuthenticatorInterface extends SimpleAuthenticatorInterface

--- a/src/Symfony/Component/Security/Core/Authentication/SimplePreAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/SimplePreAuthenticatorInterface.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Security\Core\Authentication;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * @deprecated Since version 2.8, to be removed in 3.0. Use the same interface from Security\Http\Authentication instead.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 interface SimplePreAuthenticatorInterface extends SimpleAuthenticatorInterface

--- a/src/Symfony/Component/Security/Http/Authentication/SimpleFormAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimpleFormAuthenticatorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authentication;
+
+use Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface as BaseSimpleFormAuthenticatorInterface;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface SimpleFormAuthenticatorInterface extends BaseSimpleFormAuthenticatorInterface
+{
+}

--- a/src/Symfony/Component/Security/Http/Authentication/SimplePreAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimplePreAuthenticatorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authentication;
+
+use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface as BaseSimplePreAuthenticatorInterface;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface SimplePreAuthenticatorInterface extends BaseSimplePreAuthenticatorInterface
+{
+}


### PR DESCRIPTION
## Description

The `SimpleFormAuthenticatorInterface` and `SimplePreAuthenticatorInterface` rely on `Request`, which means it's a Http land class. This means they don't belong in core.

Having a form login that doesn't depend on the request is an option as well (e.g. a console application might use the question helper to implement a "form" login). However, then there is a need for a new abstraction of the request. I don't think it's worth it.

Furthermore, the only classes typehinting/relying on this interfaces can be found in `Security\Http`.
## Implementation

The new interfaces extend the old ones for better backwards compability. Symfony doesn't trigger deprecation errors for interfaces, see https://github.com/symfony/symfony/commit/6f57b7b552e77a12f8116460671d78a3eb0ddbb9
## PR Info Table

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
