### PR TITLE
Prevent error because of too long paths

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -54,7 +54,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $realCacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
-        $oldCacheDir = $realCacheDir.'_old';
+        $oldCacheDir = substr($realCacheDir, 0, -1).'_';
         $filesystem = $this->getContainer()->get('filesystem');
 
         if (!is_writable($realCacheDir)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -55,6 +55,9 @@ EOF
     {
         $realCacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         $oldCacheDir = substr($realCacheDir, 0, -1).'_';
+        if ('_' === substr($realCacheDir, -1)) {
+            $oldCacheDir = substr($realCacheDir, 0, -1).'-';
+        }
         $filesystem = $this->getContainer()->get('filesystem');
 
         if (!is_writable($realCacheDir)) {


### PR DESCRIPTION
On Windows, there is a maximum number of characters in a path. In a project on my PC, the DoctrineCacheBundle just didn't reach this maximum number in the `dev` directory. However, when clearing the cache, the directory was renamed to `dev_old` (4 characters longer). This means the command was unable to remove the directory (I had to rename the dir to something shorter and then remove it myself).

This PR introduces a new name for the oldCacheDir, making sure it has the same length as the realCacheDir.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
