### PR TITLE
[Console] Fixed warning when command alias is longer than command name

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -249,12 +249,16 @@ class TextDescriptor extends Descriptor
      */
     private function getColumnWidth(array $commands)
     {
-        $width = 0;
+        $widths = array();
+
         foreach ($commands as $command) {
-            $width = strlen($command->getName()) > $width ? strlen($command->getName()) : $width;
+            $widths[] = strlen($command->getName());
+            foreach ($command->getAliases() as $alias) {
+                $widths[] = strlen($alias);
+            }
         }
 
-        return $width + 2;
+        return max($widths) + 2;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15511 |
| License | MIT |
