### PR TITLE
Add the ability to override commands as service's names

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
@@ -42,6 +42,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be a subclass of "Symfony\\Component\\Console\\Command\\Command".', $id));
             }
             $container->setAlias('console.command.'.strtolower(str_replace('\\', '_', $class)), $id);
+
+            if (isset($tags[0]['command'])) {
+                $definition->addMethodCall('setName', array($tags[0]['command']));
+            }
         }
 
         $container->setParameter('console.command.ids', array_keys($commandServices));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I thought it would be useful to be able to override the command's name when registering the command as service.
