### PR TITLE
[FrameworkBundle] add option to force web server startup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -37,6 +37,7 @@ class ServerStartCommand extends ServerCommand
                 new InputOption('port', 'p', InputOption::VALUE_REQUIRED, 'Address port number', '8000'),
                 new InputOption('docroot', 'd', InputOption::VALUE_REQUIRED, 'Document root', null),
                 new InputOption('router', 'r', InputOption::VALUE_REQUIRED, 'Path to custom router script'),
+                new InputOption('force', 'f', InputOption::VALUE_NONE, 'Force web server startup'),
             ))
             ->setName('server:start')
             ->setDescription('Starts PHP built-in web server in the background')
@@ -110,8 +111,9 @@ EOF
             $address = $address.':'.$input->getOption('port');
         }
 
-        if ($this->isOtherServerProcessRunning($address)) {
+        if (!$input->getOption('force') && $this->isOtherServerProcessRunning($address)) {
             $output->writeln(sprintf('<error>A process is already listening on http://%s.</error>', $address));
+            $output->writeln(sprintf('<error>Use the --force option if the server process terminated unexpectedly to start a new web server process.</error>'));
 
             return 1;
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `server:start` command will report an error message when a lock file
does exist.

However, this means that you cannot restart the web server process if
the previously running process terminated accidentally or if it was
terminated by the user without executing the `server:stop` command (e.g.
by using the system's `kill` command or the task manager).

This commit adds a `--force` option that makes it possible to launch the
web server process even if a lock file does exist.
