### PR TITLE
[Security/Http] Fix test relying on a private property

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -54,10 +54,9 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $authenticationManager
             ->expects($this->once())
             ->method('authenticate')
-            ->with(self::logicalAnd(
-                       $this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken'),
-                       $this->attributeEqualTo('key', 'TheKey')
-            ))
+            ->with($this->callback(function ($token) {
+                return 'TheKey' === $token->getKey();
+            }))
             ->will($this->returnValue($anonymousToken))
         ;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I'm not 100% sure what was tested by this, but this test was using a private property (`AnonymousToken->key`), that has been renamed to `secret` in later Sf versions.
