### PR TITLE
Implement the support of timezone objects in the stub IntlDateFormatter

### DIFF
--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -132,7 +132,7 @@ class IntlDateFormatter
      * @param string $locale   The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en").
      * @param int    $datetype Type of date formatting, one of the format type constants
      * @param int    $timetype Type of time formatting, one of the format type constants
-     * @param string $timezone Timezone identifier
+     * @param mixed  $timezone Timezone identifier
      * @param int    $calendar Calendar to use for formatting or parsing. The only currently
      *                         supported value is IntlDateFormatter::GREGORIAN.
      * @param string $pattern  Optional pattern to use when formatting
@@ -157,7 +157,7 @@ class IntlDateFormatter
         $this->timetype = $timetype;
 
         $this->setPattern($pattern);
-        $this->setTimeZoneId($timezone);
+        $this->setTimeZone($timezone);
     }
 
     /**
@@ -588,6 +588,19 @@ class IntlDateFormatter
      */
     public function setTimeZone($timeZone)
     {
+        if ($timeZone instanceof \IntlTimeZone) {
+            $timeZone = $timeZone->getID();
+        }
+
+        if ($timeZone instanceof \DateTimeZone) {
+            $timeZone = $timeZone->getName();
+
+            // DateTimeZone returns the GMT offset timezones without the leading GMT, while our parsing requires it.
+            if (!empty($timeZone) && ('+' === $timeZone[0] || '-' === $timeZone[0])) {
+                $timeZone = 'GMT'.$timeZone;
+            }
+        }
+
         return $this->setTimeZoneId($timeZone);
     }
 

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -387,6 +387,36 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFormatWithDateTimeZone()
+    {
+        if (PHP_VERSION_ID < 50500) {
+            $this->markTestSkipped('Only in PHP 5.5+ IntlDateFormatter allows to use DateTimeZone objects.');
+        }
+
+        if (defined('HHVM_VERSION_ID')) {
+            $this->markTestSkipped('This test cannot work on HHVM. See https://github.com/facebook/hhvm/issues/5875 for the issue.');
+        }
+
+        $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, new \DateTimeZone('GMT+03:00'), IntlDateFormatter::GREGORIAN, 'zzzz');
+
+        $this->assertEquals('GMT+03:00', $formatter->format(0));
+    }
+
+    public function testFormatWithIntlTimeZone()
+    {
+        if (PHP_VERSION_ID < 50500) {
+            $this->markTestSkipped('Only in PHP 5.5+ IntlDateFormatter allows to use DateTimeZone objects.');
+        }
+
+        if (!class_exists('IntlTimeZone')) {
+            $this->markTestSkipped('This test requires the IntlTimeZone class from the Intl extension.');
+        }
+
+        $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, \IntlTimeZone::createTimeZone('GMT+03:00'), IntlDateFormatter::GREGORIAN, 'zzzz');
+
+        $this->assertEquals('GMT+03:00', $formatter->format(0));
+    }
+
     public function testFormatWithTimezoneFromEnvironmentVariable()
     {
         if (PHP_VERSION_ID >= 50500) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

As of PHP 5.5, the IntlDateFormatter accepts to use DateTimeZone or IntlTimeZone objects as timezone in the constructor (and in the new setTimeZone method) rather than timezone ids.
This is even the proper way to pass a timezone from a DateTime object as DateTimeZone names are not all valid ICU identifiers (and there is a PR on the Twig-extensions repo to use such feature to support things properly: https://github.com/twigphp/Twig-extensions/pull/148).

I'm considering this as a bugfix because it is a mismatch between the stub implementation and the real class.
Note that for simplicity, these objects are accepted on all PHP versions, as reproducing the behavior of older versions is not possible in the stub anyway (triggering a warning and making the instantiating with `new` return `null`). We already have such differences anyway (the `setTimeZone` method exists in all PHP versions in the stub)
