### PR TITLE
Fix the handling of null as locale in the stub intl classes

### DIFF
--- a/src/Symfony/Component/Intl/Collator/Collator.php
+++ b/src/Symfony/Component/Intl/Collator/Collator.php
@@ -70,13 +70,13 @@ class Collator
     /**
      * Constructor.
      *
-     * @param string $locale The locale code. The only currently supported locale is "en".
+     * @param string $locale The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en").
      *
-     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      */
     public function __construct($locale)
     {
-        if ('en' != $locale) {
+        if ('en' !== $locale && null !== $locale) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
         }
     }
@@ -84,11 +84,11 @@ class Collator
     /**
      * Static constructor.
      *
-     * @param string $locale The locale code. The only currently supported locale is "en".
+     * @param string $locale The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en").
      *
      * @return Collator
      *
-     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      */
     public static function create($locale)
     {

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -129,7 +129,7 @@ class IntlDateFormatter
     /**
      * Constructor.
      *
-     * @param string $locale   The locale code. The only currently supported locale is "en".
+     * @param string $locale   The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en").
      * @param int    $datetype Type of date formatting, one of the format type constants
      * @param int    $timetype Type of time formatting, one of the format type constants
      * @param string $timezone Timezone identifier
@@ -140,12 +140,12 @@ class IntlDateFormatter
      * @see http://www.php.net/manual/en/intldateformatter.create.php
      * @see http://userguide.icu-project.org/formatparse/datetime
      *
-     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
     public function __construct($locale, $datetype, $timetype, $timezone = null, $calendar = self::GREGORIAN, $pattern = null)
     {
-        if ('en' !== $locale) {
+        if ('en' !== $locale && null !== $locale) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
         }
 
@@ -163,7 +163,7 @@ class IntlDateFormatter
     /**
      * Static constructor.
      *
-     * @param string $locale   The locale code. The only currently supported locale is "en".
+     * @param string $locale   The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en").
      * @param int    $datetype Type of date formatting, one of the format type constants
      * @param int    $timetype Type of time formatting, one of the format type constants
      * @param string $timezone Timezone identifier
@@ -176,7 +176,7 @@ class IntlDateFormatter
      * @see http://www.php.net/manual/en/intldateformatter.create.php
      * @see http://userguide.icu-project.org/formatparse/datetime
      *
-     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
     public static function create($locale, $datetype, $timetype, $timezone = null, $calendar = self::GREGORIAN, $pattern = null)

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -245,7 +245,7 @@ class NumberFormatter
     /**
      * Constructor.
      *
-     * @param string $locale  The locale code. The only currently supported locale is "en".
+     * @param string $locale  The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en").
      * @param int    $style   Style of the formatting, one of the format style constants.
      *                        The only supported styles are NumberFormatter::DECIMAL
      *                        and NumberFormatter::CURRENCY.
@@ -257,13 +257,13 @@ class NumberFormatter
      * @see http://www.icu-project.org/apiref/icu4c/classDecimalFormat.html#_details
      * @see http://www.icu-project.org/apiref/icu4c/classRuleBasedNumberFormat.html#_details
      *
-     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When the $style is not supported
      * @throws MethodArgumentNotImplementedException      When the pattern value is different than null
      */
     public function __construct($locale = 'en', $style = null, $pattern = null)
     {
-        if ('en' != $locale) {
+        if ('en' !== $locale && null !== $locale) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
         }
 
@@ -282,7 +282,7 @@ class NumberFormatter
     /**
      * Static constructor.
      *
-     * @param string $locale  The locale code. The only supported locale is "en".
+     * @param string $locale  The locale code. The only supported locale is "en" (or null using the default locale, i.e. "en").
      * @param int    $style   Style of the formatting, one of the format style constants.
      *                        The only currently supported styles are NumberFormatter::DECIMAL
      *                        and NumberFormatter::CURRENCY.
@@ -296,7 +296,7 @@ class NumberFormatter
      * @see http://www.icu-project.org/apiref/icu4c/classDecimalFormat.html#_details
      * @see http://www.icu-project.org/apiref/icu4c/classRuleBasedNumberFormat.html#_details
      *
-     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" is passed
+     * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When the $style is not supported
      * @throws MethodArgumentNotImplementedException      When the pattern value is different than null
      */

--- a/src/Symfony/Component/Intl/Tests/Collator/CollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/CollatorTest.php
@@ -60,6 +60,12 @@ class CollatorTest extends AbstractCollatorTest
         $this->assertEquals('en', $collator->getLocale());
     }
 
+    public function testConstructWithoutLocale()
+    {
+        $collator = $this->getCollator(null);
+        $this->assertInstanceOf('\Symfony\Component\Intl\Collator\Collator', $collator);
+    }
+
     /**
      * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
      */

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -22,6 +22,12 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         $this->assertEquals('y-M-d', $formatter->getPattern());
     }
 
+    public function testConstructorWithoutLocale()
+    {
+        $formatter = new IntlDateFormatter(null, IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, 'y-M-d');
+        $this->assertEquals('y-M-d', $formatter->getPattern());
+    }
+
     /**
      * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
      */

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -70,6 +70,14 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, null);
     }
 
+    public function testConstructWithoutLocale()
+    {
+        $this->assertInstanceOf(
+            '\Symfony\Component\Intl\NumberFormatter\NumberFormatter',
+            $this->getNumberFormatter(null, NumberFormatter::DECIMAL)
+        );
+    }
+
     public function testCreate()
     {
         $this->assertInstanceOf(


### PR DESCRIPTION
The Intl extension accepts null as locale in formatters and the collator and will use the default locale in such case. Given that the stub implementation considers that the default locale is always 'en', it should be supported here too instead of forcing libraries to pass the default locale explicitly. For instance, `Twig_Extensions_Extension_Intl` relies on the fact that `null` as locale uses the default one: https://github.com/twigphp/Twig-extensions/pull/94

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony-demo/pull/123 |
| License | MIT |
| Doc PR | n/a |
