### PR TITLE
Update DateTimeToArrayTransformer.php

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -179,16 +179,16 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
 
         try {
             $dateTime = new \DateTime(sprintf(
-                '%s-%s-%s %s:%s:%s %s',
+                '%s-%s-%s %s:%s:%s',
                 empty($value['year']) ? '1970' : $value['year'],
                 empty($value['month']) ? '1' : $value['month'],
                 empty($value['day']) ? '1' : $value['day'],
                 empty($value['hour']) ? '0' : $value['hour'],
                 empty($value['minute']) ? '0' : $value['minute'],
                 empty($value['second']) ? '0' : $value['second']
-+               ),
-+new \DateTimeZone($this->outputTimezone)
-+            );
+                ),
+                new \DateTimeZone($this->outputTimezone)
+            );
 
             if ($this->inputTimezone !== $this->outputTimezone) {
                 $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -185,9 +185,10 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
                 empty($value['day']) ? '1' : $value['day'],
                 empty($value['hour']) ? '0' : $value['hour'],
                 empty($value['minute']) ? '0' : $value['minute'],
-                empty($value['second']) ? '0' : $value['second'],
-                $this->outputTimezone
-            ));
+                empty($value['second']) ? '0' : $value['second']
++               ),
++               new \DateTimeZone($this->outputTimezone)
++            );
 
             if ($this->inputTimezone !== $this->outputTimezone) {
                 $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -187,7 +187,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
                 empty($value['minute']) ? '0' : $value['minute'],
                 empty($value['second']) ? '0' : $value['second']
 +               ),
-+               new \DateTimeZone($this->outputTimezone)
++new \DateTimeZone($this->outputTimezone)
 +            );
 
             if ($this->inputTimezone !== $this->outputTimezone) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

php have annoying bug with timezone handling. Some timezones (like US/Eastern, US/Central, US/Mountain) are considered "not standard" and not parsed in some cases.
For example, code

```
php -r '$d = new \DateTime("2015-07-01 16:11", new \DateTimeZone("US/Eastern")); print $d->format("r");'
```

return output 

```
Wed, 01 Jul 2015 16:11:00 -0400
```

However, code

```
php -r '$d = new \DateTime("2015-07-01 16:11 US/Eastern"); print $d->format("r");'
```

throw exception

```
Exception' with message 'DateTime::__construct(): Failed to parse time string (2015-07-01 16:11 US/Eastern) at position 17 (U): The timezone could not be found in the database'
```

Thats why timezone US/Eastern works in some cases and didnt work in other cases.
This PR fix usage of US/Eastern in code like

```
$formBuilder->add("createdTimestamp", "datetime", ['view_timezone'=$user->timezone])
```
