### PR TITLE
[Process] Return memory_limit argument for child

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -81,6 +81,11 @@ class PhpExecutableFinder
             $arguments[] = '--php';
         }
 
+        // Pass on memory_limit in case this was specified on current command
+        if ($memoryLimit = ini_get('memory_limit')) {
+            $arguments[] = '-d memory_limit=' . $memoryLimit;
+        }
+
         return $arguments;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Adds `'-d memory_limit=' . ini_get('memory_limit')` to arguments passed to sub process in case user has specified this param when executing parent. Could alternatively be fixed in DistributionBundle instead, as it seems to have some [additional logic](https://github.com/sensiolabs/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php#L432) surrounding arguments.
