### PR TITLE
Implement getStatusText() function for responses

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -501,6 +501,18 @@ class Response
     }
 
     /**
+     * Retrieves the status text for the current web response.
+     *
+     * @return string Status text
+     *
+     * @api
+     */
+    public function getStatusText()
+    {
+        return $this->statusText;
+    }
+    
+    /**
      * Sets the response charset.
      *
      * @param string $charset Character set


### PR DESCRIPTION
Add as feature allow to access to the current status text web response

| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [] |
| License | MIT |
| Doc PR | [The reference to the documentation PR if any] |
