### PR TITLE
[Console] Handle false return value from readline

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -434,10 +434,10 @@ class QuestionHelper extends Helper
             $ret = readline();
         } else {
             $ret = fgets($stream, 4096);
+        }
 
-            if (false === $ret) {
-                throw new \RuntimeException('Aborted');
-            }
+        if (false === $ret) {
+            throw new \RuntimeException('Aborted');
         }
 
         return trim($ret);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Following #15382 and as @stof mentioned, the `false` value can be returned by `readline()` and should be handled. This fixes the problem.
