### PR TITLE
Fix missing _route parameter notice in RouterListener logging case

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -118,7 +118,7 @@ class RouterListener implements EventSubscriberInterface
             }
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s".', $parameters['_route']), array(
+                $this->logger->info(sprintf('Matched route "%s".', isset($parameters['_route']) ? $parameters['_route'] : 'n/a'), array(
                     'route_parameters' => $parameters,
                     'request_uri' => $request->getUri(),
                 ));

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -128,4 +128,34 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('GET', $context->getMethod());
     }
+
+    /**
+     * @dataProvider getLoggingParameterData
+     */
+    public function testLoggingParameter($parameter, $log)
+    {
+        $requestMatcher = $this->getMock('Symfony\Component\Routing\Matcher\RequestMatcherInterface');
+        $requestMatcher->expects($this->once())
+          ->method('matchRequest')
+          ->will($this->returnValue($parameter));
+
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger->expects($this->once())
+          ->method('info')
+          ->with($this->equalTo($log));
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $request = Request::create('http://localhost/');
+
+        $listener = new RouterListener($requestMatcher, new RequestContext(), $logger, $this->requestStack);
+        $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+    }
+
+    public function getLoggingParameterData()
+    {
+        return array(
+            array(array('_route' => 'foo'), 'Matched route "foo".'),
+            array(array(), 'Matched route "n/a".'),
+        );
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | na |
| License | MIT |
| Doc PR | na |

`\Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest` missed test cases in logging condition. So if we provide routing matches without a `_route` parameter `notice` messages are thrown. In this case i added a check and use `n/a` for empty route names as this is also shown in profiler if it not exists.
