### PR TITLE
[Console] Added support for hiding choices

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -153,11 +153,14 @@ class QuestionHelper extends Helper
         $message = $question->getQuestion();
 
         if ($question instanceof ChoiceQuestion) {
-            $width = max(array_map('strlen', array_keys($question->getChoices())));
-
             $messages = (array) $question->getQuestion();
-            foreach ($question->getChoices() as $key => $value) {
-                $messages[] = sprintf("  [<info>%-${width}s</info>] %s", $key, $value);
+
+            if (!$question->isChoicesHidden()) {
+                $width = max(array_map('strlen', array_keys($question->getChoices())));
+
+                foreach ($question->getChoices() as $key => $value) {
+                    $messages[] = sprintf("  [<info>%-${width}s</info>] %s", $key, $value);
+                }
             }
 
             $output->writeln($messages);

--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -19,6 +19,7 @@ namespace Symfony\Component\Console\Question;
 class ChoiceQuestion extends Question
 {
     private $choices;
+    private $choicesHidden = false;
     private $multiselect = false;
     private $prompt = ' > ';
     private $errorMessage = 'Value "%s" is invalid';
@@ -47,6 +48,30 @@ class ChoiceQuestion extends Question
     public function getChoices()
     {
         return $this->choices;
+    }
+
+    /**
+     * Sets whether the choices are hidden or not.
+     *
+     * @param bool $choicesHidden True to hide the choices, otherwise false
+     *
+     * @return $this
+     */
+    public function setChoicesHidden($choicesHidden)
+    {
+        $this->choicesHidden = (bool) $choicesHidden;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether the choices must be hidden
+     *
+     * @return bool
+     */
+    public function isChoicesHidden()
+    {
+        return $this->choicesHidden;
     }
 
     /**

--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -65,7 +65,7 @@ class ChoiceQuestion extends Question
     }
 
     /**
-     * Returns whether the choices must be hidden
+     * Returns whether the choices must be hidden.
      *
      * @return bool
      */

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -149,6 +149,33 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('8AM', $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
     }
 
+    public function testAskWithChoicesHidden()
+    {
+        $questionHelper = new QuestionHelper();
+        $questionHelper->setInputStream($this->getInputStream("Banana\n"));
+
+        $fruits = array('Apple', 'Banana', 'Orange');
+
+        $question = new ChoiceQuestion('What is your favourite fruit?', $fruits, 1);
+
+        $this->assertFalse($question->isChoicesHidden());
+
+        $question->setChoicesHidden(true);
+
+        $this->assertTrue($question->isChoicesHidden());
+
+        $this->assertEquals('Banana', $questionHelper->ask($this->createInputInterfaceMock(), $output = $this->createOutputInterface(), $question));
+
+        rewind($output->getStream());
+        $stream = stream_get_contents($output->getStream());
+
+        $this->assertContains('What is your favourite fruit?', $stream);
+
+        $this->assertNotContains('[0] Apple', $stream);
+        $this->assertNotContains('[1] Banana', $stream);
+        $this->assertNotContains('[2] Orange', $stream);
+    }
+
     /**
      * @dataProvider getAskConfirmationData
      */


### PR DESCRIPTION
Added a method to ChoiceQuestion to set the choices as hidden, this is useful if a large number of choices is available, autocomplete is still available, but the choices are not written to the output.

| Q | A |
| --- | --- |
| Bug fix? | No |
| New feature? | Yes |
| BC breaks? | No |
| Deprecations? | No |
| Tests pass? | Yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
