### PR TITLE
[Yaml] nested merge keys

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -665,3 +665,57 @@ Security
     * `SwitchUserListener`
     * `AccessListener`
     * `RememberMeListener`
+
+UPGRADE FROM 2.7.1 to 2.7.2
+===========================
+
+Form
+----
+
+ * In order to fix a few regressions in the new `ChoiceList` implementation,
+   a few details had to be changed compared to 2.7.
+   
+   The legacy `Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface` 
+   now does not extend the new `Symfony\Component\Form\ChoiceList\ChoiceListInterface`
+   anymore. If you pass an implementation of the old interface in a context
+   where the new interface is required, wrap the list into a
+   `LegacyChoiceListAdapter`:
+   
+   Before:
+   
+   ```php
+   use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+   
+   function doSomething(ChoiceListInterface $choiceList)
+   {
+       // ...
+   }
+   
+   doSomething($legacyList);
+   ```
+   
+   After:
+   
+   ```php
+   use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+   use Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter;
+   
+   function doSomething(ChoiceListInterface $choiceList)
+   {
+       // ...
+   }
+   
+   doSomething(new LegacyChoiceListAdapter($legacyList));
+   ```
+   
+   The new `ChoiceListInterface` now has two additional methods
+   `getStructuredValues()` and `getOriginalKeys()`. You should add these methods
+   if you implement this interface. See their doc blocks and the implementation
+   of the core choice lists for inspiration.
+   
+   The method `ArrayKeyChoiceList::toArrayKey()` was marked as internal. This
+   method was never supposed to be used outside the class.
+   
+   The method `ChoiceListFactoryInterface::createView()` does not accept arrays
+   and `Traversable` instances anymore for the `$groupBy` parameter. Pass a
+   callable instead.

--- a/src/Symfony/Bridge/Twig/Extension/AssetExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/AssetExtension.php
@@ -108,11 +108,15 @@ class AssetExtension extends \Twig_Extension
             $v->setAccessible(true);
             $currentVersionStrategy = $v->getValue($package);
 
-            $f = new \ReflectionProperty($currentVersionStrategy, 'format');
-            $f->setAccessible(true);
-            $format = $f->getValue($currentVersionStrategy);
+            if (property_exists($currentVersionStrategy, 'format')) {
+                $f = new \ReflectionProperty($currentVersionStrategy, 'format');
+                $f->setAccessible(true);
+                $format = $f->getValue($currentVersionStrategy);
 
-            $v->setValue($package, new StaticVersionStrategy($version, $format));
+                $v->setValue($package, new StaticVersionStrategy($version, $format));
+            } else {
+                $v->setValue($package, new StaticVersionStrategy($version));
+            }
         }
 
         try {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AssetExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AssetExtensionTest.php
@@ -15,6 +15,7 @@ use Symfony\Bridge\Twig\Extension\AssetExtension;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 
 class AssetExtensionTest extends \PHPUnit_Framework_TestCase
@@ -39,6 +40,16 @@ class AssetExtensionTest extends \PHPUnit_Framework_TestCase
         $extension = $this->createExtension(new PathPackage('foo', new StaticVersionStrategy('22', '%s?version=%s')));
 
         $this->assertEquals('/foo/me.png?version=42', $extension->getAssetUrl('me.png', null, false, 42));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetAssetUrlWithEmptyVersionStrategy()
+    {
+        $extension = $this->createExtension(new PathPackage('foo', new EmptyVersionStrategy()));
+
+        $this->assertEquals('/foo/me.png?42', $extension->getAssetUrl('me.png', null, false, 42));
     }
 
     private function createExtension(Package $package)

--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -30,7 +30,8 @@ class Groups
 
     /**
      * @param array $data
-     * @throws \InvalidArgumentException
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(array $data)
     {
@@ -52,7 +53,7 @@ class Groups
     }
 
     /**
-     * Gets groups
+     * Gets groups.
      *
      * @return array
      */

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -110,7 +110,7 @@ class ClassMetadata implements ClassMetadataInterface
     {
         return array(
             'name',
-            'attributes',
+            'attributesMetadata',
         );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Annotation/GroupsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/GroupsTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 class GroupsTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
      */
     public function testEmptyGroupsParameter()
     {
@@ -27,7 +27,7 @@ class GroupsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
      */
     public function testNotAnArrayGroupsParameter()
     {
@@ -35,7 +35,7 @@ class GroupsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
      */
     public function testInvalidGroupsParameter()
     {

--- a/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
@@ -54,4 +54,14 @@ class AttributeMetadataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('a', 'b', 'c'), $attributeMetadata1->getGroups());
     }
+
+    public function testSerialize()
+    {
+        $attributeMetadata = new AttributeMetadata('attribute');
+        $attributeMetadata->addGroup('a');
+        $attributeMetadata->addGroup('b');
+
+        $serialized = serialize($attributeMetadata);
+        $this->assertEquals($attributeMetadata, unserialize($serialized));
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/ClassMetadataTest.php
@@ -62,4 +62,21 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('a1' => $ac1), $classMetadata2->getAttributesMetadata());
     }
+
+    public function testSerialize()
+    {
+        $classMetadata = new ClassMetadata('a');
+
+        $a1 = $this->getMock('Symfony\Component\Serializer\Mapping\AttributeMetadataInterface');
+        $a1->method('getName')->willReturn('b1');
+
+        $a2 = $this->getMock('Symfony\Component\Serializer\Mapping\AttributeMetadataInterface');
+        $a2->method('getName')->willReturn('b2');
+
+        $classMetadata->addAttributeMetadata($a1);
+        $classMetadata->addAttributeMetadata($a2);
+
+        $serialized = serialize($classMetadata);
+        $this->assertEquals($classMetadata, unserialize($serialized));
+    }
 }

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -286,7 +286,11 @@ class Parser
             }
 
             if ($isRef) {
-                $this->refs[$isRef] = end($data);
+                if (!isset($key)) {
+                    $this->refs[$isRef] = end($data);
+                } else {
+                    $this->refs[$isRef] = $data[$key];
+                }
             }
         }
 

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfMergeKey.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfMergeKey.yml
@@ -10,6 +10,10 @@ yaml: |
         a: Steve
         b: Clark
         c: Brian
+    taz: &taz
+        a: Steve
+        w:
+            p: 1234
     bar:
         a: before
         d: other
@@ -33,13 +37,22 @@ yaml: |
         isit: tested
     head:
         <<: [ *foo , *dong , *foo2 ]
+    nested:
+        <<: *taz
+        d: Doug
+        w: &nestedref
+            p: 12345
+        z:
+            <<: *nestedref
 php: |
     array(
         'foo' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian'),
+        'taz' => array('a' => 'Steve', 'w' => array('p' => 1234)),
         'bar' => array('a' => 'before', 'd' => 'other', 'b' => 'new', 'c' => array('foo' => 'bar', 'bar' => 'foo'), 'x' => 'Oren'),
         'duplicate' => array('foo' => 'bar'),
         'foo2' => array('a' => 'Ballmer'),
         'ding' => array('fi', 'fei', 'fo', 'fam'),
         'check' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam', 'isit' => 'tested'),
-        'head' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam')
+        'head' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam'),
+        'nested' => array('a' => 'Steve', 'w' => array('p' => 12345), 'd' => 'Doug', 'z' => array('p' => 12345)),
     )


### PR DESCRIPTION
When trying to use nested merge keys in Yaml, the ref sometimes had the wrong value

eg, with:

``` yaml
taz: &taz
    a: Steve
    w:
        p: 1234
nested:
    <<: *taz
    d: Doug
    w: &nestedref
        p: 12345
    z:
        <<: *nestedref 
```

in this case, the ref `nestedref` had the value "Doug", which cause this error : 

```
Symfony\Component\Yaml\Exception\ParseException: YAML merge keys used with a scalar value instead of an array at line 38 (near "<<: *nestedref").
```

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
