### PR TITLE
[ExpressionLanguage] Fixed expressions cache key generation

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -84,7 +84,14 @@ class ExpressionLanguage
             return $expression;
         }
 
-        $key = $expression.'//'.implode('-', $names);
+        asort($names);
+        $cacheKeyItems = array();
+
+        foreach ($names as $nameKey => $name) {
+            $cacheKeyItems[] = is_int($nameKey) ? $name : $nameKey.':'.$name;
+        }
+
+        $key = $expression.'//'.implode('|', $cacheKeyItems);
 
         if (null === $parsedExpression = $this->cache->fetch($key)) {
             $nodes = $this->getParser()->parse($this->getLexer()->tokenize((string) $expression), $names);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Reworked version of #15537 

Difference with original PR:
- sort $names array to ensure its order does not affect caching, added test for it
- minor tweaks for cache key format
- used `foreach` instead of `array_map`

P.S. I'm not proficient with tests so not sure if tests are correct.
