### PR TITLE
[Security] Fixed persistence of AuthenticationException

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Security/User/FilesystemUserProvider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Security/User/FilesystemUserProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Security\User;
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+
+class FilesystemUserProvider extends InMemoryUserProvider
+{
+    public static function getFilename($testCase)
+    {
+        return sys_get_temp_dir().'/'.Kernel::VERSION.'/'. $testCase .'/user.txt';
+    }
+
+    public function __construct($testCase)
+    {
+        $users = json_decode(file_get_contents(self::getFilename($testCase)), true);
+
+        parent::__construct($users);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/custom_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/custom_provider.yml
@@ -1,0 +1,27 @@
+imports:
+    - { resource: ./../config/default.yml }
+
+services:
+    filesystem_user_provider:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Security\User\FilesystemUserProvider
+        arguments:
+            - %kernel.test_case%
+
+security:
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        filesystem:
+            id: filesystem_user_provider
+
+    firewalls:
+        login_form:
+            pattern: ^/login$
+            security: false
+
+        default:
+            form_login:
+                check_path: /login_check
+                default_target_path: /profile
+            anonymous: ~

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -144,6 +144,7 @@ class ContextListener implements ListenerInterface
      *
      * @return TokenInterface|null
      *
+     * @throws UsernameNotFoundException
      * @throws \RuntimeException
      */
     private function refreshUser(TokenInterface $token)
@@ -174,7 +175,7 @@ class ContextListener implements ListenerInterface
                     $this->logger->warning(sprintf('Username "%s" could not be found.', $e->getUsername()));
                 }
 
-                return;
+                throw $e;
             }
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\InsufficientAuthenticationException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Psr\Log\LoggerInterface;
@@ -98,6 +99,15 @@ class ExceptionListener
     {
         if (null !== $this->logger) {
             $this->logger->info(sprintf('Authentication exception occurred; redirecting to authentication entry point (%s)', $exception->getMessage()));
+        }
+
+        if ($event->getRequest()->hasSession() && !$this->stateless) {
+            $session = $event->getRequest()->getSession();
+            $session->set(SecurityContextInterface::AUTHENTICATION_ERROR, $exception);
+
+            if ($exception instanceof UsernameNotFoundException) {
+                $session->set(SecurityContextInterface::LAST_USERNAME, $exception->getUsername());
+            }
         }
 
         try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

During the refresh of an authenticated user the potential AuthenticationException is ignored, now it is persisted in session just like after an authentication failure.
