### PR TITLE
[Translation] Allow to escape pipe

### DIFF
--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -51,7 +51,7 @@ class MessageSelector
      */
     public function choose($message, $number, $locale)
     {
-        $parts = explode('|', $message);
+        $parts = preg_split('/(?<!\\\\)\|/', $message)
         $explicitRules = array();
         $standardRules = array();
         foreach ($parts as $part) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15195 |
| License | MIT |
| Doc PR | - |

This allows for escaping the pipe character, so pipes can be used in strings passed to transchoice.
