### PR TITLE
[Config] deprecate cannotBeEmpty() for boolean and numeric nodes

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
@@ -31,6 +31,18 @@ class BooleanNodeDefinition extends ScalarNodeDefinition
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * @deprecated Deprecated since version 2.8, to be removed in 3.0.
+     */
+    public function cannotBeEmpty()
+    {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
+        return parent::cannotBeEmpty();
+    }
+
+    /**
      * Instantiate a Node.
      *
      * @return BooleanNode The node

--- a/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
@@ -58,4 +58,16 @@ abstract class NumericNodeDefinition extends ScalarNodeDefinition
 
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Deprecated since version 2.8, to be removed in 3.0.
+     */
+    public function cannotBeEmpty()
+    {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
+        return parent::cannotBeEmpty();
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
