### PR TITLE
[DependencyInjection] Injection to private\protected properties

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -117,7 +117,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $def->setClass($parentDef->getClass());
         $def->setArguments($parentDef->getArguments());
         $def->setMethodCalls($parentDef->getMethodCalls());
-        $def->setProperties($parentDef->getProperties());
+        $def->setPropertiesByClass($parentDef->getClass(), $parentDef->getProperties());
         if ($parentDef->getFactoryClass(false)) {
             $def->setFactoryClass($parentDef->getFactoryClass(false));
         }
@@ -188,7 +188,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
 
         // merge properties
         foreach ($definition->getProperties() as $k => $v) {
-            $def->setProperty($k, $v);
+            $def->setPropertyByClass($definition->getClass(), $k, $v);
         }
 
         // append method calls

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -117,7 +117,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $def->setClass($parentDef->getClass());
         $def->setArguments($parentDef->getArguments());
         $def->setMethodCalls($parentDef->getMethodCalls());
-        $def->setPropertiesByClass($parentDef->getClass(), $parentDef->getProperties());
+
         if ($parentDef->getFactoryClass(false)) {
             $def->setFactoryClass($parentDef->getFactoryClass(false));
         }
@@ -186,9 +186,12 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
             $def->replaceArgument($index, $v);
         }
 
+        $def->setPropertiesByClass($parentDef->getClass(), $parentDef->getProperties());
         // merge properties
-        foreach ($definition->getProperties() as $k => $v) {
-            $def->setPropertyByClass($definition->getClass(), $k, $v);
+        foreach ($definition->getPropertiesByClass() as $classPath => $properties) {
+            foreach ($properties as $k => $v) {
+                $def->setPropertyByClass($classPath, $k, $v);
+            }
         }
 
         // append method calls

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -998,20 +998,23 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         // inject property to class
         $propertiesByClass = $definition->getPropertiesByClass();
         foreach ($propertiesByClass as $classPath => $properties) {
+            if(!$properties) {
+                continue;
+            }
             $properties = $this->resolveServices($parameterBag->resolveValue($properties));
 
-            if ($classPath !== null && strpos($classPath, '%')) {
+            if ($classPath != null && strpos($classPath, '%')) {
                 $classPath = $parameterBag->resolveValue($classPath);
             }
 
             // initialize reflection class
-            if ($classPath !== null && $properties && !isset($this->injectReflectionCache[$classPath])) {
+            if ($classPath != null && $properties && !isset($this->injectReflectionCache[$classPath])) {
                 $reflectionClass = new ReflectionClass($classPath);
                 $this->injectReflectionCache[$classPath] = $reflectionClass;
             }
 
             foreach ($properties as $name => $value) {
-                if ($classPath === null) {
+                if ($classPath == null || !$this->injectReflectionCache[$classPath]->hasProperty($name)) {
                     $service->$name = $value;
                     continue;
                 }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1026,8 +1026,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             }
         }
 
-
-
         if ($callable = $definition->getConfigurator()) {
             if (is_array($callable)) {
                 $callable[0] = $parameterBag->resolveValue($callable[0]);

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -32,6 +32,7 @@ class Definition
     private $shared = true;
     private $scope = ContainerInterface::SCOPE_CONTAINER;
     private $properties = array();
+    private $propertiesByClass = array();
     private $calls = array();
     private $configurator;
     private $tags = array();
@@ -286,6 +287,21 @@ class Definition
     public function setProperties(array $properties)
     {
         $this->properties = $properties;
+        $this->propertiesByClass[$this->class] = $properties;
+
+        return $this;
+    }
+
+    /**
+     * @param string $classPath  Propertiest class path
+     * @param array  $properties Property list
+     *
+     * @return $this
+     */
+    public function setPropertiesByClass($classPath, array $properties)
+    {
+        $this->properties = $properties;
+        $this->propertiesByClass[$classPath] = $properties;
 
         return $this;
     }
@@ -299,11 +315,35 @@ class Definition
     }
 
     /**
+     * @return array
+     */
+    public function getPropertiesByClass()
+    {
+        return $this->propertiesByClass;
+    }
+
+    /**
      * @api
      */
     public function setProperty($name, $value)
     {
         $this->properties[$name] = $value;
+        $this->propertiesByClass[$this->class][$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param $classPath
+     * @param $name
+     * @param $value
+     *
+     * @return Definition
+     */
+    public function setPropertyByClass($classPath, $name, $value)
+    {
+        $this->properties[$name] = $value;
+        $this->propertiesByClass[$classPath][$name] = $value;
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -330,8 +330,6 @@ class Definition
             $properties[$this->class] = $this->properties;
         }
 
-
-
         return $properties;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -299,7 +299,11 @@ class Definition
      */
     public function setPropertiesByClass($classPath, array $properties)
     {
-        $this->propertiesByClass[$classPath] = $properties;
+        if (!$classPath || $classPath === $this->class) {
+            $this->properties = array_replace($this->properties, $properties);
+        } else {
+            $this->propertiesByClass[$classPath] = $properties;
+        }
 
         return $this;
     }
@@ -318,9 +322,15 @@ class Definition
     public function getPropertiesByClass()
     {
         $properties = $this->propertiesByClass;
-        if ($this->properties) {
+        // merge property list
+        if (isset($properties[$this->class])) {
+            $fullProperties = array_replace($properties[$this->class], $this->properties);
+            $properties[$this->class] = $fullProperties;
+        } else {
             $properties[$this->class] = $this->properties;
         }
+
+
 
         return $properties;
     }
@@ -344,7 +354,12 @@ class Definition
      */
     public function setPropertyByClass($classPath, $name, $value)
     {
-        $this->propertiesByClass[$classPath][$name] = $value;
+        // if class not set or class == current class
+        if (!$classPath || $classPath === $this->class) {
+            $this->properties[$name] = $value;
+        } else {
+            $this->propertiesByClass[$classPath][$name] = $value;
+        }
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -287,7 +287,6 @@ class Definition
     public function setProperties(array $properties)
     {
         $this->properties = $properties;
-        $this->propertiesByClass[$this->class] = $properties;
 
         return $this;
     }
@@ -300,7 +299,6 @@ class Definition
      */
     public function setPropertiesByClass($classPath, array $properties)
     {
-        $this->properties = $properties;
         $this->propertiesByClass[$classPath] = $properties;
 
         return $this;
@@ -319,7 +317,12 @@ class Definition
      */
     public function getPropertiesByClass()
     {
-        return $this->propertiesByClass;
+        $properties = $this->propertiesByClass;
+        if ($this->properties) {
+            $properties[$this->class] = $this->properties;
+        }
+
+        return $properties;
     }
 
     /**
@@ -328,7 +331,6 @@ class Definition
     public function setProperty($name, $value)
     {
         $this->properties[$name] = $value;
-        $this->propertiesByClass[$this->class][$name] = $value;
 
         return $this;
     }
@@ -342,7 +344,6 @@ class Definition
      */
     public function setPropertyByClass($classPath, $name, $value)
     {
-        $this->properties[$name] = $value;
         $this->propertiesByClass[$classPath][$name] = $value;
 
         return $this;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -458,7 +458,7 @@ class PhpDumper extends Dumper
     {
         $code = '';
         foreach ($definition->getPropertiesByClass() as $classPath => $properties) {
-            if($classPath === null) {
+            if(!$classPath || !class_exists($classPath)) {
                 foreach($properties as $name => $value) {
                     $code .= sprintf("        \$%s->%s = %s;\n", $variableName, $name, $this->dumpValue($value));
                 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -29,7 +29,6 @@ use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\ExpressionLanguage\Expression;
 
-
 class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -868,7 +867,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
                 'testPrivate1' => 'updated1',
                 'testProtected1' => 'updated2',
                 'testPublic1' => 'updated3',
-                'testPublic4' => 'updated4'
+                'testPublic4' => 'updated4',
             )
         );
         $definition->setClass('Symfony\Component\DependencyInjection\Tests\ServiceTest1');
@@ -905,7 +904,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
                 'testPrivate1' => new Reference('test0'),
                 'testProtected1' => 'updated2',
                 'testPublic1' => 'updated3',
-                'testPublic4' => 'updated4'
+                'testPublic4' => 'updated4',
             )
         );
         $definition->setClass('Symfony\Component\DependencyInjection\Tests\ServiceTest1');
@@ -919,7 +918,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
                 'testProtected2' => 'updated121',
                 'testPublic2' => 'updated13',
                 'testPublic3' => 'updated14',
-                'testPublic1' => 'updated15'
+                'testPublic1' => 'updated15',
             )
         );
         $definition2->setClass('Symfony\Component\DependencyInjection\Tests\ServiceTest2');

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -893,10 +893,16 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testPrivatePropertySetWithParent()
     {
         $container = new ContainerBuilder();
+
+        $definition0 = new Definition();
+        $definition0->setProperties(array('testPublic' => 'updated4'));
+        $definition0->setClass('stdClass');
+        $container->setDefinition('test0', $definition0);
+
         $definition = new Definition();
         $definition->setProperties(
             array(
-                'testPrivate1' => 'updated1',
+                'testPrivate1' => new Reference('test0'),
                 'testProtected1' => 'updated2',
                 'testPublic1' => 'updated3',
                 'testPublic4' => 'updated4'
@@ -917,7 +923,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
             )
         );
         $definition2->setClass('Symfony\Component\DependencyInjection\Tests\ServiceTest2');
-        $definition2->setDecoratedService('test1');
         $container->setDefinition('test2', $definition2);
 
         $container->compile();
@@ -927,7 +932,8 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $reflectionClass1 = new \ReflectionClass('Symfony\Component\DependencyInjection\Tests\ServiceTest1');
         $testPrivate1Parent = $reflectionClass1->getProperty('testPrivate1');
         $testPrivate1Parent->setAccessible(true);
-        $this->assertEquals('updated1', $testPrivate1Parent->getValue($testObject2));
+        $stdClassValue = $testPrivate1Parent->getValue($testObject2);
+        $this->assertEquals('updated4', $stdClassValue->testPublic);
 
         $reflectionClass2 = new \ReflectionClass('Symfony\Component\DependencyInjection\Tests\ServiceTest2');
         $testPrivate1 = $reflectionClass2->getProperty('testPrivate1');
@@ -947,7 +953,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('updated13', $testObject2->testPublic2);
         $this->assertEquals('updated14', $testObject2->testPublic3);
     }
-
 }
 
 class FooClass

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
@@ -27,6 +28,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\ExpressionLanguage\Expression;
+
 
 class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -856,10 +858,115 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($classInList);
     }
+
+    public function testPrivatePropertySet()
+    {
+        $container = new ContainerBuilder();
+        $definition = new Definition();
+        $definition->setProperties(
+            array(
+                'testPrivate1' => 'updated1',
+                'testProtected1' => 'updated2',
+                'testPublic1' => 'updated3',
+                'testPublic4' => 'updated4'
+            )
+        );
+        $definition->setClass('Symfony\Component\DependencyInjection\Tests\ServiceTest1');
+
+        $container->setDefinition('test1', $definition);
+        $container->compile();
+        $testObject = $container->get('test1');
+
+        $reflectionClass = new \ReflectionClass('Symfony\Component\DependencyInjection\Tests\ServiceTest1');
+        $testPrivate1 = $reflectionClass->getProperty('testPrivate1');
+        $testPrivate1->setAccessible(true);
+
+        $testProtected1 = $reflectionClass->getProperty('testProtected1');
+        $testProtected1->setAccessible(true);
+
+        $this->assertEquals('updated1', $testPrivate1->getValue($testObject));
+        $this->assertEquals('updated2', $testProtected1->getValue($testObject));
+        $this->assertEquals('updated3', $testObject->testPublic1);
+        $this->assertEquals('updated4', $testObject->testPublic4);
+    }
+
+    public function testPrivatePropertySetWithParent()
+    {
+        $container = new ContainerBuilder();
+        $definition = new Definition();
+        $definition->setProperties(
+            array(
+                'testPrivate1' => 'updated1',
+                'testProtected1' => 'updated2',
+                'testPublic1' => 'updated3',
+                'testPublic4' => 'updated4'
+            )
+        );
+        $definition->setClass('Symfony\Component\DependencyInjection\Tests\ServiceTest1');
+        $container->setDefinition('test1', $definition);
+
+        $definition2 = new DefinitionDecorator('test1');
+        $definition2->setProperties(
+            array(
+                'testPrivate1' => 'updated11',
+                'testProtected1' => 'updated12',
+                'testProtected2' => 'updated121',
+                'testPublic2' => 'updated13',
+                'testPublic3' => 'updated14',
+                'testPublic1' => 'updated15'
+            )
+        );
+        $definition2->setClass('Symfony\Component\DependencyInjection\Tests\ServiceTest2');
+        $definition2->setDecoratedService('test1');
+        $container->setDefinition('test2', $definition2);
+
+        $container->compile();
+
+        $testObject2 = $container->get('test2');
+
+        $reflectionClass1 = new \ReflectionClass('Symfony\Component\DependencyInjection\Tests\ServiceTest1');
+        $testPrivate1Parent = $reflectionClass1->getProperty('testPrivate1');
+        $testPrivate1Parent->setAccessible(true);
+        $this->assertEquals('updated1', $testPrivate1Parent->getValue($testObject2));
+
+        $reflectionClass2 = new \ReflectionClass('Symfony\Component\DependencyInjection\Tests\ServiceTest2');
+        $testPrivate1 = $reflectionClass2->getProperty('testPrivate1');
+        $testPrivate1->setAccessible(true);
+
+        $testProtected1 = $reflectionClass2->getProperty('testProtected1');
+        $testProtected1->setAccessible(true);
+
+        $testProtected2 = $reflectionClass2->getProperty('testProtected2');
+        $testProtected2->setAccessible(true);
+
+        $this->assertEquals('updated11', $testPrivate1->getValue($testObject2));
+        $this->assertEquals('updated12', $testProtected1->getValue($testObject2));
+        $this->assertEquals('updated121', $testProtected2->getValue($testObject2));
+        $this->assertEquals('updated15', $testObject2->testPublic1);
+        $this->assertEquals('updated13', $testObject2->testPublic2);
+        $this->assertEquals('updated13', $testObject2->testPublic2);
+        $this->assertEquals('updated14', $testObject2->testPublic3);
+    }
+
 }
 
 class FooClass
 {
+}
+
+class ServiceTest1
+{
+    private $testPrivate1 = 'default1';
+    protected $testProtected1 = 'default1';
+    public $testPublic1 = 'default1';
+}
+
+class ServiceTest2 extends ServiceTest1
+{
+    private $testPrivate1 = 'default2';
+    protected $testProtected1 = 'default2';
+    protected $testProtected2 = 'default2';
+    public $testPublic2 = 'default2';
 }
 
 class ProjectContainer extends ContainerBuilder


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | not yet |
| License | MIT |
| Doc PR | not yet |

Definition property section now can contain protected and private attributes.
Also it will work for parent services and parent classes.

Let`s look to example:

``` php
class ExampleService {

    /**
     *
     * @var Doctrine
     */
    private $doctrine;

    /**
     * @return Doctrine
     */
    public function getDoctrine()
    {
        return $this->doctrine;
    }
}

class ExampleAnother extends ExampleService
{
    public function getEntity()
    {
        $doctrine = $this->getDoctrine();

        return $doctrine->getRepository("abd")->findObeById(123);
    }
}
```

and config.yml:

``` php
    example_service:
        class: ExampleService
        properties:
          doctrine: @doctrine
    example_another:
        class: ExampleAnother
        parent: example_service
```

will work correctly!
Now, no longer need to clutter up a bunch of classes setters and parameters in the constructor. It is only necessary to mark the variables that they set through DI.
