### PR TITLE
[HttpFoundation] Remove unused var

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -510,7 +510,6 @@ class Request
      */
     public function __toString()
     {
-        $content = '';
         try {
             $content = $this->getContent();
         } catch (\LogicException $e) {


### PR DESCRIPTION
Minor. Looks like the var `$content` got introduced in aa5e6165, then in 8982c324 the early return meant it wasn't needed.

| Q | A |
| --- | --- |
| Fixed tickets | N/A |
| License | MIT |
