### PR TITLE
Check for not empty HTTP_HOST

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -556,7 +556,7 @@ abstract class Client
         } else {
             $currentUri = sprintf('http%s://%s/',
                 isset($this->server['HTTPS']) ? 's' : '',
-                !empty($this->server['HTTP_HOST']) ? $this->server['HTTP_HOST'] : 'localhost'
+                isset($this->server['HTTP_HOST']) && '' !== $this->server['HTTP_HOST'] ? $this->server['HTTP_HOST'] : 'localhost'
             );
         }
 

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -556,7 +556,7 @@ abstract class Client
         } else {
             $currentUri = sprintf('http%s://%s/',
                 isset($this->server['HTTPS']) ? 's' : '',
-                isset($this->server['HTTP_HOST']) && !empty($this->server['HTTP_HOST']) ? $this->server['HTTP_HOST'] : 'localhost'
+                !empty($this->server['HTTP_HOST']) ? $this->server['HTTP_HOST'] : 'localhost'
             );
         }
 

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -556,7 +556,7 @@ abstract class Client
         } else {
             $currentUri = sprintf('http%s://%s/',
                 isset($this->server['HTTPS']) ? 's' : '',
-                isset($this->server['HTTP_HOST']) ? $this->server['HTTP_HOST'] : 'localhost'
+                isset($this->server['HTTP_HOST']) && !empty($this->server['HTTP_HOST']) ? $this->server['HTTP_HOST'] : 'localhost'
             );
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Example:

``` php
$client->setServerParameter('HTTP_HOST', (string) parse_url('/index.php', PHP_URL_HOST));
```

`parse_url` return empty string, and in method `getAbsoluteUri` `$currentUri` will be contain `http:///`.

Need check that `HTTP_HOST` is exist and is not empty.
