### PR TITLE
[Form] [DoctrineBridge] added a failing test for EntityType

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationKeyEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationKeyEntity.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping AS ORM;
+
+/**
+ * An entity whose primary key is a foreign key to another entity.
+ *
+ * @see http://doctrine-orm.readthedocs.org/en/latest/tutorials/composite-primary-keys.html#use-case-2-simple-derived-identity
+ * @ORM\Entity
+ */
+class AssociationKeyEntity
+{
+    /**
+     * @ORM\Id @ORM\OneToOne(targetEntity="SingleIntIdEntity")
+     * @var SingleIntIdEntity
+     */
+    public $single;
+
+    /**
+     * AssociationKeyEntity constructor.
+     * @param SingleIntIdEntity $single
+     */
+    public function __construct(SingleIntIdEntity $single)
+    {
+        $this->single = $single;
+    }
+
+    public function getName()
+    {
+        return $this->single->name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationKeyEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationKeyEntity.php
@@ -23,12 +23,14 @@ class AssociationKeyEntity
 {
     /**
      * @ORM\Id @ORM\OneToOne(targetEntity="SingleIntIdEntity")
+     *
      * @var SingleIntIdEntity
      */
     public $single;
 
     /**
      * AssociationKeyEntity constructor.
+     *
      * @param SingleIntIdEntity $single
      */
     public function __construct(SingleIntIdEntity $single)

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationKeyEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationKeyEntity.php
@@ -22,7 +22,8 @@ use Doctrine\ORM\Mapping AS ORM;
 class AssociationKeyEntity
 {
     /**
-     * @ORM\Id @ORM\OneToOne(targetEntity="SingleIntIdEntity")
+     * @ORM\Id
+     * @ORM\OneToOne(targetEntity="SingleIntIdEntity")
      *
      * @var SingleIntIdEntity
      */

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationKeyEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/AssociationKeyEntity.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Mapping AS ORM;
 /**
  * An entity whose primary key is a foreign key to another entity.
  *
- * @see http://doctrine-orm.readthedocs.org/en/latest/tutorials/composite-primary-keys.html#use-case-2-simple-derived-identity
+ * @see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/composite-primary-keys.html#identity-through-foreign-entities
  * @ORM\Entity
  */
 class AssociationKeyEntity

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -20,6 +20,7 @@ use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationKeyEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeStringIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\GroupableEntity;
@@ -42,6 +43,7 @@ class EntityTypeTest extends TypeTestCase
     const SINGLE_ASSOC_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleAssociationToIntIdEntity';
     const COMPOSITE_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity';
     const COMPOSITE_STRING_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeStringIdEntity';
+    const ASSOCIATION_KEY_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationKeyEntity';
 
     /**
      * @var EntityManager
@@ -69,6 +71,7 @@ class EntityTypeTest extends TypeTestCase
             $this->em->getClassMetadata(self::SINGLE_ASSOC_IDENT_CLASS),
             $this->em->getClassMetadata(self::COMPOSITE_IDENT_CLASS),
             $this->em->getClassMetadata(self::COMPOSITE_STRING_IDENT_CLASS),
+            $this->em->getClassMetadata(self::ASSOCIATION_KEY_CLASS),
         );
 
         try {
@@ -578,6 +581,26 @@ class EntityTypeTest extends TypeTestCase
         $this->assertEquals($expected, $field->getData());
         $this->assertTrue($field['_1']->getData());
         $this->assertFalse($field['2']->getData());
+    }
+
+    public function testSubmitAssociationKey()
+    {
+        $single = new SingleIntIdEntity(1, 'Foo');
+        $assoc = new AssociationKeyEntity($single);
+
+        $this->persist(array($single, $assoc));
+
+        $field = $this->factory->createNamed('name', 'entity', null, array(
+            'multiple' => false,
+            'expanded' => false,
+            'em' => 'default',
+            'class' => self::ASSOCIATION_KEY_CLASS,
+            'choice_label' => 'name',
+        ));
+
+        $field->submit('1');
+
+        $this->assertSame($assoc, $field->getData());
     }
 
     public function testOverrideChoices()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | sometimes `*` |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

This is a new test for `EntityType` that uses an entity whose primary key is a foreign key to
another entity (an "association key"), as described here:

http://doctrine-orm.readthedocs.org/en/latest/tutorials/composite-primary-keys.html#identity-through-foreign-entities

Using the `entity` form type with an association-key entity used to work before 2.7, so I believe this is a BC break.

**Update:** I've added a possible fix to the `IdReader` class in the latest commit. I don't know if it is the _right_ fix, but...

`*` I say the tests pass "sometimes" because `Symfony\Component\HttpKernel\Tests\HttpCache\HttpCacheTest` is failing intermittently, and I don't think it is related to my change.
