### PR TITLE
[Routing] Fix the retrieval of the default value for variadic arguments in the annotation loader

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -180,7 +180,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
 
         $defaults = array_replace($globals['defaults'], $annot->getDefaults());
         foreach ($method->getParameters() as $param) {
-            if (!isset($defaults[$param->getName()]) && $param->isOptional()) {
+            if (!isset($defaults[$param->getName()]) && $param->isDefaultValueAvailable()) {
                 $defaults[$param->getName()] = $param->getDefaultValue();
             }
         }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/VariadicClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/VariadicClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
+
+class VariadicClass
+{
+    public function routeAction(...$params)
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/OtherAnnotatedClasses/VariadicClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/OtherAnnotatedClasses/VariadicClass.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
+namespace Symfony\Component\Routing\Tests\Fixtures\OtherAnnotatedClasses;
 
 class VariadicClass
 {

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 {
     protected $loader;
+    private $reader;
 
     protected function setUp()
     {

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use Symfony\Component\Routing\Loader\AnnotationFileLoader;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Annotation\Route;
 
 class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
 {
@@ -32,6 +33,19 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader->expects($this->once())->method('getClassAnnotation');
 
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/FooClass.php');
+    }
+
+    /**
+     * @requires PHP 5.6
+     */
+    public function testLoadVariadic()
+    {
+        $route = new Route(["path" => "/path/to/{id}"]);
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+        $this->reader->expects($this->once())->method('getMethodAnnotations')
+            ->will($this->returnValue([$route]));
+
+        $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/VariadicClass.php');
     }
 
     public function testSupports()

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -40,12 +40,12 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
      */
     public function testLoadVariadic()
     {
-        $route = new Route(["path" => "/path/to/{id}"]);
+        $route = new Route(array('path' => '/path/to/{id}'));
         $this->reader->expects($this->once())->method('getClassAnnotation');
         $this->reader->expects($this->once())->method('getMethodAnnotations')
-            ->will($this->returnValue([$route]));
+            ->will($this->returnValue(array($route)));
 
-        $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/VariadicClass.php');
+        $this->loader->load(__DIR__.'/../Fixtures/OtherAnnotatedClasses/VariadicClass.php');
     }
 
     public function testSupports()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13690 |
| License | MIT |
| Doc PR | n/a |

This takes the test submitted in #13690 and implements the fix for this bug
