### PR TITLE
Add appveyor.yml for C.I. on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpunit.xml
 composer.phar
 package.tar
 /packages.json
+/.phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: php
 sudo: false
 
 addons:
-  apt_packages:
-    - parallel
-    - language-pack-fr-base
+    apt_packages:
+        - parallel
+        - language-pack-fr-base
 
 matrix:
     include:
@@ -31,24 +31,22 @@ env:
 before_install:
     - composer self-update
     - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
-    - if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi;
-    - if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
-    - if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
-    - if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then (pecl install -f memcached-2.1.0 && echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini) || echo "Let's continue without memcache extension"; fi;
-    - if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then php -i; fi;
-    # Build a standalone phpunit without symfony/yaml and that works around https://github.com/sebastianbergmann/phpunit-mock-objects/issues/223
-    - (mkdir phpunit && cd phpunit && wget https://github.com/sebastianbergmann/phpunit/archive/4.7.zip && unzip 4.7.zip && cd phpunit-4.7 && composer remove --no-update symfony/yaml && composer require --prefer-source phpunit/phpunit-mock-objects '2.3.0')
-    - export PHPUNIT="$(readlink -f ./phpunit/phpunit-4.7/phpunit) --colors=always"
-    # Set the COMPOSER_ROOT_VERSION to the right version according to the branch being built
-    - if [ "$TRAVIS_BRANCH" = "master" ]; then export COMPOSER_ROOT_VERSION=dev-master; else export COMPOSER_ROOT_VERSION="$TRAVIS_BRANCH".x-dev; fi;
+    - if [[ "$TRAVIS_PHP_VERSION" = 5.* ]]; then phpenv config-rm xdebug.ini; fi;
+    - if [[ "$TRAVIS_PHP_VERSION" = 5.* ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+    - if [[ "$TRAVIS_PHP_VERSION" =~ 5.[34] ]]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+    - if [[ "$TRAVIS_PHP_VERSION" = 5.* ]]; then (pecl install -f memcached-2.1.0 && echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini) || echo "Let's continue without memcache extension"; fi;
+    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then php -i; fi;
+    - ./phpunit install
+    - export PHPUNIT="$(readlink -f ./phpunit)"
 
 install:
+    - if [ "$TRAVIS_BRANCH" = "master" ]; then export COMPOSER_ROOT_VERSION=dev-master; else export COMPOSER_ROOT_VERSION="$TRAVIS_BRANCH".x-dev; fi;
     - if [ "$deps" = "no" ]; then composer --prefer-source install; fi;
-    - components=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n')
-    - if [ "$deps" != "no" ]; then php .travis.php $TRAVIS_COMMIT_RANGE $TRAVIS_BRANCH $components; fi;
+    - COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n')
+    - if [ "$deps" != "no" ]; then php .travis.php $TRAVIS_COMMIT_RANGE $TRAVIS_BRANCH $COMPONENTS; fi;
 
 script:
-    - if [ "$deps" = "no" ]; then echo "$components" | parallel --gnu --keep-order 'echo -e "\\nRunning {} tests"; $PHPUNIT --exclude-group tty,benchmark,intl-data {} || (echo -e "\\e[41mKO\\e[0m {}" && $(exit 1));'; fi;
-    - if [ "$deps" = "no" ]; then echo -e "\\nRunning tests requiring tty"; $PHPUNIT --group tty || (echo -e "\\e[41mKO\\e[0m tty group" && $(exit 1)); fi;
-    - if [ "$deps" = "high" ]; then echo "$components" | parallel --gnu --keep-order -j10% 'echo -e "\\nRunning {} tests"; cd {}; composer --prefer-source update; $PHPUNIT --exclude-group tty,benchmark,intl-data || (echo -e "\\e[41mKO\\e[0m {}" && $(exit 1));'; fi;
-    - if [ "$deps" = "low" ]; then echo "$components" | parallel --gnu --keep-order -j10% 'echo -e "\\nRunning {} tests"; cd {}; composer --prefer-source --prefer-lowest --prefer-stable update; $PHPUNIT --exclude-group tty,benchmark,intl-data || (echo -e "\\e[41mKO\\e[0m {}" && $(exit 1));'; fi;
+    - if [ "$deps" = "no" ]; then echo "$COMPONENTS" | parallel --gnu --keep-order 'echo -e "\\nRunning {} tests"; $PHPUNIT --exclude-group tty,benchmark,intl-data {}'; fi;
+    - if [ "$deps" = "no" ]; then echo -e "\\nRunning tests requiring tty"; $PHPUNIT --group tty; fi;
+    - if [ "$deps" = "high" ]; then echo "$COMPONENTS" | parallel --gnu --keep-order -j10% 'echo -e "\\nRunning {} tests"; cd {}; composer --prefer-source update; $PHPUNIT --exclude-group tty,benchmark,intl-data'; fi;
+    - if [ "$deps" = "low" ]; then echo "$COMPONENTS" | parallel --gnu --keep-order -j10% 'echo -e "\\nRunning {} tests"; cd {}; composer --prefer-source --prefer-lowest --prefer-stable update; $PHPUNIT --exclude-group tty,benchmark,intl-data'; fi;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,53 @@
+build: false
+shallow_clone: true
+platform: x86
+clone_folder: c:\projects\symfony
+
+environment:
+    matrix:
+        - PHP_EXT: 1
+        - PHP_EXT: 0
+
+cache:
+    - c:\php -> appveyor.yml
+    - .phpunit -> phpunit
+    - vendor -> composer.json
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET SYMFONY_DEPRECATIONS_HELPER=weak
+    - SET PHP=1
+
+install:
+    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+    - cd c:\php
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.4.43-nts-Win32-VC9-x86.zip
+    - IF %PHP%==1 7z x php-5.4.43-nts-Win32-VC9-x86.zip -y > 7z.log
+    - IF %PHP%==1 appveyor DownloadFile http://nebm.ist.utl.pt/~glopes/misc/intl_win/ICU-51.2-dlls.zip
+    - IF %PHP%==1 7z x ICU-51.2-dlls.zip -y > 7z.log
+    - IF %PHP%==1 cd ext
+    - IF %PHP%==1 appveyor DownloadFile http://nebm.ist.utl.pt/~glopes/misc/intl_win/php_intl-3.0.0-5.4-nts-vc9-x86.zip
+    - IF %PHP%==1 7z x php_intl-3.0.0-5.4-nts-vc9-x86.zip -y > 7z.log
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/apc/3.1.13/php_apc-3.1.13-5.4-nts-vc9-x86.zip
+    - IF %PHP%==1 7z x php_apc-3.1.13-5.4-nts-vc9-x86.zip -y > 7z.log
+    - IF %PHP%==1 cd ..
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - copy php.ini-production php.ini /Y
+    - echo date.timezone="UTC" >> php.ini
+    - echo extension_dir=ext >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - IF %PHP_EXT%==1 echo extension=php_apc.dll >> php.ini
+    - IF %PHP_EXT%==1 echo extension=php_intl.dll >> php.ini
+    - IF %PHP_EXT%==1 echo extension=php_mbstring.dll >> php.ini
+    - IF %PHP_EXT%==1 echo extension=php_fileinfo.dll >> php.ini
+    - IF %PHP_EXT%==1 echo extension=php_pdo_sqlite.dll >> php.ini
+    - cd c:\projects\symfony
+    - php phpunit install
+    - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
+    - composer update --prefer-dist --no-progress --ansi
+
+test_script:
+    - cd c:\projects\symfony
+    - php phpunit symfony --exclude-group benchmark,intl-data

--- a/phpunit
+++ b/phpunit
@@ -1,0 +1,116 @@
+#!/usr/bin/env php
+<?php
+
+error_reporting(-1);
+
+$PHPUNIT_VERSION = 4.8;
+$PHPUNIT_DIR = __DIR__.'/.phpunit';
+
+if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit")) {
+    # Build a standalone phpunit without symfony/yaml
+
+    $oldPwd = getcwd();
+    mkdir($PHPUNIT_DIR);
+    chdir($PHPUNIT_DIR);
+    if (extension_loaded('openssl') && ini_get('allow_url_fopen')) {
+        stream_copy_to_stream(fopen("https://github.com/sebastianbergmann/phpunit/archive/$PHPUNIT_VERSION.zip", 'rb'), fopen("$PHPUNIT_VERSION.zip", 'wb'));
+    } else {
+        passthru("wget https://github.com/sebastianbergmann/phpunit/archive/$PHPUNIT_VERSION.zip");
+    }
+    $zip = new ZipArchive();
+    $zip->open("$PHPUNIT_VERSION.zip");
+    $zip->extractTo(getcwd());
+    $zip->close();
+    chdir("phpunit-$PHPUNIT_VERSION");
+    passthru("composer remove --no-update symfony/yaml");
+    passthru("composer install --prefer-source --no-progress --ansi");
+    chdir($oldPwd);
+}
+
+$cmd = array_map('escapeshellarg', $argv);
+$exit = 0;
+
+if (isset($argv[1]) && 'symfony' === $argv[1]) {
+    # Find Symfony components in plain php for Windows portability
+
+    $finder = new RecursiveDirectoryIterator('src/Symfony', FilesystemIterator::KEY_AS_FILENAME | FilesystemIterator::UNIX_PATHS);
+    $finder = new RecursiveIteratorIterator($finder);
+    $finder->setMaxDepth(3);
+
+    array_shift($cmd);
+    $cmd[0] = "php $PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit --colors=always";
+    $procs = array();
+
+    foreach ($finder as $file => $fileInfo) {
+        if ('phpunit.xml.dist' === $file) {
+            $component = dirname($fileInfo->getPathname());
+
+            # Run phpunit tests in parallel
+
+            $c = escapeshellarg($component);
+
+            if ($proc = proc_open(implode(' ', $cmd)." $c > $c/phpunit.stdout 2> $c/phpunit.stderr", array(), $pipes)) {
+                $procs[$component] = $proc;
+            } else {
+                $exit = 1;
+                echo "\033[41mKO\033[0m $component\n\n";
+            }
+        }
+    }
+
+    foreach ($procs as $component => $proc) {
+        $procStatus = proc_close($proc);
+
+        foreach (array('out', 'err') as $file) {
+            $file = "$component/phpunit.std$file";
+            $h = fopen($file, 'rb');
+            while (false !== $line = fgets($h)) {
+                echo preg_replace_callback(
+                    '/\033\[[0-9]++(?:;[0-9]++)++m/',
+                    function ($m) {return str_replace(';', "m\033[", $m[0]);},
+                    $line
+                );
+            }
+            fclose($h);
+            unlink($file);
+        }
+
+        if ($procStatus) {
+            $exit = 1;
+            echo "\033[41mKO\033[0m $component\n\n";
+        } else {
+            echo "\033[32mOK\033[0m $component\n\n";
+        }
+    }
+
+} elseif (!isset($argv[1]) || 'install' !== $argv[1]) {
+    # Run regular phpunit in a subprocess
+
+    $cmd[0] = "php $PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit --colors=always";
+
+    $errFile = tempnam(sys_get_temp_dir(), 'phpunit.stderr.');
+    if ($proc = proc_open(implode(' ', $cmd).' 2> '.escapeshellarg($errFile), array(1 => array('pipe', 'w')), $pipes)) {
+        while (false !== $line = fgets($pipes[1])) {
+            echo $line;
+        }
+        fclose($pipes[1]);
+        $exit = proc_close($proc);
+
+        $h = fopen($errFile, 'rb');
+        while (false !== $line = fgets($h)) {
+            echo $line;
+        }
+        fclose($h);
+        unlink($errFile);
+    }
+
+    if (file_exists($component = array_pop($argv))) {
+        if ($exit) {
+            echo "\033[41mKO\033[0m $component\n\n";
+        } else {
+            echo "\033[32mOK\033[0m $component\n\n";
+        }
+    }
+}
+
+exit($exit);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -491,6 +491,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderExceptionWithDoubleWidthCharacters()
     {
+        if (!function_exists('mb_strwidth')) {
+            $this->markTestSkipped('The "mb_strwidth" function is not available');
+        }
+
         $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
         $application->setAutoExit(false);
         $application->expects($this->any())

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -156,19 +156,42 @@ class Crawler extends \SplObjectStorage
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
 
-        if (function_exists('mb_convert_encoding')) {
-            $hasError = false;
-            set_error_handler(function () use (&$hasError) {
-                $hasError = true;
-            });
-            $tmpContent = @mb_convert_encoding($content, 'HTML-ENTITIES', $charset);
+        set_error_handler(function () {throw new \Exception();});
 
-            restore_error_handler();
+        try {
+            // Convert charset to HTML-entities to work around bugs in DOMDocument::loadHTML()
 
-            if (!$hasError) {
-                $content = $tmpContent;
+            if (function_exists('mb_convert_encoding')) {
+                $content = mb_convert_encoding($content, 'HTML-ENTITIES', $charset);
+            } elseif (function_exists('iconv')) {
+                $content = preg_replace_callback(
+                    '/[\x80-\xFF]+/',
+                    function ($m) {
+                        $m = unpack('C*', $m[0]);
+                        $i = 1;
+                        $entities = '';
+
+                        while (isset($m[$i])) {
+                            if (0xF0 <= $m[$i]) {
+                                $c = (($m[$i++] - 0xF0) << 18) + (($m[$i++] - 0x80) << 12) + (($m[$i++] - 0x80) << 6) + $m[$i++] - 0x80;
+                            } elseif (0xE0 <= $m[$i]) {
+                                $c = (($m[$i++] - 0xE0) << 12) + (($m[$i++] - 0x80) << 6) + $m[$i++]  - 0x80;
+                            } else {
+                                $c = (($m[$i++] - 0xC0) << 6) + $m[$i++] - 0x80;
+                            }
+
+                            $entities .= '&#'.$c.';';
+                        }
+
+                        return $entities;
+                    },
+                    iconv($charset, 'UTF-8', $content)
+                );
             }
+        } catch (\Exception $e) {
         }
+
+        restore_error_handler();
 
         if ('' !== trim($content)) {
             @$dom->loadHTML($content);

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -80,6 +80,7 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
+     * @requires extension mbstring
      */
     public function testAddHtmlContentCharset()
     {
@@ -114,6 +115,7 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
+     * @requires extension mbstring
      */
     public function testAddHtmlContentCharsetGbk()
     {
@@ -234,7 +236,7 @@ EOF
         $this->assertEquals('中文', $crawler->filterXPath('//span')->text(), '->addContent() guess wrong charset');
 
         $crawler = new Crawler();
-        $crawler->addContent(mb_convert_encoding('<html><head><meta charset="Shift_JIS"></head><body>日本語</body></html>', 'SJIS', 'UTF-8'));
+        $crawler->addContent(iconv('UTF-8', 'SJIS', '<html><head><meta charset="Shift_JIS"></head><body>日本語</body></html>'));
         $this->assertEquals('日本語', $crawler->filterXPath('//body')->text(), '->addContent() can recognize "Shift_JIS" in html5 meta charset tag');
     }
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RecursiveDirectoryIteratorTest.php
@@ -60,9 +60,6 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
         $i->seek(1);
         $actual[] = $i->getPathname();
 
-        $i->seek(2);
-        $actual[] = $i->getPathname();
-
         $this->assertEquals($contains, $actual);
     }
 
@@ -73,7 +70,6 @@ class RecursiveDirectoryIteratorTest extends IteratorTestCase
         // ftp
         $contains = array(
             'ftp://ftp.mozilla.org'.DIRECTORY_SEPARATOR.'README',
-            'ftp://ftp.mozilla.org'.DIRECTORY_SEPARATOR.'index.html',
             'ftp://ftp.mozilla.org'.DIRECTORY_SEPARATOR.'pub',
         );
         $data[] = array('ftp://ftp.mozilla.org/', false, $contains);

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -33,7 +33,11 @@ class SortableIteratorTest extends RealIteratorTestCase
         if (!is_callable($mode)) {
             switch ($mode) {
                 case SortableIterator::SORT_BY_ACCESSED_TIME :
-                    file_get_contents(self::toAbsolute('.git'));
+                    if ('\\' === DIRECTORY_SEPARATOR) {
+                        touch(self::toAbsolute('.git'));
+                    } else {
+                        file_get_contents(self::toAbsolute('.git'));
+                    }
                     sleep(1);
                     file_get_contents(self::toAbsolute('.bar'));
                     break;
@@ -56,7 +60,11 @@ class SortableIteratorTest extends RealIteratorTestCase
 
         if ($mode === SortableIterator::SORT_BY_ACCESSED_TIME
             || $mode === SortableIterator::SORT_BY_CHANGED_TIME
-            || $mode === SortableIterator::SORT_BY_MODIFIED_TIME) {
+            || $mode === SortableIterator::SORT_BY_MODIFIED_TIME
+        ) {
+            if ('\\' === DIRECTORY_SEPARATOR && SortableIterator::SORT_BY_MODIFIED_TIME !== $mode) {
+                $this->markTestSkipped('Sorting by atime or ctime is not supported on Windows');
+            }
             $this->assertOrderedIteratorForGroups($expected, $iterator);
         } else {
             $this->assertOrderedIterator($expected, $iterator);

--- a/src/Symfony/Component/Finder/Tests/Shell/CommandTest.php
+++ b/src/Symfony/Component/Finder/Tests/Shell/CommandTest.php
@@ -86,7 +86,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $cmd = Command::create()->add('--force');
 
         $cmd->arg('--run');
-        $this->assertSame('--force \'--run\'', $cmd->join());
+        $this->assertSame('--force '.escapeshellarg('--run'), $cmd->join());
     }
 
     public function testCmd()

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -260,7 +260,7 @@ class DateType extends AbstractType
         $pattern = $formatter->getPattern();
         $timezone = $formatter->getTimezoneId();
 
-        if ($setTimeZone = method_exists($formatter, 'setTimeZone')) {
+        if ($setTimeZone = PHP_VERSION_ID >= 50500 || method_exists($formatter, 'setTimeZone')) {
             $formatter->setTimeZone('UTC');
         } else {
             $formatter->setTimeZoneId('UTC');

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -27,6 +27,10 @@ class JsonResponse extends Response
     protected $data;
     protected $callback;
 
+    // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
+    // 15 === JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT
+    private $encodingOptions = 15;
+
     /**
      * Constructor.
      *
@@ -41,6 +45,7 @@ class JsonResponse extends Response
         if (null === $data) {
             $data = new \ArrayObject();
         }
+
         $this->setData($data);
     }
 
@@ -55,11 +60,11 @@ class JsonResponse extends Response
     /**
      * Sets the JSONP callback.
      *
-     * @param string $callback
+     * @param string|null $callback The JSONP callback or null to use none
      *
      * @return JsonResponse
      *
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException When the callback name is not valid
      */
     public function setCallback($callback = null)
     {
@@ -80,7 +85,7 @@ class JsonResponse extends Response
     }
 
     /**
-     * Sets the data to be sent as json.
+     * Sets the data to be sent as JSON.
      *
      * @param mixed $data
      *
@@ -90,18 +95,63 @@ class JsonResponse extends Response
      */
     public function setData($data = array())
     {
-        // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
-        $this->data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
+        if (defined('HHVM_VERSION')) {
+            // HHVM does not trigger any warnings and let exceptions
+            // thrown from a JsonSerializable object pass through.
+            // If only PHP did the same...
+            $data = json_encode($data, $this->encodingOptions);
+        } else {
+            try {
+                if (PHP_VERSION_ID < 50400) {
+                    // PHP 5.3 triggers annoying warnings for some
+                    // types that can't be serialized as JSON (INF, resources, etc.)
+                    // but doesn't provide the JsonSerializable interface.
+                    set_error_handler('var_dump', 0);
+                    $data = @json_encode($data, $this->encodingOptions);
+                } else {
+                    // PHP 5.4 and up wrap exceptions thrown by JsonSerializable
+                    // objects in a new exception that needs to be removed.
+                    // Fortunately, PHP 5.5 and up do not trigger any warning anymore.
+                    if (PHP_VERSION_ID < 50500) {
+                        // Clear json_last_error()
+                        json_encode(null);
+                        $errorHandler = set_error_handler('var_dump');
+                        restore_error_handler();
+                        set_error_handler(function () use ($errorHandler) {
+                            if (JSON_ERROR_NONE === json_last_error()) {
+                                return $errorHandler && false !== call_user_func_array($errorHandler, func_get_args());
+                            }
+                        });
+                    }
+
+                    $data = json_encode($data, $this->encodingOptions);
+                }
+
+                if (PHP_VERSION_ID < 50500) {
+                    restore_error_handler();
+                }
+            } catch (\Exception $e) {
+                if (PHP_VERSION_ID < 50500) {
+                    restore_error_handler();
+                }
+                if (PHP_VERSION_ID >= 50400 && 'Exception' === get_class($e) && 0 === strpos($e->getMessage(), 'Failed calling ')) {
+                    throw $e->getPrevious() ?: $e;
+                }
+                throw $e;
+            }
+        }
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new \InvalidArgumentException($this->transformJsonError());
         }
 
+        $this->data = $data;
+
         return $this->update();
     }
 
     /**
-     * Updates the content and headers according to the json data and callback.
+     * Updates the content and headers according to the JSON data and callback.
      *
      * @return JsonResponse
      */

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1740,9 +1740,9 @@ class Request
             return $prefix;
         }
 
-        if ($baseUrl && false !== $prefix = $this->getUrlencodedPrefix($requestUri, rtrim(dirname($baseUrl), '/').'/')) {
+        if ($baseUrl && false !== $prefix = $this->getUrlencodedPrefix($requestUri, rtrim(dirname($baseUrl), '/'.DIRECTORY_SEPARATOR).'/')) {
             // directory portion of $baseUrl matches
-            return rtrim($prefix, '/');
+            return rtrim($prefix, '/'.DIRECTORY_SEPARATOR);
         }
 
         $truncatedRequestUri = $requestUri;
@@ -1763,7 +1763,7 @@ class Request
             $baseUrl = substr($requestUri, 0, $pos + strlen($baseUrl));
         }
 
-        return rtrim($baseUrl, '/');
+        return rtrim($baseUrl, '/'.DIRECTORY_SEPARATOR);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -54,7 +54,7 @@ class BinaryFileResponseTest extends ResponseTestCase
      */
     public function testRequests($requestRange, $offset, $length, $responseRange)
     {
-        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif')->setAutoEtag();
+        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif', 200, array('Content-Type' => 'application/octet-stream'))->setAutoEtag();
 
         // do a request to get the ETag
         $request = Request::create('/');
@@ -96,7 +96,7 @@ class BinaryFileResponseTest extends ResponseTestCase
      */
     public function testFullFileRequests($requestRange)
     {
-        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif')->setAutoEtag();
+        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif', 200, array('Content-Type' => 'application/octet-stream'))->setAutoEtag();
 
         // prepare a request for a range of the testing file
         $request = Request::create('/');
@@ -131,7 +131,7 @@ class BinaryFileResponseTest extends ResponseTestCase
      */
     public function testInvalidRequests($requestRange)
     {
-        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif')->setAutoEtag();
+        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif', 200, array('Content-Type' => 'application/octet-stream'))->setAutoEtag();
 
         // prepare a request for a range of the testing file
         $request = Request::create('/');
@@ -159,7 +159,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         $request->headers->set('X-Sendfile-Type', 'X-Sendfile');
 
         BinaryFileResponse::trustXSendfileTypeHeader();
-        $response = BinaryFileResponse::create(__DIR__.'/../README.md');
+        $response = BinaryFileResponse::create(__DIR__.'/../README.md', 200, array('Content-Type' => 'application/octet-stream'));
         $response->prepare($request);
 
         $this->expectOutputString('');
@@ -180,7 +180,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         $file = new FakeFile($realpath, __DIR__.'/File/Fixtures/test');
 
         BinaryFileResponse::trustXSendfileTypeHeader();
-        $response = new BinaryFileResponse($file);
+        $response = new BinaryFileResponse($file, 200, array('Content-Type' => 'application/octet-stream'));
         $reflection = new \ReflectionObject($response);
         $property = $reflection->getProperty('file');
         $property->setAccessible(true);
@@ -203,7 +203,7 @@ class BinaryFileResponseTest extends ResponseTestCase
     public function testAcceptRangeOnUnsafeMethods()
     {
         $request = Request::create('/', 'POST');
-        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif');
+        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif', 200, array('Content-Type' => 'application/octet-stream'));
         $response->prepare($request);
 
         $this->assertEquals('none', $response->headers->get('Accept-Ranges'));
@@ -212,7 +212,7 @@ class BinaryFileResponseTest extends ResponseTestCase
     public function testAcceptRangeNotOverriden()
     {
         $request = Request::create('/', 'POST');
-        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif');
+        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif', 200, array('Content-Type' => 'application/octet-stream'));
         $response->headers->set('Accept-Ranges', 'foo');
         $response->prepare($request);
 
@@ -229,6 +229,6 @@ class BinaryFileResponseTest extends ResponseTestCase
 
     protected function provideResponse()
     {
-        return new BinaryFileResponse(__DIR__.'/../README.md');
+        return new BinaryFileResponse(__DIR__.'/../README.md', 200, array('Content-Type' => 'application/octet-stream'));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -45,6 +45,9 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('gif', $file->guessExtension());
     }
 
+    /**
+     * @requires extension fileinfo
+     */
     public function testGuessExtensionWithReset()
     {
         $file = new File(__DIR__.'/Fixtures/other-file.example');

--- a/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
@@ -14,17 +14,16 @@ namespace Symfony\Component\HttpFoundation\Tests\File\MimeType;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\FileBinaryMimeTypeGuesser;
 
+/**
+ * @requires extension fileinfo
+ */
 class MimeTypeTest extends \PHPUnit_Framework_TestCase
 {
     protected $path;
 
     public function testGuessImageWithoutExtension()
     {
-        if (extension_loaded('fileinfo')) {
-            $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
-        } else {
-            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
-        }
+        $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
     }
 
     public function testGuessImageWithDirectory()
@@ -38,29 +37,17 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
     {
         $guesser = MimeTypeGuesser::getInstance();
         $guesser->register(new FileBinaryMimeTypeGuesser());
-        if (extension_loaded('fileinfo')) {
-            $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
-        } else {
-            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
-        }
+        $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
     }
 
     public function testGuessImageWithKnownExtension()
     {
-        if (extension_loaded('fileinfo')) {
-            $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test.gif'));
-        } else {
-            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test.gif'));
-        }
+        $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test.gif'));
     }
 
     public function testGuessFileWithUnknownExtension()
     {
-        if (extension_loaded('fileinfo')) {
-            $this->assertEquals('application/octet-stream', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/.unknownextension'));
-        } else {
-            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/.unknownextension'));
-        }
+        $this->assertEquals('application/octet-stream', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/.unknownextension'));
     }
 
     public function testGuessWithIncorrectPath()
@@ -75,7 +62,7 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Can not verify chmod operations on Windows');
         }
 
-        if ('root' === get_current_user()) {
+        if (!getenv('USER') || 'root' === getenv('USER')) {
             $this->markTestSkipped('This test will fail if run under superuser');
         }
 
@@ -83,7 +70,7 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
         touch($path);
         @chmod($path, 0333);
 
-        if (get_current_user() != 'root' && substr(sprintf('%o', fileperms($path)), -4) == '0333') {
+        if (substr(sprintf('%o', fileperms($path)), -4) == '0333') {
             $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException');
             MimeTypeGuesser::getInstance()->guess($path);
         } else {

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -520,22 +520,30 @@ class NumberFormatter
             return false;
         }
 
-        preg_match('/^([^0-9\-\.]{0,})(.*)/', $value, $matches);
+        $groupSep = $this->getAttribute(self::GROUPING_USED) ? ',' : '';
 
         // Any string before the numeric value causes error in the parsing
-        if (isset($matches[1]) && !empty($matches[1])) {
+        if (preg_match("/^-?(?:\.\d++|([\d{$groupSep}]++)(?:\.\d++)?)/", $value, $matches)) {
+            $value = $matches[0];
+            $position = strlen($value);
+            if ($error = $groupSep && isset($matches[1]) && !preg_match('/^\d{1,3}+(?:(?:,\d{3})++|\d*+)$/', $matches[1])) {
+                $position -= strlen(preg_replace('/^\d{1,3}+(?:(?:,\d++)++|\d*+)/', '', $matches[1]));
+            }
+        } else {
+            $error = 1;
+            $position = 0;
+        }
+
+        if ($error) {
             IntlGlobals::setError(IntlGlobals::U_PARSE_ERROR, 'Number parsing failed');
             $this->errorCode = IntlGlobals::getErrorCode();
             $this->errorMessage = IntlGlobals::getErrorMessage();
-            $position = 0;
 
             return false;
         }
 
-        preg_match('/^[0-9\-\.\,]*/', $value, $matches);
-        $value = preg_replace('/[^0-9\.\-]/', '', $matches[0]);
+        $value = str_replace(',', '', $value);
         $value = $this->convertValueDataType($value, $type);
-        $position = strlen($matches[0]);
 
         // behave like the intl extension
         $this->resetError();

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -38,11 +38,16 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
         $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if (PHP_VERSION_ID >= 50500) {
+        if (PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
         } else {
             $this->assertNull($formatter->getTimeZoneId());
         }
+
+        $this->assertEquals(
+            $this->getDateTime(0, $formatter->getTimeZoneId())->format('M j, Y, g:i A'),
+            $formatter->format(0)
+        );
     }
 
     /**
@@ -270,7 +275,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     public function formatErrorProvider()
     {
         // With PHP 5.5 IntlDateFormatter accepts empty values ('0')
-        if (PHP_VERSION_ID >= 50500) {
+        if (PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             return array(
                 array('y-M-d', 'foobar', 'datefmt_format: string \'foobar\' is not numeric, which would be required for it to be a valid date: U_ILLEGAL_ARGUMENT_ERROR'),
             );
@@ -327,7 +332,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
         );
 
         // As of PHP 5.5, intl ext no longer fallbacks invalid time zones to UTC
-        if (PHP_VERSION_ID < 50500) {
+        if (PHP_VERSION_ID < 50500 && !(extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             // When time zone not exists, uses UTC by default
             $data[] = array(0, 'Foo/Bar', '1970-01-01 00:00:00');
             $data[] = array(0, 'UTC+04:30', '1970-01-01 00:00:00');
@@ -341,7 +346,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (PHP_VERSION_ID >= 50500) {
+        if (PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $formatter->setTimeZone('GMT+03:00');
         } else {
             $formatter->setTimeZoneId('GMT+03:00');
@@ -354,7 +359,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (PHP_VERSION_ID >= 50500) {
+        if (PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $formatter->setTimeZone('GMT+00:30');
         } else {
             $formatter->setTimeZoneId('GMT+00:30');
@@ -367,7 +372,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter('zzzz');
 
-        if (PHP_VERSION_ID >= 50500) {
+        if (PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $formatter->setTimeZone('Pacific/Fiji');
         } else {
             $formatter->setTimeZoneId('Pacific/Fiji');
@@ -404,7 +409,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatWithIntlTimeZone()
     {
-        if (PHP_VERSION_ID < 50500) {
+        if (PHP_VERSION_ID < 50500 && !(extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $this->markTestSkipped('Only in PHP 5.5+ IntlDateFormatter allows to use DateTimeZone objects.');
         }
 
@@ -419,7 +424,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatWithTimezoneFromEnvironmentVariable()
     {
-        if (PHP_VERSION_ID >= 50500) {
+        if (PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $this->markTestSkipped('IntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
         }
 
@@ -442,7 +447,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatWithTimezoneFromPhp()
     {
-        if (PHP_VERSION_ID < 50500) {
+        if (PHP_VERSION_ID < 50500 && !(extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $this->markTestSkipped('Only in PHP 5.5 IntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
         }
 
@@ -873,7 +878,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getDefaultDateFormatter();
 
-        if (PHP_VERSION_ID >= 50500) {
+        if (PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $formatter->setTimeZone($timeZoneId);
         } else {
             $formatter->setTimeZoneId($timeZoneId);
@@ -884,15 +889,17 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function setTimeZoneIdProvider()
     {
+        $isPhp55 = PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'));
+
         return array(
             array('UTC', 'UTC'),
             array('GMT', 'GMT'),
             array('GMT-03:00', 'GMT-03:00'),
             array('Europe/Zurich', 'Europe/Zurich'),
-            array('GMT-0300', 'GMT-0300'),
-            array('Foo/Bar', 'Foo/Bar'),
-            array('GMT+00:AA', 'GMT+00:AA'),
-            array('GMT+00AA', 'GMT+00AA'),
+            array(null, $isPhp55 ? date_default_timezone_get() : null),
+            array('Foo/Bar', $isPhp55 ? 'UTC' : 'Foo/Bar'),
+            array('GMT+00:AA', $isPhp55 ? 'UTC' : 'GMT+00:AA'),
+            array('GMT+00AA', $isPhp55 ? 'UTC' : 'GMT+00AA'),
         );
     }
 
@@ -905,7 +912,9 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $dateTime = new \DateTime();
         $dateTime->setTimestamp(null === $timestamp ? time() : $timestamp);
-        $dateTime->setTimezone(new \DateTimeZone($timeZone));
+        if (null !== $timeZone) {
+            $dateTime->setTimezone(new \DateTimeZone($timeZone));
+        }
 
         return $dateTime;
     }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
@@ -45,7 +45,11 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
 
     protected function getDateFormatter($locale, $datetype, $timetype, $timezone = null, $calendar = IntlDateFormatter::GREGORIAN, $pattern = null)
     {
-        return new \IntlDateFormatter($locale, $datetype, $timetype, $timezone, $calendar, $pattern);
+        if (!$formatter = new \IntlDateFormatter($locale, $datetype, $timetype, $timezone, $calendar, $pattern)) {
+            throw new \InvalidArgumentException(intl_get_error_message());
+        }
+
+        return $formatter;
     }
 
     protected function getIntlErrorMessage()

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -506,10 +506,11 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider parseProvider
      */
-    public function testParse($value, $expected, $message, $expectedPosition)
+    public function testParse($value, $expected, $message, $expectedPosition, $groupingUsed = true)
     {
         $position = 0;
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
+        $formatter->setAttribute(NumberFormatter::GROUPING_USED, $groupingUsed);
         $parsedValue = $formatter->parse($value, NumberFormatter::TYPE_DOUBLE, $position);
         $this->assertSame($expected, $parsedValue, $message);
         $this->assertSame($expectedPosition, $position, $message);
@@ -535,6 +536,11 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
         return array(
             array('prefix1', false, '->parse() does not parse a number with a string prefix.', 0),
             array('1.4suffix', (float) 1.4, '->parse() parses a number with a string suffix.', 3),
+            array('-.4suffix', (float) -0.4, '->parse() parses a negative dot float with suffix.', 3),
+            array('-123,4', false, '->parse() does not parse when invalid grouping used.', 6),
+            array('-1234,567', false, '->parse() does not parse when invalid grouping used.', 5),
+            array('-123,,456', false, '->parse() does not parse when invalid grouping used.', 4),
+            array('-123,,456', -123.0, '->parse() parses when grouping is disabled.', 4, false),
         );
     }
 

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -543,8 +543,10 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     {
         $process = $this->getProcess(self::$phpBin.' -r "sleep(1);"');
         $process->start();
+
+        $this->assertFalse($process->isSuccessful());
+
         while ($process->isRunning()) {
-            $this->assertFalse($process->isSuccessful());
             usleep(300000);
         }
 

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -40,23 +40,25 @@ class LengthValidator extends ConstraintValidator
             $charset = 'UTF-8';
         }
 
-        if (function_exists('iconv_strlen')) {
-            $length = @iconv_strlen($stringValue, $constraint->charset);
-            $invalidCharset = false === $length;
+        if ('UTF-8' === $charset) {
+            if (!preg_match('//u', $stringValue)) {
+                $invalidCharset = true;
+            } elseif (function_exists('utf8_decode')) {
+                $length = strlen(utf8_decode($stringValue));
+            } else {
+                preg_replace('/./u', '', $stringValue, -1, $length);
+            }
         } elseif (function_exists('mb_strlen')) {
-            if (mb_check_encoding($stringValue, $constraint->charset)) {
+            if (@mb_check_encoding($stringValue, $constraint->charset)) {
                 $length = mb_strlen($stringValue, $constraint->charset);
             } else {
                 $invalidCharset = true;
             }
-        } elseif ('UTF-8' !== $charset) {
-            $length = strlen($stringValue);
-        } elseif (!preg_match('//u', $stringValue)) {
-            $invalidCharset = true;
-        } elseif (function_exists('utf8_decode')) {
-            $length = strlen(utf8_decode($stringValue));
+        } elseif (function_exists('iconv_strlen')) {
+            $length = @iconv_strlen($stringValue, $constraint->charset);
+            $invalidCharset = false === $length;
         } else {
-            preg_replace('/./u', '', $stringValue, -1, $length);
+            $length = strlen($stringValue);
         }
 
         if ($invalidCharset) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Component\Validator\Constraints\ImageValidator;
 
+/**
+ * @requires extension fileinfo
+ */
 class ImageValidatorTest extends AbstractConstraintValidatorTest
 {
     protected $context;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | YES, both on Travis (Linux) and on Appveyor (Windows)! |
| Fixed tickets | #13934, #15049, #14259, #15045, #15444 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/5654 |
- testing two matrix lines:
  - one without mbtring nor fileinfo nor intl
  - one with these ext enables, intl version 51.2 so that almost no test is skipped on our Intl component
- bug fixes thanks to these harder testing conditions
- some display bug on appveyor, [reported here](http://help.appveyor.com/discussions/suggestions/197-support-ansi-color-codes).
