### PR TITLE
[Debug] Deprecate ExceptionHandler::createResponse

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -164,6 +164,7 @@ class ExceptionHandler
             $response = $this->createResponse($exception);
             $response->sendHeaders();
             $response->sendContent();
+            @trigger_error(sprintf("The %s::createResponse method is deprecated since 2.8 and won't be called anymore when handling an exception in 3.0.", $reflector->class), E_USER_DEPRECATED);
 
             return;
         }
@@ -202,9 +203,13 @@ class ExceptionHandler
      * @param \Exception|FlattenException $exception An \Exception instance
      *
      * @return Response A Response instance
+     *
+     * @deprecated since 2.8, to be removed in 3.0.
      */
     public function createResponse($exception)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
         if (!$exception instanceof FlattenException) {
             $exception = FlattenException::create($exception);
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #15414 |
| License | MIT |
| Doc PR | - |

This does deprecate a behavior that might be specialized by someone somewhere, but I seriously doubt anyone did. It complicated the implementation for no gain IMHO.
