### PR TITLE
Enhance hhvm test skip message

### DIFF
--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -40,7 +40,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testCompileTimeError()
     {
         if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('HHVM behaves differently in this test case.');
+            $this->markTestSkipped('HHVM does not trigger strict notices.');
         }
 
         // the ContextErrorException must not be loaded to test the workaround


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Reading our blog about hhvm (http://symfony.com/blog/symfony-2-3-achieves-100-hhvm-compatibility)
I'd like to improve the only single test skip in our code base that exists for hhvm.

HHVM does not trigger strict notices. This is a missing feature of the HHVM parser (https://github.com/facebook/hhvm/issues/5583). But this does not affect in any way the behavior of any PHP app. Strict notices are only for the dev stage.

There is some FUD-friendliness in the article and in the comments (no offence @javiereguiluz ☮):
100% hhvm compat is 100% honest. We did not skip any single tests because of errors, issues nor bugs. And the single missing "feature" of hhvm is this one: strict notices. Kudos to hhvm for what they did: parity is close enough so that the delta can be handled in exactly the same way as we handle deltas between PHP versions.
