### PR TITLE
Use EntityManagerInterface instead of EntityManager

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\Doctrine\Form\ChoiceList;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Loads entities using a {@link QueryBuilder} instance.
@@ -37,14 +37,14 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
     /**
      * Construct an ORM Query Builder Loader.
      *
-     * @param QueryBuilder|\Closure $queryBuilder The query builder or a closure
-     *                                            for creating the query builder.
-     *                                            Passing a closure is
-     *                                            deprecated and will not be
-     *                                            supported anymore as of
-     *                                            Symfony 3.0.
-     * @param EntityManager         $manager      Deprecated.
-     * @param string                $class        Deprecated.
+     * @param QueryBuilder|\Closure  $queryBuilder The query builder or a closure
+     *                                             for creating the query builder.
+     *                                             Passing a closure is
+     *                                             deprecated and will not be
+     *                                             supported anymore as of
+     *                                             Symfony 3.0.
+     * @param EntityManagerInterface $manager      Deprecated.
+     * @param string                 $class        Deprecated.
      *
      * @throws UnexpectedTypeException
      */
@@ -59,8 +59,8 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
         if ($queryBuilder instanceof \Closure) {
             @trigger_error('Passing a QueryBuilder closure to '.__CLASS__.'::__construct() is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
 
-            if (!$manager instanceof EntityManager) {
-                throw new UnexpectedTypeException($manager, 'Doctrine\ORM\EntityManager');
+            if (!$manager instanceof EntityManagerInterface) {
+                throw new UnexpectedTypeException($manager, 'Doctrine\ORM\EntityManagerInterface');
             }
 
             @trigger_error('Passing an EntityManager to '.__CLASS__.'::__construct() is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

If you use the EntityManager Decorator pattern that doctrine provides then simply specifying a query_builder closure where your decorated em is used fails as it isn't an instance of Doctrine\ORM\EntityManager. Testing against the EntityManagerInterface fixes the issue. This should be backported to other symfony versions as well.
