### PR TITLE
[VarDumper] fixed HtmlDumper to target specific the head tag

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -125,7 +125,7 @@ var refStyle = doc.createElement('style'),
     rxEsc = /([.*+?^${}()|\[\]\/\\])/g,
     idRx = /\bsf-dump-\d+-ref[012]\w+\b/;
 
-doc.documentElement.firstChild.appendChild(refStyle);
+doc.getElementsByTagName('head')[0].appendChild(refStyle);
 
 function toggle(a) {
     var s = a.nextSibling || {};

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -125,7 +125,7 @@ var refStyle = doc.createElement('style'),
     rxEsc = /([.*+?^${}()|\[\]\/\\])/g,
     idRx = /\bsf-dump-\d+-ref[012]\w+\b/;
 
-doc.documentElement.firstElementChild.appendChild(refStyle);
+(doc.documentElement.firstElementChild || doc.documentElement.children[0]).appendChild(refStyle);
 
 function toggle(a) {
     var s = a.nextSibling || {};

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -125,7 +125,7 @@ var refStyle = doc.createElement('style'),
     rxEsc = /([.*+?^${}()|\[\]\/\\])/g,
     idRx = /\bsf-dump-\d+-ref[012]\w+\b/;
 
-doc.getElementsByTagName('head')[0].appendChild(refStyle);
+doc.documentElement.firstElementChild.appendChild(refStyle);
 
 function toggle(a) {
     var s = a.nextSibling || {};


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

On our webportals we faced the issue that we received the following js error: `Uncaught HierarchyRequestError: Failed to execute 'appendChild' on 'Node': This node type does not support this method.` and then the full dump is displaying without the arrows to collapse.

To simulate this error I've created a [Gist](https://gist.github.com/SaschaDens/0c5cc610ba168f6206d2) and as reference used [Adventures With document.documentElement.firstChild](https://robert.accettura.com/blog/2009/12/12/adventures-with-document-documentelement-firstchild/)

This PR specifically targets the head by using `document.getElementsByTagName('head')[0]` instead of `document.documentElement.firstChild`
