### PR TITLE
[ExpressionLanguage] Add between operator

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -73,7 +73,7 @@ class Lexer
                 // strings
                 $tokens[] = new Token(Token::STRING_TYPE, stripcslashes(substr($match[0], 1, -1)), $cursor + 1);
                 $cursor += strlen($match[0]);
-            } elseif (preg_match('/not in(?=[\s(])|\!\=\=|not(?=[\s(])|and(?=[\s(])|\=\=\=|\>\=|or(?=[\s(])|\<\=|\*\*|\.\.|in(?=[\s(])|&&|\|\||matches|\=\=|\!\=|\*|~|%|\/|\>|\||\!|\^|&|\+|\<|\-/A', $expression, $match, null, $cursor)) {
+            } elseif (preg_match('/not in(?=[\s(])|\!\=\=|not(?=[\s(])|and(?=[\s(])|\=\=\=|\>\=|or(?=[\s(])|\<\=|\*\*|\.\.|in(?=[\s(])|&&|\|\||matches|between|\=\=|\!\=|\*|~|%|\/|\>|\||\!|\^|&|\+|\<|\-/A', $expression, $match, null, $cursor)) {
                 // operators
                 $tokens[] = new Token(Token::OPERATOR_TYPE, $match[0], $cursor + 1);
                 $cursor += strlen($match[0]);

--- a/src/Symfony/Component/ExpressionLanguage/Node/BetweenNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BetweenNode.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Node;
+
+use Symfony\Component\ExpressionLanguage\Compiler;
+
+class BetweenNode extends Node
+{
+    public function __construct(Node $value, Node $min, Node $max)
+    {
+        parent::__construct(
+            array('value' => $value, 'min' => $min, 'max' => $max)
+        );
+    }
+
+    public function compile(Compiler $compiler)
+    {
+        $compiler
+            ->raw('(')
+            ->compile($this->nodes['value'])
+            ->raw(' >= ')
+            ->compile($this->nodes['min'])
+            ->raw(' && ')
+            ->compile($this->nodes['value'])
+            ->raw(' <= ')
+            ->compile($this->nodes['max'])
+            ->raw(')')
+        ;
+    }
+
+    public function evaluate($functions, $values)
+    {
+        $value = $this->nodes['value']->evaluate($functions, $values);
+        $min = $this->nodes['min']->evaluate($functions, $values);
+        $max = $this->nodes['max']->evaluate($functions, $values);
+
+        return ($value >= $min && $value <= $max);
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BetweenNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BetweenNodeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Tests\Node;
+
+use Symfony\Component\ExpressionLanguage\Node\BetweenNode;
+use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
+
+class BetweenNodeTest extends AbstractNodeTest
+{
+    public function getEvaluateData()
+    {
+        return array(
+            array(false, new BetweenNode(new ConstantNode(10), new ConstantNode(20), new ConstantNode(30))),
+            array(true, new BetweenNode(new ConstantNode(25), new ConstantNode(20), new ConstantNode(30))),
+        );
+    }
+
+    public function getCompileData()
+    {
+        return array(
+            array('(10 >= 20 && 10 <= 30)', new BetweenNode(new ConstantNode(10), new ConstantNode(20), new ConstantNode(30))),
+            array('(25 >= 20 && 25 <= 30)', new BetweenNode(new ConstantNode(25), new ConstantNode(20), new ConstantNode(30))),
+        );
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -135,6 +135,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 new Node\BinaryNode('matches', new Node\ConstantNode('foo'), new Node\ConstantNode('/foo/')),
                 '"foo" matches "/foo/"',
             ),
+            array(
+                new Node\BetweenNode(new Node\ConstantNode(10), new Node\ConstantNode(20), new Node\ConstantNode(30)),
+                '10 between 20 and 30',
+            ),
 
             // chained calls
             array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15485 |
| License | MIT |

This PR is adding a `between` operator. 
Example : `article.price between 10.50 and 20.50`
#15485 have very good arguments for a `between` operator in addition to `in` :
- `in ..` doesn't work for float (`20.30 in 10..30` will result to false)
- `in ..` is expensive for big range because it use the range() php function. (`10 in 0..10000000` will create a very big array)

Moreover, the expression language should be usable by non-IT people. It's easiest to read and understand.
`article.price >= 10.50 and article.price <= 20.50` 
vs
`article.price between 10.50 and 20.50`

I can create a doc PR too. I'm open to suggestions about implementation, adding tests or anything!!
