### PR TITLE
[Form] only use PropertyPath if not already callable

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
@@ -84,7 +84,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
      */
     public function createListFromChoices($choices, $value = null)
     {
-        if (is_string($value)) {
+        if (is_string($value) && !is_callable($value)) {
             $value = new PropertyPath($value);
         }
 
@@ -134,7 +134,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
      */
     public function createListFromLoader(ChoiceLoaderInterface $loader, $value = null)
     {
-        if (is_string($value)) {
+        if (is_string($value) && !is_callable($value)) {
             $value = new PropertyPath($value);
         }
 
@@ -164,7 +164,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
     {
         $accessor = $this->propertyAccessor;
 
-        if (is_string($label)) {
+        if (is_string($label) && !is_callable($label)) {
             $label = new PropertyPath($label);
         }
 
@@ -174,7 +174,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             };
         }
 
-        if (is_string($preferredChoices)) {
+        if (is_string($preferredChoices) && !is_callable($preferredChoices)) {
             $preferredChoices = new PropertyPath($preferredChoices);
         }
 
@@ -189,7 +189,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             };
         }
 
-        if (is_string($index)) {
+        if (is_string($index) && !is_callable($index)) {
             $index = new PropertyPath($index);
         }
 
@@ -199,7 +199,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             };
         }
 
-        if (is_string($groupBy)) {
+        if (is_string($groupBy) && !is_callable($groupBy)) {
             $groupBy = new PropertyPath($groupBy);
         }
 
@@ -213,7 +213,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             };
         }
 
-        if (is_string($attr)) {
+        if (is_string($attr) && !is_callable($attr)) {
             $attr = new PropertyPath($attr);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | could be in edge cases |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15542 |
| License | MIT |
| Doc PR | - |

Currently it uses a PropertyPath even when the string is already a callable. But the callable string should have higher priority since that is also the one documented in ChoiceListFactoryInterface.
