### PR TITLE
[WebProfilerBundle] Profiler View Latest should preserve all the current query parameters

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -57,7 +57,8 @@
                             <span class="icon">{{ include('@WebProfiler/Icon/menu.svg') }}</span>
                         </a>
 
-                        <a class="btn btn-sm" href="{{ path('_profiler_search', { limit: 10 }) }}">Latest profiles</a>
+                        <a class="btn btn-sm" href="{{ path('_profiler_search', { limit: 10 }) }}">Last 10</a>
+                        <a class="btn btn-sm" href="{{ path('_profiler', { token: 'latest' }|merge(request.query.all)) }}">Latest</a>
 
                         <a class="sf-toggle btn btn-sm" data-toggle-selector="#sidebar-search" {% if tokens is defined or about is defined %}data-toggle-initial="display"{% endif %}>
                             {{ include('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -512,7 +512,10 @@ tr.status-warning td {
     color: #F5F5F5;
 }
 #sidebar #sidebar-shortcuts .btn + .btn {
-    margin-left: 10px;
+    margin-left: 5px;
+}
+#sidebar #sidebar-shortcuts .btn {
+    padding: .5em .6em;
 }
 
 {# Sidebar Search


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This improves the View Latest link by preserving all of the current query parameters, which makes it more useful with the Logs panel, for example.
