### PR TITLE
[HttpKernel] Added 'isDevEnvironment' method to Kernel class

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -348,6 +348,16 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @api
      */
+    public function isDevEnvironment()
+    {
+        return $this->getEnvironment() === 'dev';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
     public function isDebug()
     {
         return $this->debug;

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -147,6 +147,15 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     public function getEnvironment();
 
     /**
+     * Checks if current environment is dev.
+     *
+     * @return bool true if current environment is dev
+     *
+     * @api
+     */
+    public function isDevEnvironment();
+
+    /**
      * Checks if debug mode is enabled.
      *
      * @return bool true if debug mode is enabled, false otherwise

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -764,6 +764,15 @@ EOF;
         $kernel->terminate(Request::create('/'), new Response());
     }
 
+    public function testKernelIsDevEnvironment()
+    {
+        $devKernel = new KernelForTest('dev', true);
+        $this->assertTrue($devKernel->isDevEnvironment());
+
+        $prodKernel = new KernelForTest('prod', false);
+        $this->assertFalse($prodKernel->isDevEnvironment());
+    }
+
     /**
      * Returns a mock for the BundleInterface
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I have worked with many symfony based projects which uses different/multiple environments and I hate when people are checking if current environment is dev by using statement like this:
`->getEnvironment() === 'dev'`
which breaks all other environment namings. By providing a kernel method which will tell you if you are in dev environment will help people like me to extend it for own project environment naming strategy.

Please support this common convention for detecting dev environment. This will help to stop hacking things.
