### PR TITLE
[travis] Tests deps=low with PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
         - php: 5.4
         - php: 5.5
         - php: 5.6
-        - php: 5.3
           env: deps=low
         - php: 5.6
           env: deps=high


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I noticed that testing deps=low with the lowest supported PHP skips some tests/features.
I propose to merge the 5.6 and deps=low lines of the test matrix in order to both fix this issue and remove one line in the matrix (thus making tests a bit lighter/faster on travis).
