### PR TITLE
[BrowserKit] fix: moved closing bracket on UnexpectedValueException ...

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -77,7 +77,7 @@ class Cookie
         if (null !== $expires) {
             $timestampAsDateTime = \DateTime::createFromFormat('U', $expires);
             if (false === $timestampAsDateTime) {
-                throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.'), $expires);
+                throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.', $expires));
             }
 
             $this->expires = $timestampAsDateTime->getTimestamp();


### PR DESCRIPTION
…  to prevent it throwing its own exception

Found this whilst trying to run some Codeception acceptance tests. 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
