### PR TITLE
Move HHVM tests out of the allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
         - php: hhvm
     allow_failures:
         - php: nightly
-        - php: hhvm
     fast_finish: true
 
 services: mongodb


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

2.3, 2.6 and 2.7 are now green on HHVM, let's ensure this remains always true!
