### PR TITLE
[HttpKernel] [HttpCache] Fix deprecated error in HttpCache#getSurrogate

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -160,7 +160,11 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      */
     public function getSurrogate()
     {
-        return $this->getEsi();
+        if (!$this->surrogate instanceof Esi) {
+            throw new \LogicException('This instance of HttpCache was not set up to use ESI as surrogate handler. You must overwrite and use createSurrogate');
+        }
+
+        return $this->surrogate;
     }
 
     /**
@@ -176,11 +180,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     {
         @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the getSurrogate() method instead.', E_USER_DEPRECATED);
 
-        if (!$this->surrogate instanceof Esi) {
-            throw new \LogicException('This instance of HttpCache was not set up to use ESI as surrogate handler. You must overwrite and use createSurrogate');
-        }
-
-        return $this->surrogate;
+        return $this->getSurrogate();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes? - I could not find an open issue, but it does appear to be a but to throw a `E_USER_DEPRECATED` when calling a non-depreciated method. |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no - but related to |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently calls to `HttpCache#getEsi` correctly trigger a `E_USER_DEPRECATED` error and inform the user that they should instead use `HttpCache#getSurrogate`.

Unfortunately `HttpCache#getSurrogate` currently calls `$this->getEsi();` which will result in the `E_USER_DEPRECATED` still being triggered.

This pull request simply moves the logic that was previously in `getEsi` to `getSurrogate`, and leaves `getEsi` as a wrapper around `getSurrogate` with the addition of also triggering this warning.

This pull request also effects the 2.7 branch.
