### PR TITLE
[WIP][Translation] Allow use of Infinite in sets of numbers

### DIFF
--- a/src/Symfony/Component/Translation/Interval.php
+++ b/src/Symfony/Component/Translation/Interval.php
@@ -53,7 +53,7 @@ class Interval
 
         if ($matches[1]) {
             foreach (explode(',', $matches[2]) as $n) {
-                if ($number == $n) {
+                if ($number == self::convertNumber($n)) {
                     return true;
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | not yet |

TODO:
- [ ] Test
- [ ] Doc PR

This allows to specify explicit cases for infinites in sets (`{-Inf, +Inf}`) without having to specify `[-Inf, -Inf]` or `[+Inf,+Inf]`.
This could be useful to specify explicit cases covering generic plurals, in the case of undefined quantities. It doesn't make anything new possible per se, just an easier way to do it. Both maintenance and performance costs appear negligible.

This is the global code. If you are interested by the PR, I will write appropriate update for the code and doc.
