### PR TITLE
[WIP] [BinaryFileResponse] Added support for php://temp wrapper

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -91,7 +91,7 @@ class BinaryFileResponse extends Response
             }
         }
 
-        if (!$file->isReadable()) {
+        if (!$file->isReadable() && !(($fp = @fopen($file->getPath(), 'r')) && fclose($fp))) {
             throw new FileException('File must be readable.');
         }
 
@@ -127,7 +127,12 @@ class BinaryFileResponse extends Response
      */
     public function setAutoLastModified()
     {
-        $this->setLastModified(\DateTime::createFromFormat('U', $this->file->getMTime()));
+        if ($this->file->isReadable()) {
+            $mtime = $this->file->getMTime();
+        } else {
+            $mtime = date('U');
+        }
+        $this->setLastModified(\DateTime::createFromFormat('U', $mtime));
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -37,7 +37,7 @@ class File extends \SplFileInfo
      */
     public function __construct($path, $checkPath = true)
     {
-        if ($checkPath && !is_file($path)) {
+        if ($checkPath && !is_file($path) && !(($fp = @fopen($path, 'r')) && fclose($fp))) {
             throw new FileNotFoundException($path);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -200,6 +200,18 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertEquals(realpath($response->getFile()->getPathname()), realpath($filePath));
     }
 
+    public function testSplTempFileObject()
+    {
+        $filePath = __DIR__.'/File/Fixtures/test';
+        $file = new \SplTempFileObject(0);
+        $file->fwrite(file_get_contents($filePath));
+        $file->fflush();
+
+        $response = new BinaryFileResponse($file);
+
+        $this->assertEquals($response->getFile()->getFileInfo()->getPathname(), $file->getFileInfo()->getPathname());
+    }
+
     public function testAcceptRangeOnUnsafeMethods()
     {
         $request = Request::create('/', 'POST');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14969 (partially) |
| License | MIT |
| Doc PR |  |

Allows to identify as readable streams writen to `php://temp` when they are
flushed to temp dir.

Example:

``` php
// http://php.net/manual/es/wrappers.php.php#refsect2-wrappers.php-unknown-unknown-unknown-unknown-unknown-descriptios
// '0' forces php://temp to be writen always to disk, otherwise it uses the value
// defined in php.ini
$tmpfile = new \SplTempFileObject(0);
// behaves like
$file = new \SplFileObject('php://temp/maxmemory:0', 'w');
```
