### PR TITLE
[Translation][Extractor] Add failing test case for TwigExtractor

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -130,6 +130,7 @@ class TwigExtractorTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(__DIR__.'/../Fixtures'),
+            array(__DIR__.'/../Fixtures/extractor/syntax_error.twig'),
             array(new \SplFileInfo(__DIR__.'/../Fixtures/extractor/syntax_error.twig')),
         );
     }

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -74,14 +74,15 @@ class TwigExtractorTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException              \Twig_Error
      * @expectedExceptionMessageRegExp /Unclosed "block" in "extractor(\/|\\)syntax_error\.twig" at line 1/
+     * @dataProvider resourcesWithSyntaxErrorsProvider
      */
-    public function testExtractSyntaxError()
+    public function testExtractSyntaxError($resources)
     {
         $twig = new \Twig_Environment(new \Twig_Loader_Array(array()));
         $twig->addExtension(new TranslationExtension($this->getMock('Symfony\Component\Translation\TranslatorInterface')));
 
         $extractor = new TwigExtractor($twig);
-        $extractor->extract(__DIR__.'/../Fixtures', new MessageCatalogue('en'));
+        $extractor->extract($resources, new MessageCatalogue('en'));
     }
 
     /**
@@ -119,6 +120,17 @@ class TwigExtractorTest extends \PHPUnit_Framework_TestCase
             array(array(new \SplFileInfo($directory.'with_translations.html.twig'))),
             array(new \ArrayObject(array($directory.'with_translations.html.twig'))),
             array(new \ArrayObject(array(new \SplFileInfo($directory.'with_translations.html.twig')))),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function resourcesWithSyntaxErrorsProvider()
+    {
+        return array(
+            array(__DIR__.'/../Fixtures'),
+            array(new \SplFileInfo(__DIR__.'/../Fixtures/extractor/syntax_error.twig')),
         );
     }
 }


### PR DESCRIPTION
Introduce failing test case when a SplFileInfo object is passed to the extract() method in the TwigExtractor.

The problem is that when there's a twig error, symfony expects the `getRelativePath` method that the native object doesn't have.

I'm creating this PR with the failing test and without a fix to gather feedback on the best way to fix this issue.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
