### PR TITLE
[Yaml] Nested merge keys

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -113,6 +113,9 @@ class Parser
                         $data[] = $this->parseValue($values['value'], $exceptionOnInvalidType, $objectSupport);
                     }
                 }
+                if ($isRef) {
+                    $this->refs[$isRef] = end($data);
+                }
             } elseif (preg_match('#^(?P<key>'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\[\{].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $this->currentLine, $values) && (false === strpos($values['key'], ' #') || in_array($values['key'][0], array('"', "'")))) {
                 if ($context && 'sequence' == $context) {
                     throw new ParseException('You cannot define a mapping item when in a sequence');
@@ -191,6 +194,9 @@ class Parser
                         $data[$key] = $this->parseValue($values['value'], $exceptionOnInvalidType, $objectSupport);
                     }
                 }
+                if ($isRef) {
+                    $this->refs[$isRef] = $data[$key];
+                }
             } else {
                 // multiple documents are not supported
                 if ('---' === $this->currentLine) {
@@ -247,10 +253,6 @@ class Parser
                 }
 
                 throw new ParseException($error, $this->getRealCurrentLineNb() + 1, $this->currentLine);
-            }
-
-            if ($isRef) {
-                $this->refs[$isRef] = end($data);
             }
         }
 

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfMergeKey.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfMergeKey.yml
@@ -23,5 +23,16 @@ yaml: |
         isit: tested
     head:
         <<: [ *foo , *dong , *foo2 ]
+    taz: &taz
+        a: Steve
+        w:
+            p: 1234
+    nested:
+        <<: *taz
+        d: Doug
+        w: &nestedref
+            p: 12345
+        z:
+            <<: *nestedref
 php: |
-    array('foo' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian'), 'bar' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'x' => 'Oren'), 'foo2' => array('a' => 'Ballmer'), 'ding' => array('fi', 'fei', 'fo', 'fam'), 'check' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam', 'isit' => 'tested'), 'head' => array('a' => 'Ballmer', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam'))
+    array('foo' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian'), 'bar' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'x' => 'Oren'), 'foo2' => array('a' => 'Ballmer'), 'ding' => array('fi', 'fei', 'fo', 'fam'), 'check' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam', 'isit' => 'tested'), 'head' => array('a' => 'Ballmer', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam'), 'taz' => array('a' => 'Steve', 'w' => array('p' => 1234)), 'nested' => array('a' => 'Steve', 'w' => array('p' => 12345), 'd' => 'Doug', 'z' => array('p' => 12345)),)


### PR DESCRIPTION
When trying to use nested merge keys in Yaml, the ref sometimes had the wrong value

eg, with:

``` yaml
taz: &taz
    a: Steve
    w:
        p: 1234
nested:
    <<: *taz
    d: Doug
    w: &nestedref
        p: 12345
    z:
        <<: *nestedref 
```

in this case, the ref `nestedref` had the value "Doug", which cause this error : 

```
Symfony\Component\Yaml\Exception\ParseException: YAML merge keys used with a scalar value instead of an array at line 38 (near "<<: *nestedref").
```

It now works as expected

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

note: this PR replace #15241 
