### PR TITLE
[symfony/translation] Fix logic error in DiffOperation

### DIFF
--- a/src/Symfony/Component/Translation/Catalogue/DiffOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/DiffOperation.php
@@ -30,7 +30,7 @@ class DiffOperation extends AbstractOperation
         );
 
         foreach ($this->source->all($domain) as $id => $message) {
-            if ($this->target->has($id, $domain)) {
+            if (!$this->target->has($id, $domain)) {
                 $this->messages[$domain]['all'][$id] = $message;
                 $this->result->add(array($id => $message), $domain);
             } else {

--- a/src/Symfony/Component/Translation/Tests/Catalogue/DiffOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/DiffOperationTest.php
@@ -25,7 +25,7 @@ class DiffOperationTest extends AbstractOperationTest
         );
 
         $this->assertEquals(
-            array('a' => 'old_a', 'c' => 'new_c'),
+            array('b' => 'old_b', 'c' => 'new_c'),
             $operation->getMessages('messages')
         );
 
@@ -35,7 +35,7 @@ class DiffOperationTest extends AbstractOperationTest
         );
 
         $this->assertEquals(
-            array('b' => 'old_b'),
+            array('a' => 'old_a'),
             $operation->getObsoleteMessages('messages')
         );
     }
@@ -44,7 +44,7 @@ class DiffOperationTest extends AbstractOperationTest
     {
         $this->assertEquals(
             new MessageCatalogue('en', array(
-                'messages' => array('a' => 'old_a', 'c' => 'new_c'),
+                'messages' => array('b' => 'old_b', 'c' => 'new_c'),
             )),
             $this->createOperation(
                 new MessageCatalogue('en', array('messages' => array('a' => 'old_a', 'b' => 'old_b'))),


### PR DESCRIPTION
The purpose of DiffOperation is returning messages that:
1. Exist in source catalog, but don't exist in target catalog.
2. Exist in targe catalog, but don't exist in source catalog.

Currently, it returns messages that:
1. Exist in source catalog and also exist in target catalog.
2. Exist in target catalog, but don't exist in source catalog.

This does not make any sense.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
