### PR TITLE
[Filesystem] Add feature to create hardlinks for files

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -306,14 +306,57 @@ class Filesystem
         }
 
         if (!$ok && true !== @symlink($originDir, $targetDir)) {
-            $report = error_get_last();
-            if (is_array($report)) {
-                if ('\\' === DIRECTORY_SEPARATOR && false !== strpos($report['message'], 'error code(1314)')) {
-                    throw new IOException('Unable to create symlink due to error code 1314: \'A required privilege is not held by the client\'. Do you have the required Administrator-rights?', 0, null, $targetDir);
-                }
-            }
-            throw new IOException(sprintf('Failed to create symbolic link from "%s" to "%s".', $originDir, $targetDir), 0, null, $targetDir);
+            $this->linkException($originDir, $targetDir, 'symbolic');
         }
+    }
+
+    /**
+     * Creates a hard link, or several hard links to a file.
+     *
+     * @param string          $originFile  The original file
+     * @param string|string[] $targetFiles The target file(s)
+     *
+     * @throws FileNotFoundException When original file is missing or not a file
+     * @throws IOException           When link fails, including if link already exists
+     */
+    public function hardlink($originFile, $targetFiles)
+    {
+        if (!$this->exists($originFile)) {
+            throw new FileNotFoundException(null, 0, null, $originFile);
+        }
+
+        if (!is_file($originFile)) {
+            throw new FileNotFoundException(sprintf('Origin file "%s" is not a file', $originFile));
+        }
+
+        foreach ($this->toIterator($targetFiles) as $targetFile) {
+            if (is_file($targetFile)) {
+                if (fileinode($originFile) === fileinode($targetFile)) {
+                    continue;
+                }
+                $this->remove($targetFile);
+            }
+
+            if (true !== @link($originFile, $targetFile)) {
+                $this->linkException($originFile, $targetFile, 'hard');
+            }
+        }
+    }
+
+    /**
+     * @param string $origin
+     * @param string $target
+     * @param string $linkType Name of the link type, typically 'symbolic' or 'hard'
+     */
+    private function linkException($origin, $target, $linkType)
+    {
+        $report = error_get_last();
+        if (is_array($report)) {
+            if ('\\' === DIRECTORY_SEPARATOR && false !== strpos($report['message'], 'error code(1314)')) {
+                throw new IOException(sprintf('Unable to create %s link due to error code 1314: \'A required privilege is not held by the client\'. Do you have the required Administrator-rights?', $linkType), 0, null, $target);
+            }
+        }
+        throw new IOException(sprintf('Failed to create %s link from "%s" to "%s".', $linkType, $origin, $target), 0, null, $target);
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1309,8 +1309,8 @@ class FilesystemTest extends FilesystemTestCase
     {
         $this->markAsSkippedIfChmodIsMissing();
 
-        $sourceFilePath = $this->workspace . DIRECTORY_SEPARATOR . 'copy_source_file';
-        $targetFilePath = $this->workspace . DIRECTORY_SEPARATOR . 'copy_target_file';
+        $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';
+        $targetFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_target_file';
 
         file_put_contents($sourceFilePath, 'SOURCE FILE');
         chmod($sourceFilePath, 0745);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -535,6 +535,20 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chown($link, $this->getFileOwner($link));
     }
 
+    public function testChownLink()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+
+        $this->filesystem->hardlink($file, $link);
+
+        $this->filesystem->chown($link, $this->getFileOwner($link));
+    }
+
     /**
      * @expectedException \Symfony\Component\Filesystem\Exception\IOException
      */
@@ -548,6 +562,23 @@ class FilesystemTest extends FilesystemTestCase
         touch($file);
 
         $this->filesystem->symlink($file, $link);
+
+        $this->filesystem->chown($link, 'user'.time().mt_rand(1000, 9999));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
+     */
+    public function testChownLinkFails()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+
+        $this->filesystem->hardlink($file, $link);
 
         $this->filesystem->chown($link, 'user'.time().mt_rand(1000, 9999));
     }
@@ -601,6 +632,20 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chgrp($link, $this->getFileGroup($link));
     }
 
+    public function testChgrpLink()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+
+        $this->filesystem->hardlink($file, $link);
+
+        $this->filesystem->chgrp($link, $this->getFileGroup($link));
+    }
+
     /**
      * @expectedException \Symfony\Component\Filesystem\Exception\IOException
      */
@@ -614,6 +659,23 @@ class FilesystemTest extends FilesystemTestCase
         touch($file);
 
         $this->filesystem->symlink($file, $link);
+
+        $this->filesystem->chgrp($link, 'user'.time().mt_rand(1000, 9999));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
+     */
+    public function testChgrpLinkFails()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+
+        $this->filesystem->hardlink($file, $link);
 
         $this->filesystem->chgrp($link, 'user'.time().mt_rand(1000, 9999));
     }
@@ -765,6 +827,103 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertEquals($file, readlink($link1));
         $this->assertTrue(is_link($link2));
         $this->assertEquals($file, readlink($link2));
+    }
+
+    public function testLink()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+        $this->filesystem->hardlink($file, $link);
+
+        $this->assertTrue(is_file($link));
+        $this->assertEquals(fileinode($file), fileinode($link));
+    }
+
+    /**
+     * @depends testLink
+     */
+    public function testRemoveLink()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        $this->filesystem->remove($link);
+
+        $this->assertTrue(!is_file($link));
+    }
+
+    public function testLinkIsOverwrittenIfPointsToDifferentTarget()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $file2 = $this->workspace.DIRECTORY_SEPARATOR.'file2';
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+        touch($file2);
+        link($file2, $link);
+
+        $this->filesystem->hardlink($file, $link);
+
+        $this->assertTrue(is_file($link));
+        $this->assertEquals(fileinode($file), fileinode($link));
+    }
+
+    public function testLinkIsNotOverwrittenIfAlreadyCreated()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+        link($file, $link);
+
+        $this->filesystem->hardlink($file, $link);
+
+        $this->assertTrue(is_file($link));
+        $this->assertEquals(fileinode($file), fileinode($link));
+
+    }
+
+    public function testLinkWithSeveralTargets()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link1 = $this->workspace.DIRECTORY_SEPARATOR.'link';
+        $link2 = $this->workspace.DIRECTORY_SEPARATOR.'link2';
+
+        touch($file);
+
+        $this->filesystem->hardlink($file, array($link1,$link2));
+
+        $this->assertTrue(is_file($link1));
+        $this->assertEquals(fileinode($file), fileinode($link1));
+        $this->assertTrue(is_file($link2));
+        $this->assertEquals(fileinode($file), fileinode($link2));
+    }
+
+    public function testLinkWithSameTarget()
+    {
+        $this->markAsSkippedIfLinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+
+        // practically same as testLinkIsNotOverwrittenIfAlreadyCreated
+        $this->filesystem->hardlink($file, array($link,$link));
+
+        $this->assertTrue(is_file($link));
+        $this->assertEquals(fileinode($file), fileinode($link));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Todo:
- [x] Tests
- [ ] Doc
- [x] Getting someone to test on Windows as exception might differ from symlink functionality
## Why

Symlinks are good for directories, but for files hardlinks are sometime a better match when needing to represent same file in several locations.

One use case for this feature is for multi tagging of Http Cache when running against FileSystem. Multi tagging is used in FoSHttpCache and supported when running Varnish, but not with Symfony HTTPCache, yet.. With hardlinks combined with meta information containing tags within the file, lookup and reverse lookup is thus easily possible.
## What

Introduces method `hardlink()` with similar behavior as `symlink`, difference being:
- Allowing several targets to be provided to match use case in 'why'
- Like `symlink` removes existing target if not the same, but uses `fileinode` to compare target & source
