### PR TITLE
[Form] Fix a BC break in the entity

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -87,7 +87,7 @@ abstract class DoctrineType extends AbstractType
      */
     public static function createChoiceName($choice, $key, $value)
     {
-        return (string) $value;
+        return str_replace('-', '_', (string) $value);
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -495,6 +495,31 @@ class EntityTypeTest extends TypeTestCase
         $this->assertSame('3', $field['3']->getViewData());
     }
 
+    public function testSubmitMultipleExpandedWithNegativeIntegerId()
+    {
+        $entity1 = new SingleIntIdEntity(-1, 'Foo');
+        $entity2 = new SingleIntIdEntity(2, 'Bar');
+
+        $this->persist(array($entity1, $entity2));
+
+        $field = $this->factory->createNamed('name', 'entity', null, array(
+            'multiple' => true,
+            'expanded' => true,
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'choice_label' => 'name',
+        ));
+
+        $field->submit(array('-1'));
+
+        $expected = new ArrayCollection(array($entity1));
+
+        $this->assertTrue($field->isSynchronized());
+        $this->assertEquals($expected, $field->getData());
+        $this->assertTrue($field['_1']->getData());
+        $this->assertFalse($field['2']->getData());
+    }
+
     public function testOverrideChoices()
     {
         $entity1 = new SingleIntIdEntity(1, 'Foo');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15273 |
| License | MIT |
| Doc PR | - |

@webmozart this brings back the old behaviour. Attached test case passes on 2.3 with no code modifications. 

Code [here](https://github.com/symfony/symfony/blob/73bbaa6cc7d706b0e945107657fbd240efec0c97/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php#L199-L206) promises any integer number can be handled with `createChoiceName()`:

``` php
            // If the object has a single-column, numeric ID, use that ID as
            // field name. We can only use numeric IDs as names, as we cannot
            // guarantee that a non-numeric ID contains a valid form name
            if ($idReader->isIntId()) {
                return array(__CLASS__, 'createChoiceName');
            }
            // Otherwise, an incrementing integer is used as name automatically
```

While `createChoiceName()` can only handle natural numbers.
