### PR TITLE
[HttpFoundation] Request::enableHttpMethodParameterOverride() does not work if Request->getMethod() was previously called

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -81,7 +81,7 @@ class Request
 
     protected static $httpMethodParameterOverride = false;
 
-    protected static $httpMethodCachedIsValid = true;
+    protected static $httpMethodCacheIsValid = true;
 
     /**
      * Custom parameters.
@@ -713,7 +713,7 @@ class Request
     public static function enableHttpMethodParameterOverride()
     {
         self::$httpMethodParameterOverride = true;
-        self::$httpMethodCachedIsValid = false;
+        self::$httpMethodCacheIsValid = false;
     }
 
     /**
@@ -1341,7 +1341,7 @@ class Request
      */
     public function getMethod()
     {
-        if (null === $this->method || !self::$httpMethodCachedIsValid) {
+        if (null === $this->method || !self::$httpMethodCacheIsValid) {
             $this->method = strtoupper($this->server->get('REQUEST_METHOD', 'GET'));
 
             if ('POST' === $this->method) {
@@ -1351,7 +1351,7 @@ class Request
                     $this->method = strtoupper($this->request->get('_method', $this->query->get('_method', 'POST')));
                 }
             }
-            self::$httpMethodCachedIsValid = true;
+            self::$httpMethodCacheIsValid = true;
         }
 
         return $this->method;

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -81,6 +81,8 @@ class Request
 
     protected static $httpMethodParameterOverride = false;
 
+    protected static $httpMethodCachedIsValid = true;
+
     /**
      * Custom parameters.
      *
@@ -711,6 +713,7 @@ class Request
     public static function enableHttpMethodParameterOverride()
     {
         self::$httpMethodParameterOverride = true;
+        self::$httpMethodCachedIsValid = false;
     }
 
     /**
@@ -1338,7 +1341,7 @@ class Request
      */
     public function getMethod()
     {
-        if (null === $this->method) {
+        if (null === $this->method || !self::$httpMethodCachedIsValid) {
             $this->method = strtoupper($this->server->get('REQUEST_METHOD', 'GET'));
 
             if ('POST' === $this->method) {
@@ -1348,6 +1351,7 @@ class Request
                     $this->method = strtoupper($this->request->get('_method', $this->query->get('_method', 'POST')));
                 }
             }
+            self::$httpMethodCachedIsValid = true;
         }
 
         return $this->method;

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -847,7 +847,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->query->set('_method', 'purge');
         $request->getMethod();
         Request::enableHttpMethodParameterOverride();
-        $this->assertEquals('PURGE', $request->getMethod(), '->getMethod() returned a cached value, instead of expected');
+        $this->assertEquals('PURGE', $request->getMethod(), '->getMethod() returned a previously cached value after enabling parameter override');
         $this->disableHttpMethodParameterOverride();
 
         $request = new Request();

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -844,6 +844,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $request = new Request();
         $request->setMethod('POST');
+        $request->query->set('_method', 'purge');
+        $request->getMethod();
+        Request::enableHttpMethodParameterOverride();
+        $this->assertEquals('PURGE', $request->getMethod(), '->getMethod() returned a cached value, instead of expected');
+        $this->disableHttpMethodParameterOverride();
+
+        $request = new Request();
+        $request->setMethod('POST');
         $request->headers->set('X-HTTP-METHOD-OVERRIDE', 'delete');
         $this->assertEquals('DELETE', $request->getMethod(), '->getMethod() returns the method from X-HTTP-Method-Override even though _method is set if defined and POST');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Hi!

Currently the Request class caches the method of the request. But if i enable the HttpMethodParameterOverride feature after the cache was already set, the option has no influence on the returned method.

Example current:

``` php
$request = new Request();
$request->setMethod('POST');
$request->query->set('_method', 'purge');
$request->getMethod(); // POST
Request::enableHttpMethodParameterOverride();
$request->getMethod(); // POST, but expected would be PURGE
```
