### PR TITLE
Allow to define Enum nodes with 1 single element

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -399,3 +399,23 @@ FrameworkBundle
        session:
            cookie_httponly: false
    ```
+
+Config
+------
+
+The edge case of defining just one value for nodes of type Enum is now allowed:
+
+```php
+$rootNode
+    ->children()
+        ->enumNode('variable')
+            ->values(array('value'))
+        ->end()
+    ->end()
+;
+```
+
+Before: `InvalidArgumentException` (variable must contain at least two
+distinct elements).
+After: the code will work as expected and it will restrict the values of the
+`variable` option to just `value`.

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -24,13 +24,8 @@ class EnumNode extends ScalarNode
 
     public function __construct($name, NodeInterface $parent = null, array $values = array())
     {
-        $values = array_unique($values);
-        if (count($values) <= 1) {
-            throw new \InvalidArgumentException('$values must contain at least two distinct elements.');
-        }
-
         parent::__construct($name, $parent);
-        $this->values = $values;
+        $this->values = array_unique($values);
     }
 
     public function getValues()

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -24,8 +24,13 @@ class EnumNode extends ScalarNode
 
     public function __construct($name, NodeInterface $parent = null, array $values = array())
     {
+        $values = array_unique($values);
+        if (empty($values)) {
+            throw new \InvalidArgumentException('$values must contain at least one element.');
+        }
+
         parent::__construct($name, $parent);
-        $this->values = array_unique($values);
+        $this->values = $values;
     }
 
     public function getValues()

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -21,6 +21,15 @@ class EnumNodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo', $node->finalize('foo'));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage $values must contain at least one element.
+     */
+    public function testConstructionWithNoValues()
+    {
+        new EnumNode('foo', null, array());
+    }
+
     public function testConstructionWithOneValue()
     {
         $node = new EnumNode('foo', null, array('foo'));

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -21,12 +21,16 @@ class EnumNodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo', $node->finalize('foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructionWithOneValue()
     {
-        new EnumNode('foo', null, array('foo', 'foo'));
+        $node = new EnumNode('foo', null, array('foo'));
+        $this->assertSame('foo', $node->finalize('foo'));
+    }
+
+    public function testConstructionWithOneDistinctValue()
+    {
+        $node = new EnumNode('foo', null, array('foo', 'foo'));
+        $this->assertSame('foo', $node->finalize('foo'));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15402 |
| License | MIT |
| Doc PR | - |
