### PR TITLE
Remove skipping of tests based on ICU data version whenever possible

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -170,9 +170,11 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
     {
         $transformer = new DateTimeToLocalizedStringTransformer();
 
+        $this->markTestIncomplete('Checking for intl errors needs to be reimplemented');
+
         // HOW TO REPRODUCE?
 
-        //$this->setExpectedException('Symfony\Component\Form\Extension\Core\DataTransformer\Transdate_formationFailedException');
+        //$this->setExpectedException('Symfony\Component\Form\Extension\Core\DataTransformer\TransformationFailedException');
 
         //$transformer->transform(1.5);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -20,14 +20,16 @@ class IntegerToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCas
     {
         parent::setUp();
 
-        // Since we test against "de_AT", we need the full implementation
-        IntlTestHelper::requireFullIntl($this);
-
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('en');
     }
 
     public function testReverseTransform()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new IntegerToLocalizedStringTransformer();
 
         $this->assertEquals(1, $transformer->reverseTransform('1'));
@@ -45,6 +47,11 @@ class IntegerToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCas
 
     public function testReverseTransformWithGrouping()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new IntegerToLocalizedStringTransformer(null, true);
 
         $this->assertEquals(1234, $transformer->reverseTransform('1.234,5'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -16,18 +16,13 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class MoneyToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
+    public function testTransform()
     {
-        parent::setUp();
-
         // Since we test against "de_AT", we need the full implementation
         IntlTestHelper::requireFullIntl($this);
 
         \Locale::setDefault('de_AT');
-    }
 
-    public function testTransform()
-    {
         $transformer = new MoneyToLocalizedStringTransformer(null, null, null, 100);
 
         $this->assertEquals('1,23', $transformer->transform(123));
@@ -51,6 +46,11 @@ class MoneyToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransform()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new MoneyToLocalizedStringTransformer(null, null, null, 100);
 
         $this->assertEquals(123, $transformer->reverseTransform('1,23'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -20,10 +20,7 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        // Since we test against "de_AT", we need the full implementation
-        IntlTestHelper::requireFullIntl($this);
-
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('en');
     }
 
     public function provideTransformations()
@@ -44,6 +41,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransform($from, $to, $locale)
     {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault($locale);
 
         $transformer = new NumberToLocalizedStringTransformer();
@@ -67,6 +67,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransformWithGrouping($from, $to, $locale)
     {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault($locale);
 
         $transformer = new NumberToLocalizedStringTransformer(null, true);
@@ -76,6 +79,11 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testTransformWithPrecision()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new NumberToLocalizedStringTransformer(2);
 
         $this->assertEquals('1234,50', $transformer->transform(1234.5));
@@ -84,6 +92,11 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testTransformWithRoundingMode()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new NumberToLocalizedStringTransformer(null, null, NumberToLocalizedStringTransformer::ROUND_DOWN);
         $this->assertEquals('1234,547', $transformer->transform(1234.547), '->transform() only applies rounding mode if precision set');
 
@@ -96,6 +109,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testReverseTransform($to, $from, $locale)
     {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault($locale);
 
         $transformer = new NumberToLocalizedStringTransformer();
@@ -108,6 +124,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testReverseTransformWithGrouping($to, $from, $locale)
     {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault($locale);
 
         $transformer = new NumberToLocalizedStringTransformer(null, true);
@@ -122,6 +141,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The "mbstring" extension is required for this test.');
         }
 
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('ru');
 
         $transformer = new NumberToLocalizedStringTransformer(null, true);
@@ -131,6 +153,11 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransformWithGroupingButWithoutGroupSeparator()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new NumberToLocalizedStringTransformer(null, true);
 
         // omit group separator
@@ -140,6 +167,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsNotDot()
     {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('fr');
         $transformer = new NumberToLocalizedStringTransformer(null, true);
 
@@ -157,6 +187,11 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new NumberToLocalizedStringTransformer(null, true);
 
         $transformer->reverseTransform('1.234.5');
@@ -167,6 +202,11 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new NumberToLocalizedStringTransformer(null, true);
 
         $transformer->reverseTransform('1234.5');
@@ -174,6 +214,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsDotButNoGroupingUsed()
     {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('fr');
         $transformer = new NumberToLocalizedStringTransformer();
 
@@ -183,6 +226,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsNotComma()
     {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('bg');
         $transformer = new NumberToLocalizedStringTransformer(null, true);
 
@@ -200,7 +246,6 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
     {
-        \Locale::setDefault('en');
         $transformer = new NumberToLocalizedStringTransformer(null, true);
 
         $transformer->reverseTransform('1,234,5');
@@ -211,7 +256,6 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
     {
-        \Locale::setDefault('en');
         $transformer = new NumberToLocalizedStringTransformer(null, true);
 
         $transformer->reverseTransform('1234,5');
@@ -219,7 +263,6 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsCommaButNoGroupingUsed()
     {
-        \Locale::setDefault('en');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
@@ -339,6 +382,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The "mbstring" extension is required for this test.');
         }
 
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('ru');
 
         $transformer = new NumberToLocalizedStringTransformer(null, true);
@@ -355,6 +401,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
         if (!function_exists('mb_detect_encoding')) {
             $this->markTestSkipped('The "mbstring" extension is required for this test.');
         }
+
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
 
         \Locale::setDefault('ru');
 
@@ -383,6 +432,9 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
         if (!function_exists('mb_detect_encoding')) {
             $this->markTestSkipped('The "mbstring" extension is required for this test.');
         }
+
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
 
         \Locale::setDefault('ru');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -20,10 +20,7 @@ class PercentToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCas
     {
         parent::setUp();
 
-        // Since we test against "de_AT", we need the full implementation
-        IntlTestHelper::requireFullIntl($this);
-
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('en');
     }
 
     public function testTransform()
@@ -55,6 +52,11 @@ class PercentToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCas
 
     public function testTransformWithPrecision()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new PercentToLocalizedStringTransformer(2);
 
         $this->assertEquals('12,34', $transformer->transform(0.1234));
@@ -89,6 +91,11 @@ class PercentToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCas
 
     public function testReverseTransformWithPrecision()
     {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $transformer = new PercentToLocalizedStringTransformer(2);
 
         $this->assertEquals(0.1234, $transformer->reverseTransform('12,34'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -13,13 +13,12 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Test\TypeTestCase as TestCase;
-use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class DateTimeTypeTest extends TestCase
 {
     protected function setUp()
     {
-        IntlTestHelper::requireIntl($this);
+        \Locale::setDefault('en');
 
         parent::setUp();
     }
@@ -269,16 +268,6 @@ class DateTimeTypeTest extends TestCase
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
         $this->factory->create('datetime', new \DateTime());
-    }
-
-    public function testSingleTextWidgetShouldUseTheRightInputType()
-    {
-        $form = $this->factory->create('datetime', null, array(
-            'widget' => 'single_text',
-        ));
-
-        $view = $form->createView();
-        $this->assertEquals('datetime', $view->vars['type']);
     }
 
     public function testPassDefaultEmptyValueToViewIfNotRequired()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -22,10 +22,7 @@ class DateTypeTest extends TestCase
     {
         parent::setUp();
 
-        // we test against "de_AT", so we need the full implementation
-        IntlTestHelper::requireFullIntl($this);
-
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('en');
     }
 
     /**
@@ -65,6 +62,11 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextDateTime()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
@@ -81,6 +83,11 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextString()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
@@ -97,6 +104,11 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextTimestamp()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
@@ -115,6 +127,11 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextRaw()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
@@ -373,6 +390,11 @@ class DateTypeTest extends TestCase
 
     public function testSetDataWithDifferentTimezones()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'America/New_York',
@@ -388,6 +410,11 @@ class DateTypeTest extends TestCase
 
     public function testSetDataWithDifferentTimezonesDateTime()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'America/New_York',
@@ -422,18 +449,24 @@ class DateTypeTest extends TestCase
     {
         $form = $this->factory->create('date', null, array(
             'months' => array(6, 7),
+            'format' => \IntlDateFormatter::SHORT,
         ));
 
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('6', '6', '06'),
-            new ChoiceView('7', '7', '07'),
+            new ChoiceView(6, '6', '06'),
+            new ChoiceView(7, '7', '07'),
         ), $view['month']->vars['choices']);
     }
 
     public function testMonthsOptionShortFormat()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMM.yy',
@@ -442,13 +475,18 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('1', '1', 'Jän'),
-            new ChoiceView('4', '4', 'Apr.'),
+            new ChoiceView(1, '1', 'Jän'),
+            new ChoiceView(4, '4', 'Apr.'),
         ), $view['month']->vars['choices']);
     }
 
     public function testMonthsOptionLongFormat()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMMM.yy',
@@ -457,13 +495,18 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('1', '1', 'Jänner'),
-            new ChoiceView('4', '4', 'April'),
+            new ChoiceView(1, '1', 'Jänner'),
+            new ChoiceView(4, '4', 'April'),
         ), $view['month']->vars['choices']);
     }
 
     public function testMonthsOptionLongFormatWithDifferentTimezone()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMMM.yy',
@@ -472,8 +515,8 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('1', '1', 'Jänner'),
-            new ChoiceView('4', '4', 'April'),
+            new ChoiceView(1, '1', 'Jänner'),
+            new ChoiceView(4, '4', 'April'),
         ), $view['month']->vars['choices']);
     }
 
@@ -486,8 +529,8 @@ class DateTypeTest extends TestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('6', '6', '06'),
-            new ChoiceView('7', '7', '07'),
+            new ChoiceView(6, '6', '06'),
+            new ChoiceView(7, '7', '07'),
         ), $view['day']->vars['choices']);
     }
 
@@ -565,6 +608,11 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToView()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date');
         $view = $form->createView();
 
@@ -573,6 +621,11 @@ class DateTypeTest extends TestCase
 
     public function testPassDatePatternToViewDifferentFormat()
     {
+        // we test against "de_AT", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::LONG,
         ));
@@ -616,6 +669,9 @@ class DateTypeTest extends TestCase
 
     public function testDatePatternFormatWithQuotedStrings()
     {
+        // we test against "es_ES", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('es_ES');
 
         $form = $this->factory->create('date', null, array(
@@ -644,16 +700,6 @@ class DateTypeTest extends TestCase
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
         $this->factory->create('date', new \DateTime());
-    }
-
-    public function testSingleTextWidgetShouldUseTheRightInputType()
-    {
-        $form = $this->factory->create('date', null, array(
-            'widget' => 'single_text',
-        ));
-
-        $view = $form->createView();
-        $this->assertEquals('date', $view->vars['type']);
     }
 
     public function testPassDefaultEmptyValueToViewIfNotRequired()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -14,17 +14,9 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Test\TypeTestCase as TestCase;
-use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class TimeTypeTest extends TestCase
 {
-    protected function setUp()
-    {
-        IntlTestHelper::requireIntl($this);
-
-        parent::setUp();
-    }
-
     public function testSubmitDateTime()
     {
         $form = $this->factory->create('time', null, array(

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Reader;
 
 use Symfony\Component\Intl\Data\Bundle\Reader\IntlBundleReader;
-use Symfony\Component\Intl\Util\IntlTestHelper;
+use Symfony\Component\Intl\Intl;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -26,7 +26,10 @@ class IntlBundleReaderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        IntlTestHelper::requireFullIntl($this);
+        // We only run tests if the intl extension is loaded...
+        if (!Intl::isExtensionLoaded()) {
+            $this->markTestSkipped('The intl extension is not available.');
+        }
 
         $this->reader = new IntlBundleReader();
     }
@@ -52,6 +55,14 @@ class IntlBundleReaderTest extends \PHPUnit_Framework_TestCase
 
     public function testReadDoesNotFollowFallback()
     {
+        if (PHP_VERSION_ID < 50307 || PHP_VERSION_ID === 50400) {
+            $this->markTestSkipped('ResourceBundle handles disabling fallback properly only as of PHP 5.3.7 and 5.4.1.');
+        }
+
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('ResourceBundle does not support disabling fallback properly on HHVM.');
+        }
+
         // "ro_MD" -> "ro"
         $data = $this->reader->read(__DIR__.'/Fixtures/res', 'ro_MD');
 
@@ -64,6 +75,14 @@ class IntlBundleReaderTest extends \PHPUnit_Framework_TestCase
 
     public function testReadDoesNotFollowFallbackAlias()
     {
+        if (PHP_VERSION_ID < 50307 || PHP_VERSION_ID === 50400) {
+            $this->markTestSkipped('ResourceBundle handles disabling fallback properly only as of PHP 5.3.7 and 5.4.1.');
+        }
+
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('ResourceBundle does not support disabling fallback properly on HHVM.');
+        }
+
         // "mo" = "ro_MD" -> "ro"
         $data = $this->reader->read(__DIR__.'/Fixtures/res', 'mo');
 

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Intl\Tests\Data\Bundle\Writer;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Intl\Data\Bundle\Writer\JsonBundleWriter;
-use Symfony\Component\Intl\Util\IntlTestHelper;
+use Symfony\Component\Intl\Intl;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -74,7 +74,10 @@ class JsonBundleWriterTest extends \PHPUnit_Framework_TestCase
 
     public function testWriteResourceBundle()
     {
-        IntlTestHelper::requireFullIntl($this);
+        // We only run tests if the intl extension is loaded...
+        if (!Intl::isExtensionLoaded()) {
+            $this->markTestSkipped('The intl extension is not available.');
+        }
 
         $bundle = new \ResourceBundle('rb', __DIR__.'/Fixtures', false);
 

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/PhpBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/PhpBundleWriterTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Intl\Tests\Data\Bundle\Writer;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Intl\Data\Bundle\Writer\PhpBundleWriter;
-use Symfony\Component\Intl\Util\IntlTestHelper;
+use Symfony\Component\Intl\Intl;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -66,7 +66,14 @@ class PhpBundleWriterTest extends \PHPUnit_Framework_TestCase
 
     public function testWriteResourceBundle()
     {
-        IntlTestHelper::requireFullIntl($this);
+        // We only run tests if the intl extension is loaded...
+        if (!Intl::isExtensionLoaded()) {
+            $this->markTestSkipped('The intl extension is not available.');
+        }
+
+        if (PHP_VERSION_ID < 50315 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404)) {
+            $this->markTestSkipped('ResourceBundle implements Traversable only as of PHP 5.3.15 and 5.4.4');
+        }
 
         $bundle = new \ResourceBundle('rb', __DIR__.'/Fixtures', false);
 

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -56,8 +56,6 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatCurrencyWithCurrencyStyle($value, $currency, $expected)
     {
-        IntlTestHelper::requireFullIntl($this);
-
         $formatter = $this->getNumberFormatter('en', NumberFormatter::CURRENCY);
         $this->assertEquals($expected, $formatter->formatCurrency($value, $currency));
     }
@@ -84,8 +82,6 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatCurrencyWithCurrencyStyleCostaRicanColonsRounding($value, $currency, $symbol, $expected)
     {
-        IntlTestHelper::requireFullIntl($this);
-
         $formatter = $this->getNumberFormatter('en', NumberFormatter::CURRENCY);
         $this->assertEquals(sprintf($expected, $symbol), $formatter->formatCurrency($value, $currency));
     }
@@ -104,8 +100,6 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatCurrencyWithCurrencyStyleBrazilianRealRounding($value, $currency, $symbol, $expected)
     {
-        IntlTestHelper::requireFullIntl($this);
-
         $formatter = $this->getNumberFormatter('en', NumberFormatter::CURRENCY);
         $this->assertEquals(sprintf($expected, $symbol), $formatter->formatCurrency($value, $currency));
     }
@@ -133,8 +127,6 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatCurrencyWithCurrencyStyleSwissRounding($value, $currency, $symbol, $expected)
     {
-        IntlTestHelper::requireFullIntl($this);
-
         $formatter = $this->getNumberFormatter('en', NumberFormatter::CURRENCY);
         $this->assertEquals(sprintf($expected, $symbol), $formatter->formatCurrency($value, $currency));
     }

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Intl\Tests\NumberFormatter;
 
 use Symfony\Component\Intl\Globals\IntlGlobals;
 use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
-use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * Note that there are some values written like -2147483647 - 1. This is the lower 32bit int max and is a known
@@ -21,13 +20,6 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class NumberFormatterTest extends AbstractNumberFormatterTest
 {
-    protected function setUp()
-    {
-        IntlTestHelper::requireIntl($this);
-
-        parent::setUp();
-    }
-
     /**
      * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
      */

--- a/src/Symfony/Component/Locale/Tests/LocaleTest.php
+++ b/src/Symfony/Component/Locale/Tests/LocaleTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Locale\Tests;
 
-use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Locale\Locale;
 
 /**
@@ -25,8 +24,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
 
-        // Locale extends \Locale, so intl must be present
-        IntlTestHelper::requireIntl($this);
+        \Locale::setDefault('en');
     }
 
     public function testGetDisplayCountries()

--- a/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Locale\Tests\Stub;
 
-use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Locale\Stub\StubLocale;
 
 /**
@@ -22,9 +21,6 @@ class StubLocaleTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
-
-        // Locale extends \Locale, so intl must be present
-        IntlTestHelper::requireIntl($this);
     }
 
     public function testGetCurrenciesData()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\Validator\Constraints\CountryValidator;
 
 class CountryValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function setUp()
-    {
-        IntlTestHelper::requireFullIntl($this);
-
-        parent::setUp();
-    }
-
     protected function createValidator()
     {
         return new CountryValidator();

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\Validator\Constraints\CurrencyValidator;
 
 class CurrencyValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function setUp()
-    {
-        IntlTestHelper::requireFullIntl($this);
-
-        parent::setUp();
-    }
-
     protected function createValidator()
     {
         return new CurrencyValidator();
@@ -66,6 +59,8 @@ class CurrencyValidatorTest extends AbstractConstraintValidatorTest
      **/
     public function testValidCurrenciesWithCountrySpecificLocale($currency)
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('en_GB');
 
         $this->validator->validate($currency, new Currency());

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -22,13 +22,6 @@ class LanguageValidatorTest extends AbstractConstraintValidatorTest
         return new LanguageValidator();
     }
 
-    protected function setUp()
-    {
-        IntlTestHelper::requireFullIntl($this);
-
-        parent::setUp();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Language());
@@ -96,6 +89,8 @@ class LanguageValidatorTest extends AbstractConstraintValidatorTest
 
     public function testValidateUsingCountrySpecificLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('fr_FR');
         $existingLanguage = 'en';
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Locale;
 use Symfony\Component\Validator\Constraints\LocaleValidator;
 
@@ -20,13 +19,6 @@ class LocaleValidatorTest extends AbstractConstraintValidatorTest
     protected function createValidator()
     {
         return new LocaleValidator();
-    }
-
-    protected function setUp()
-    {
-        IntlTestHelper::requireIntl($this);
-
-        parent::setUp();
     }
 
     public function testNullIsValid()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Many tests being skipped based on the ICU data version don't actually need it. They might be testing code paths not relying on Intl, or not performing assertions on the values depending on the ICU data and so not dependant on the exact ICU version being used.

this is somewhat related to https://github.com/symfony/symfony/issues/14259 as it allows to reduce the number of tests not running on Travis.
