### PR TITLE
[DependencyInjection] Added ParameterBagInterface::remove

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -61,6 +61,13 @@ interface ParameterBagInterface
     public function get($name);
 
     /**
+     * Removes a parameter.
+     *
+     * @param string $name The parameter name
+     */
+    public function remove($name);
+
+    /**
      * Sets a service container parameter.
      *
      * @param string $name  The parameter name


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kinda |
| New feature? | no |
| BC breaks? | only between 2.X and 3.X, this PR target 3.X |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I created this PR because the method is implemented in `ParameterBag` but is not declared in the interface.
