### PR TITLE
[DX] [Security] Renamed Token#getKey() to getSecret()

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -593,6 +593,86 @@ UPGRADE FROM 2.x to 3.0
 
  * The `Resources/` directory was moved to `Core/Resources/`
 
+ * The `key` settings of `anonymous` and `remember_me` are renamed to `secret`.
+
+   Before:
+
+   ```yaml
+   security:
+       # ...
+       firewalls:
+           default:
+               # ...
+               anonymous: { key: "%secret%" }
+               remember_me:
+                   key: "%secret%"
+   ```
+
+   ```xml
+   <!-- ... -->
+   <config>
+       <!-- ... -->
+
+       <firewall>
+           <!-- ... -->
+
+           <anonymous key="%secret%"/>
+           <remember-me key="%secret%"/>
+       </firewall>
+   </config>
+   ```
+
+   ```php
+   // ...
+   $container->loadFromExtension('security', array(
+       // ...
+       'firewalls' => array(
+           // ...
+           'anonymous' => array('key' => '%secret%'),
+           'remember_me' => array('key' => '%secret%'),
+       ),
+   ));
+   ```
+
+   After:
+
+   ```yaml
+   security:
+       # ...
+       firewalls:
+           default:
+               # ...
+               anonymous: { secret: "%secret%" }
+               remember_me:
+                   secret: "%secret%"
+   ```
+
+   ```xml
+   <!-- ... -->
+   <config>
+       <!-- ... -->
+
+       <firewall>
+           <!-- ... -->
+
+           <anonymous secret="%secret%"/>
+           <remember-me secret="%secret%"/>
+       </firewall>
+   </config>
+   ```
+
+   ```php
+   // ...
+   $container->loadFromExtension('security', array(
+       // ...
+       'firewalls' => array(
+           // ...
+           'anonymous' => array('secret' => '%secret%'),
+           'remember_me' => array('secret' => '%secret%'),
+       ),
+   ));
+  ```
+
 ### Translator
 
  * The `Translator::setFallbackLocale()` method has been removed in favor of

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,12 +1,18 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * deprecated the `key` setting of `anonymous` and `remember_me` in favor of the
+   `secret` setting.
+
 2.6.0
 -----
 
  * Added the possibility to override the default success/failure handler
    to get the provider key and the options injected
- * Deprecated the `security.context` service for the `security.token_storage` and 
+ * Deprecated the `security.context` service for the `security.token_storage` and
    `security.authorization_checker` services.
 
 2.4.0

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -285,8 +285,22 @@ class MainConfiguration implements ConfigurationInterface
             ->end()
             ->arrayNode('anonymous')
                 ->canBeUnset()
+                ->beforeNormalization()
+                    ->ifTrue(function ($v) { return isset($v['key']); })
+                    ->then(function ($v) {
+                        if (isset($v['secret'])) {
+                            throw new \LogicException('Cannot set both key and secret options for security.firewall.anonymous, use only secret instead.');
+                        }
+
+                        @trigger_error('security.firewall.anonymous.key is deprecated since version 2.8 and will be removed in 3.0. Use security.firewall.anonymous.secret instead.', E_USER_DEPRECATED);
+
+                        $v['secret'] = $v['key'];
+
+                        unset($v['key']);
+                    })
+                ->end()
                 ->children()
-                    ->scalarNode('key')->defaultValue(uniqid())->end()
+                    ->scalarNode('secret')->defaultValue(uniqid())->end()
                 ->end()
             ->end()
             ->arrayNode('switch_user')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -35,7 +35,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         $authProviderId = 'security.authentication.provider.rememberme.'.$id;
         $container
             ->setDefinition($authProviderId, new DefinitionDecorator('security.authentication.provider.rememberme'))
-            ->addArgument($config['key'])
+            ->addArgument($config['secret'])
             ->addArgument($id)
         ;
 
@@ -56,7 +56,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         }
 
         $rememberMeServices = $container->setDefinition($rememberMeServicesId, new DefinitionDecorator($templateId));
-        $rememberMeServices->replaceArgument(1, $config['key']);
+        $rememberMeServices->replaceArgument(1, $config['secret']);
         $rememberMeServices->replaceArgument(2, $id);
 
         if (isset($config['token_provider'])) {
@@ -120,10 +120,25 @@ class RememberMeFactory implements SecurityFactoryInterface
     public function addConfiguration(NodeDefinition $node)
     {
         $node->fixXmlConfig('user_provider');
-        $builder = $node->children();
+        $builder = $node
+            ->beforeNormalization()
+                ->ifTrue(function ($v) { return isset($v['key']); })
+                ->then(function ($v) {
+                    if (isset($v['secret'])) {
+                        throw new \LogicException('Cannot set both key and secret options for remember_me, use only secret instead.');
+                    }
+
+                    @trigger_error('remember_me.key is deprecated since version 2.8 and will be removed in 3.0. Use remember_me.secret instead.', E_USER_DEPRECATED);
+
+                    $v['secret'] = $v['key'];
+
+                    unset($v['key']);
+                })
+                ->end()
+            ->children();
 
         $builder
-            ->scalarNode('key')->isRequired()->cannotBeEmpty()->end()
+            ->scalarNode('secret')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('token_provider')->end()
             ->arrayNode('user_providers')
                 ->beforeNormalization()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -410,7 +410,7 @@ class SecurityExtension extends Extension
             $listenerId = 'security.authentication.listener.anonymous.'.$id;
             $container
                 ->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.anonymous'))
-                ->replaceArgument(1, $firewall['anonymous']['key'])
+                ->replaceArgument(1, $firewall['anonymous']['secret'])
             ;
 
             $listeners[] = new Reference($listenerId);
@@ -418,7 +418,7 @@ class SecurityExtension extends Extension
             $providerId = 'security.authentication.provider.anonymous.'.$id;
             $container
                 ->setDefinition($providerId, new DefinitionDecorator('security.authentication.provider.anonymous'))
-                ->replaceArgument(0, $firewall['anonymous']['key'])
+                ->replaceArgument(0, $firewall['anonymous']['secret'])
             ;
 
             $authenticationProviders[] = $providerId;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -71,7 +71,7 @@ $container->loadFromExtension('security', array(
             'x509' => true,
             'remote_user' => true,
             'logout' => true,
-            'remember_me' => array('key' => 'TheKey'),
+            'remember_me' => array('secret' => 'TheSecret'),
         ),
         'host' => array(
             'pattern' => '/test',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
@@ -8,7 +8,7 @@ $container->loadFromExtension('security', array(
         'main' => array(
             'form_login' => true,
             'remember_me' => array(
-                'key' => 'TheyKey',
+                'secret' => 'TheSecret',
                 'catch_exceptions' => false,
                 'token_provider' => 'token_provider_id',
             ),

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
@@ -1,4 +1,5 @@
 <?php
+
 $container->loadFromExtension('security', array(
     'providers' => array(
         'default' => array('id' => 'foo'),

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -56,7 +56,7 @@
             <x509 />
             <remote-user />
             <logout />
-            <remember-me key="TheyKey"/>
+            <remember-me secret="TheSecret"/>
         </firewall>
 
         <firewall name="host" pattern="/test" host="foo\.example\.org" methods="GET,POST">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/remember_me_options.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/remember_me_options.xml
@@ -11,7 +11,7 @@
         </sec:providers>
         <sec:firewall name="main">
             <sec:form-login/>
-            <sec:remember-me key="TheKey" catch-exceptions="false" token-provider="token_provider_id" />
+            <sec:remember-me secret="TheSecret" catch-exceptions="false" token-provider="token_provider_id" />
         </sec:firewall>
     </sec:config>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -55,7 +55,7 @@ security:
             remote_user: true
             logout: true
             remember_me:
-                key: TheKey
+                secret: TheSecret
         host:
             pattern: /test
             host: foo\.example\.org

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/remember_me_options.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/remember_me_options.yml
@@ -7,6 +7,6 @@ security:
         main:
             form_login: true
             remember_me:
-                key: TheKey
+                secret: TheSecret
                 catch_exceptions: false
                 token_provider: token_provider_id

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * deprecated `getKey()` of the `AnonymousToken`, `RememberMeToken` and `AbstractRememberMeServices` classes
+   in favor of `getSecret()`.
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/AnonymousAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/AnonymousAuthenticationProvider.php
@@ -22,16 +22,22 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
  */
 class AnonymousAuthenticationProvider implements AuthenticationProviderInterface
 {
-    private $key;
+    /**
+     * Used to determine if the token is created by the application
+     * instead of a malicious client.
+     *
+     * @var string
+     */
+    private $secret;
 
     /**
      * Constructor.
      *
-     * @param string $key The key shared with the authentication token
+     * @param string $secret The secret shared with the AnonymousToken
      */
-    public function __construct($key)
+    public function __construct($secret)
     {
-        $this->key = $key;
+        $this->secret = $secret;
     }
 
     /**
@@ -43,7 +49,7 @@ class AnonymousAuthenticationProvider implements AuthenticationProviderInterface
             return;
         }
 
-        if ($this->key !== $token->getKey()) {
+        if ($this->secret !== $token->getSecret()) {
             throw new BadCredentialsException('The Token does not contain the expected key.');
         }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
@@ -19,20 +19,20 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 class RememberMeAuthenticationProvider implements AuthenticationProviderInterface
 {
     private $userChecker;
-    private $key;
+    private $secret;
     private $providerKey;
 
     /**
      * Constructor.
      *
      * @param UserCheckerInterface $userChecker An UserCheckerInterface interface
-     * @param string               $key         A key
-     * @param string               $providerKey A provider key
+     * @param string               $secret         A secret
+     * @param string               $providerKey A provider secret
      */
-    public function __construct(UserCheckerInterface $userChecker, $key, $providerKey)
+    public function __construct(UserCheckerInterface $userChecker, $secret, $providerKey)
     {
         $this->userChecker = $userChecker;
-        $this->key = $key;
+        $this->secret = $secret;
         $this->providerKey = $providerKey;
     }
 
@@ -45,14 +45,14 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
             return;
         }
 
-        if ($this->key !== $token->getKey()) {
-            throw new BadCredentialsException('The presented key does not match.');
+        if ($this->secret !== $token->getSecret()) {
+            throw new BadCredentialsException('The presented secret does not match.');
         }
 
         $user = $token->getUser();
         $this->userChecker->checkPreAuth($user);
 
-        $authenticatedToken = new RememberMeToken($user, $this->providerKey, $this->key);
+        $authenticatedToken = new RememberMeToken($user, $this->providerKey, $this->secret);
         $authenticatedToken->setAttributes($token->getAttributes());
 
         return $authenticatedToken;

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
@@ -26,7 +26,7 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
      * Constructor.
      *
      * @param UserCheckerInterface $userChecker An UserCheckerInterface interface
-     * @param string               $secret         A secret
+     * @param string               $secret      A secret
      * @param string               $providerKey A provider secret
      */
     public function __construct(UserCheckerInterface $userChecker, $secret, $providerKey)

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -20,20 +20,20 @@ use Symfony\Component\Security\Core\Role\RoleInterface;
  */
 class AnonymousToken extends AbstractToken
 {
-    private $key;
+    private $secret;
 
     /**
      * Constructor.
      *
-     * @param string          $key   The key shared with the authentication provider
-     * @param string          $user  The user
-     * @param RoleInterface[] $roles An array of roles
+     * @param string          $secret A secret used to make sure the token is created by the app and not by a malicious client
+     * @param string          $user   The user
+     * @param RoleInterface[] $roles  An array of roles
      */
-    public function __construct($key, $user, array $roles = array())
+    public function __construct($secret, $user, array $roles = array())
     {
         parent::__construct($roles);
 
-        $this->key = $key;
+        $this->secret = $secret;
         $this->setUser($user);
         $this->setAuthenticated(true);
     }
@@ -47,13 +47,23 @@ class AnonymousToken extends AbstractToken
     }
 
     /**
-     * Returns the key.
-     *
-     * @return string The Key
+     * @deprecated Since version 2.8, to be removed in 3.0. Use getSecret() instead.
      */
     public function getKey()
     {
-        return $this->key;
+        @trigger_error(__method__.'() is deprecated since version 2.8 and will be removed in 3.0. Use getSecret() instead.', E_USER_DEPRECATED);
+
+        return $this->getSecret();
+    }
+
+    /**
+     * Returns the secret.
+     *
+     * @return string
+     */
+    public function getSecret()
+    {
+        return $this->secret;
     }
 
     /**
@@ -61,7 +71,7 @@ class AnonymousToken extends AbstractToken
      */
     public function serialize()
     {
-        return serialize(array($this->key, parent::serialize()));
+        return serialize(array($this->secret, parent::serialize()));
     }
 
     /**
@@ -69,7 +79,7 @@ class AnonymousToken extends AbstractToken
      */
     public function unserialize($serialized)
     {
-        list($this->key, $parentStr) = unserialize($serialized);
+        list($this->secret, $parentStr) = unserialize($serialized);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class RememberMeToken extends AbstractToken
 {
-    private $key;
+    private $secret;
     private $providerKey;
 
     /**
@@ -28,16 +28,16 @@ class RememberMeToken extends AbstractToken
      *
      * @param UserInterface $user
      * @param string        $providerKey
-     * @param string        $key
+     * @param string        $secret      A secret used to make sure the token is created by the app and not by a malicious client
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(UserInterface $user, $providerKey, $key)
+    public function __construct(UserInterface $user, $providerKey, $secret)
     {
         parent::__construct($user->getRoles());
 
-        if (empty($key)) {
-            throw new \InvalidArgumentException('$key must not be empty.');
+        if (empty($secret)) {
+            throw new \InvalidArgumentException('$secret must not be empty.');
         }
 
         if (empty($providerKey)) {
@@ -45,7 +45,7 @@ class RememberMeToken extends AbstractToken
         }
 
         $this->providerKey = $providerKey;
-        $this->key = $key;
+        $this->secret = $secret;
 
         $this->setUser($user);
         parent::setAuthenticated(true);
@@ -64,9 +64,9 @@ class RememberMeToken extends AbstractToken
     }
 
     /**
-     * Returns the provider key.
+     * Returns the provider secret.
      *
-     * @return string The provider key
+     * @return string The provider secret
      */
     public function getProviderKey()
     {
@@ -74,13 +74,23 @@ class RememberMeToken extends AbstractToken
     }
 
     /**
-     * Returns the key.
-     *
-     * @return string The Key
+     * @deprecated Since version 2.8, to be removed in 3.0. Use getSecret() instead.
      */
     public function getKey()
     {
-        return $this->key;
+        @trigger_error(__method__.'() is deprecated since version 2.8 and will be removed in 3.0. Use getSecret() instead.', E_USER_DEPRECATED);
+
+        return $this->getSecret();
+    }
+
+    /**
+     * Returns the secret.
+     *
+     * @return string
+     */
+    public function getSecret()
+    {
+        return $this->secret;
     }
 
     /**
@@ -97,7 +107,7 @@ class RememberMeToken extends AbstractToken
     public function serialize()
     {
         return serialize(array(
-            $this->key,
+            $this->secret,
             $this->providerKey,
             parent::serialize(),
         ));
@@ -108,7 +118,7 @@ class RememberMeToken extends AbstractToken
      */
     public function unserialize($serialized)
     {
-        list($this->key, $this->providerKey, $parentStr) = unserialize($serialized);
+        list($this->secret, $this->providerKey, $parentStr) = unserialize($serialized);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
@@ -37,7 +37,7 @@ class AnonymousAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->getProvider('foo');
 
-        $this->assertNull($provider->authenticate($this->getSupportedToken('bar')));
+        $provider->authenticate($this->getSupportedToken('bar'));
     }
 
     public function testAuthenticate()
@@ -50,9 +50,9 @@ class AnonymousAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function getSupportedToken($key)
     {
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', array('getKey'), array(), '', false);
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', array('getSecret'), array(), '', false);
         $token->expects($this->any())
-              ->method('getKey')
+              ->method('getSecret')
               ->will($this->returnValue($key))
         ;
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -36,10 +36,10 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
      */
-    public function testAuthenticateWhenKeysDoNotMatch()
+    public function testAuthenticateWhenSecretsDoNotMatch()
     {
-        $provider = $this->getProvider(null, 'key1');
-        $token = $this->getSupportedToken(null, 'key2');
+        $provider = $this->getProvider(null, 'secret1');
+        $token = $this->getSupportedToken(null, 'secret2');
 
         $provider->authenticate($token);
     }
@@ -77,7 +77,7 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $authToken->getCredentials());
     }
 
-    protected function getSupportedToken($user = null, $key = 'test')
+    protected function getSupportedToken($user = null, $secret = 'test')
     {
         if (null === $user) {
             $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
@@ -87,7 +87,7 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue(array()));
         }
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', array('getProviderKey'), array($user, 'foo', $key));
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', array('getProviderKey'), array($user, 'foo', $secret));
         $token
             ->expects($this->once())
             ->method('getProviderKey')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AnonymousTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AnonymousTokenTest.php
@@ -28,7 +28,7 @@ class AnonymousTokenTest extends \PHPUnit_Framework_TestCase
     public function testGetKey()
     {
         $token = new AnonymousToken('foo', 'bar');
-        $this->assertEquals('foo', $token->getKey());
+        $this->assertEquals('foo', $token->getSecret());
     }
 
     public function testGetCredentials()

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -22,7 +22,7 @@ class RememberMeTokenTest extends \PHPUnit_Framework_TestCase
         $token = new RememberMeToken($user, 'fookey', 'foo');
 
         $this->assertEquals('fookey', $token->getProviderKey());
-        $this->assertEquals('foo', $token->getKey());
+        $this->assertEquals('foo', $token->getSecret());
         $this->assertEquals(array(new Role('ROLE_FOO')), $token->getRoles());
         $this->assertSame($user, $token->getUser());
         $this->assertTrue($token->isAuthenticated());
@@ -31,7 +31,7 @@ class RememberMeTokenTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testConstructorKeyCannotBeNull()
+    public function testConstructorSecretCannotBeNull()
     {
         new RememberMeToken(
             $this->getUser(),
@@ -43,7 +43,7 @@ class RememberMeTokenTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testConstructorKeyCannotBeEmptyString()
+    public function testConstructorSecretCannotBeEmptyString()
     {
         new RememberMeToken(
             $this->getUser(),

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -36,24 +36,24 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
     protected $logger;
     protected $options;
     private $providerKey;
-    private $key;
+    private $secret;
     private $userProviders;
 
     /**
      * Constructor.
      *
      * @param array           $userProviders
-     * @param string          $key
+     * @param string          $secret
      * @param string          $providerKey
      * @param array           $options
      * @param LoggerInterface $logger
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(array $userProviders, $key, $providerKey, array $options = array(), LoggerInterface $logger = null)
+    public function __construct(array $userProviders, $secret, $providerKey, array $options = array(), LoggerInterface $logger = null)
     {
-        if (empty($key)) {
-            throw new \InvalidArgumentException('$key must not be empty.');
+        if (empty($secret)) {
+            throw new \InvalidArgumentException('$secret must not be empty.');
         }
         if (empty($providerKey)) {
             throw new \InvalidArgumentException('$providerKey must not be empty.');
@@ -63,7 +63,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
         }
 
         $this->userProviders = $userProviders;
-        $this->key = $key;
+        $this->secret = $secret;
         $this->providerKey = $providerKey;
         $this->options = $options;
         $this->logger = $logger;
@@ -81,11 +81,21 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
     }
 
     /**
-     * @return string
+     * @deprecated Since version 2.8, to be removed in 3.0. Use getSecret() instead.
      */
     public function getKey()
     {
-        return $this->key;
+        @trigger_error(__method__.'() is deprecated since version 2.8 and will be removed in 3.0. Use getSecret() instead.', E_USER_DEPRECATED);
+
+        return $this->getSecret();
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecret()
+    {
+        return $this->secret;
     }
 
     /**
@@ -122,7 +132,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
                 $this->logger->info('Remember-me cookie accepted.');
             }
 
-            return new RememberMeToken($user, $this->providerKey, $this->key);
+            return new RememberMeToken($user, $this->providerKey, $this->secret);
         } catch (CookieTheftException $e) {
             $this->cancelCookie($request);
 

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -38,15 +38,15 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
      * Constructor.
      *
      * @param array                 $userProviders
-     * @param string                $key
+     * @param string                $secret
      * @param string                $providerKey
      * @param array                 $options
      * @param LoggerInterface       $logger
      * @param SecureRandomInterface $secureRandom
      */
-    public function __construct(array $userProviders, $key, $providerKey, array $options = array(), LoggerInterface $logger = null, SecureRandomInterface $secureRandom)
+    public function __construct(array $userProviders, $secret, $providerKey, array $options = array(), LoggerInterface $logger = null, SecureRandomInterface $secureRandom)
     {
-        parent::__construct($userProviders, $key, $providerKey, $options, $logger);
+        parent::__construct($userProviders, $secret, $providerKey, $options, $logger);
 
         $this->secureRandom = $secureRandom;
     }

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -121,6 +121,6 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      */
     protected function generateCookieHash($class, $username, $expires, $password)
     {
-        return hash_hmac('sha256', $class.$username.$expires.$password, $this->getKey());
+        return hash_hmac('sha256', $class.$username.$expires.$password, $this->getSecret());
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -35,7 +35,7 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->method('authenticate')
         ;
 
-        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheKey', null, $authenticationManager);
+        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheSecret', null, $authenticationManager);
         $listener->handle($this->getMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false));
     }
 
@@ -48,7 +48,7 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(null))
         ;
 
-        $anonymousToken = new AnonymousToken('TheKey', 'anon.', array());
+        $anonymousToken = new AnonymousToken('TheSecret', 'anon.', array());
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
         $authenticationManager
@@ -56,7 +56,7 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->method('authenticate')
             ->with(self::logicalAnd(
                        $this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken'),
-                       $this->attributeEqualTo('key', 'TheKey')
+                       $this->attributeEqualTo('secret', 'TheSecret')
             ))
             ->will($this->returnValue($anonymousToken))
         ;
@@ -67,7 +67,7 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->with($anonymousToken)
         ;
 
-        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheKey', null, $authenticationManager);
+        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheSecret', null, $authenticationManager);
         $listener->handle($this->getMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false));
     }
 
@@ -82,7 +82,7 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
         $authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheKey', $logger, $authenticationManager);
+        $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheSecret', $logger, $authenticationManager);
         $listener->handle($this->getMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false));
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -25,10 +25,10 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $service->getRememberMeParameter());
     }
 
-    public function testGetKey()
+    public function testGetSecret()
     {
         $service = $this->getService();
-        $this->assertEquals('fookey', $service->getKey());
+        $this->assertEquals('foosecret', $service->getSecret());
     }
 
     public function testAutoLoginReturnsNullWhenNoCookie()
@@ -78,7 +78,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
         $returnedToken = $service->autoLogin($request);
 
         $this->assertSame($user, $returnedToken->getUser());
-        $this->assertSame('fookey', $returnedToken->getKey());
+        $this->assertSame('foosecret', $returnedToken->getSecret());
         $this->assertSame('fookey', $returnedToken->getProviderKey());
     }
 
@@ -268,7 +268,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
         }
 
         return $this->getMockForAbstractClass('Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices', array(
-            array($userProvider), 'fookey', 'fookey', $options, $logger,
+            array($userProvider), 'foosecret', 'fookey', $options, $logger,
         ));
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -174,7 +174,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
 
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', $returnedToken);
         $this->assertSame($user, $returnedToken->getUser());
-        $this->assertEquals('fookey', $returnedToken->getKey());
+        $this->assertEquals('foosecret', $returnedToken->getSecret());
         $this->assertTrue($request->attributes->has(RememberMeServicesInterface::COOKIE_ATTR_NAME));
     }
 
@@ -311,7 +311,7 @@ class PersistentTokenBasedRememberMeServicesTest extends \PHPUnit_Framework_Test
             $userProvider = $this->getProvider();
         }
 
-        return new PersistentTokenBasedRememberMeServices(array($userProvider), 'fookey', 'fookey', $options, $logger, new SecureRandom(sys_get_temp_dir().'/_sf2.seed'));
+        return new PersistentTokenBasedRememberMeServices(array($userProvider), 'foosecret', 'fookey', $options, $logger, new SecureRandom(sys_get_temp_dir().'/_sf2.seed'));
     }
 
     protected function getProvider()

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -140,7 +140,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', $returnedToken);
         $this->assertSame($user, $returnedToken->getUser());
-        $this->assertEquals('fookey', $returnedToken->getKey());
+        $this->assertEquals('foosecret', $returnedToken->getSecret());
     }
 
     public function provideUsernamesForAutoLogin()
@@ -264,7 +264,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
             $userProvider = $this->getProvider();
         }
 
-        $service = new TokenBasedRememberMeServices(array($userProvider), 'fookey', 'fookey', $options, $logger);
+        $service = new TokenBasedRememberMeServices(array($userProvider), 'foosecret', 'fookey', $options, $logger);
 
         return $service;
     }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/security-core": "~2.6|~3.0.0",
+        "symfony/security-core": "~2.8|~3.0.0",
         "symfony/event-dispatcher": "~2.1|~3.0.0",
         "symfony/http-foundation": "~2.4|~3.0.0",
         "symfony/http-kernel": "~2.4|~3.0.0"


### PR DESCRIPTION
There are 2 very vague parameter names in the authentication process: `$providerKey` and `$key`. Some tokens/providers have the first one, some tokens/providers the second one and some both. An overview:

| Token | `providerKey` | `key` |
| --- | --- | --- |
| `AnonymousToken` | - | yes |
| `PreAuth...Token` | yes | - |
| `RememberMeToken` | yes | yes |
| `UsernamePasswordToken` | yes | - |

Both names are extremely general and their PHPdocs contains pure no-shit-sherlock-descriptions :squirrel: (like "The key."). This made me and @iltar think it's just an inconsistency and they have the same meaning.
...until we dived deeper into the code and came to the conclusion that `$key` has a Security task (while `$providerKey` doesn't really). If it takes people connected to Symfony internals 30+ minutes to find this out, it should be considered for an improvement imo.

So here is our suggestion: **Rename `$key` to `$secret`**. This explains much better what the value of the string has to be (for instance, it's important that the string is not easily guessable and cannot be found out, according to the Spring docs). It also explains the usage better (it's used as a replacement for credentials and to hash the RememberMeToken).

**Tl;dr**: `$key` and `$providerKey` are too general names, let's improve DX by renaming them. This PR tackles `$key` by renaming it to `$secret`.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

_My excuse for the completely unrelated branch name_
