### PR TITLE
[2.8][Translation][Profiler] Removed int and empty ids from collected data

### DIFF
--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -97,6 +97,10 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
     {
         $result = array();
         foreach ($messages as $key => $message) {
+            if (empty($message['id']) || is_int($message['id']) || intval($message['id']) !== 0 && intval($message['id']) == $message['id']) {
+                continue;
+            }
+
             $messageId = $message['locale'].$message['domain'].$message['id'];
 
             if (!isset($result[$messageId])) {
@@ -109,7 +113,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
                     $result[$messageId]['parameters'][] = $message['parameters'];
                 }
 
-                $result[$messageId]['count']++;
+                ++$result[$messageId]['count'];
             }
 
             unset($messages[$key]);

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -85,6 +85,33 @@ class TranslationDataCollectorTest extends \PHPUnit_Framework_TestCase
                   'parameters' => array('%count%' => 4, '%foo%' => 'bar'),
                   'transChoiceNumber' => 4,
             ),
+            array(
+                  'id' => 12,
+                  'translation' => 12,
+                  'locale' => 'en',
+                  'domain' => 'messages',
+                  'state' => DataCollectorTranslator::MESSAGE_MISSING,
+                  'parameters' => array(),
+                  'transChoiceNumber' => null,
+            ),
+            array(
+                  'id' => '64',
+                  'translation' => '64',
+                  'locale' => 'en',
+                  'domain' => 'messages',
+                  'state' => DataCollectorTranslator::MESSAGE_MISSING,
+                  'parameters' => array(),
+                  'transChoiceNumber' => null,
+            ),
+            array(
+                  'id' => '',
+                  'translation' => '',
+                  'locale' => 'en',
+                  'domain' => 'messages',
+                  'state' => DataCollectorTranslator::MESSAGE_MISSING,
+                  'parameters' => array(),
+                  'transChoiceNumber' => null,
+            ),
         );
         $expectedMessages = array(
             array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Note that `(int) 0` has not been removed since it could also match strings
