### PR TITLE
[Debug] Add BufferingLogger for errors that happen before a proper logger is configured

### DIFF
--- a/src/Symfony/Component/Debug/BufferingLogger.php
+++ b/src/Symfony/Component/Debug/BufferingLogger.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * A buffering logger that stacks logs for later.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class BufferingLogger extends AbstractLogger
+{
+    private $logs = array();
+
+    public function log($level, $message, array $context = array())
+    {
+        $this->logs[] = array($level, $message, $context);
+    }
+
+    public function cleanLogs()
+    {
+        $logs = $this->logs;
+        $this->logs = array();
+
+        return $logs;
+    }
+}

--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+* added BufferingLogger for errors that happen before a proper logger is configured
+* allow throwing from `__toString()` with `return trigger_error($e, E_USER_ERROR);`
+* deprecate ExceptionHandler::createResponse
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/Debug/Debug.php
+++ b/src/Symfony/Component/Debug/Debug.php
@@ -52,9 +52,10 @@ class Debug
             // CLI - display errors only if they're not already logged to STDERR
             ini_set('display_errors', 1);
         }
-        $handler = ErrorHandler::register();
-        if (!$displayErrors) {
-            $handler->throwAt(0, true);
+        if ($displayErrors) {
+            ErrorHandler::register(new ErrorHandler(new BufferingLogger()))->screamAt(E_DEPRECATED | E_USER_DEPRECATED);
+        } else {
+            ErrorHandler::register()->throwAt(0, true);
         }
 
         DebugClassLoader::enable();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This allows catching e.g. deprecations that happen during bootstrapping.
