### PR TITLE
Remove duplicate example in UPGRADE-3.0.md

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -304,10 +304,6 @@ UPGRADE FROM 2.x to 3.0
    echo $form->getErrors(true, false);
    ```
 
-   ```php
-   echo $form->getErrors(true, false);
-   ```
-
 ### FrameworkBundle
 
  * The `config:debug`, `container:debug`, `router:debug`, `translation:debug`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |

The example:

``` php
echo $form->getErrors(true, false);     
```

is duplicated in the file.
