### PR TITLE
[BrowserKit] Corrected HTTP_HOST logic

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -120,7 +120,6 @@ abstract class Client
     public function setServerParameters(array $server)
     {
         $this->server = array_merge(array(
-            'HTTP_HOST' => 'localhost',
             'HTTP_USER_AGENT' => 'Symfony2 BrowserKit',
         ), $server);
     }
@@ -303,21 +302,19 @@ abstract class Client
 
         $uri = $this->getAbsoluteUri($uri);
 
-        if (!empty($server['HTTP_HOST'])) {
-            $uri = preg_replace('{^(https?\://)'.preg_quote($this->extractHost($uri)).'}', '${1}'.$server['HTTP_HOST'], $uri);
-        }
+        $server = array_merge($this->server, $server);
 
         if (isset($server['HTTPS'])) {
             $uri = preg_replace('{^'.parse_url($uri, PHP_URL_SCHEME).'}', $server['HTTPS'] ? 'https' : 'http', $uri);
         }
 
-        $server = array_merge($this->server, $server);
-
         if (!$this->history->isEmpty()) {
             $server['HTTP_REFERER'] = $this->history->current()->getUri();
         }
 
-        $server['HTTP_HOST'] = $this->extractHost($uri);
+        if (empty($server['HTTP_HOST'])) {
+          $server['HTTP_HOST'] = $this->extractHost($uri);
+        }
         $server['HTTPS'] = 'https' == parse_url($uri, PHP_URL_SCHEME);
 
         $this->internalRequest = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -102,12 +102,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://example.com/', $client->getRequest()->getUri(), '->getCrawler() returns the Request of the last request');
     }
 
-    public function testGetRequestWithIpAsHost()
+    public function testGetRequestWithIpAsHttpHost()
     {
         $client = new TestClient();
         $client->request('GET', 'https://example.com/foo', array(), array(), array('HTTP_HOST' => '127.0.0.1'));
 
-        $this->assertEquals('https://127.0.0.1/foo', $client->getRequest()->getUri());
+        $this->assertEquals('https://example.com/foo', $client->getRequest()->getUri());
+        $headers = $client->getRequest()->getServer();
+        $this->assertEquals('127.0.0.1', $headers['HTTP_HOST']);
     }
 
     public function testGetResponse()
@@ -222,24 +224,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->request('GET', 'http://www.example.com/');
         $client->request('GET', 'http');
         $this->assertEquals('http://www.example.com/http', $client->getRequest()->getUri(), '->request() uses the previous request for relative URLs');
-    }
-
-    public function testRequestURIConversionByServerHost()
-    {
-        $client = new TestClient();
-
-        $server = array('HTTP_HOST' => 'www.exampl+e.com:8000');
-        $parameters = array();
-        $files = array();
-
-        $client->request('GET', 'http://exampl+e.com', $parameters, $files, $server);
-        $this->assertEquals('http://www.exampl+e.com:8000', $client->getRequest()->getUri(), '->request() uses HTTP_HOST to add port');
-
-        $client->request('GET', 'http://exampl+e.com:8888', $parameters, $files, $server);
-        $this->assertEquals('http://www.exampl+e.com:8000', $client->getRequest()->getUri(), '->request() uses HTTP_HOST to modify existing port');
-
-        $client->request('GET', 'http://exampl+e.com:8000', $parameters, $files, $server);
-        $this->assertEquals('http://www.exampl+e.com:8000', $client->getRequest()->getUri(), '->request() uses HTTP_HOST respects correct set port');
     }
 
     public function testRequestReferer()
@@ -584,7 +568,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetServerParameter()
     {
         $client = new TestClient();
-        $this->assertEquals('localhost', $client->getServerParameter('HTTP_HOST'));
+        $this->assertEquals('', $client->getServerParameter('HTTP_HOST'));
         $this->assertEquals('Symfony2 BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
         $this->assertEquals('testvalue', $client->getServerParameter('testkey', 'testvalue'));
     }
@@ -593,7 +577,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new TestClient();
 
-        $this->assertEquals('localhost', $client->getServerParameter('HTTP_HOST'));
+        $this->assertEquals('', $client->getServerParameter('HTTP_HOST'));
         $this->assertEquals('Symfony2 BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
 
         $client->setServerParameter('HTTP_HOST', 'testhost');
@@ -607,7 +591,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new TestClient();
 
-        $this->assertEquals('localhost', $client->getServerParameter('HTTP_HOST'));
+        $this->assertEquals('', $client->getServerParameter('HTTP_HOST'));
         $this->assertEquals('Symfony2 BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
 
         $client->request('GET', 'https://www.example.com/https/www.example.com', array(), array(), array(
@@ -617,10 +601,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'NEW_SERVER_KEY' => 'new-server-key-value',
         ));
 
-        $this->assertEquals('localhost', $client->getServerParameter('HTTP_HOST'));
+        $this->assertEquals('', $client->getServerParameter('HTTP_HOST'));
         $this->assertEquals('Symfony2 BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
 
-        $this->assertEquals('http://testhost/https/www.example.com', $client->getRequest()->getUri());
+        $this->assertEquals('http://www.example.com/https/www.example.com', $client->getRequest()->getUri());
 
         $server = $client->getRequest()->getServer();
 


### PR DESCRIPTION
HTTP_HOST is just a header - it does not override URI,
uri does not override HTTP_HOST header. 
If HTTP_HOST is not set then and only then hostname is extracted from uri. 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15398 |
| License | MIT |
| Doc PR |  |

I made a new pull request, because I have broken the first one with rebase.
