### PR TITLE
[Validator] Added missing error codes and turned codes into UUIDs

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolationInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationInterface.php
@@ -130,7 +130,7 @@ interface ConstraintViolationInterface
     /**
      * Returns a machine-digestible error code for the violation.
      *
-     * @return mixed The error code.
+     * @return string|null The error code.
      */
     public function getCode();
 }

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  * Used for the comparison of values.
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class AbstractComparison extends Constraint
 {

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -60,12 +60,14 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
                     ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE))
                     ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE))
                     ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($comparedValue))
+                    ->setCode($this->getErrorCode())
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE))
                     ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE))
                     ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($comparedValue))
+                    ->setCode($this->getErrorCode())
                     ->addViolation();
             }
         }
@@ -80,4 +82,13 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
      * @return bool true if the relationship is valid, false otherwise
      */
     abstract protected function compareValues($value1, $value2);
+
+    /**
+     * Returns the error code used if the comparison fails.
+     *
+     * @return string|null The error code or `null` if no code should be set
+     */
+    protected function getErrorCode()
+    {
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Blank.php
+++ b/src/Symfony/Component/Validator/Constraints/Blank.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class Blank extends Constraint
 {
+    const NOT_BLANK_ERROR = '183ad2de-533d-4796-a439-6d3c3852b549';
+
+    protected static $errorNames = array(
+        self::NOT_BLANK_ERROR => 'NOT_BLANK_ERROR',
+    );
+
     public $message = 'This value should be blank.';
 }

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -36,10 +36,12 @@ class BlankValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Blank::NOT_BLANK_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Blank::NOT_BLANK_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/CardScheme.php
+++ b/src/Symfony/Component/Validator/Constraints/CardScheme.php
@@ -24,8 +24,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class CardScheme extends Constraint
 {
-    const NOT_NUMERIC_ERROR = 1;
-    const INVALID_FORMAT_ERROR = 2;
+    const NOT_NUMERIC_ERROR = 'a2ad9231-e827-485f-8a1e-ef4d9a6d5c2e';
+    const INVALID_FORMAT_ERROR = 'a8faedbf-1c2f-4695-8d22-55783be8efed';
 
     protected static $errorNames = array(
         self::NOT_NUMERIC_ERROR => 'NOT_NUMERIC_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Choice.php
+++ b/src/Symfony/Component/Validator/Constraints/Choice.php
@@ -23,9 +23,9 @@ use Symfony\Component\Validator\Constraint;
  */
 class Choice extends Constraint
 {
-    const NO_SUCH_CHOICE_ERROR = 1;
-    const TOO_FEW_ERROR = 2;
-    const TOO_MANY_ERROR = 3;
+    const NO_SUCH_CHOICE_ERROR = '8e179f1b-97aa-4560-a02f-2a8b42e49df7';
+    const TOO_FEW_ERROR = '11edd7eb-5872-4b6e-9f12-89923999fd0e';
+    const TOO_MANY_ERROR = '9bd98e49-211c-433f-8630-fd1c2d0f08c3';
 
     protected static $errorNames = array(
         self::NO_SUCH_CHOICE_ERROR => 'NO_SUCH_CHOICE_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -23,8 +23,8 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class Collection extends Composite
 {
-    const MISSING_FIELD_ERROR = 1;
-    const NO_SUCH_FIELD_ERROR = 2;
+    const MISSING_FIELD_ERROR = '2fa2158c-2a7f-484b-98aa-975522539ff8';
+    const NO_SUCH_FIELD_ERROR = '7703c766-b5d5-4cef-ace7-ae0dd82304e9';
 
     protected static $errorNames = array(
         self::MISSING_FIELD_ERROR => 'MISSING_FIELD_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -24,8 +24,8 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  */
 class Count extends Constraint
 {
-    const TOO_FEW_ERROR = 1;
-    const TOO_MANY_ERROR = 2;
+    const TOO_FEW_ERROR = 'bef8e338-6ae5-4caf-b8e2-50e7b0579e69';
+    const TOO_MANY_ERROR = '756b1212-697c-468d-a9ad-50dd783bb169';
 
     protected static $errorNames = array(
         self::TOO_FEW_ERROR => 'TOO_FEW_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Country.php
+++ b/src/Symfony/Component/Validator/Constraints/Country.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class Country extends Constraint
 {
+    const NO_SUCH_COUNTRY_ERROR = '8f900c12-61bd-455d-9398-996cd040f7f0';
+
+    protected static $errorNames = array(
+        self::NO_SUCH_COUNTRY_ERROR => 'NO_SUCH_COUNTRY_ERROR',
+    );
+
     public $message = 'This value is not a valid country.';
 }

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -50,10 +50,12 @@ class CountryValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Country::NO_SUCH_COUNTRY_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Country::NO_SUCH_COUNTRY_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Currency.php
+++ b/src/Symfony/Component/Validator/Constraints/Currency.php
@@ -18,10 +18,17 @@ use Symfony\Component\Validator\Constraint;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Miha Vrhovnik <miha.vrhovnik@pagein.si>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
 class Currency extends Constraint
 {
+    const NO_SUCH_CURRENCY_ERROR = '69945ac1-2db4-405f-bec7-d2772f73df52';
+
+    protected static $errorNames = array(
+        self::NO_SUCH_CURRENCY_ERROR => 'NO_SUCH_CURRENCY_ERROR',
+    );
+
     public $message = 'This value is not a valid currency.';
 }

--- a/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
@@ -21,6 +21,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * Validates whether a value is a valid currency.
  *
  * @author Miha Vrhovnik <miha.vrhovnik@pagein.si>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
@@ -50,10 +51,12 @@ class CurrencyValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Currency::NO_SUCH_CURRENCY_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Currency::NO_SUCH_CURRENCY_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -23,8 +23,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class Date extends Constraint
 {
-    const INVALID_FORMAT_ERROR = 1;
-    const INVALID_DATE_ERROR = 2;
+    const INVALID_FORMAT_ERROR = '69819696-02ac-4a99-9ff0-14e127c4d1bc';
+    const INVALID_DATE_ERROR = '3c184ce5-b31d-4de7-8b76-326da7b2be93';
 
     protected static $errorNames = array(
         self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -23,9 +23,9 @@ use Symfony\Component\Validator\Constraint;
  */
 class DateTime extends Constraint
 {
-    const INVALID_FORMAT_ERROR = 1;
-    const INVALID_DATE_ERROR = 2;
-    const INVALID_TIME_ERROR = 3;
+    const INVALID_FORMAT_ERROR = '1a9da513-2640-4f84-9b6a-4d99dcddc628';
+    const INVALID_DATE_ERROR = 'd52afa47-620d-4d99-9f08-f4d85b36e33c';
+    const INVALID_TIME_ERROR = '5e797c9d-74f7-4098-baa3-94390c447b27';
 
     protected static $errorNames = array(
         self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -23,9 +23,9 @@ use Symfony\Component\Validator\Constraint;
  */
 class Email extends Constraint
 {
-    const INVALID_FORMAT_ERROR = 1;
-    const MX_CHECK_FAILED_ERROR = 2;
-    const HOST_CHECK_FAILED_ERROR = 3;
+    const INVALID_FORMAT_ERROR = 'bd79c0ab-ddba-46cc-a703-a7a4b08de310';
+    const MX_CHECK_FAILED_ERROR = 'bf447c1c-0266-4e10-9c6c-573df282e413';
+    const HOST_CHECK_FAILED_ERROR = '7da53a8b-56f3-4288-bb3e-ee9ede4ef9a1';
 
     protected static $errorNames = array(
         self::INVALID_FORMAT_ERROR => 'STRICT_CHECK_FAILED_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/EqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/EqualTo.php
@@ -16,8 +16,15 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class EqualTo extends AbstractComparison
 {
+    const NOT_EQUAL_ERROR = '478618a7-95ba-473d-9101-cabd45e49115';
+
+    protected static $errorNames = array(
+        self::NOT_EQUAL_ERROR => 'NOT_EQUAL_ERROR',
+    );
+
     public $message = 'This value should be equal to {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/EqualToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EqualToValidator.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are equal (==).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class EqualToValidator extends AbstractComparisonValidator
 {
@@ -24,5 +25,13 @@ class EqualToValidator extends AbstractComparisonValidator
     protected function compareValues($value1, $value2)
     {
         return $value1 == $value2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return EqualTo::NOT_EQUAL_ERROR;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -22,6 +22,12 @@ use Symfony\Component\Validator\Constraint;
  */
 class Expression extends Constraint
 {
+    const EXPRESSION_FAILED_ERROR = '6b3befbc-2f01-4ddf-be21-b57898905284';
+
+    protected static $errorNames = array(
+        self::EXPRESSION_FAILED_ERROR => 'EXPRESSION_FAILED_ERROR',
+    );
+
     public $message = 'This value is not valid.';
     public $expression;
 

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -88,10 +88,12 @@ class ExpressionValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Expression::EXPRESSION_FAILED_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Expression::EXPRESSION_FAILED_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -26,11 +26,11 @@ class File extends Constraint
 {
     // Check the Image constraint for clashes if adding new constants here
 
-    const NOT_FOUND_ERROR = 1;
-    const NOT_READABLE_ERROR = 2;
-    const EMPTY_ERROR = 3;
-    const TOO_LARGE_ERROR = 4;
-    const INVALID_MIME_TYPE_ERROR = 5;
+    const NOT_FOUND_ERROR = 'd2a3fb6e-7ddc-4210-8fbf-2ab345ce1998';
+    const NOT_READABLE_ERROR = 'c20c92a4-5bfa-4202-9477-28e800e0f6ff';
+    const EMPTY_ERROR = '5d743385-9775-4aa5-8ff5-495fb1e60137';
+    const TOO_LARGE_ERROR = 'df8637af-d466-48c6-a59d-e7126250a654';
+    const INVALID_MIME_TYPE_ERROR = '744f00bc-4389-4c74-92de-9a43cde55534';
 
     protected static $errorNames = array(
         self::NOT_FOUND_ERROR => 'NOT_FOUND_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/GreaterThan.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThan.php
@@ -16,8 +16,15 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class GreaterThan extends AbstractComparison
 {
+    const TOO_LOW_ERROR = '778b7ae0-84d3-481a-9dec-35fdb64b1d78';
+
+    protected static $errorNames = array(
+        self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
+    );
+
     public $message = 'This value should be greater than {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
@@ -16,8 +16,15 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class GreaterThanOrEqual extends AbstractComparison
 {
+    const TOO_LOW_ERROR = 'ea4e51d1-3342-48bd-87f1-9e672cd90cad';
+
+    protected static $errorNames = array(
+        self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
+    );
+
     public $message = 'This value should be greater than or equal to {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqualValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqualValidator.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are greater than or equal to the previous (>=).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class GreaterThanOrEqualValidator extends AbstractComparisonValidator
 {
@@ -24,5 +25,13 @@ class GreaterThanOrEqualValidator extends AbstractComparisonValidator
     protected function compareValues($value1, $value2)
     {
         return $value1 >= $value2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return GreaterThanOrEqual::TOO_LOW_ERROR;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanValidator.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are greater than the previous (>).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class GreaterThanValidator extends AbstractComparisonValidator
 {
@@ -24,5 +25,13 @@ class GreaterThanValidator extends AbstractComparisonValidator
     protected function compareValues($value1, $value2)
     {
         return $value1 > $value2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return GreaterThan::TOO_LOW_ERROR;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/GroupSequenceProvider.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequenceProvider.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @Annotation
  * @Target({"CLASS", "ANNOTATION"})
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class GroupSequenceProvider
 {

--- a/src/Symfony/Component/Validator/Constraints/Iban.php
+++ b/src/Symfony/Component/Validator/Constraints/Iban.php
@@ -23,11 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class Iban extends Constraint
 {
-    const TOO_SHORT_ERROR = 1;
-    const INVALID_COUNTRY_CODE_ERROR = 2;
-    const INVALID_CHARACTERS_ERROR = 3;
-    const INVALID_CASE_ERROR = 4;
-    const CHECKSUM_FAILED_ERROR = 5;
+    const TOO_SHORT_ERROR = '88e5e319-0aeb-4979-a27e-3d9ce0c16166';
+    const INVALID_COUNTRY_CODE_ERROR = 'de78ee2c-bd50-44e2-aec8-3d8228aeadb9';
+    const INVALID_CHARACTERS_ERROR = '8d3d85e4-784f-4719-a5bc-d9e40d45a3a5';
+    const INVALID_CASE_ERROR = 'f4bf62fe-03ec-42af-a53b-68e21b1e7274';
+    const CHECKSUM_FAILED_ERROR = 'b9401321-f9bf-4dcb-83c1-f31094440795';
 
     protected static $errorNames = array(
         self::TOO_SHORT_ERROR => 'TOO_SHORT_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
@@ -16,8 +16,15 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class IdenticalTo extends AbstractComparison
 {
+    const NOT_IDENTICAL_ERROR = '2a8cc50f-58a2-4536-875e-060a2ce69ed5';
+
+    protected static $errorNames = array(
+        self::NOT_IDENTICAL_ERROR => 'NOT_IDENTICAL_ERROR',
+    );
+
     public $message = 'This value should be identical to {{ compared_value_type }} {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/IdenticalToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IdenticalToValidator.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are identical (===).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class IdenticalToValidator extends AbstractComparisonValidator
 {
@@ -24,5 +25,13 @@ class IdenticalToValidator extends AbstractComparisonValidator
     protected function compareValues($value1, $value2)
     {
         return $value1 === $value2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return IdenticalTo::NOT_IDENTICAL_ERROR;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -22,18 +22,16 @@ namespace Symfony\Component\Validator\Constraints;
  */
 class Image extends File
 {
-    // Don't reuse values used in File
-
-    const SIZE_NOT_DETECTED_ERROR = 10;
-    const TOO_WIDE_ERROR = 11;
-    const TOO_NARROW_ERROR = 12;
-    const TOO_HIGH_ERROR = 13;
-    const TOO_LOW_ERROR = 14;
-    const RATIO_TOO_BIG_ERROR = 15;
-    const RATIO_TOO_SMALL_ERROR = 16;
-    const SQUARE_NOT_ALLOWED_ERROR = 17;
-    const LANDSCAPE_NOT_ALLOWED_ERROR = 18;
-    const PORTRAIT_NOT_ALLOWED_ERROR = 19;
+    const SIZE_NOT_DETECTED_ERROR = '6d55c3f4-e58e-4fe3-91ee-74b492199956';
+    const TOO_WIDE_ERROR = '7f87163d-878f-47f5-99ba-a8eb723a1ab2';
+    const TOO_NARROW_ERROR = '9afbd561-4f90-4a27-be62-1780fc43604a';
+    const TOO_HIGH_ERROR = '7efae81c-4877-47ba-aa65-d01ccb0d4645';
+    const TOO_LOW_ERROR = 'aef0cb6a-c07f-4894-bc08-1781420d7b4c';
+    const RATIO_TOO_BIG_ERROR = '70cafca6-168f-41c9-8c8c-4e47a52be643';
+    const RATIO_TOO_SMALL_ERROR = '59b8c6ef-bcf2-4ceb-afff-4642ed92f12e';
+    const SQUARE_NOT_ALLOWED_ERROR = '5d41425b-facb-47f7-a55a-de9fbe45cb46';
+    const LANDSCAPE_NOT_ALLOWED_ERROR = '6f895685-7cf2-4d65-b3da-9029c5581d88';
+    const PORTRAIT_NOT_ALLOWED_ERROR = '65608156-77da-4c79-a88c-02ef6d18c782';
 
     // Include the mapping from the base class
 

--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -46,6 +46,8 @@ class Ip extends Constraint
     const V6_ONLY_PUBLIC = '6_public';
     const ALL_ONLY_PUBLIC = 'all_public';
 
+    const INVALID_IP_ERROR = 'b1b427ae-9f6f-41b0-aa9b-84511fbb3c5b';
+
     protected static $versions = array(
         self::V4,
         self::V6,
@@ -62,6 +64,10 @@ class Ip extends Constraint
         self::V4_ONLY_PUBLIC,
         self::V6_ONLY_PUBLIC,
         self::ALL_ONLY_PUBLIC,
+    );
+
+    protected static $errorNames = array(
+        self::INVALID_IP_ERROR => 'INVALID_IP_ERROR',
     );
 
     public $version = self::V4;

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -99,10 +99,12 @@ class IpValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Ip::INVALID_IP_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Ip::INVALID_IP_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/IsFalse.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalse.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class IsFalse extends Constraint
 {
+    const NOT_FALSE_ERROR = 'd53a91b0-def3-426a-83d7-269da7ab4200';
+
+    protected static $errorNames = array(
+        self::NOT_FALSE_ERROR => 'NOT_FALSE_ERROR',
+    );
+
     public $message = 'This value should be false.';
 }

--- a/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
@@ -39,10 +39,12 @@ class IsFalseValidator extends ConstraintValidator
         if ($this->context instanceof ExecutionContextInterface) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(IsFalse::NOT_FALSE_ERROR)
                 ->addViolation();
         } else {
             $this->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(IsFalse::NOT_FALSE_ERROR)
                 ->addViolation();
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/IsNull.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNull.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class IsNull extends Constraint
 {
+    const NOT_NULL_ERROR = '60d2f30b-8cfa-4372-b155-9656634de120';
+
+    protected static $errorNames = array(
+        self::NOT_NULL_ERROR => 'NOT_NULL_ERROR',
+    );
+
     public $message = 'This value should be null.';
 }

--- a/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
@@ -36,10 +36,12 @@ class IsNullValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(IsNull::NOT_NULL_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(IsNull::NOT_NULL_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/IsTrue.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrue.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class IsTrue extends Constraint
 {
+    const NOT_TRUE_ERROR = '2beabf1c-54c0-4882-a928-05249b26e23b';
+
+    protected static $errorNames = array(
+        self::NOT_TRUE_ERROR => 'NOT_TRUE_ERROR',
+    );
+
     public $message = 'This value should be true.';
 }

--- a/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
@@ -40,10 +40,12 @@ class IsTrueValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(IsTrue::NOT_TRUE_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(IsTrue::NOT_TRUE_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Isbn.php
+++ b/src/Symfony/Component/Validator/Constraints/Isbn.php
@@ -23,11 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class Isbn extends Constraint
 {
-    const TOO_SHORT_ERROR = 1;
-    const TOO_LONG_ERROR = 2;
-    const INVALID_CHARACTERS_ERROR = 3;
-    const CHECKSUM_FAILED_ERROR = 4;
-    const TYPE_NOT_RECOGNIZED_ERROR = 5;
+    const TOO_SHORT_ERROR = '949acbb0-8ef5-43ed-a0e9-032dfd08ae45';
+    const TOO_LONG_ERROR = '3171387d-f80a-47b3-bd6e-60598545316a';
+    const INVALID_CHARACTERS_ERROR = '23d21cea-da99-453d-98b1-a7d916fbb339';
+    const CHECKSUM_FAILED_ERROR = '2881c032-660f-46b6-8153-d352d9706640';
+    const TYPE_NOT_RECOGNIZED_ERROR = 'fa54a457-f042-441f-89c4-066ee5bdd3e1';
 
     protected static $errorNames = array(
         self::TOO_SHORT_ERROR => 'TOO_SHORT_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Issn.php
+++ b/src/Symfony/Component/Validator/Constraints/Issn.php
@@ -22,12 +22,12 @@ use Symfony\Component\Validator\Constraint;
  */
 class Issn extends Constraint
 {
-    const TOO_SHORT_ERROR = 1;
-    const TOO_LONG_ERROR = 2;
-    const MISSING_HYPHEN_ERROR = 3;
-    const INVALID_CHARACTERS_ERROR = 4;
-    const INVALID_CASE_ERROR = 5;
-    const CHECKSUM_FAILED_ERROR = 6;
+    const TOO_SHORT_ERROR = '6a20dd3d-f463-4460-8e7b-18a1b98abbfb';
+    const TOO_LONG_ERROR = '37cef893-5871-464e-8b12-7fb79324833c';
+    const MISSING_HYPHEN_ERROR = '2983286f-8134-4693-957a-1ec4ef887b15';
+    const INVALID_CHARACTERS_ERROR = 'a663d266-37c2-4ece-a914-ae891940c588';
+    const INVALID_CASE_ERROR = '7b6dd393-7523-4a6c-b84d-72b91bba5e1a';
+    const CHECKSUM_FAILED_ERROR = 'b0f92dbc-667c-48de-b526-ad9586d43e85';
 
     protected static $errorNames = array(
         self::TOO_SHORT_ERROR => 'TOO_SHORT_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Language.php
+++ b/src/Symfony/Component/Validator/Constraints/Language.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class Language extends Constraint
 {
+    const NO_SUCH_LANGUAGE_ERROR = 'ee65fec4-9a20-4202-9f39-ca558cd7bdf7';
+
+    protected static $errorNames = array(
+        self::NO_SUCH_LANGUAGE_ERROR => 'NO_SUCH_LANGUAGE_ERROR',
+    );
+
     public $message = 'This value is not a valid language.';
 }

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -50,10 +50,12 @@ class LanguageValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Language::NO_SUCH_LANGUAGE_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Language::NO_SUCH_LANGUAGE_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -24,12 +24,14 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  */
 class Length extends Constraint
 {
-    const TOO_SHORT_ERROR = 1;
-    const TOO_LONG_ERROR = 2;
+    const TOO_SHORT_ERROR = '9ff3fdc4-b214-49db-8718-39c315e33d45';
+    const TOO_LONG_ERROR = 'd94b19cc-114f-4f44-9cc4-4138e80a87b9';
+    const INVALID_CHARACTERS_ERROR = '35e6a710-aa2e-4719-b58e-24b35749b767';
 
     protected static $errorNames = array(
         self::TOO_SHORT_ERROR => 'TOO_SHORT_ERROR',
         self::TOO_LONG_ERROR => 'TOO_LONG_ERROR',
+        self::INVALID_CHARACTERS_ERROR => 'INVALID_CHARACTERS_ERROR',
     );
 
     public $maxMessage = 'This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.';

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -70,12 +70,14 @@ class LengthValidator extends ConstraintValidator
                     ->setParameter('{{ value }}', $this->formatValue($stringValue))
                     ->setParameter('{{ charset }}', $constraint->charset)
                     ->setInvalidValue($value)
+                    ->setCode(Length::INVALID_CHARACTERS_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->charsetMessage)
                     ->setParameter('{{ value }}', $this->formatValue($stringValue))
                     ->setParameter('{{ charset }}', $constraint->charset)
                     ->setInvalidValue($value)
+                    ->setCode(Length::INVALID_CHARACTERS_ERROR)
                     ->addViolation();
             }
 

--- a/src/Symfony/Component/Validator/Constraints/LessThan.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThan.php
@@ -16,8 +16,15 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class LessThan extends AbstractComparison
 {
+    const TOO_HIGH_ERROR = '079d7420-2d13-460c-8756-de810eeb37d2';
+
+    protected static $errorNames = array(
+        self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
+    );
+
     public $message = 'This value should be less than {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
@@ -16,8 +16,15 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class LessThanOrEqual extends AbstractComparison
 {
+    const TOO_HIGH_ERROR = '079d7420-2d13-460c-8756-de810eeb37d2';
+
+    protected static $errorNames = array(
+        self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
+    );
+
     public $message = 'This value should be less than or equal to {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqualValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqualValidator.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are less than or equal to the previous (<=).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class LessThanOrEqualValidator extends AbstractComparisonValidator
 {
@@ -24,5 +25,13 @@ class LessThanOrEqualValidator extends AbstractComparisonValidator
     protected function compareValues($value1, $value2)
     {
         return $value1 <= $value2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return LessThanOrEqual::TOO_HIGH_ERROR;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LessThanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanValidator.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are less than the previous (<).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class LessThanValidator extends AbstractComparisonValidator
 {
@@ -24,5 +25,13 @@ class LessThanValidator extends AbstractComparisonValidator
     protected function compareValues($value1, $value2)
     {
         return $value1 < $value2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return LessThan::TOO_HIGH_ERROR;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Locale.php
+++ b/src/Symfony/Component/Validator/Constraints/Locale.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class Locale extends Constraint
 {
+    const NO_SUCH_LOCALE_ERROR = 'a0af4293-1f1a-4a1c-a328-979cba6182a2';
+
+    protected static $errorNames = array(
+        self::NO_SUCH_LOCALE_ERROR => 'NO_SUCH_LOCALE_ERROR',
+    );
+
     public $message = 'This value is not a valid locale.';
 }

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -50,10 +50,12 @@ class LocaleValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Luhn.php
+++ b/src/Symfony/Component/Validator/Constraints/Luhn.php
@@ -25,8 +25,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class Luhn extends Constraint
 {
-    const INVALID_CHARACTERS_ERROR = 1;
-    const CHECKSUM_FAILED_ERROR = 2;
+    const INVALID_CHARACTERS_ERROR = 'dfad6d23-1b74-4374-929b-5cbb56fc0d9e';
+    const CHECKSUM_FAILED_ERROR = '4d760774-3f50-4cd5-a6d5-b10a3299d8d3';
 
     protected static $errorNames = array(
         self::INVALID_CHARACTERS_ERROR => 'INVALID_CHARACTERS_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/NotBlank.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlank.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class NotBlank extends Constraint
 {
+    const IS_BLANK_ERROR = 'c1051bb4-d103-4f74-8988-acbcafc7fdc3';
+
+    protected static $errorNames = array(
+        self::IS_BLANK_ERROR => 'IS_BLANK_ERROR',
+    );
+
     public $message = 'This value should not be blank.';
 }

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -36,10 +36,12 @@ class NotBlankValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(NotBlank::IS_BLANK_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(NotBlank::IS_BLANK_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
@@ -16,8 +16,15 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class NotEqualTo extends AbstractComparison
 {
+    const IS_EQUAL_ERROR = 'aa2e33da-25c8-4d76-8c6c-812f02ea89dd';
+
+    protected static $errorNames = array(
+        self::IS_EQUAL_ERROR => 'IS_EQUAL_ERROR',
+    );
+
     public $message = 'This value should not be equal to {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/NotEqualToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotEqualToValidator.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values are all unequal (!=).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class NotEqualToValidator extends AbstractComparisonValidator
 {
@@ -24,5 +25,13 @@ class NotEqualToValidator extends AbstractComparisonValidator
     protected function compareValues($value1, $value2)
     {
         return $value1 != $value2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return NotEqualTo::IS_EQUAL_ERROR;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
@@ -16,8 +16,15 @@ namespace Symfony\Component\Validator\Constraints;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class NotIdenticalTo extends AbstractComparison
 {
+    const IS_IDENTICAL_ERROR = '4aaac518-0dda-4129-a6d9-e216b9b454a0';
+
+    protected static $errorNames = array(
+        self::IS_IDENTICAL_ERROR => 'IS_IDENTICAL_ERROR',
+    );
+
     public $message = 'This value should not be identical to {{ compared_value_type }} {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/NotIdenticalToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotIdenticalToValidator.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validates values aren't identical (!==).
  *
  * @author Daniel Holmes <daniel@danielholmes.org>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class NotIdenticalToValidator extends AbstractComparisonValidator
 {
@@ -24,5 +25,13 @@ class NotIdenticalToValidator extends AbstractComparisonValidator
     protected function compareValues($value1, $value2)
     {
         return $value1 !== $value2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return NotIdenticalTo::IS_IDENTICAL_ERROR;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotNull.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNull.php
@@ -23,5 +23,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class NotNull extends Constraint
 {
+    const IS_NULL_ERROR = 'ad32d13f-c3d4-423b-909a-857b961eb720';
+
+    protected static $errorNames = array(
+        self::IS_NULL_ERROR => 'IS_NULL_ERROR',
+    );
+
     public $message = 'This value should not be null.';
 }

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
@@ -32,7 +33,17 @@ class NotNullValidator extends ConstraintValidator
         }
 
         if (null === $value) {
-            $this->context->addViolation($constraint->message);
+            if ($this->context instanceof ExecutionContextInterface) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(NotNull::IS_NULL_ERROR)
+                    ->addViolation();
+            } else {
+                $this->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(NotNull::IS_NULL_ERROR)
+                    ->addViolation();
+            }
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -24,14 +24,32 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  */
 class Range extends Constraint
 {
-    const INVALID_VALUE_ERROR = 1;
-    const BEYOND_RANGE_ERROR = 2;
-    const BELOW_RANGE_ERROR = 3;
+    const INVALID_CHARACTERS_ERROR = 'ad9a9798-7a99-4df7-8ce9-46e416a1e60b';
+    const TOO_HIGH_ERROR = '2d28afcb-e32e-45fb-a815-01c431a86a69';
+    const TOO_LOW_ERROR = '76454e69-502c-46c5-9643-f447d837c4d5';
+
+    /**
+     * @deprecated Deprecated since version 2.8, to be removed in 3.0. Use
+     *             {@link INVALID_CHARACTERS_ERROR} instead.
+     */
+    const INVALID_VALUE_ERROR = self::INVALID_CHARACTERS_ERROR;
+
+    /**
+     * @deprecated Deprecated since version 2.8, to be removed in 3.0. Use
+     *             {@link TOO_HIGH_ERROR} instead.
+     */
+    const BEYOND_RANGE_ERROR = self::TOO_HIGH_ERROR;
+
+    /**
+     * @deprecated Deprecated since version 2.8, to be removed in 3.0. Use
+     *             {@link TOO_LOW_ERROR} instead.
+     */
+    const BELOW_RANGE_ERROR = self::TOO_LOW_ERROR;
 
     protected static $errorNames = array(
-        self::INVALID_VALUE_ERROR => 'INVALID_VALUE_ERROR',
-        self::BEYOND_RANGE_ERROR => 'BEYOND_RANGE_ERROR',
-        self::BELOW_RANGE_ERROR => 'BELOW_RANGE_ERROR',
+        self::INVALID_CHARACTERS_ERROR => 'INVALID_CHARACTERS_ERROR',
+        self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
+        self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
     );
 
     public $minMessage = 'This value should be {{ limit }} or more.';

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -38,12 +38,12 @@ class RangeValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->invalidMessage)
                     ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                    ->setCode(Range::INVALID_VALUE_ERROR)
+                    ->setCode(Range::INVALID_CHARACTERS_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->invalidMessage)
                     ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                    ->setCode(Range::INVALID_VALUE_ERROR)
+                    ->setCode(Range::INVALID_CHARACTERS_ERROR)
                     ->addViolation();
             }
 
@@ -72,13 +72,13 @@ class RangeValidator extends ConstraintValidator
                 $this->context->buildViolation($constraint->maxMessage)
                     ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
                     ->setParameter('{{ limit }}', $this->formatValue($max, self::PRETTY_DATE))
-                    ->setCode(Range::BEYOND_RANGE_ERROR)
+                    ->setCode(Range::TOO_HIGH_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->maxMessage)
                     ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
                     ->setParameter('{{ limit }}', $this->formatValue($max, self::PRETTY_DATE))
-                    ->setCode(Range::BEYOND_RANGE_ERROR)
+                    ->setCode(Range::TOO_HIGH_ERROR)
                     ->addViolation();
             }
 
@@ -90,13 +90,13 @@ class RangeValidator extends ConstraintValidator
                 $this->context->buildViolation($constraint->minMessage)
                     ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
                     ->setParameter('{{ limit }}', $this->formatValue($min, self::PRETTY_DATE))
-                    ->setCode(Range::BELOW_RANGE_ERROR)
+                    ->setCode(Range::TOO_LOW_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->minMessage)
                     ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
                     ->setParameter('{{ limit }}', $this->formatValue($min, self::PRETTY_DATE))
-                    ->setCode(Range::BELOW_RANGE_ERROR)
+                    ->setCode(Range::TOO_LOW_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -23,6 +23,12 @@ use Symfony\Component\Validator\Constraint;
  */
 class Regex extends Constraint
 {
+    const REGEX_FAILED_ERROR = 'de1e3db3-5ed4-4941-aae4-59f3667cc3a3';
+
+    protected static $errorNames = array(
+        self::REGEX_FAILED_ERROR => 'REGEX_FAILED_ERROR',
+    );
+
     public $message = 'This value is not valid.';
     public $pattern;
     public $htmlPattern;

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -49,10 +49,12 @@ class RegexValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Regex::REGEX_FAILED_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Regex::REGEX_FAILED_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -23,8 +23,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class Time extends Constraint
 {
-    const INVALID_FORMAT_ERROR = 1;
-    const INVALID_TIME_ERROR = 2;
+    const INVALID_FORMAT_ERROR = '9d27b2bb-f755-4fbf-b725-39b1edbdebdf';
+    const INVALID_TIME_ERROR = '8532f9e1-84b2-4d67-8989-0818bc38533b';
 
     protected static $errorNames = array(
         self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Type.php
+++ b/src/Symfony/Component/Validator/Constraints/Type.php
@@ -23,6 +23,12 @@ use Symfony\Component\Validator\Constraint;
  */
 class Type extends Constraint
 {
+    const INVALID_TYPE_ERROR = 'ba785a8c-82cb-4283-967c-3cf342181b40';
+
+    protected static $errorNames = array(
+        self::INVALID_TYPE_ERROR => 'INVALID_TYPE_ERROR',
+    );
+
     public $message = 'This value should be of type {{ type }}.';
     public $type;
 

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -53,11 +53,13 @@ class TypeValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setParameter('{{ type }}', $constraint->type)
+                ->setCode(Type::INVALID_TYPE_ERROR)
                 ->addViolation();
         } else {
             $this->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setParameter('{{ type }}', $constraint->type)
+                ->setCode(Type::INVALID_TYPE_ERROR)
                 ->addViolation();
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -23,6 +23,12 @@ use Symfony\Component\Validator\Constraint;
  */
 class Url extends Constraint
 {
+    const INVALID_URL_ERROR = '57c2f299-1154-4870-89bb-ef3b1f5ad229';
+
+    protected static $errorNames = array(
+        self::INVALID_URL_ERROR => 'INVALID_URL_ERROR',
+    );
+
     public $message = 'This value is not a valid URL.';
     public $dnsMessage = 'The host could not be resolved.';
     public $protocols = array('http', 'https');

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -63,10 +63,12 @@ class UrlValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Url::INVALID_URL_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Url::INVALID_URL_ERROR)
                     ->addViolation();
             }
 
@@ -79,12 +81,14 @@ class UrlValidator extends ConstraintValidator
             if (!checkdnsrr($host, 'ANY')) {
                 if ($this->context instanceof ExecutionContextInterface) {
                     $this->context->buildViolation($constraint->dnsMessage)
-                       ->setParameter('{{ value }}', $this->formatValue($host))
-                       ->addViolation();
+                        ->setParameter('{{ value }}', $this->formatValue($host))
+                        ->setCode(Url::INVALID_URL_ERROR)
+                        ->addViolation();
                 } else {
                     $this->buildViolation($constraint->dnsMessage)
-                       ->setParameter('{{ value }}', $this->formatValue($host))
-                       ->addViolation();
+                        ->setParameter('{{ value }}', $this->formatValue($host))
+                        ->setCode(Url::INVALID_URL_ERROR)
+                        ->addViolation();
                 }
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Uuid.php
+++ b/src/Symfony/Component/Validator/Constraints/Uuid.php
@@ -21,12 +21,12 @@ use Symfony\Component\Validator\Constraint;
  */
 class Uuid extends Constraint
 {
-    const TOO_SHORT_ERROR = 1;
-    const TOO_LONG_ERROR = 2;
-    const INVALID_CHARACTERS_ERROR = 3;
-    const INVALID_HYPHEN_PLACEMENT_ERROR = 4;
-    const INVALID_VERSION_ERROR = 5;
-    const INVALID_VARIANT_ERROR = 6;
+    const TOO_SHORT_ERROR = 'aa314679-dac9-4f54-bf97-b2049df8f2a3';
+    const TOO_LONG_ERROR = '494897dd-36f8-4d31-8923-71a8d5f3000d';
+    const INVALID_CHARACTERS_ERROR = '51120b12-a2bc-41bf-aa53-cd73daf330d0';
+    const INVALID_HYPHEN_PLACEMENT_ERROR = '98469c83-0309-4f5d-bf95-a496dcaa869c';
+    const INVALID_VERSION_ERROR = '21ba13b4-b185-4882-ac6f-d147355987eb';
+    const INVALID_VARIANT_ERROR = '164ef693-2b9d-46de-ad7f-836201f0c2db';
 
     protected static $errorNames = array(
         self::TOO_SHORT_ERROR => 'TOO_SHORT_ERROR',

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -140,6 +140,7 @@ abstract class AbstractComparisonValidatorTestCase extends AbstractConstraintVal
             ->setParameter('{{ value }}', $dirtyValueAsString)
             ->setParameter('{{ compared_value }}', $comparedValueString)
             ->setParameter('{{ compared_value_type }}', $comparedValueType)
+            ->setCode($this->getErrorCode())
             ->assertRaised();
     }
 
@@ -170,4 +171,11 @@ abstract class AbstractComparisonValidatorTestCase extends AbstractConstraintVal
      * @return Constraint
      */
     abstract protected function createConstraint(array $options);
+
+    /**
+     * @return string|null
+     */
+    protected function getErrorCode()
+    {
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
@@ -54,6 +54,7 @@ class BlankValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $valueAsString)
+            ->setCode(Blank::NOT_BLANK_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -89,6 +89,7 @@ class CountryValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$country.'"')
+            ->setCode(Country::NO_SUCH_COUNTRY_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -103,6 +103,7 @@ class CurrencyValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$currency.'"')
+            ->setCode(Currency::NO_SUCH_CURRENCY_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -35,6 +35,11 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
         return new EqualTo($options);
     }
 
+    protected function getErrorCode()
+    {
+        return EqualTo::NOT_EQUAL_ERROR;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -40,6 +40,7 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'null')
+            ->setCode(Expression::EXPRESSION_FAILED_ERROR)
             ->assertRaised();
     }
 
@@ -54,6 +55,7 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '""')
+            ->setCode(Expression::EXPRESSION_FAILED_ERROR)
             ->assertRaised();
     }
 
@@ -87,6 +89,7 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'object')
+            ->setCode(Expression::EXPRESSION_FAILED_ERROR)
             ->assertRaised();
     }
 
@@ -123,8 +126,9 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate('2', $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '"2"')
             ->atPath('data')
+            ->setParameter('{{ value }}', '"2"')
+            ->setCode(Expression::EXPRESSION_FAILED_ERROR)
             ->assertRaised();
     }
 
@@ -167,8 +171,9 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate('2', $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '"2"')
             ->atPath('reference.data')
+            ->setParameter('{{ value }}', '"2"')
+            ->setCode(Expression::EXPRESSION_FAILED_ERROR)
             ->assertRaised();
     }
 
@@ -207,8 +212,9 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate('2', $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '"2"')
             ->atPath('')
+            ->setParameter('{{ value }}', '"2"')
+            ->setCode(Expression::EXPRESSION_FAILED_ERROR)
             ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
@@ -17,8 +17,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @param mixed $maxSize
-     * @param int   bytes
-     * @param bool  $bytes
+     * @param int   $bytes
+     * @param bool  $binaryFormat
      * @dataProvider provideValidSizes
      */
     public function testMaxSize($maxSize, $bytes, $binaryFormat)
@@ -31,13 +31,12 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param mixed $maxSize
-     * @param int   $bytes
      * @dataProvider provideInValidSizes
-     * @expectedException Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
-    public function testInvalideMaxSize($maxSize)
+    public function testInvalidMaxSize($maxSize)
     {
-        $file = new File(array('maxSize' => $maxSize));
+        new File(array('maxSize' => $maxSize));
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -35,6 +35,11 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
         return new GreaterThanOrEqual($options);
     }
 
+    protected function getErrorCode()
+    {
+        return GreaterThanOrEqual::TOO_LOW_ERROR;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -35,6 +35,11 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
         return new GreaterThan($options);
     }
 
+    protected function getErrorCode()
+    {
+        return GreaterThan::TOO_LOW_ERROR;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -35,6 +35,11 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         return new IdenticalTo($options);
     }
 
+    protected function getErrorCode()
+    {
+        return IdenticalTo::NOT_IDENTICAL_ERROR;
+    }
+
     public function provideAllValidComparisons()
     {
         $this->setDefaultTimezone('UTC');

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -153,6 +153,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -185,6 +186,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -211,6 +213,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -237,6 +240,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -259,6 +263,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -295,6 +300,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -321,6 +327,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -346,6 +353,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -368,6 +376,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -390,6 +399,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -412,6 +422,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 
@@ -434,6 +445,7 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
+            ->setCode(Ip::INVALID_IP_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
@@ -51,6 +51,7 @@ class IsFalseValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'true')
+            ->setCode(IsFalse::NOT_FALSE_ERROR)
             ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
@@ -47,6 +47,7 @@ class IsNullValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $valueAsString)
+            ->setCode(IsNull::NOT_NULL_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
@@ -51,6 +51,7 @@ class IsTrueValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'false')
+            ->setCode(IsTrue::NOT_TRUE_ERROR)
             ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -89,6 +89,7 @@ class LanguageValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$language.'"')
+            ->setCode(Language::NO_SUCH_LANGUAGE_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -241,6 +241,7 @@ class LengthValidatorTest extends AbstractConstraintValidatorTest
                 ->setParameter('{{ value }}', '"'.$value.'"')
                 ->setParameter('{{ charset }}', $charset)
                 ->setInvalidValue($value)
+                ->setCode(Length::INVALID_CHARACTERS_ERROR)
                 ->assertRaised();
         }
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -35,6 +35,11 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
         return new LessThanOrEqual($options);
     }
 
+    protected function getErrorCode()
+    {
+        return LessThanOrEqual::TOO_HIGH_ERROR;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -35,6 +35,11 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
         return new LessThan($options);
     }
 
+    protected function getErrorCode()
+    {
+        return LessThan::TOO_HIGH_ERROR;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -91,6 +91,7 @@ class LocaleValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$locale.'"')
+            ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -58,6 +58,7 @@ class NotBlankValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'null')
+            ->setCode(NotBlank::IS_BLANK_ERROR)
             ->assertRaised();
     }
 
@@ -71,6 +72,7 @@ class NotBlankValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '""')
+            ->setCode(NotBlank::IS_BLANK_ERROR)
             ->assertRaised();
     }
 
@@ -84,6 +86,7 @@ class NotBlankValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'false')
+            ->setCode(NotBlank::IS_BLANK_ERROR)
             ->assertRaised();
     }
 
@@ -97,6 +100,7 @@ class NotBlankValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'array')
+            ->setCode(NotBlank::IS_BLANK_ERROR)
             ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -35,6 +35,11 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
         return new NotEqualTo($options);
     }
 
+    protected function getErrorCode()
+    {
+        return NotEqualTo::IS_EQUAL_ERROR;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -35,6 +35,11 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         return new NotIdenticalTo($options);
     }
 
+    protected function getErrorCode()
+    {
+        return NotIdenticalTo::IS_IDENTICAL_ERROR;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
@@ -55,6 +55,9 @@ class NotNullValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate(null, $constraint);
 
-        $this->buildViolation('myMessage')->assertRaised();
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'null')
+            ->setCode(NotNull::IS_NULL_ERROR)
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -117,7 +117,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $formattedValue)
             ->setParameter('{{ limit }}', 10)
-            ->setCode(Range::BELOW_RANGE_ERROR)
+            ->setCode(Range::TOO_LOW_ERROR)
             ->assertRaised();
     }
 
@@ -136,7 +136,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $formattedValue)
             ->setParameter('{{ limit }}', 20)
-            ->setCode(Range::BEYOND_RANGE_ERROR)
+            ->setCode(Range::TOO_HIGH_ERROR)
             ->assertRaised();
     }
 
@@ -157,7 +157,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMaxMessage')
             ->setParameter('{{ value }}', $formattedValue)
             ->setParameter('{{ limit }}', 20)
-            ->setCode(Range::BEYOND_RANGE_ERROR)
+            ->setCode(Range::TOO_HIGH_ERROR)
             ->assertRaised();
     }
 
@@ -178,7 +178,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMinMessage')
             ->setParameter('{{ value }}', $formattedValue)
             ->setParameter('{{ limit }}', 10)
-            ->setCode(Range::BELOW_RANGE_ERROR)
+            ->setCode(Range::TOO_LOW_ERROR)
             ->assertRaised();
     }
 
@@ -299,7 +299,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
             ->setParameter('{{ limit }}', 'Mar 10, 2014, 12:00 AM')
-            ->setCode(Range::BELOW_RANGE_ERROR)
+            ->setCode(Range::TOO_LOW_ERROR)
             ->assertRaised();
     }
 
@@ -322,7 +322,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
             ->setParameter('{{ limit }}', 'Mar 20, 2014, 12:00 AM')
-            ->setCode(Range::BEYOND_RANGE_ERROR)
+            ->setCode(Range::TOO_HIGH_ERROR)
             ->assertRaised();
     }
 
@@ -347,7 +347,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMaxMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
             ->setParameter('{{ limit }}', 'Mar 20, 2014, 12:00 AM')
-            ->setCode(Range::BEYOND_RANGE_ERROR)
+            ->setCode(Range::TOO_HIGH_ERROR)
             ->assertRaised();
     }
 
@@ -372,7 +372,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMinMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
             ->setParameter('{{ limit }}', 'Mar 10, 2014, 12:00 AM')
-            ->setCode(Range::BELOW_RANGE_ERROR)
+            ->setCode(Range::TOO_LOW_ERROR)
             ->assertRaised();
     }
 
@@ -397,7 +397,7 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"abcd"')
-            ->setCode(Range::INVALID_VALUE_ERROR)
+            ->setCode(Range::INVALID_CHARACTERS_ERROR)
             ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -84,6 +84,7 @@ class RegexValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
+            ->setCode(Regex::REGEX_FAILED_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -59,6 +59,7 @@ class TypeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '""')
             ->setParameter('{{ type }}', 'integer')
+            ->setCode(Type::INVALID_TYPE_ERROR)
             ->assertRaised();
     }
 
@@ -126,6 +127,7 @@ class TypeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $valueAsString)
             ->setParameter('{{ type }}', $type)
+            ->setCode(Type::INVALID_TYPE_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -126,6 +126,7 @@ class UrlValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$url.'"')
+            ->setCode(Url::INVALID_URL_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -93,7 +93,7 @@ interface ConstraintViolationBuilderInterface
     /**
      * Sets the violation code.
      *
-     * @param int $code The violation code
+     * @param string|null $code The violation code
      *
      * @return ConstraintViolationBuilderInterface This builder
      */


### PR DESCRIPTION
Reopened #12388 on the 2.8 branch.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

With the current implementation of error codes, checking which error occurred is unnecessarily complex:

``` php
if ($violation->getConstraint() instanceof Length && Length::TOO_SHORT_ERROR === $violation->getCode()) {
    // ...
}
```

Also, the code is completely missing for some constraints. This is fixed now. By using UUIDs, the check is reduced to:

``` php
if (Length::TOO_SHORT_ERROR === $violation->getCode()) {
    // ...
}
```

Also, APIs can simply output the error code and the name of the error without needing to point to the constraint as well.

Before:

``` json
[
    {
        "code": "1",
        "name": "TOO_SHORT_ERROR",
        "message": "This value is too short. ...",
        "constraint": "Symfony\\Component\\Validator\\Constraints\\Length"
    }
]
```

After:

``` json
[
    {
        "code": "9ff3fdc4-b214-49db-8718-39c315e33d45",
        "name": "TOO_SHORT_ERROR",
        "message": "This value is too short. ..."
    }
]
```

This makes it possible to implement a service on symfony.com which looks up error codes, e.g.

symfony.com/error?code=9ff3fdc4-b214-49db-8718-39c315e33d45

Such a URL could redirect directly to the documentation of the appropriate constraint. We could even support user-submitted error codes which redirect to the documentation of that constraint.
