### PR TITLE
[Security] Add missing docblock in PreAuthenticatedToken

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -33,7 +33,7 @@ abstract class AbstractToken implements TokenInterface
     /**
      * Constructor.
      *
-     * @param RoleInterface[] $roles An array of roles
+     * @param RoleInterface[]|string[] $roles An array of roles
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
+use Symfony\Component\Security\Core\Role\RoleInterface;
+
 /**
  * PreAuthenticatedToken implements a pre-authenticated token.
  *
@@ -23,6 +25,11 @@ class PreAuthenticatedToken extends AbstractToken
 
     /**
      * Constructor.
+     *
+     * @param string|object            $user        The user
+     * @param mixed                    $credentials The user credentials
+     * @param string                   $providerKey The provider key
+     * @param RoleInterface[]|string[] $roles       An array of roles
      */
     public function __construct($user, $credentials, $providerKey, array $roles = array())
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I noticed the `PreAuthenticatedToken` does not provide any dockblock about its constructor parameters so PHPStorm uses the `AbstractToken` parameters and think I'm using `PreAuthenticatedToken` badly.

This fix it by adding the missing docblock and I also added the string[] possibility for roles in `AbstractToken` as it's present in the code and the exception message.
