### PR TITLE
removed _self usage when not needed

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -434,7 +434,7 @@
         {% if data.children is not empty %}
             <ul id="{{ data.id }}-children"{% if not expanded %} class="hidden"{% endif %}>
                 {% for childName, childData in data.children %}
-                    {{ _self.form_tree_entry(childName, childData, false) }}
+                    {{ form_tree_entry(childName, childData, false) }}
                 {% endfor %}
             </ul>
         {% endif %}
@@ -673,6 +673,6 @@
     </div>
 
     {% for childName, childData in data.children %}
-        {{ _self.form_tree_details(childName, childData, forms_by_hash) }}
+        {{ form_tree_details(childName, childData, forms_by_hash) }}
     {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

As those calls are macros, there are already imported via the `from` call, so accessing them directly is not need, nor desired.
