### PR TITLE
[Finder] Fix PHPUnit param order

### DIFF
--- a/src/Symfony/Component/Finder/Tests/GlobTest.php
+++ b/src/Symfony/Component/Finder/Tests/GlobTest.php
@@ -15,11 +15,10 @@ use Symfony\Component\Finder\Glob;
 
 class GlobTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testGlobToRegexDelimiters()
     {
-        $this->assertEquals(Glob::toRegex('.*'), '#^\.[^/]*$#');
-        $this->assertEquals(Glob::toRegex('.*', true, true, ''), '^\.[^/]*$');
-        $this->assertEquals(Glob::toRegex('.*', true, true, '/'), '/^\.[^/]*$/');
+        $this->assertEquals('#^\.[^/]*$#', Glob::toRegex('.*'));
+        $this->assertEquals('^\.[^/]*$', Glob::toRegex('.*', true, true, ''));
+        $this->assertEquals('/^\.[^/]*$/', Glob::toRegex('.*', true, true, '/'));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Fairly cosmetic but it confused me for a while when I broke tests and PHPUnit said something like

```
--- Expected
+++ Actual
@@ @@
-'/^(?=[^\.])x\.[^/]*$/'
+'/^\.[^/]*$/'
```

Looks like 2.7 is the earliest this can be merged into.
