### PR TITLE
[HttpFoundation] fixed the check of 'proxy-revalidate' in Response::mustRevalidate()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -587,7 +587,7 @@ class Response
      */
     public function mustRevalidate()
     {
-        return $this->headers->hasCacheControlDirective('must-revalidate') || $this->headers->has('proxy-revalidate');
+        return $this->headers->hasCacheControlDirective('must-revalidate') || $this->headers->hasCacheControlDirective('proxy-revalidate');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -92,6 +92,22 @@ class ResponseTest extends ResponseTestCase
         $this->assertFalse($response->mustRevalidate());
     }
 
+    public function testMustRevalidateWithMustRevalidateCacheControlHeader()
+    {
+        $response = new Response();
+        $response->headers->set('cache-control', 'must-revalidate');
+
+        $this->assertTrue($response->mustRevalidate());
+    }
+
+    public function testMustRevalidateWithProxyRevalidateCacheControlHeader()
+    {
+        $response = new Response();
+        $response->headers->set('cache-control', 'proxy-revalidate');
+
+        $this->assertTrue($response->mustRevalidate());
+    }
+
     public function testSetNotModified()
     {
         $response = new Response();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #15262 |
| License | MIT |

'proxy-revalidate' is not a header on its own but a 'Cache-Control' directive
See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
