### PR TITLE
Fix the return value on error for intl methods returning arrays

### DIFF
--- a/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundle.php
@@ -76,7 +76,7 @@ class CurrencyBundle extends CurrencyDataProvider implements CurrencyBundleInter
         try {
             return $this->getNames($displayLocale);
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 
@@ -112,7 +112,7 @@ class CurrencyBundle extends CurrencyDataProvider implements CurrencyBundleInter
         try {
             return $this->localeProvider->getLocales();
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 }

--- a/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
@@ -80,7 +80,7 @@ class LanguageBundle extends LanguageDataProvider implements LanguageBundleInter
         try {
             return $this->getNames($displayLocale);
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 
@@ -104,7 +104,7 @@ class LanguageBundle extends LanguageDataProvider implements LanguageBundleInter
         try {
             return $this->scriptProvider->getNames($displayLocale);
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 
@@ -116,7 +116,7 @@ class LanguageBundle extends LanguageDataProvider implements LanguageBundleInter
         try {
             return $this->localeProvider->getLocales();
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 }

--- a/src/Symfony/Component/Intl/ResourceBundle/LocaleBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LocaleBundle.php
@@ -31,7 +31,7 @@ class LocaleBundle extends LocaleDataProvider implements LocaleBundleInterface
         try {
             return parent::getLocales();
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 
@@ -55,7 +55,7 @@ class LocaleBundle extends LocaleDataProvider implements LocaleBundleInterface
         try {
             return $this->getNames($displayLocale);
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 }

--- a/src/Symfony/Component/Intl/ResourceBundle/RegionBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/RegionBundle.php
@@ -64,7 +64,7 @@ class RegionBundle extends RegionDataProvider implements RegionBundleInterface
         try {
             return $this->getNames($displayLocale);
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 
@@ -76,7 +76,7 @@ class RegionBundle extends RegionDataProvider implements RegionBundleInterface
         try {
             return $this->localeProvider->getLocales();
         } catch (MissingResourceException $e) {
-            return;
+            return array();
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When the resource is missing, an empty array should be returned rather than null to respect the interface saying an array is always returned.
