### PR TITLE
[Form] Fix not-BC test assertion

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -216,24 +216,14 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
 
     protected function expectValidateAt($i, $propertyPath, $value, $group)
     {
-        switch ($this->getApiVersion()) {
-            case Validation::API_VERSION_2_4:
-                $this->context->expects($this->at($i))
-                    ->method('validate')
-                    ->with($value, $propertyPath, $group);
-                break;
-            case Validation::API_VERSION_2_5:
-            case Validation::API_VERSION_2_5_BC:
-                $validator = $this->context->getValidator()->inContext($this->context);
-                $validator->expects($this->at(2 * $i))
-                    ->method('atPath')
-                    ->with($propertyPath)
-                    ->will($this->returnValue($validator));
-                $validator->expects($this->at(2 * $i + 1))
-                    ->method('validate')
-                    ->with($value, $this->logicalOr(null, array(), $this->isInstanceOf('\Symfony\Component\Validator\Constraints\Valid')), $group);
-                break;
-        }
+        $validator = $this->context->getValidator()->inContext($this->context);
+        $validator->expects($this->at(2 * $i))
+            ->method('atPath')
+            ->with($propertyPath)
+            ->will($this->returnValue($validator));
+        $validator->expects($this->at(2 * $i + 1))
+            ->method('validate')
+            ->with($value, $this->logicalOr(null, array(), $this->isInstanceOf('\Symfony\Component\Validator\Constraints\Valid')), $group);
     }
 
     protected function expectValidateValueAt($i, $propertyPath, $value, $constraints, $group = null)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The 2.6 branch is failing because of this case for `Validation::API_VERSION_2_4`, that can't work because `$this->context` is not a mock object, thus has no "expect" method.
See https://travis-ci.org/symfony/symfony/jobs/72100346#L2902
This got unnoticed because only 2.6 is testing the 2.4 validator api.
