### PR TITLE
[Yaml] nested merge keys

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -286,7 +286,7 @@ class Parser
             }
 
             if ($isRef) {
-                $this->refs[$isRef] = end($data);
+                $this->refs[$isRef] = 'mapping' === $context ? $data[$key] : end($data);
             }
         }
 

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfMergeKey.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfMergeKey.yml
@@ -10,6 +10,10 @@ yaml: |
         a: Steve
         b: Clark
         c: Brian
+    taz: &taz
+        a: Steve
+        w:
+            p: 1234
     bar:
         a: before
         d: other
@@ -33,13 +37,22 @@ yaml: |
         isit: tested
     head:
         <<: [ *foo , *dong , *foo2 ]
+    nested:
+        <<: *taz
+        d: Doug
+        w: &nestedref
+            p: 12345
+        z:
+            <<: *nestedref
 php: |
     array(
         'foo' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian'),
+        'taz' => array('a' => 'Steve', 'w' => array('p' => 1234)),
         'bar' => array('a' => 'before', 'd' => 'other', 'b' => 'new', 'c' => array('foo' => 'bar', 'bar' => 'foo'), 'x' => 'Oren'),
         'duplicate' => array('foo' => 'bar'),
         'foo2' => array('a' => 'Ballmer'),
         'ding' => array('fi', 'fei', 'fo', 'fam'),
         'check' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam', 'isit' => 'tested'),
-        'head' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam')
+        'head' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam'),
+        'nested' => array('a' => 'Steve', 'w' => array('p' => 12345), 'd' => 'Doug', 'z' => array('p' => 12345)),
     )


### PR DESCRIPTION
When trying to use nested merge keys in Yaml, the ref sometimes had the wrong value

eg, with:

``` yaml
taz: &taz
    a: Steve
    w:
        p: 1234
nested:
    <<: *taz
    d: Doug
    w: &nestedref
        p: 12345
    z:
        <<: *nestedref 
```

in this case, the ref `nestedref` had the value "Doug", which cause this error : 

```
Symfony\Component\Yaml\Exception\ParseException: YAML merge keys used with a scalar value instead of an array at line 38 (near "<<: *nestedref").
```

It now works as expected

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
