### PR TITLE
[HttpKernel][DX] Add EnvironmentNotSupportedException

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/EnvironmentNotSupportedException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/EnvironmentNotSupportedException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * LengthRequiredHttpException.
+ *
+ * @author Zander Baldwin <hello@zanderbaldwin.com>
+ */
+class EnvironmentNotSupportedException extends \RuntimeException
+{
+}
+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | n/a (not implemented) |
| Fixed tickets | #15165 |
| License | MIT |
| Doc PR | - |

Add an exception to be thrown when an environment-specific configuration file cannot be found. This PR is just to add the exception, but not implement it - until a future version (`2.8` or `3.0` perhaps), it should probably lie with end-users to decide to implement this functionality.

Following on from issue #15165, I've made a pull request to discuss the implementation of this exception (does it extend from the correct base exception? is it located in the correct namespace? etc) - there is already a discussion about the usefulness of such an addition on the issue itself.
