### PR TITLE
do not remove space between attributes

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -304,7 +304,7 @@
 
 {%- block widget_container_attributes -%}
     {% if id is not empty %}id="{{ id }}" {% endif %}
-    {%- for attrname, attrvalue in attr %}{{ attrname }}="{{ attrvalue }}" {%- endfor -%}
+    {%- for attrname, attrvalue in attr %}{{ attrname }}="{{ attrvalue }}" {% endfor -%}
 {%- endblock widget_container_attributes -%}
 
 {%- block button_attributes -%}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | n/a |

This piece of code adds a space then removes it immediately. One could think that only the space after the last element of the loop is removed, but this is not the case. Space between loop elements are also removed.
