### PR TITLE
Use str_replace instead of the slower strtr

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -125,7 +125,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function get($key, $default = null, $first = true)
     {
-        $key = strtr(strtolower($key), '_', '-');
+        $key = str_replace('_', '-', strtolower($key));
 
         if (!array_key_exists($key, $this->headers)) {
             if (null === $default) {
@@ -153,7 +153,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function set($key, $values, $replace = true)
     {
-        $key = strtr(strtolower($key), '_', '-');
+        $key = str_replace('_', '-', strtolower($key));
 
         $values = array_values((array) $values);
 
@@ -179,7 +179,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function has($key)
     {
-        return array_key_exists(strtr(strtolower($key), '_', '-'), $this->headers);
+        return array_key_exists(str_replace('_', '-', strtolower($key)), $this->headers);
     }
 
     /**
@@ -206,7 +206,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function remove($key)
     {
-        $key = strtr(strtolower($key), '_', '-');
+        $key = str_replace('_', '-', strtolower($key));
 
         unset($this->headers[$key]);
 

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -107,7 +107,7 @@ class ResponseHeaderBag extends HeaderBag
     {
         parent::set($key, $values, $replace);
 
-        $uniqueKey = strtr(strtolower($key), '_', '-');
+        $uniqueKey = str_replace('_', '-', strtolower($key));
         $this->headerNames[$uniqueKey] = $key;
 
         // ensure the cache-control header has sensible defaults
@@ -128,7 +128,7 @@ class ResponseHeaderBag extends HeaderBag
     {
         parent::remove($key);
 
-        $uniqueKey = strtr(strtolower($key), '_', '-');
+        $uniqueKey = str_replace('_', '-', strtolower($key));
         unset($this->headerNames[$uniqueKey]);
 
         if ('cache-control' === $uniqueKey) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

`str_replace` is faster than `strtr` and none of the additional functionality of `strtr` is being used here.
Whilst this looks like a pointless micro optimisation when profiling I found that when having quite a few calls to the various header getting and setting methods this added up to make a noticeable difference.
