### PR TITLE
[Form] Fix the handling of values for multiple choice types

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -155,7 +155,7 @@ class ArrayChoiceList implements ChoiceListInterface
             $givenValues = array();
 
             foreach ($choices as $i => $givenChoice) {
-                $givenValues[$i] = call_user_func($this->valueCallback, $givenChoice);
+                $givenValues[$i] = (string) call_user_func($this->valueCallback, $givenChoice);
             }
 
             return array_intersect($givenValues, array_keys($this->choices));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1327,6 +1327,42 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[4]->getViewData());
     }
 
+    public function testSingleSelectedObjectChoices()
+    {
+        $form = $this->factory->create('choice', $this->objectChoices[3], array(
+            'multiple' => false,
+            'expanded' => false,
+            'choices' => $this->objectChoices,
+            'choices_as_values' => true,
+            'choice_label' => 'name',
+            'choice_value' => 'id',
+        ));
+
+        $view = $form->createView();
+        $selectedChecker = $view->vars['is_selected'];
+
+        $this->assertTrue($selectedChecker($view->vars['choices'][3]->value, $view->vars['value']));
+        $this->assertFalse($selectedChecker($view->vars['choices'][1]->value, $view->vars['value']));
+    }
+
+    public function testMultipleSelectedObjectChoices()
+    {
+        $form = $this->factory->create('choice', array($this->objectChoices[3]), array(
+            'multiple' => true,
+            'expanded' => false,
+            'choices' => $this->objectChoices,
+            'choices_as_values' => true,
+            'choice_label' => 'name',
+            'choice_value' => 'id',
+        ));
+
+        $view = $form->createView();
+        $selectedChecker = $view->vars['is_selected'];
+
+        $this->assertTrue($selectedChecker($view->vars['choices'][3]->value, $view->vars['value']));
+        $this->assertFalse($selectedChecker($view->vars['choices'][1]->value, $view->vars['value']));
+    }
+
     /*
      * We need this functionality to create choice fields for Boolean types,
      * e.g. false => 'No', true => 'Yes'


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Choice values must always be strings (the ChoiceListInterface documents this requirement), but a place was missing the casting, breaking the comparison of selected choices when the callback does not return a string. This happens when a property path is used and points to a non-string property for instance (in the tests, the id is an integer, which is common).
Single choice types are not affected by the bug because the data transformer was also taking care of the string casting in this case.
