### PR TITLE
[Http Foundation] Don't send content for notModified streamedResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -124,4 +124,20 @@ class StreamedResponse extends Response
     {
         return false;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return Response
+     *
+     * @see http://tools.ietf.org/html/rfc2616#section-10.3.5
+     *
+     * @api
+     */
+    public function setNotModified()
+    {
+        $this->streamed = true;
+
+        return parent::setNotModified();
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -111,4 +111,18 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response);
         $this->assertEquals(204, $response->getStatusCode());
     }
+
+    public function testSetNotModified()
+    {
+        $response = new StreamedResponse();
+        $response->setNotModified();
+        $responseSend = $response->send();
+        $this->assertObjectHasAttribute('headers', $responseSend);
+        $this->assertObjectHasAttribute('content', $responseSend);
+        $this->assertObjectHasAttribute('version', $responseSend);
+        $this->assertObjectHasAttribute('statusCode', $responseSend);
+        $this->assertObjectHasAttribute('statusText', $responseSend);
+        $this->assertObjectHasAttribute('charset', $responseSend);
+        $this->assertEquals(304, $responseSend->getStatusCode());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15564 |
| License | MIT |
| Doc PR |  |

Setting `notModified` on a `streamedResponse` caused it to throws a`LogicException: The Response callback must not be null.` exception.

Setting `streamed` to true in the `setNotModified ()` method causes the streamedResponse not to stream a body.
