### PR TITLE
[Twig][Bridge] replaced `extends` with `use` in bootstrap_3_horizontal_layout.html.twig

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
@@ -1,4 +1,4 @@
-{% extends "bootstrap_3_layout.html.twig" %}
+{% use "bootstrap_3_layout.html.twig" %}
 
 {% block form_start -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-horizontal')|trim}) %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets |  |
| License | MIT |

The fact `bootstrap_3_horizontal_layout.html.twig` **extends** `bootstrap_3_layout.html.twig` prevent to `use` it while using `{% form_theme form _self %}`.

As form templates don't have any code outside blocks this PR shouldn't induce any BC break.
