### PR TITLE
[Translation] Azerbaijani language pluralization rule is wrong

### DIFF
--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -55,6 +55,7 @@ class PluralizationRules
          * Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
          */
         switch ($locale) {
+            case 'az':
             case 'bo':
             case 'dz':
             case 'id':
@@ -73,7 +74,6 @@ class PluralizationRules
                 break;
 
             case 'af':
-            case 'az':
             case 'bn':
             case 'bg':
             case 'ca':


### PR DESCRIPTION
In AZ, as in TR, pluralization is always 0: 

0 kitab (zero books)
1 kitab (1 book)
3 kitab (3 books)
104 kitab (104 books)

Apparently ZF ruleset was wrong in the first place :)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15152 |
| License | MIT |
| Doc PR | - |
