### PR TITLE
Deprecated Security ClassUtils in favor of Acl ClassUtils

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
    `Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface` instead
  * deprecated `Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface`, use
    `Symfony\Component\Security\Http\Authentication\SimpleFormAuthenticatorInterface` instead
+ * deprecated `Symfony\Component\Security\Core\Util\ClassUtils`, use
+   `Symfony\Component\Security\Acl\Util\ClassUtils` instead
 
 2.7.0
 -----

--- a/src/Symfony/Component/Security/Core/Tests/Util/ClassUtilsTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Util/ClassUtilsTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Security\Core\Tests\Util
 {
     use Symfony\Component\Security\Core\Util\ClassUtils;
 
+    /**
+     * @group legacy
+     */
     class ClassUtilsTest extends \PHPUnit_Framework_TestCase
     {
         public static function dataGetClass()

--- a/src/Symfony/Component/Security/Core/Util/ClassUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/ClassUtils.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Component\Security\Core\Util;
 
-use Doctrine\Common\Util\ClassUtils as DoctrineClassUtils;
+use Symfony\Component\Security\Acl\Util\ClassUtils as AclClassUtils;
+
+@trigger_error('The '.__NAMESPACE__.'\ClassUtils class is deprecated since version 2.8, to be removed in 3.0. Use Symfony\Component\Security\Acl\Util\ClassUtils instead.', E_USER_DEPRECATED);
 
 /**
  * Class related functionality for objects that
  * might or might not be proxy objects at the moment.
  *
- * @see DoctrineClassUtils
+ * @deprecated ClassUtils is deprecated since version 2.8, to be removed in 3.0. Use Acl ClassUtils instead.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @author Johannes Schmitt <schmittjoh@gmail.com>
@@ -54,6 +56,11 @@ class ClassUtils
      */
     public static function getRealClass($object)
     {
+        if (class_exists('Symfony\Component\Security\Acl\Util\ClassUtils')) {
+            return AclClassUtils::getRealClass($object);
+        }
+
+        // fallback in case security-acl is not installed
         $class = is_object($object) ? get_class($object) : $object;
 
         if (false === $pos = strrpos($class, '\\'.self::MARKER.'\\')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | symfony/symfony/issues/14718 |
| Relates to | symfony/security-acl/pull/3 |
| License | MIT |
| Doc PR | ~ |

Should be removed from the core as it's only used in the Acl component.
