### PR TITLE
[Serializer] Fix ClassMetadata::sleep()

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -110,7 +110,7 @@ class ClassMetadata implements ClassMetadataInterface
     {
         return array(
             'name',
-            'attributes',
+            'attributesMetadata',
         );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
@@ -54,4 +54,14 @@ class AttributeMetadataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('a', 'b', 'c'), $attributeMetadata1->getGroups());
     }
+
+    public function testSerialize()
+    {
+        $attributeMetadata = new AttributeMetadata('attribute');
+        $attributeMetadata->addGroup('a');
+        $attributeMetadata->addGroup('b');
+
+        $serialized = serialize($attributeMetadata);
+        $this->assertEquals($attributeMetadata, unserialize($serialized));
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/ClassMetadataTest.php
@@ -62,4 +62,21 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('a1' => $ac1), $classMetadata2->getAttributesMetadata());
     }
+
+    public function testSerialize()
+    {
+        $classMetadata = new ClassMetadata('a');
+
+        $a1 = $this->getMock('Symfony\Component\Serializer\Mapping\AttributeMetadataInterface');
+        $a1->method('getName')->willReturn('b1');
+
+        $a2 = $this->getMock('Symfony\Component\Serializer\Mapping\AttributeMetadataInterface');
+        $a2->method('getName')->willReturn('b2');
+
+        $classMetadata->addAttributeMetadata($a1);
+        $classMetadata->addAttributeMetadata($a2);
+
+        $serialized = serialize($classMetadata);
+        $this->assertEquals($classMetadata, unserialize($serialized));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Fix a bug with the `sleep()` method. It is blocking under when using the APC metadata cache.
