### PR TITLE
[Security] removed useless else condition in SwitchUserListener class.

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -116,9 +116,9 @@ class SwitchUserListener implements ListenerInterface
         if (false !== $originalToken) {
             if ($token->getUsername() === $request->get($this->usernameParameter)) {
                 return $token;
-            } else {
-                throw new \LogicException(sprintf('You are already switched to "%s" user.', $token->getUsername()));
             }
+
+            throw new \LogicException(sprintf('You are already switched to "%s" user.', $token->getUsername()));
         }
 
         if (false === $this->accessDecisionManager->decide($token, array($this->role))) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
