### PR TITLE
[WIP] [Serializer] Alias support

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/Alias.php
+++ b/src/Symfony/Component/Serializer/Annotation/Alias.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @Alias().
+ *
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class Alias
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param array $data
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(array $data)
+    {
+        if (!isset($data['value']) || !$data['value']) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" cannot be empty.', get_class($this)));
+        }
+
+        if (!is_string($data['value'])) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a string.', get_class($this)));
+        }
+
+        $this->name = $data['value'];
+    }
+
+    /**
+     * Gets name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -37,6 +37,15 @@ class AttributeMetadata implements AttributeMetadataInterface
     public $groups = array();
 
     /**
+     * @var string|null
+     *
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getAlias()} instead.
+     */
+    public $alias;
+
+    /**
      * Constructs a metadata for the given attribute.
      *
      * @param string $name
@@ -75,10 +84,30 @@ class AttributeMetadata implements AttributeMetadataInterface
     /**
      * {@inheritdoc}
      */
+    public function setAlias($alias)
+    {
+        $this->alias = $alias;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function merge(AttributeMetadataInterface $attributeMetadata)
     {
         foreach ($attributeMetadata->getGroups() as $group) {
             $this->addGroup($group);
+        }
+
+        if (!$this->alias) {
+            $this->alias = $attributeMetadata->getAlias();
         }
     }
 
@@ -89,6 +118,6 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public function __sleep()
     {
-        return array('name', 'groups');
+        return array('name', 'groups', 'alias');
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -42,6 +42,20 @@ interface AttributeMetadataInterface
     public function getGroups();
 
     /**
+     * Sets the normalization alias of this attribute.
+     *
+     * @param string|null $alias
+     */
+    public function setAlias($alias);
+
+    /**
+     * Gets the normalization alias of this attribute.
+     *
+     * @return string|null
+     */
+    public function getAlias();
+
+    /**
      * Merges an {@see AttributeMetadataInterface} with in the current one.
      *
      * @param AttributeMetadataInterface $attributeMetadata

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -62,6 +62,10 @@ class XmlFileLoader extends FileLoader
                 foreach ($attribute->group as $group) {
                     $attributeMetadata->addGroup((string) $group);
                 }
+
+                if ($alias = (string) $attribute->alias) {
+                    $attributeMetadata->setAlias($alias);
+                }
             }
 
             return true;

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -78,6 +78,10 @@ class YamlFileLoader extends FileLoader
                             $attributeMetadata->addGroup($group);
                         }
                     }
+
+                    if (isset($data['alias'])) {
+                        $attributeMetadata->setAlias($data['alias']);
+                    }
                 }
             }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
@@ -44,11 +44,14 @@
     <xsd:complexType name="attribute">
         <xsd:annotation>
             <xsd:documentation><![CDATA[
-        Contains serialization groups for a attributes. The name of the attribute should be given in the "name" option.
+        Contains serialization metadata for a attributes. The name of the attribute should be given in the "name" attribute.
       ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="group" type="xsd:string" maxOccurs="unbounded" />
+            <xsd:choice>
+                <xsd:element name="group" type="xsd:string" maxOccurs="unbounded" />
+            </xsd:choice>
+            <xsd:element name="alias" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required" />
     </xsd:complexType>

--- a/src/Symfony/Component/Serializer/NameConverter/AliasNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/AliasNameConverter.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\NameConverter;
+
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+
+/**
+ * Converts name of properties using the alias specified in the attribute metadata.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class AliasNameConverter implements NameConverterInterface
+{
+    /**
+     * @var ClassMetadataFactoryInterface
+     */
+    private $classMetadataFactory;
+
+    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory)
+    {
+        $this->classMetadataFactory = $classMetadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $propertyName)
+    {
+        $attributesMetadata = $this->getAttributesMetadata($object);
+
+        if (isset($attributesMetadata[$propertyName]) && $alias = $attributesMetadata[$propertyName]->getAlias()) {
+            return $alias;
+        }
+
+        return $propertyName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($object, $propertyName)
+    {
+        $attributesMetadata = $this->getAttributesMetadata($object);
+
+        // TODO: cache that
+        foreach ($attributesMetadata as $attributeMetadata) {
+            $alias = $attributeMetadata->getAlias();
+            if ($propertyName === $alias) {
+                return $alias;
+            }
+        }
+
+        return $propertyName;
+    }
+
+    /**
+     * Gets attributes metadata.
+     *
+     * @param string|object $class
+     *
+     * @return array
+     */
+    private function getAttributesMetadata($class)
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
+        return $this->classMetadataFactory->getMetadataFor($class)->getAttributesMetadata();
+    }
+}

--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Serializer\NameConverter;
 
 /**
- * CamelCase to Underscore name converter.
+ * Converts names of properties from CamelCase to Underscore.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -40,7 +40,7 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($propertyName)
+    public function normalize($object, $propertyName)
     {
         if (null === $this->attributes || in_array($propertyName, $this->attributes)) {
             $snakeCasedName = '';
@@ -63,7 +63,7 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function denormalize($propertyName)
+    public function denormalize($object, $propertyName)
     {
         $camelCasedName = preg_replace_callback('/(^|_|\.)+(.)/', function ($match) {
             return ('.' === $match[1] ? '_' : '').strtoupper($match[2]);

--- a/src/Symfony/Component/Serializer/NameConverter/NameConverterInterface.php
+++ b/src/Symfony/Component/Serializer/NameConverter/NameConverterInterface.php
@@ -21,16 +21,20 @@ interface NameConverterInterface
     /**
      * Converts a property name to its normalized value.
      *
-     * @param string $propertyName
+     * @param string|object $class
+     * @param string        $propertyName
+     *
      * @return string
      */
-    public function normalize($propertyName);
+    public function normalize($class, $propertyName);
 
     /**
      * Converts a property name to its denormalized value.
      *
-     * @param string $propertyName
+     * @param string|object $class
+     * @param string        $propertyName
+     *
      * @return string
      */
-    public function denormalize($propertyName);
+    public function denormalize($class, $propertyName);
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -230,11 +230,11 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      *
      * @return string
      */
-    protected function formatAttribute($attributeName)
+    protected function formatAttribute($object, $attributeName)
     {
         @trigger_error(sprintf('%s is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->nameConverter ? $this->nameConverter->normalize($attributeName) : $attributeName;
+        return $this->nameConverter ? $this->nameConverter->normalize($object, $attributeName) : $attributeName;
     }
 
     /**
@@ -320,7 +320,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
             $params = array();
             foreach ($constructorParameters as $constructorParameter) {
                 $paramName = $constructorParameter->name;
-                $key = $this->nameConverter ? $this->nameConverter->normalize($paramName) : $paramName;
+                $key = $this->nameConverter ? $this->nameConverter->denormalize($class, $paramName) : $paramName;
 
                 $allowed = $allowedAttributes === false || in_array($paramName, $allowedAttributes);
                 $ignored = in_array($paramName, $this->ignoredAttributes);

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -79,7 +79,7 @@ class GetSetMethodNormalizer extends AbstractNormalizer
                 }
 
                 if ($this->nameConverter) {
-                    $attributeName = $this->nameConverter->normalize($attributeName);
+                    $attributeName = $this->nameConverter->normalize($object, $attributeName);
                 }
 
                 $attributes[$attributeName] = $attributeValue;
@@ -104,7 +104,7 @@ class GetSetMethodNormalizer extends AbstractNormalizer
 
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {
-                $attribute = $this->nameConverter->denormalize($attribute);
+                $attribute = $this->nameConverter->denormalize($object, $attribute);
             }
 
             $allowed = $allowedAttributes === false || in_array($attribute, $allowedAttributes);

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -112,7 +112,7 @@ class ObjectNormalizer extends AbstractNormalizer
             }
 
             if ($this->nameConverter) {
-                $attribute = $this->nameConverter->normalize($attribute);
+                $attribute = $this->nameConverter->normalize($object, $attribute);
             }
 
             $data[$attribute] = $attributeValue;
@@ -142,7 +142,7 @@ class ObjectNormalizer extends AbstractNormalizer
 
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {
-                $attribute = $this->nameConverter->denormalize($attribute);
+                $attribute = $this->nameConverter->denormalize($object, $attribute);
             }
 
             $allowed = $allowedAttributes === false || in_array($attribute, $allowedAttributes);

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -78,7 +78,7 @@ class PropertyNormalizer extends AbstractNormalizer
 
             $propertyName = $property->name;
             if ($this->nameConverter) {
-                $propertyName = $this->nameConverter->normalize($propertyName);
+                $propertyName = $this->nameConverter->normalize($object, $propertyName);
             }
 
             $attributes[$propertyName] = $attributeValue;
@@ -102,7 +102,7 @@ class PropertyNormalizer extends AbstractNormalizer
 
         foreach ($data as $propertyName => $value) {
             if ($this->nameConverter) {
-                $propertyName = $this->nameConverter->denormalize($propertyName);
+                $propertyName = $this->nameConverter->denormalize($object, $propertyName);
             }
 
             $allowed = $allowedAttributes === false || in_array($propertyName, $allowedAttributes);

--- a/src/Symfony/Component/Serializer/Tests/Annotation/AliasTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/AliasTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Annotation;
+
+use Symfony\Component\Serializer\Annotation\Alias;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class AliasTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testEmptyParameter()
+    {
+        new Alias(array('value' => ''));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testNotAStringGroupsParameter()
+    {
+        new Alias(array('value' => array()));
+    }
+
+    public function testGroupsParameters()
+    {
+        $validData = 'a';
+
+        $alias = new Alias(array('value' => $validData));
+        $this->assertEquals($validData, $alias->getName());
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/MappedDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/MappedDummy.php
@@ -11,15 +11,17 @@
 
 namespace Symfony\Component\Serializer\Tests\Fixtures;
 
+use Symfony\Component\Serializer\Annotation\Alias;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class GroupDummy extends GroupDummyParent implements GroupDummyInterface
+class MappedDummy extends MappedDummyParent implements MappedDummyInterface
 {
     /**
      * @Groups({"a"})
+     * @Alias("myAlias")
      */
     private $foo;
     /**

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/MappedDummyInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/MappedDummyInterface.php
@@ -16,7 +16,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface GroupDummyInterface
+interface MappedDummyInterface
 {
     /**
      * @Groups({"a", "name_converter"})

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/MappedDummyParent.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/MappedDummyParent.php
@@ -16,7 +16,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class GroupDummyParent
+class MappedDummyParent
 {
     /**
      * @Groups({"a"})

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -4,7 +4,7 @@
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping http://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
 
-    <class name="Symfony\Component\Serializer\Tests\Fixtures\GroupDummy">
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\MappedDummy">
         <attribute name="foo">
             <group>group1</group>
             <group>group2</group>
@@ -12,6 +12,7 @@
 
         <attribute name="bar">
             <group>group2</group>
+            <alias>myBar</alias>
         </attribute>
     </class>
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -1,6 +1,7 @@
-Symfony\Component\Serializer\Tests\Fixtures\GroupDummy:
+Symfony\Component\Serializer\Tests\Fixtures\MappedDummy:
   attributes:
     foo:
       groups: ['group1', 'group2']
     bar:
       groups: ['group2']
+      alias:  'myBar'

--- a/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
@@ -49,9 +49,24 @@ class AttributeMetadataTest extends \PHPUnit_Framework_TestCase
         $attributeMetadata2 = new AttributeMetadata('a2');
         $attributeMetadata2->addGroup('a');
         $attributeMetadata2->addGroup('c');
+        $attributeMetadata2->setAlias('alias');
 
         $attributeMetadata1->merge($attributeMetadata2);
 
         $this->assertEquals(array('a', 'b', 'c'), $attributeMetadata1->getGroups());
+        $this->assertEquals('alias', $attributeMetadata1->getAlias());
+    }
+
+    public function testMergeWithExistingAlias()
+    {
+        $attributeMetadata1 = new AttributeMetadata('a1');
+        $attributeMetadata1->setAlias('a1');
+
+        $attributeMetadata2 = new AttributeMetadata('a2');
+        $attributeMetadata2->setAlias('a2');
+
+        $attributeMetadata1->merge($attributeMetadata2);
+
+        $this->assertEquals('a1', $attributeMetadata1->getAlias());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/ClassMetadataTest.php
@@ -62,4 +62,21 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('a1' => $ac1), $classMetadata2->getAttributesMetadata());
     }
+
+    public function testSerialize()
+    {
+        $classMetadata = new ClassMetadata('a');
+
+        $a1 = $this->getMock('Symfony\Component\Serializer\Mapping\AttributeMetadataInterface');
+        $a1->method('getName')->willReturn('b1');
+
+        $a2 = $this->getMock('Symfony\Component\Serializer\Mapping\AttributeMetadataInterface');
+        $a2->method('getName')->willReturn('b2');
+
+        $classMetadata->addAttributeMetadata($a1);
+        $classMetadata->addAttributeMetadata($a2);
+
+        $serialized = serialize($classMetadata);
+        $this->assertEquals($classMetadata, unserialize($serialized));
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -38,14 +38,14 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MappedDummy');
 
         $this->assertTrue($this->loader->loadClassMetadata($classMetadata));
     }
 
     public function testLoadClassMetadata()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MappedDummy');
         $this->loader->loadClassMetadata($classMetadata);
 
         $this->assertEquals(TestClassMetadataFactory::createClassMetadata(), $classMetadata);
@@ -53,8 +53,8 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadClassMetadataAndMerge()
     {
-        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');
-        $parentClassMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummyParent');
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MappedDummy');
+        $parentClassMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MappedDummyParent');
 
         $this->loader->loadClassMetadata($parentClassMetadata);
         $classMetadata->merge($parentClassMetadata);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -32,7 +32,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->loader = new XmlFileLoader(__DIR__.'/../../Fixtures/serialization.xml');
-        $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');
+        $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MappedDummy');
     }
 
     public function testInterface()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -32,7 +32,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->loader = new YamlFileLoader(__DIR__.'/../../Fixtures/serialization.yml');
-        $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');
+        $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MappedDummy');
     }
 
     public function testInterface()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
@@ -21,10 +21,11 @@ class TestClassMetadataFactory
 {
     public static function createClassMetadata($withParent = false, $withInterface = false)
     {
-        $expected = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');
+        $expected = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MappedDummy');
 
         $foo = new AttributeMetadata('foo');
         $foo->addGroup('a');
+        $foo->setAlias('myAlias');
         $expected->addAttributeMetadata($foo);
 
         $bar = new AttributeMetadata('bar');
@@ -66,7 +67,7 @@ class TestClassMetadataFactory
 
     public static function createXmlCLassMetadata()
     {
-        $expected = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');
+        $expected = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MappedDummy');
 
         $foo = new AttributeMetadata('foo');
         $foo->addGroup('group1');
@@ -75,6 +76,7 @@ class TestClassMetadataFactory
 
         $bar = new AttributeMetadata('bar');
         $bar->addGroup('group2');
+        $bar->setAlias('myBar');
         $expected->addAttributeMetadata($bar);
 
         return $expected;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
-use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\MappedDummy;
 
 class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 {
@@ -234,7 +234,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory);
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
         $obj->setFooBar('fooBar');
@@ -262,7 +262,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory);
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFoo('foo');
 
         $toNormalize = array('foo' => 'foo', 'bar' => 'bar');
@@ -292,7 +292,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFooBar('@dunglas');
         $obj->setSymfony('@coopTilleuls');
         $obj->setCoopTilleuls('les-tilleuls.coop');
@@ -313,7 +313,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFooBar('@dunglas');
         $obj->setSymfony('@coopTilleuls');
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
-use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\MappedDummy;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -182,7 +182,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new ObjectNormalizer($classMetadataFactory);
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
         $obj->setFooBar('fooBar');
@@ -210,7 +210,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new ObjectNormalizer($classMetadataFactory);
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFoo('foo');
 
         $toNormalize = array('foo' => 'foo', 'bar' => 'bar');
@@ -240,7 +240,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFooBar('@dunglas');
         $obj->setSymfony('@coopTilleuls');
         $obj->setCoopTilleuls('les-tilleuls.coop');
@@ -261,7 +261,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFooBar('@dunglas');
         $obj->setSymfony('@coopTilleuls');
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\MappedDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\PropertyCircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\PropertySiblingHolder;
 
@@ -204,7 +204,7 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new PropertyNormalizer($classMetadataFactory);
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
         $obj->setFooBar('fooBar');
@@ -231,7 +231,7 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new PropertyNormalizer($classMetadataFactory);
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFoo('foo');
 
         $toNormalize = array('foo' => 'foo', 'bar' => 'bar');
@@ -261,7 +261,7 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new PropertyNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFooBar('@dunglas');
         $obj->setSymfony('@coopTilleuls');
         $obj->setCoopTilleuls('les-tilleuls.coop');
@@ -282,7 +282,7 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->normalizer = new PropertyNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
 
-        $obj = new GroupDummy();
+        $obj = new MappedDummy();
         $obj->setFooBar('@dunglas');
         $obj->setSymfony('@coopTilleuls');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | not yet |
| Fixed tickets | #15171 |
| License | MIT |
| Doc PR | not yet |

Follows up #15171. It's the POC I was speaking about @estahn

Progression:
- [x] Metadata (works fine)
- [x] Tests for the metadata
- [x] Name converter leveraging the new metadata
- [ ] Tests for the new name converter
- [ ] Update of current normalizers (the code exists but **I've not tried yet**)

The main issue about this PR is that it introduces a huge BC break in the Name Converter. To make it working it's needed to inject the current object or at least its class in the name converter and it's currently not possible.
What do you think about that @symfony/deciders?

@estahn you're welcome to contribute or rework this PR!
