### PR TITLE
[Serializer] Add post normalization feature

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SerializerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SerializerPass.php
@@ -36,13 +36,17 @@ class SerializerPass implements CompilerPassInterface
         // Looks for all the services tagged "serializer.encoders" and adds them to the Serializer service
         $encoders = $this->findAndSortTaggedServices('serializer.encoder', $container);
         $container->getDefinition('serializer')->replaceArgument(1, $encoders);
+
+        // Looks for all the services tagged "serializer.post_normalizer" and adds them to the Serializer service
+        $encoders = $this->findAndSortTaggedServices('serializer.post_normalizer', $container, false);
+        $container->getDefinition('serializer')->replaceArgument(2, $encoders);
     }
 
-    private function findAndSortTaggedServices($tagName, ContainerBuilder $container)
+    private function findAndSortTaggedServices($tagName, ContainerBuilder $container, $notEmpty = true)
     {
         $services = $container->findTaggedServiceIds($tagName);
 
-        if (empty($services)) {
+        if ($notEmpty && empty($services)) {
             throw new \RuntimeException(sprintf('You must tag at least one service as "%s" to use the Serializer service', $tagName));
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -15,6 +15,7 @@
         <service id="serializer" class="%serializer.class%">
             <argument type="collection" />
             <argument type="collection" />
+            <argument type="collection" />
         </service>
 
         <service id="serializer.property_accessor" alias="property_accessor" public="false" />

--- a/src/Symfony/Component/Serializer/Normalizer/PostNormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PostNormalizerInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+/**
+ * Defines the interface of post-normalizers.
+ *
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+interface PostNormalizerInterface
+{
+    /**
+     * Normalizes an object into a set of arrays/scalars.
+     *
+     * @param mixed  $originalData Initial data to normalize
+     * @param array  $data         Normalized data to post-normalize
+     * @param string $format       format the normalization result will be encoded as
+     * @param array  $context      Context options for the normalizer
+     *
+     * @return array|bool|float|int|null|string
+     */
+    public function postNormalize($originalData, $data, $format = null, array $context = array());
+
+    /**
+     * Checks whether the given class is supported for post-normalization by this normalizer.
+     *
+     * @param mixed  $originalData Initial data to normalize
+     * @param array  $data         Normalized data to post-normalize.
+     * @param string $format       The format being (de-)serialized from or into.
+     *
+     * @return bool
+     */
+    public function supportsPostNormalization($originalData, $data, $format = null);
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NaturalOrderPostNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NaturalOrderPostNormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\PostNormalizerInterface;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class NaturalOrderPostNormalizer implements PostNormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function postNormalize($originalData, $data, $format = null, array $context = array())
+    {
+        uksort($data, 'strnatcasecmp');
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsPostNormalization($originalData, $data, $format = null)
+    {
+        return is_array($data) && !ctype_digit(implode('', array_keys($data)));
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
+use Symfony\Component\Serializer\Tests\Fixtures\NaturalOrderPostNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\TraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Normalizer\TestNormalizer;
@@ -267,6 +268,19 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
             $expectedData,
             $serializer->deserialize($jsonData, __NAMESPACE__.'\Model[]', 'json')
         );
+    }
+
+    public function testPostNormalization()
+    {
+        $this->serializer = new Serializer(
+            array(new GetSetMethodNormalizer()),
+            array('json' => new JsonEncoder()),
+            array(new NaturalOrderPostNormalizer())
+        );
+        $data = array('title' => 'foo', 'numbers' => array(5, 3));
+        $result = $this->serializer->normalize(Model::fromArray($data), 'json');
+        uksort($data, 'strnatcasecmp');
+        $this->assertSame($data, $result);
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | If approved |

I don't know if it should go into the core, as it is already doable for most usages by decorating the `ObjectNormalizer`. But where normalizers act as a specific type/format handler, post normalizers would be able to be chained and simplify extensibility of the serialization behavior.

For instance, the `NaturalOrderPostNormalizer` can be extended to work with a custom order defined by a class annotation, and other post normalizers could be chained if applicable, without wondering much about the decoration order (post normalizers would work by priority instead).

However, it won't be relevant for things such as a `MaxDepth` annotation for instance, as normalizers would already have normalized the whole graph for nothing.

Another consideration is that the post normalizer might need the normalizer name converter instance if it needs to deal with initial data properties names. It can eventually be passed as the last `PostNormalizerInterface::postNormalize()` method argument (But I doubt different name converters will be used between normalizers and it might be tricky anyway).
