### PR TITLE
Added 'default' color

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -29,6 +29,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         'magenta' => array('set' => 35, 'unset' => 39),
         'cyan' => array('set' => 36, 'unset' => 39),
         'white' => array('set' => 37, 'unset' => 39),
+        'default' => array('set' => 39, 'unset' => 39),
     );
     private static $availableBackgroundColors = array(
         'black' => array('set' => 40, 'unset' => 49),
@@ -39,6 +40,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         'magenta' => array('set' => 45, 'unset' => 49),
         'cyan' => array('set' => 46, 'unset' => 49),
         'white' => array('set' => 47, 'unset' => 49),
+        'default' => array('set' => 49, 'unset' => 49),
     );
     private static $availableOptions = array(
         'bold' => array('set' => 1, 'unset' => 22),

--- a/src/Symfony/Component/Console/Helper/DebugFormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/DebugFormatterHelper.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Console\Helper;
  */
 class DebugFormatterHelper extends Helper
 {
-    private $colors = array('black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white');
+    private $colors = array('black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'default');
     private $started = array();
     private $count = -1;
 

--- a/src/Symfony/Component/Console/Helper/DebugFormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/DebugFormatterHelper.php
@@ -25,7 +25,7 @@ class DebugFormatterHelper extends Helper
     private $count = -1;
 
     /**
-     * Starts a debug formatting session
+     * Starts a debug formatting session.
      *
      * @param string $id      The id of the formatting session
      * @param string $message The message to display
@@ -41,7 +41,7 @@ class DebugFormatterHelper extends Helper
     }
 
     /**
-     * Adds progress to a formatting session
+     * Adds progress to a formatting session.
      *
      * @param string $id          The id of the formatting session
      * @param string $buffer      The message to display
@@ -61,7 +61,7 @@ class DebugFormatterHelper extends Helper
                 unset($this->started[$id]['out']);
             }
             if (!isset($this->started[$id]['err'])) {
-                $message .= sprintf("%s<bg=red;fg=white> %s </> ", $this->getBorder($id), $errorPrefix);
+                $message .= sprintf('%s<bg=red;fg=white> %s </> ', $this->getBorder($id), $errorPrefix);
                 $this->started[$id]['err'] = true;
             }
 
@@ -72,7 +72,7 @@ class DebugFormatterHelper extends Helper
                 unset($this->started[$id]['err']);
             }
             if (!isset($this->started[$id]['out'])) {
-                $message .= sprintf("%s<bg=green;fg=white> %s </> ", $this->getBorder($id), $prefix);
+                $message .= sprintf('%s<bg=green;fg=white> %s </> ', $this->getBorder($id), $prefix);
                 $this->started[$id]['out'] = true;
             }
 
@@ -83,7 +83,7 @@ class DebugFormatterHelper extends Helper
     }
 
     /**
-     * Stops a formatting session
+     * Stops a formatting session.
      *
      * @param string $id         The id of the formatting session
      * @param string $message    The message to display

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
@@ -37,6 +37,9 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
         $style->setForeground('blue');
         $this->assertEquals("\033[34mfoo\033[39m", $style->apply('foo'));
 
+        $style->setForeground('default');
+        $this->assertEquals("\033[39mfoo\033[39m", $style->apply('foo'));
+
         $this->setExpectedException('InvalidArgumentException');
         $style->setForeground('undefined-color');
     }
@@ -50,6 +53,9 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
 
         $style->setBackground('yellow');
         $this->assertEquals("\033[43mfoo\033[49m", $style->apply('foo'));
+
+        $style->setBackground('default');
+        $this->assertEquals("\033[49mfoo\033[49m", $style->apply('foo'));
 
         $this->setExpectedException('InvalidArgumentException');
         $style->setBackground('undefined-color');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15246 |
| License | MIT |
| Doc PR |  |

Adding a "default" ansi color which corresponds to 39 and 49.
