### PR TITLE
[expression-language] Cache not Related to Variable Keys

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -77,7 +77,11 @@ class ExpressionLanguage
             return $expression;
         }
 
-        $key = $expression.'//'.implode('-', $names);
+        $keys = array_map(function($key, $value){
+            return '{'."$key:$value".'}';
+        }, array_keys($names), $names);
+
+        $key = $expression.'//'.implode('-', $keys);
 
         if (null === $parsedExpression = $this->cache->fetch($key)) {
             $nodes = $this->getParser()->parse($this->getLexer()->tokenize((string) $expression), $names);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -96,4 +96,17 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
             array('true or foo', array('foo' => 'foo'), true),
         );
     }
+
+    public function testExpressionLanguageCacheForOverriddenVariableNames()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $expression = 'a + b';
+        $values = array('a' => 1, 'b' => 1);
+        $names = array('a', 'B' => 'b');
+        $expressionLanguage->evaluate($expression, $values);
+        $result = $expressionLanguage->compile($expression, $names);
+        $expected = '($a + $B)';
+        $this->assertSame($expected, $result);
+    }
+
 }


### PR DESCRIPTION
According to the spec, at the compiling time, it's possible to replace
the default variable names by passing the new names as the associative
keys in the names array:

``` php
$expr = 'a + b';
$code = $expressionLanguage->compile($expr, array('a', 'B' => 'b'));
// This should return "($a + $B)"
```

However, we found this does not work if the expression is evaluated
first, because the parsed expression will be cached and variable 'b'
won't be replaced at the compiling time:

``` php
$expr = 'a + b';
$expressionLanguage->evaluate($expr, array('a' => 1, 'b' => 2));
$code = $expression->compile($expr, array('a', 'B' => 'b'));
// This returns "($a + $b)" instead of "($a + $B)"
```

This patch fixed this issue by including variable keys in the cache key.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
