### PR TITLE
[php7] Fix for substr() always returning a string

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -379,7 +379,7 @@ class SymfonyStyle extends OutputStyle
     {
         $chars = substr(str_replace(PHP_EOL, "\n", $this->bufferedOutput->fetch()), -2);
 
-        if (false === $chars) {
+        if (!isset($chars[0])) {
             return $this->newLine(); //empty history, so we should start with a new line.
         }
         //Prepend new line for each non LF chars (This means no blank line was output before)

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\VarDumper\Tests\Caster;
 
-use Symfony\Component\VarDumper\Cloner\VarCloner;
-use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Test\VarDumperTestCase;
 
 /**
@@ -34,7 +32,7 @@ ReflectionClass {
   constants: array:3 [
     "IS_IMPLICIT_ABSTRACT" => 16
     "IS_EXPLICIT_ABSTRACT" => 32
-    "IS_FINAL" => 64
+    "IS_FINAL" => %d
   ]
   properties: array:%d [
     "name" => ReflectionProperty {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14086 |
| License | MIT |
| Doc PR | - |

The remaining failures will stop once https://bugs.php.net/bug.php?id=70159 is fixed ([patch pending](https://github.com/php/php-src/commit/a28115ccdb11301a418cc748ef7716a1687cc585)).
