### PR TITLE
[Translation] Add parameters to DataCollectorTranslator

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -81,7 +81,6 @@
             <th>Locale</th>
             <th>Domain</th>
             <th>Id</th>
-            <th>Parameters</th>
             <th>Message Preview</th>
         </tr>
         {% for message in collector.messages %}
@@ -91,20 +90,44 @@
                 <td><code>{{ message.domain }}</code></td>
                 <td>
                     <code>{{ message.id }}</code>
+
                     {% if message.count > 1 %}<br><small style="color: gray;">(used {{ message.count }} times)</small>{% endif %}
-                </td>
-                <td>
-                    {% for key, value in message.parameters %}
-                        <code>{{ key }} = {{ value }}</code>{% if message.transChoiceNumber is not null or not loop.last %}<br />{% endif %}
-                    {% endfor %}
-                    {% if message.transChoiceNumber is not null %}
-                        <em><code>pluralization = {{ message.transChoiceNumber }}</code></em>
-                    {% endif %}
+                    {% if message.transChoiceNumber is not null %}<br><small style="color: gray;">(use pluralization)</small>{% endif %}
+
+                    <div>
+                        [<a href="#" onclick="return openParameters(this);" style="text-decoration: none;"
+                            title="Toggle parameters display" data-target-id="parameters-{{ loop.index }}" >
+                            <img alt="+" src="data:image/gif;base64,R0lGODlhEgASAMQTANft99/v+Ga44bHb8ITG52S44dXs9+z1+uPx+YvK6WC24G+944/M6W28443L6dnu+Ge54v/+/l614P///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAABMALAAAAAASABIAQAVS4DQBTiOd6LkwgJgeUSzHSDoNaZ4PU6FLgYBA5/vFID/DbylRGiNIZu74I0h1hNsVxbNuUV4d9SsZM2EzWe1qThVzwWFOAFCQFa1RQq6DJB4iIQA7" style="display: inline; width: 12px; height: 12px;" />
+                            <img alt="-" src="data:image/gif;base64,R0lGODlhEgASAMQSANft94TG57Hb8GS44ez1+mC24IvK6ePx+Wa44dXs92+942e54o3L6W2844/M6dnu+P/+/l614P///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAABIALAAAAAASABIAQAVCoCQBTBOd6Kk4gJhGBCTPxysJb44K0qD/ER/wlxjmisZkMqBEBW5NHrMZmVKvv9hMVsO+hE0EoNAstEYGxG9heIhCADs=" style="display: none; width: 12px; height: 12px;" />
+                            <span style="vertical-align:top">Parameters</span>
+                        </a>]
+
+                        <div id="parameters-{{ loop.index }}" style="display: none;">
+                            {% for parameters in message.parameters %}
+                                {% if parameters|length > 0 %}
+                                    {{ dump(parameters) }}
+                                {% else %}
+                                    {{ dump(null) }}
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                    </div>
                 </td>
                 <td><code>{{ message.translation }}</code></td>
             </tr>
         {% endfor %}
     </table>
+
+    <script type="text/javascript">
+        function openParameters(link) {
+            "use strict";
+
+            var imgs = link.children,
+                target = link.getAttribute('data-target-id');
+
+            Sfjs.toggle(target, imgs[0], imgs[1]);
+        }
+    </script>
 {% endblock %}
 
 {% macro state(translation) %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -78,7 +78,6 @@
     <table>
         <tr>
             <th>State</th>
-            <th>Type</th>
             <th>Locale</th>
             <th>Domain</th>
             <th>Id</th>
@@ -88,7 +87,6 @@
         {% for message in collector.messages %}
             <tr>
                 <td><code>{{ translator.state(message) }}</code></td>
-                <td>{{ message.transChoiceNumber in not null ? 'transChoice' : 'trans' }}</td>
                 <td><code>{{ message.locale }}</code></td>
                 <td><code>{{ message.domain }}</code></td>
                 <td>
@@ -99,7 +97,7 @@
                     {% for key, value in message.parameters %}
                         <code>{{ key }} = {{ value }}</code><br />
                     {% endfor %}
-                    {% if message.transChoiceNumber in not null %}
+                    {% if message.transChoiceNumber is not null %}
                         <em><code>transChoice count = {{ message.transChoiceNumber }}</code></em>
                     {% endif %}
                 </td>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -95,10 +95,10 @@
                 </td>
                 <td>
                     {% for key, value in message.parameters %}
-                        <code>{{ key }} = {{ value }}</code><br />
+                        <code>{{ key }} = {{ value }}</code>{% if message.transChoiceNumber is not null or not loop.last %}<br />{% endif %}
                     {% endfor %}
                     {% if message.transChoiceNumber is not null %}
-                        <em><code>transChoice count = {{ message.transChoiceNumber }}</code></em>
+                        <em><code>pluralization = {{ message.transChoiceNumber }}</code></em>
                     {% endif %}
                 </td>
                 <td><code>{{ message.translation }}</code></td>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -81,6 +81,7 @@
             <th>Locale</th>
             <th>Domain</th>
             <th>Id</th>
+            <th>Parameters</th>
             <th>Message Preview</th>
         </tr>
         {% for message in collector.messages %}
@@ -91,6 +92,11 @@
                 <td>
                     <code>{{ message.id }}</code>
                     {% if message.count > 1 %}<br><small style="color: gray;">(used {{ message.count }} times)</small>{% endif %}
+                </td>
+                <td>
+                    {% for key, value in message.parameters %}
+                        <code>{{ key }} = {{ value }}</code>{% if not loop.last %}<br />{% endif %}
+                    {% endfor %}
                 </td>
                 <td><code>{{ message.translation }}</code></td>
             </tr>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -105,11 +105,7 @@
 
                             <div id="parameters-{{ loop.index }}" style="display: none;">
                                 {% for parameters in message.parameters %}
-                                    {% if parameters|length > 0 %}
-                                        {{ profiler_dump(parameters) }}
-                                    {% else %}
-                                        {{ profiler_dump(null) }}
-                                    {% endif %}
+                                    {{ profiler_dump(parameters) }}
                                     {% if not loop.last %}<br />{% endif %}
                                 {% endfor %}
                             </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -94,24 +94,27 @@
                     {% if message.count > 1 %}<br><small style="color: gray;">(used {{ message.count }} times)</small>{% endif %}
                     {% if message.transChoiceNumber is not null %}<br><small style="color: gray;">(use pluralization)</small>{% endif %}
 
-                    <div>
-                        [<a href="#" onclick="return openParameters(this);" style="text-decoration: none;"
-                            title="Toggle parameters display" data-target-id="parameters-{{ loop.index }}" >
-                            <img alt="+" src="data:image/gif;base64,R0lGODlhEgASAMQTANft99/v+Ga44bHb8ITG52S44dXs9+z1+uPx+YvK6WC24G+944/M6W28443L6dnu+Ge54v/+/l614P///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAABMALAAAAAASABIAQAVS4DQBTiOd6LkwgJgeUSzHSDoNaZ4PU6FLgYBA5/vFID/DbylRGiNIZu74I0h1hNsVxbNuUV4d9SsZM2EzWe1qThVzwWFOAFCQFa1RQq6DJB4iIQA7" style="display: inline; width: 12px; height: 12px;" />
-                            <img alt="-" src="data:image/gif;base64,R0lGODlhEgASAMQSANft94TG57Hb8GS44ez1+mC24IvK6ePx+Wa44dXs92+942e54o3L6W2844/M6dnu+P/+/l614P///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAABIALAAAAAASABIAQAVCoCQBTBOd6Kk4gJhGBCTPxysJb44K0qD/ER/wlxjmisZkMqBEBW5NHrMZmVKvv9hMVsO+hE0EoNAstEYGxG9heIhCADs=" style="display: none; width: 12px; height: 12px;" />
-                            <span style="vertical-align:top">Parameters</span>
-                        </a>]
+                    {% if message.parameters|length > 0 %}
+                        <div>
+                            [<a href="#" onclick="return openParameters(this);" style="text-decoration: none;"
+                                title="Toggle parameters display" data-target-id="parameters-{{ loop.index }}" >
+                                <img alt="+" src="data:image/gif;base64,R0lGODlhEgASAMQTANft99/v+Ga44bHb8ITG52S44dXs9+z1+uPx+YvK6WC24G+944/M6W28443L6dnu+Ge54v/+/l614P///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAABMALAAAAAASABIAQAVS4DQBTiOd6LkwgJgeUSzHSDoNaZ4PU6FLgYBA5/vFID/DbylRGiNIZu74I0h1hNsVxbNuUV4d9SsZM2EzWe1qThVzwWFOAFCQFa1RQq6DJB4iIQA7" style="display: inline; width: 12px; height: 12px;" />
+                                <img alt="-" src="data:image/gif;base64,R0lGODlhEgASAMQSANft94TG57Hb8GS44ez1+mC24IvK6ePx+Wa44dXs92+942e54o3L6W2844/M6dnu+P/+/l614P///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAABIALAAAAAASABIAQAVCoCQBTBOd6Kk4gJhGBCTPxysJb44K0qD/ER/wlxjmisZkMqBEBW5NHrMZmVKvv9hMVsO+hE0EoNAstEYGxG9heIhCADs=" style="display: none; width: 12px; height: 12px;" />
+                                <span style="vertical-align:top">Parameters</span>
+                            </a>]
 
-                        <div id="parameters-{{ loop.index }}" style="display: none;">
-                            {% for parameters in message.parameters %}
-                                {% if parameters|length > 0 %}
-                                    {{ dump(parameters) }}
-                                {% else %}
-                                    {{ dump(null) }}
-                                {% endif %}
-                            {% endfor %}
+                            <div id="parameters-{{ loop.index }}" style="display: none;">
+                                {% for parameters in message.parameters %}
+                                    {% if parameters|length > 0 %}
+                                        {{ profiler_dump(parameters) }}
+                                    {% else %}
+                                        {{ profiler_dump(null) }}
+                                    {% endif %}
+                                    {% if not loop.last %}<br />{% endif %}
+                                {% endfor %}
+                            </div>
                         </div>
-                    </div>
+                    {% endif %}
                 </td>
                 <td><code>{{ message.translation }}</code></td>
             </tr>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -78,6 +78,7 @@
     <table>
         <tr>
             <th>State</th>
+            <th>Type</th>
             <th>Locale</th>
             <th>Domain</th>
             <th>Id</th>
@@ -87,6 +88,7 @@
         {% for message in collector.messages %}
             <tr>
                 <td><code>{{ translator.state(message) }}</code></td>
+                <td>{{ message.transChoiceNumber in not null ? 'transChoice' : 'trans' }}</td>
                 <td><code>{{ message.locale }}</code></td>
                 <td><code>{{ message.domain }}</code></td>
                 <td>
@@ -95,8 +97,11 @@
                 </td>
                 <td>
                     {% for key, value in message.parameters %}
-                        <code>{{ key }} = {{ value }}</code>{% if not loop.last %}<br />{% endif %}
+                        <code>{{ key }} = {{ value }}</code><br />
                     {% endfor %}
+                    {% if message.transChoiceNumber in not null %}
+                        <em><code>transChoice count = {{ message.transChoiceNumber }}</code></em>
+                    {% endif %}
                 </td>
                 <td><code>{{ message.translation }}</code></td>
             </tr>

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -101,11 +101,14 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
 
             if (!isset($result[$messageId])) {
                 $message['count'] = 1;
-                $message['parameters'] = array($message['parameters']);
+                $message['parameters'] = !empty($message['parameters']) ? array($message['parameters']) : array();
                 $messages[$key]['translation'] = $this->sanitizeString($message['translation']);
                 $result[$messageId] = $message;
             } else {
-                $result[$messageId]['parameters'][] = $message['parameters'];
+                if (!empty($message['parameters'])) {
+                    $result[$messageId]['parameters'][] = $message['parameters'];
+                }
+
                 $result[$messageId]['count']++;
             }
 

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -101,9 +101,11 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
 
             if (!isset($result[$messageId])) {
                 $message['count'] = 1;
+                $message['parameters'] = [$message['parameters']];
                 $messages[$key]['translation'] = $this->sanitizeString($message['translation']);
                 $result[$messageId] = $message;
             } else {
+                $result[$messageId]['parameters'][] = $message['parameters'];
                 $result[$messageId]['count']++;
             }
 

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -101,7 +101,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
 
             if (!isset($result[$messageId])) {
                 $message['count'] = 1;
-                $message['parameters'] = [$message['parameters']];
+                $message['parameters'] = array($message['parameters']);
                 $messages[$key]['translation'] = $this->sanitizeString($message['translation']);
                 $result[$messageId] = $message;
             } else {

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -111,10 +111,10 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     /**
      * @param string|null $locale
      * @param string|null $domain
-     * @param string $id
-     * @param string $translation
-     * @param array|null $parameters
-     * @param integer|null $number
+     * @param string      $id
+     * @param string      $translation
+     * @param array|null  $parameters
+     * @param int|null    $number
      */
     private function collectMessage($locale, $domain, $id, $translation, $parameters = array(), $number = null)
     {

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -48,7 +48,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
         $trans = $this->translator->trans($id, $parameters, $domain, $locale);
-        $this->collectMessage($locale, $domain, $id, $trans);
+        $this->collectMessage($locale, $domain, $id, $trans, $parameters);
 
         return $trans;
     }
@@ -59,7 +59,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
         $trans = $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
-        $this->collectMessage($locale, $domain, $id, $trans);
+        $this->collectMessage($locale, $domain, $id, $trans, $parameters);
 
         return $trans;
     }
@@ -112,9 +112,10 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
      * @param string|null $locale
      * @param string|null $domain
      * @param string      $id
-     * @param string      $trans
+     * @param string      $translation
+     * @param array|null  $parameters
      */
-    private function collectMessage($locale, $domain, $id, $translation)
+    private function collectMessage($locale, $domain, $id, $translation, $parameters = array())
     {
         if (null === $domain) {
             $domain = 'messages';
@@ -146,6 +147,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
             'domain' => $domain,
             'id' => $id,
             'translation' => $translation,
+            'parameters' => $parameters,
             'state' => $state,
         );
     }

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -59,7 +59,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
         $trans = $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
-        $this->collectMessage($locale, $domain, $id, $trans, $parameters);
+        $this->collectMessage($locale, $domain, $id, $trans, $parameters, $number);
 
         return $trans;
     }
@@ -111,11 +111,12 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     /**
      * @param string|null $locale
      * @param string|null $domain
-     * @param string      $id
-     * @param string      $translation
-     * @param array|null  $parameters
+     * @param string $id
+     * @param string $translation
+     * @param array|null $parameters
+     * @param integer|null $number
      */
-    private function collectMessage($locale, $domain, $id, $translation, $parameters = array())
+    private function collectMessage($locale, $domain, $id, $translation, $parameters = array(), $number = null)
     {
         if (null === $domain) {
             $domain = 'messages';
@@ -148,6 +149,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
             'id' => $id,
             'translation' => $translation,
             'parameters' => $parameters,
+            'transChoiceNumber' => $number,
             'state' => $state,
         );
     }

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -95,7 +95,7 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'state' => DataCollectorTranslator::MESSAGE_DEFINED,
                   'count' => 1,
                   'parameters' => array(
-                      [],
+                      array(),
                   ),
                   'transChoiceNumber' => null,
             ),
@@ -107,7 +107,7 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
                   'count' => 1,
                   'parameters' => array(
-                      [],
+                      array(),
                   ),
                   'transChoiceNumber' => null,
             ),
@@ -119,9 +119,9 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'state' => DataCollectorTranslator::MESSAGE_MISSING,
                   'count' => 3,
                   'parameters' => array(
-                      ['%count%' => 3],
-                      ['%count%' => 3],
-                      ['%count%' => 4, '%foo%' => 'bar'],
+                      array('%count%' => 3),
+                      array('%count%' => 3),
+                      array('%count%' => 4, '%foo%' => 'bar'),
                   ),
                   'transChoiceNumber' => 3,
             ),

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -95,7 +95,7 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'state' => DataCollectorTranslator::MESSAGE_DEFINED,
                   'count' => 1,
                   'parameters' => array(
-                      []
+                      [],
                   ),
                   'transChoiceNumber' => null,
             ),
@@ -107,7 +107,7 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
                   'count' => 1,
                   'parameters' => array(
-                      []
+                      [],
                   ),
                   'transChoiceNumber' => null,
             ),

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -46,6 +46,8 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'locale' => 'en',
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_DEFINED,
+                  'parameters' => array(),
+                  'transChoiceNumber' => null,
             ),
             array(
                   'id' => 'bar',
@@ -53,6 +55,8 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'locale' => 'fr',
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
+                  'parameters' => array(),
+                  'transChoiceNumber' => null,
             ),
             array(
                   'id' => 'choice',
@@ -60,6 +64,8 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'locale' => 'en',
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_MISSING,
+                  'parameters' => array('%count%' => 3),
+                  'transChoiceNumber' => 3,
             ),
             array(
                   'id' => 'choice',
@@ -67,6 +73,17 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'locale' => 'en',
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_MISSING,
+                  'parameters' => array('%count%' => 3),
+                  'transChoiceNumber' => 3,
+            ),
+            array(
+                  'id' => 'choice',
+                  'translation' => 'choice',
+                  'locale' => 'en',
+                  'domain' => 'messages',
+                  'state' => DataCollectorTranslator::MESSAGE_MISSING,
+                  'parameters' => array('%count%' => 4, '%foo%' => 'bar'),
+                  'transChoiceNumber' => 4,
             ),
         );
         $expectedMessages = array(
@@ -77,6 +94,10 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_DEFINED,
                   'count' => 1,
+                  'parameters' => array(
+                      []
+                  ),
+                  'transChoiceNumber' => null,
             ),
             array(
                   'id' => 'bar',
@@ -85,6 +106,10 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
                   'count' => 1,
+                  'parameters' => array(
+                      []
+                  ),
+                  'transChoiceNumber' => null,
             ),
             array(
                   'id' => 'choice',
@@ -92,7 +117,13 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'locale' => 'en',
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_MISSING,
-                  'count' => 2,
+                  'count' => 3,
+                  'parameters' => array(
+                      ['%count%' => 3],
+                      ['%count%' => 3],
+                      ['%count%' => 4, '%foo%' => 'bar'],
+                  ),
+                  'transChoiceNumber' => 3,
             ),
         );
 

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -94,9 +94,7 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_DEFINED,
                   'count' => 1,
-                  'parameters' => array(
-                      array(),
-                  ),
+                  'parameters' => array(),
                   'transChoiceNumber' => null,
             ),
             array(
@@ -106,9 +104,7 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'domain' => 'messages',
                   'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
                   'count' => 1,
-                  'parameters' => array(
-                      array(),
-                  ),
+                  'parameters' => array(),
                   'transChoiceNumber' => null,
             ),
             array(

--- a/src/Symfony/Component/Translation/Tests/DataCollectorTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollectorTranslatorTest.php
@@ -42,6 +42,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_DEFINED,
               'parameters' => array(),
+              'transChoiceNumber' => null,
         );
         $expectedMessages[] = array(
               'id' => 'bar',
@@ -50,6 +51,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
               'parameters' => array(),
+              'transChoiceNumber' => null,
         );
         $expectedMessages[] = array(
               'id' => 'choice',
@@ -58,6 +60,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_MISSING,
               'parameters' => array(),
+              'transChoiceNumber' => 0,
         );
         $expectedMessages[] = array(
               'id' => 'bar_ru',
@@ -66,6 +69,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
               'parameters' => array(),
+              'transChoiceNumber' => null,
         );
         $expectedMessages[] = array(
               'id' => 'bar_ru',
@@ -74,6 +78,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
               'parameters' => array('foo' => 'bar'),
+              'transChoiceNumber' => null,
         );
 
         $this->assertEquals($expectedMessages, $collector->getCollectedMessages());

--- a/src/Symfony/Component/Translation/Tests/DataCollectorTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollectorTranslatorTest.php
@@ -32,6 +32,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
         $collector->trans('bar');
         $collector->transChoice('choice', 0);
         $collector->trans('bar_ru');
+        $collector->trans('bar_ru', array('foo' => 'bar'));
 
         $expectedMessages = array();
         $expectedMessages[] = array(
@@ -40,6 +41,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'locale' => 'en',
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_DEFINED,
+              'parameters' => array(),
         );
         $expectedMessages[] = array(
               'id' => 'bar',
@@ -47,6 +49,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'locale' => 'fr',
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
+              'parameters' => array(),
         );
         $expectedMessages[] = array(
               'id' => 'choice',
@@ -54,6 +57,7 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'locale' => 'en',
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_MISSING,
+              'parameters' => array(),
         );
         $expectedMessages[] = array(
               'id' => 'bar_ru',
@@ -61,6 +65,15 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
               'locale' => 'ru',
               'domain' => 'messages',
               'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
+              'parameters' => array(),
+        );
+        $expectedMessages[] = array(
+              'id' => 'bar_ru',
+              'translation' => 'bar (ru)',
+              'locale' => 'ru',
+              'domain' => 'messages',
+              'state' => DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK,
+              'parameters' => array('foo' => 'bar'),
         );
 
         $this->assertEquals($expectedMessages, $collector->getCollectedMessages());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The new translation web profiler panel miss a important piece of information: the parameters that can be used for placeholders.

This PR add parameters in the collected translations and display them in the WebProfiler translation list.

![image](https://cloud.githubusercontent.com/assets/225704/8426851/31234cdc-1f13-11e5-8e9c-87420bb43bd5.png)

Original idea by my team-mate @joelwurtz :metal: 
