### PR TITLE
[Asset] Allow object implementing __toString() being passed to packages

### DIFF
--- a/src/Symfony/Component/Templating/Asset/Package.php
+++ b/src/Symfony/Component/Templating/Asset/Package.php
@@ -56,8 +56,8 @@ class Package implements PackageInterface
     /**
      * Applies version to the supplied path.
      *
-     * @param string              $path    A path
-     * @param string|bool|null    $version A specific version
+     * @param string           $path    A path
+     * @param string|bool|null $version A specific version
      *
      * @return string The versionized path
      */
@@ -70,7 +70,7 @@ class Package implements PackageInterface
 
         $versionized = sprintf($this->format, ltrim($path, '/'), $version);
 
-        if ($path && '/' == $path[0]) {
+        if ($path && '/' == substr($path, 0, 1)) {
             $versionized = '/'.$versionized;
         }
 

--- a/src/Symfony/Component/Templating/Asset/PathPackage.php
+++ b/src/Symfony/Component/Templating/Asset/PathPackage.php
@@ -34,7 +34,7 @@ class PathPackage extends Package
         if (!$basePath) {
             $this->basePath = '/';
         } else {
-            if ('/' != $basePath[0]) {
+            if ('/' != substr($basePath, 0, 1)) {
                 $basePath = '/'.$basePath;
             }
 

--- a/src/Symfony/Component/Templating/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Templating/Asset/UrlPackage.php
@@ -52,7 +52,7 @@ class UrlPackage extends Package
 
         $url = $this->applyVersion($path, $version);
 
-        if ($url && '/' != $url[0]) {
+        if ($url && '/' != substr($url, 0, 1)) {
             $url = '/'.$url;
         }
 

--- a/src/Symfony/Component/Templating/Tests/Fixtures/StringObject.php
+++ b/src/Symfony/Component/Templating/Tests/Fixtures/StringObject.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Templating\Tests\Fixtures;
+
+class StringObject
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Templating/Tests/Helper/AssetsHelperTest.php
+++ b/src/Symfony/Component/Templating/Tests/Helper/AssetsHelperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Templating\Tests\Helper;
 
 use Symfony\Component\Templating\Helper\AssetsHelper;
+use Symfony\Component\Templating\Tests\Fixtures\StringObject;
 
 class AssetsHelperTest extends \PHPUnit_Framework_TestCase
 {
@@ -69,5 +70,14 @@ class AssetsHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new AssetsHelper(null, 'http://foo.com');
         $this->assertEquals('//bar.com/asset', $helper->getUrl('//bar.com/asset'));
+    }
+
+    public function testWorksWithObjectsAndToString()
+    {
+        $helper = new AssetsHelper(null, new StringObject('http://foo.com'), new StringObject('version'));
+        $this->assertSame('http://foo.com/asset?version', $helper->getUrl(new StringObject('asset')));
+
+        $helper = new AssetsHelper(new StringObject('/base/path/'), array(), new StringObject('version'));
+        $this->assertSame('/base/path/asset?version', $helper->getUrl(new StringObject('asset')));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n.A. |
| License | MIT |
| Doc PR | n.A. |

This fixes an issue where `LiipImagineBundle` would return a `Twig_Markup` instance and one passes that to the `assets()` helper.
