### PR TITLE
[Form] Refactors to string conversion of form errors

### DIFF
--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -85,10 +85,10 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
 
         foreach ($this->errors as $error) {
             if ($error instanceof FormError) {
-                $string .= 'ERROR: '.$error->getMessage()."\n";
+                $string .= $error->getMessage().PHP_EOL;
             } else {
                 /** @var $error FormErrorIterator */
-                $string .= $error->form->getName().":\n";
+                $string .= $error->form->getName().':' . PHP_EOL;
                 $string .= self::indent((string) $error);
             }
         }
@@ -276,6 +276,6 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
      */
     private static function indent($string)
     {
-        return rtrim(self::INDENTATION.str_replace("\n", "\n".self::INDENTATION, $string), ' ');
+        return rtrim(self::INDENTATION.str_replace(PHP_EOL, PHP_EOL.self::INDENTATION, $string), ' ');
     }
 }

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -87,7 +87,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
             if ($error instanceof FormError) {
                 $string .= $error->getMessage().PHP_EOL;
             } else {
-                /** @var $error FormErrorIterator */
+                /* @var $error FormErrorIterator */
                 $string .= $error->form->getName().':'.PHP_EOL;
                 $string .= self::indent((string) $error);
             }

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -88,7 +88,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
                 $string .= $error->getMessage().PHP_EOL;
             } else {
                 /** @var $error FormErrorIterator */
-                $string .= $error->form->getName().':' . PHP_EOL;
+                $string .= $error->form->getName().':'.PHP_EOL;
                 $string .= self::indent((string) $error);
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

We're running into a problem with string coercion output for form validation caused by the forced prefix of "Error: " to the output. To resolve this I've removed this forced string in favor of giving the developer the opportunity to implement or omit a prefix. Additionally, I've converted the "\n" new lines to PHP_EOL in order to better support varying platforms.
