### PR TITLE
[Config] Fix ArrayNode extra keys "ignore" and "remove" behaviors 

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -303,9 +303,8 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
             if (isset($this->children[$name])) {
                 $normalized[$name] = $this->children[$name]->normalize($val);
                 unset($value[$name]);
-            } elseif (false === $this->removeExtraKeys) {
+            } elseif (!$this->removeExtraKeys) {
                 $normalized[$name] = $val;
-                unset($value[$name]);
             }
         }
 

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\ScalarNode;
 
 class ArrayNodeTest extends \PHPUnit_Framework_TestCase
@@ -35,34 +36,30 @@ class ArrayNodeTest extends \PHPUnit_Framework_TestCase
         $node->normalize(array('foo' => 'bar'));
     }
 
-    /**
-     * Tests that no exception is thrown for an unrecognized child if the
-     * ignoreExtraKeys option is set to true.
-     *
-     * Related to testExceptionThrownOnUnrecognizedChild
-     */
-    public function testIgnoreExtraKeysNoException()
+    public function ignoreAndRemoveMatrixProvider()
     {
-        $node = new ArrayNode('roo');
-        $node->setIgnoreExtraKeys(true);
+        $unrecognizedOptionException = new InvalidConfigurationException('Unrecognized option "foo" under "root"');
 
-        $node->normalize(array('foo' => 'bar'));
-        $this->assertTrue(true, 'No exception was thrown when setIgnoreExtraKeys is true');
+        return array(
+            array(true, true, array(), 'no exception is thrown for an unrecognized child if the ignoreExtraKeys option is set to true'),
+            array(true, false, array('foo' => 'bar'), 'extra keys are not removed when ignoreExtraKeys second option is set to false'),
+            array(false, true, $unrecognizedOptionException),
+            array(false, false, $unrecognizedOptionException),
+        );
     }
 
     /**
-     * Tests that extra keys are not removed when
-     * ignoreExtraKeys second option is set to false.
-     *
-     * Related to testExceptionThrownOnUnrecognizedChild
+     * @dataProvider ignoreAndRemoveMatrixProvider
      */
-    public function testIgnoreExtraKeysNotRemoved()
+    public function testIgnoreAndRemoveBehaviors($ignore, $remove, $expected, $message = '')
     {
-        $node = new ArrayNode('roo');
-        $node->setIgnoreExtraKeys(true, false);
-
-        $data = array('foo' => 'bar');
-        $this->assertSame($data, $node->normalize($data));
+        if ($expected instanceof \Exception) {
+            $this->setExpectedException(get_class($expected), $expected->getMessage());
+        }
+        $node = new ArrayNode('root');
+        $node->setIgnoreExtraKeys($ignore, $remove);
+        $result = $node->normalize(array('foo' => 'bar'));
+        $this->assertSame($expected, $result, $message);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Due to #14238 , no more exception is thrown when submitting extra keys to an `ArrayNode`.
For instance:

``` php
$builder = new TreeBuilder();

$nodeDefinition = $builder->root('root')
    ->children()
        ->scalarNode('foo')
    ->end()
->end();

$node = $nodeDefinition->getNode(true);
$node->normalize(array(
    'foo' => 'ok',
    'bar' => 'ko',
));
```

will not throw a 

> Symfony\Component\Config\Definition\Exception\InvalidConfigurationException: Unrecognized option "bar" under "root"`

anymore, as it does in 2.7.

I think the expected behavior is:

`Submitted data: ['bar' => 'ko']`

| Ignore | Remove | Expected | OK | Comment |
| --- | --- | --- | --- | --- |
| true | true | `[ ]` | ✔︎ | Previous behavior when ignoring. |
| true | false | `['bar' => 'ko']` | ✔︎ | This is the result targeted by #14238. |
| false | true | exception | ✘ | Removing makes no sense when not ignoring extra keys. <br/>The exception should still be thrown. |
| false | false | exception | ✘ | Previous behavior (2.7). <br/>Should not have changed |
