### PR TITLE
[DependencyInjection] mention added method in upgrade docs

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -94,6 +94,8 @@ UPGRADE FROM 2.x to 3.0
 
 ### DependencyInjection
 
+ * The method `remove` was added to `Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface`.
+
  * The methods `Definition::setFactoryClass()`,
    `Definition::setFactoryMethod()`, and `Definition::setFactoryService()` have
    been removed in favor of `Definition::setFactory()`. Services defined using


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #15219 |
| License | MIT |

This commit documents the addition of the `remove()` method to the
`ParameterBagInterface` which was done in #15219.
