### PR TITLE
[validator] Add 'Class Name' Group to the 'Default' Group

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -236,6 +236,8 @@ abstract class Constraint
     {
         if (in_array(self::DEFAULT_GROUP, $this->groups) && !in_array($group, $this->groups)) {
             $this->groups[] = $group;
+        } else if (in_array($group, $this->groups) && !in_array(self::DEFAULT_GROUP, $this->groups)) {
+            $this->groups[] = self::DEFAULT_GROUP;
         }
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -135,4 +135,19 @@ class CompositeTest extends \PHPUnit_Framework_TestCase
             new Valid(),
         ));
     }
+
+    public function testDefaultGroupIsEquivalentToImplicitGroup()
+    {
+        $constraint = new ConcreteComposite(array(
+            new NotNull(array('groups' => 'ImplicitGroup')),
+            new NotBlank(array('groups' => array('Strict', 'ImplicitGroup'))),
+        ));
+
+        $constraint->addImplicitGroupName('ImplicitGroup');
+
+        $this->assertEquals(array('ImplicitGroup', 'Strict', 'Default'), $constraint->groups);
+        $this->assertEquals(array('ImplicitGroup', 'Default'), $constraint->constraints[0]->groups);
+        $this->assertEquals(array('Strict', 'ImplicitGroup', 'Default'), $constraint->constraints[1]->groups);
+    }
+
 }


### PR DESCRIPTION
According to the spec:

> "Constraints in the Default group of a class are the constraints that
> have either no explicit group configured or that are configured to a
> group equal to the class name or the string Default."

Currently, if a constraint belongs to the 'Default' group, it will be added
to the "class name" group automatically.

However, we found that if a constraint is explicitly configured for
the "class name" group, it won't be added to the "Default" group.

The following example reproduces this issue.

``` php
...
class Foo
{
    /**
     * @Assert\NotNull(
     *     groups = {"Foo"}
     * )
     */
    public $nameInFooGroup;

    /**
     * @Assert\NotNull
     */
    public $nameWithoutGroup;

    /**
     * @Assert\NotNull(
     *     groups = {"Default"}
     * )
     */
    public $nameInDefaultGroup;

}

$foo = new Foo();
$errors1 = $validator->validate($foo);
$errors2 = $validator->validate($foo, array('Default'));
$errors3 = $validator->validate($foo, array('Foo'));

if ($errors1 == $errors2 && $errors2 == $errors3) {
    echo "Default group is equivalent to class name group \n";
} else {
    echo "Default group is not equivalent to class name group \n";
}
```

This patch fixed this issue.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
