### PR TITLE
fix debug-ext 003.phpt

### DIFF
--- a/src/Symfony/Component/Debug/Resources/ext/tests/003.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/003.phpt
@@ -56,7 +56,7 @@ Symfony\Component\Debug\Exception\UndefinedFunctionException Object
     [message:protected] => Attempted to call function "notexist" from namespace "Symfony\Component\Debug".
     [string:Exception:private] => 
     [code:protected] => 0
-    [file:protected] => -
+    [file:protected] => %s
     [line:protected] => %d
     [trace:Exception:private] => Array
         (


### PR DESCRIPTION
in my environment the filename is filled, not "-"

$ php --version
PHP 5.5.27 (cli) (built: Jul 17 2015 12:32:05)
Copyright (c) 1997-2015 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2015 Zend Technologies

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
