### PR TITLE
[Console] Use readline for user input when available #DX

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * use readline for user input in the question helper when available to allow
+   the use of arrow keys
+
 2.6.0
 -----
 

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -77,7 +77,7 @@ class QuestionHelper extends Helper
     }
 
     /**
-     * Returns the helper's input stream
+     * Returns the helper's input stream.
      *
      * @return resource
      */
@@ -146,7 +146,7 @@ class QuestionHelper extends Helper
      * Outputs the question prompt.
      *
      * @param OutputInterface $output
-     * @param Question $question
+     * @param Question        $question
      */
     protected function writePrompt(OutputInterface $output, Question $question)
     {
@@ -218,7 +218,7 @@ class QuestionHelper extends Helper
             // Backspace Character
             if ("\177" === $c) {
                 if (0 === $numMatches && 0 !== $i) {
-                    $i--;
+                    --$i;
                     // Move cursor backwards
                     $output->write("\033[1D");
                 }
@@ -271,7 +271,7 @@ class QuestionHelper extends Helper
             } else {
                 $output->write($c);
                 $ret .= $c;
-                $i++;
+                ++$i;
 
                 $numMatches = 0;
                 $ofs = 0;

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -127,11 +127,7 @@ class QuestionHelper extends Helper
             }
 
             if (false === $ret) {
-                $ret = fgets($inputStream, 4096);
-                if (false === $ret) {
-                    throw new \RuntimeException('Aborted');
-                }
-                $ret = trim($ret);
+                $ret = $this->readFromInput($inputStream);
             }
         } else {
             $ret = trim($this->autocomplete($output, $question, $inputStream));
@@ -421,6 +417,30 @@ class QuestionHelper extends Helper
         }
 
         return self::$shell;
+    }
+
+    /**
+     * Reads user input.
+     *
+     * @param resource $stream The input stream
+     *
+     * @return string User input
+     *
+     * @throws \RuntimeException
+     */
+    private function readFromInput($stream)
+    {
+        if (STDIN === $stream && function_exists('readline')) {
+            $ret = readline();
+        } else {
+            $ret = fgets($stream, 4096);
+
+            if (false === $ret) {
+                throw new \RuntimeException('Aborted');
+            }
+        }
+
+        return trim($ret);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Given I am entering data in an user input
When I use left and right keys to make some changes in what I have typed
Then the cursor should move accordingly instead of adding characters at the end of the line

To make it simple: using the arrow keys (←  →)  to make changes to what I already typed would be much handier than getting `^[[D` and `^[[C` characters in the terminal and having to delete all chars to type everything again.

I could not add any extra tests to this as the STDIN can't be used during tests. But they are not breaking and I tried again all types of questions (text, choices, hidden) by myself.

Note that `readline` can't be used for hidden questions, as `stty -echo` is not taken into account.
