### PR TITLE
[DependencyInjection] implemented parameter expansion in Reference Ids

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\ParameterBag;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Holds parameters.
@@ -196,6 +197,10 @@ class ParameterBag implements ParameterBagInterface
             }
 
             return $args;
+        }
+
+        if ($value instanceof Reference && false !== strpos((string) $value, '%')) {
+            return new Reference($this->resolveString((string) $value, $resolving), $value->getInvalidBehavior(), $value->isStrict());
         }
 
         if (!is_string($value)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -15,6 +15,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\Validator\Tests\Fixtures\Reference;
+use Symfony\Component\DependencyInjection\Reference as DicReference;
 
 class ParameterBagTest extends \PHPUnit_Framework_TestCase
 {
@@ -196,6 +198,9 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
         $bag = new ParameterBag(array('host' => 'foo.bar', 'port' => 1337));
         $this->assertEquals('foo.bar:1337', $bag->resolveValue('%host%:%port%'));
+
+        $bag = new ParameterBag(array('foo' => 'bar'));
+        $this->assertEquals('bar.bar', (string) $bag->resolveValue(new DicReference('bar.%foo%')), '->resolveValue() replaces placeholders in ids of References');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15304 |
| License | MIT |
| Doc PR | - |

this PR fixes Parameter Expansion in Reference Ids
