### PR TITLE
[Validator] Require the intl extension to be installed for one of the test cases

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -78,7 +78,7 @@ abstract class AbstractComparisonValidatorTestCase extends AbstractConstraintVal
         // Conversion of dates to string differs between ICU versions
         // Make sure we have the correct version loaded
         if ($dirtyValue instanceof \DateTime) {
-            IntlTestHelper::requireIntl($this);
+            IntlTestHelper::requireFullIntl($this);
         }
 
         $constraint = $this->createConstraint(array('value' => $comparedValue));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15049 |
| License | MIT |
| Doc PR | - |

Requiring a specific version of the intl data is not sufficient, we need the extension to be installed.
