### PR TITLE
Fix the validation of form resources to register the default theme

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -260,7 +260,7 @@ class Configuration implements ConfigurationInterface
                                     ->addDefaultChildrenIfNoneSet()
                                     ->prototype('scalar')->defaultValue('FrameworkBundle:Form')->end()
                                     ->validate()
-                                        ->ifNotInArray(array('FrameworkBundle:Form'))
+                                        ->ifTrue(function ($v) {return !in_array('FrameworkBundle:Form', $v); })
                                         ->then(function ($v) {
                                             return array_merge(array('FrameworkBundle:Form'), $v);
                                         })

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -27,6 +27,19 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDoNoDuplicateDefaultFormResources()
+    {
+        $input = array('templating' => array(
+            'form' => array('resources' => array('FrameworkBundle:Form')),
+            'engines' => array('php'),
+        ));
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), array($input));
+
+        $this->assertEquals(array('FrameworkBundle:Form'), $config['templating']['form']['resources']);
+    }
+
     /**
      * @dataProvider getTestValidTrustedProxiesData
      */

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -58,7 +58,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->defaultValue('form_div_layout.html.twig')->end()
                             ->example(array('MyBundle::form.html.twig'))
                             ->validate()
-                                ->ifNotInArray(array('form_div_layout.html.twig'))
+                                ->ifTrue(function ($v) {return !in_array('form_div_layout.html.twig', $v); })
                                 ->then(function ($v) {
                                     return array_merge(array('form_div_layout.html.twig'), $v);
                                 })

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection;
+
+use Symfony\Bundle\TwigBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDoNoDuplicateDefaultFormResources()
+    {
+        $input = array(
+            'form' => array('resources' => array('form_div_layout.html.twig')),
+        );
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), array($input));
+
+        $this->assertEquals(array('form_div_layout.html.twig'), $config['form']['resources']);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

https://github.com/symfony/symfony/pull/14173 made some wrong changes, changing the behavior of the code. This reverts to the right behavior in affected places
