### PR TITLE
[VarDumper] Autoload dump() also when whole Symfony is installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,10 @@
             "src/Symfony/Component/HttpFoundation/Resources/stubs",
             "src/Symfony/Component/Intl/Resources/stubs"
         ],
-        "files": [ "src/Symfony/Component/Intl/Resources/stubs/functions.php" ]
+        "files": [
+            "src/Symfony/Component/Intl/Resources/stubs/functions.php",
+            "src/Symfony/Component/VarDumper/Resources/functions/dump.php"
+        ]
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When using VarDumper as separate composer component (symfony/var-dumper), its composer.json is taken in account, containing this in autoload section:

``` json
    "autoload": {
        "files": [ "Resources/functions/dump.php" ],
        "psr-0": { "Symfony\\Component\\VarDumper\\": "" }
    },
```

Thanks to the dump.php file, the global `dump()` function is registered and it could be used everywhere, where Composer autoloader is initialized, eg. in PHPUnit tests (if you call vendor/autoload.php as bootstrap) .

However, when whole Symfony is installed (using symfony/symfony), autoloading of this dump.php file is missing in the main composer.json file, making the `dump()` function undefined if the VarDumper.php file is not previously loaded (this is the case in eg. PHPUnit tests, where you don't bootstrap DebugBundle). 

This PR adds the file autoloading from the VarDumper's composer.json also to the main composer.json.
