### PR TITLE
[DependencyInjection] fixed FrozenParameterBag and improved Parameter…

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
@@ -69,4 +69,12 @@ class FrozenParameterBag extends ParameterBag
     {
         throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($name)
+    {
+        throw new LogicException('Impossible to call remove() on a frozen ParameterBag.');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -89,17 +89,6 @@ interface ParameterBagInterface
     public function has($name);
 
     /**
-     * Removes a parameter.
-     *
-     * @param string $name The parameter name
-     *
-     * @throws LogicException if the parameter can not be removed
-     *
-     * @api
-     */
-    public function remove($name);
-
-    /**
      * Replaces parameter placeholders (%name%) by their values for all parameters.
      */
     public function resolve();

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\ParameterBag;
 
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 
 /**
@@ -25,6 +26,8 @@ interface ParameterBagInterface
     /**
      * Clears all parameters.
      *
+     * @throws LogicException if the ParameterBagInterface can not be cleared
+     *
      * @api
      */
     public function clear();
@@ -33,6 +36,8 @@ interface ParameterBagInterface
      * Adds parameters to the service container parameters.
      *
      * @param array $parameters An array of parameters
+     *
+     * @throws LogicException if the parameter can not be added
      *
      * @api
      */
@@ -66,6 +71,8 @@ interface ParameterBagInterface
      * @param string $name  The parameter name
      * @param mixed  $value The parameter value
      *
+     * @throws LogicException if the parameter can not be set
+     *
      * @api
      */
     public function set($name, $value);
@@ -80,6 +87,17 @@ interface ParameterBagInterface
      * @api
      */
     public function has($name);
+
+    /**
+     * Removes a parameter.
+     *
+     * @param string $name The parameter name
+     *
+     * @throws LogicException if the parameter can not be removed
+     *
+     * @api
+     */
+    public function remove($name);
 
     /**
      * Replaces parameter placeholders (%name%) by their values for all parameters.

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
@@ -57,4 +57,13 @@ class FrozenParameterBagTest extends \PHPUnit_Framework_TestCase
         $bag = new FrozenParameterBag(array());
         $bag->add(array());
     }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testRemove()
+    {
+        $bag = new FrozenParameterBag(array('foo' => 'bar'));
+        $bag->remove('foo');
+    }
 }


### PR DESCRIPTION
The ParameterBagInterface was missing some @throws annotations, so the FrozenParameterBag class was a violation of Liskov subtitution principle. Also the ParameterBagInterface was missing the remove method.

(Optionally the ParameterBagInterface can be later split into two smaller interfaces, because the FrozenParameterBag shouldn't have the add, remove methods in the first place.)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I have also fixed removing elements from FrozenParameterBag, as introduced by @satahippy
https://github.com/symfony/DependencyInjection/pull/8
