### PR TITLE
[Security] Added more tests for Firewall

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Security\Http\Tests;
 
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -46,8 +49,6 @@ class FirewallTest extends \PHPUnit_Framework_TestCase
 
     public function testOnKernelRequestStopsWhenThereIsAResponse()
     {
-        $response = $this->getMock('Symfony\Component\HttpFoundation\Response');
-
         $first = $this->getMock('Symfony\Component\Security\Http\Firewall\ListenerInterface');
         $first
             ->expects($this->once())
@@ -104,5 +105,53 @@ class FirewallTest extends \PHPUnit_Framework_TestCase
         $firewall->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
+    }
+
+    public function testOnKernelFinishRequestUnregistersExceptionsListeners()
+    {
+        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+
+        $listener = $this->getMock('Symfony\Component\Security\Http\Firewall\ExceptionListener', array(), array(), '', false);
+        $listener
+            ->expects($this->once())
+            ->method('register')
+            ->with($this->equalTo($dispatcher))
+        ;
+        $listener
+            ->expects($this->once())
+            ->method('unregister')
+            ->with($this->equalTo($dispatcher))
+        ;
+
+        $request = new Request();
+
+        $map = $this->getMock('Symfony\Component\Security\Http\FirewallMapInterface');
+        $map
+            ->expects($this->once())
+            ->method('getListeners')
+            ->with($this->equalTo($request))
+            ->will($this->returnValue(array(array(), $listener)))
+        ;
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+
+        $getResponseEvent = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $finishRequestEvent = new FinishRequestEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $firewall = new Firewall($map, $dispatcher);
+        $firewall->onKernelRequest($getResponseEvent);
+        $firewall->onKernelFinishRequest($finishRequestEvent);
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $map = $this->getMock('Symfony\Component\Security\Http\FirewallMapInterface');
+        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+
+        $firewall = new Firewall($map, $dispatcher);
+        $subscription = $firewall->getSubscribedEvents();
+
+        $this->assertTrue(array_key_exists(KernelEvents::REQUEST, $subscription));
+        $this->assertTrue(array_key_exists(KernelEvents::FINISH_REQUEST, $subscription));
     }
 }


### PR DESCRIPTION
Symfony\Component\Security\Http\Firewall now has 100% of
statement and method coverage

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
