### PR TITLE
[php7] Fix for substr() always returning a string

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -215,8 +215,8 @@ class ArgvInput extends Input
 
         $option = $this->definition->getOption($name);
 
-        // Convert false values (from a previous call to substr()) to null
-        if (false === $value) {
+        // Convert empty values to null
+        if (!isset($value[0])) {
             $value = null;
         }
 

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -121,11 +121,11 @@ PHP
             $that->assertEquals('->', $trace[0]['type']);
 
             $that->assertEquals(__FILE__, $trace[1]['file']);
-            $that->assertEquals(__CLASS__, $trace[1]['class']);
+            $that->assertEquals('Symfony\Component\Debug\Tests\ErrorHandlerTest', $trace[1]['class']);
             $that->assertEquals('triggerNotice', $trace[1]['function']);
             $that->assertEquals('::', $trace[1]['type']);
 
-            $that->assertEquals(__CLASS__, $trace[2]['class']);
+            $that->assertEquals('Symfony\Component\Debug\Tests\ErrorHandlerTest', $trace[2]['class']);
             $that->assertEquals('testNotice', $trace[2]['function']);
             $that->assertEquals('->', $trace[2]['type']);
         };

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -320,7 +320,7 @@ class Parser
             return;
         }
 
-        if ($inSequence && $oldLineIndentation === $newIndent && '-' === $data[0][0]) {
+        if ($inSequence && $oldLineIndentation === $newIndent && isset($data[0][0]) && '-' === $data[0][0]) {
             // the previous line contained a dash but no item content, this line is a sequence item with the same indentation
             // and therefore no nested list or mapping
             $this->moveToPreviousLine();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14086 |
| License | MIT |
| Doc PR | - |

This should be the last required fix for PHP7 support.

The patch in the debug component is a workaround for a bug in PHP7 (http://3v4l.org/8rm9B) that is going to be fixed soon (@jpauli power).
