### PR TITLE
fix broken ChoiceQuestion

### DIFF
--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -162,7 +162,7 @@ class ChoiceQuestion extends Question
                     throw new \InvalidArgumentException(sprintf($errorMessage, $value));
                 }
 
-                $multiselectChoices[] = $choices[(string) $result];
+                $multiselectChoices[] = (string) $result;
             }
 
             if ($multiselect) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | yes |
| New Feature? | n |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | yes |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

Commit https://github.com/symfony/symfony/commit/175af7f3acc0f7f994885388daca366e800db538#diff-e1d5cef4b49c9c530f50aae153f6a541 seems to have introduced an unnoticed bug. QuestionHelperTest hangs the tests (due to throwing an undefined index exception internally).

Its a bit strange why this happend but it seems somehow Git messed-up the patch somewhere during the process. The broken commit only exists in the commit and not in any downstream branches.
