### PR TITLE
[VarDumper] Ingore PHPUnit and Prophecy object when they are nested

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -69,6 +69,10 @@ abstract class AbstractCloner implements ClonerInterface
         'Symfony\Component\DependencyInjection\ContainerInterface' => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
         'Symfony\Component\VarDumper\Exception\ThrowingCasterException' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castThrowingCasterException',
 
+        'PHPUnit_Framework_MockObject_MockObject' => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
+        'Prophecy\Prophecy\ProphecySubjectInterface' => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
+        'Mockery\MockInterface' => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
+
         'PDO' => 'Symfony\Component\VarDumper\Caster\PdoCaster::castPdo',
         'PDOStatement' => 'Symfony\Component\VarDumper\Caster\PdoCaster::castPdoStatement',
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The purpose of this PR is to ignore nested PHPUnit/Prophecy object when `dump`ing.

Reproducer:

``` php
$a = $this->getMock('Datetime');
$b = $this->prophesize('Datetime')->reveal();
$std = new \stdClass;
$std->my = 'property';
$std->a = $a;
$std->b = $b;

die(dump($a, $b, $std));
```

=> 

```
{#86
  +"my": "property"
  +"a": Mock_Datetime_8ba7f351 {#22 …5}
  +"b": Double\DateTime\P1 {#90 …1}
}
```
