### PR TITLE
consistently use str_replace to unify directory separators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateFilenameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateFilenameParser.php
@@ -26,7 +26,7 @@ class TemplateFilenameParser implements TemplateNameParserInterface
      */
     public function parse($file)
     {
-        $parts = explode('/', strtr($file, '\\', '/'));
+        $parts = explode('/', str_replace('\\', '/', $file));
 
         $elements = explode('.', array_pop($parts));
         if (3 > count($elements)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
@@ -50,7 +50,7 @@ class TemplateNameParser extends BaseTemplateNameParser
         }
 
         // normalize name
-        $name = str_replace(':/', ':', preg_replace('#/{2,}#', '/', strtr($name, '\\', '/')));
+        $name = str_replace(':/', ':', preg_replace('#/{2,}#', '/', str_replace('\\', '/', $name)));
 
         if (false !== strpos($name, '..')) {
             throw new \RuntimeException(sprintf('Template name "%s" contains invalid characters.', $name));

--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -140,10 +140,10 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function assertEqualsNormalized($expected, $actual, $message = null)
     {
         foreach ($expected as $ns => $path) {
-            $expected[$ns] = strtr($path, '\\', '/');
+            $expected[$ns] = str_replace('\\', '/', $path);
         }
         foreach ($actual as $ns => $path) {
-            $actual[$ns] = strtr($path, '\\', '/');
+            $actual[$ns] = str_replace('\\', '/', $path);
         }
         $this->assertEquals($expected, $actual, $message);
     }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -313,8 +313,8 @@ class Filesystem
     {
         // Normalize separators on Windows
         if ('\\' === DIRECTORY_SEPARATOR) {
-            $endPath = strtr($endPath, '\\', '/');
-            $startPath = strtr($startPath, '\\', '/');
+            $endPath = str_replace('\\', '/', $endPath);
+            $startPath = str_replace('\\', '/', $startPath);
         }
 
         // Split the paths into arrays

--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -44,7 +44,7 @@ class ExcludeDirectoryFilterIterator extends FilterIterator
     public function accept()
     {
         $path = $this->isDir() ? $this->current()->getRelativePathname() : $this->current()->getRelativePath();
-        $path = strtr($path, '\\', '/');
+        $path = str_replace('\\', '/', $path);
         foreach ($this->patterns as $pattern) {
             if (preg_match($pattern, $path)) {
                 return false;

--- a/src/Symfony/Component/Finder/Iterator/PathFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/PathFilterIterator.php
@@ -29,7 +29,7 @@ class PathFilterIterator extends MultiplePcreFilterIterator
         $filename = $this->current()->getRelativePathname();
 
         if ('\\' === DIRECTORY_SEPARATOR) {
-            $filename = strtr($filename, '\\', '/');
+            $filename = str_replace('\\', '/', $filename);
         }
 
         // should at least not match one rule to exclude


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | - |

We used a mix of `str_replace` and `strtr` for the same thing. `str_replace` is faster as [I tested myself](https://3v4l.org/MNrgC) which is logical since strtr adds logic we don't need here.
