### PR TITLE
[TwigBridge] type-dependent path discovery

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -73,7 +73,7 @@ class TwigExtractorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException              \Twig_Error
-     * @expectedExceptionMessageRegExp /Unclosed "block" in "extractor(\/|\\)syntax_error\.twig" at line 1/
+     * @expectedExceptionMessageRegExp /Unclosed "block" in ".*extractor(\/|\\)syntax_error\.twig" at line 1/
      * @dataProvider resourcesWithSyntaxErrorsProvider
      */
     public function testExtractSyntaxError($resources)

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -92,6 +92,7 @@ class TwigExtractorTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(__DIR__.'/../Fixtures'),
+            array(__DIR__.'/../Fixtures/extractor/syntax_error.twig'),
             array(new \SplFileInfo(__DIR__.'/../Fixtures/extractor/syntax_error.twig')),
         );
     }

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -74,14 +74,26 @@ class TwigExtractorTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException              \Twig_Error
      * @expectedExceptionMessageRegExp /Unclosed "block" in "extractor(\/|\\)syntax_error\.twig" at line 1/
+     * @dataProvider resourcesWithSyntaxErrorsProvider
      */
-    public function testExtractSyntaxError()
+    public function testExtractSyntaxError($resources)
     {
         $twig = new \Twig_Environment(new \Twig_Loader_Array(array()));
         $twig->addExtension(new TranslationExtension($this->getMock('Symfony\Component\Translation\TranslatorInterface')));
 
         $extractor = new TwigExtractor($twig);
-        $extractor->extract(__DIR__.'/../Fixtures', new MessageCatalogue('en'));
+        $extractor->extract($resources, new MessageCatalogue('en'));
+    }
+
+    /**
+     * @return array
+     */
+    public function resourcesWithSyntaxErrorsProvider()
+    {
+        return array(
+            array(__DIR__.'/../Fixtures'),
+            array(new \SplFileInfo(__DIR__.'/../Fixtures/extractor/syntax_error.twig')),
+        );
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Translation;
 
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Translation\Extractor\AbstractFileExtractor;
 use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -60,7 +61,11 @@ class TwigExtractor extends AbstractFileExtractor implements ExtractorInterface
             try {
                 $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
             } catch (\Twig_Error $e) {
-                $e->setTemplateFile($file->getRelativePathname());
+                if ($file instanceof SplFileInfo) {
+                    $e->setTemplateFile($file->getRelativePathname());
+                } elseif ($file instanceof \SplFileInfo) {
+                    $e->setTemplateFile($file->getRealPath());
+                }
 
                 throw $e;
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15340 |
| License | MIT |
| Doc PR |  |

With the introduction of the `AbstractFileExtractor` in Symfony 2.7, the
`extract()` method in the `TwigExtractor` class does not necessarily
deal with `SplFileInfo` instances from the Finder component, but also
receives `\SplFileInfo` objects initialized by the base extractor class.
