### PR TITLE
[Translation] Fix the string casting in the XliffFileLoader

### DIFF
--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -53,7 +53,7 @@ class XliffFileLoader implements LoaderInterface
             }
 
             $source = isset($attributes['resname']) && $attributes['resname'] ? $attributes['resname'] : $translation->source;
-            $target = (string) isset($translation->target) ? $translation->target : $source;
+            $target = (string) (isset($translation->target) ? $translation->target : $source);
 
             // If the xlf file has another encoding specified, try to convert it because
             // simple_xml will always return utf-8 encoded values

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -25,6 +25,7 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
         $this->assertSame(array(), libxml_get_errors());
+        $this->assertContainsOnly('string', $catalogue->all('domain1'));
     }
 
     public function testLoadWithInternalErrorsEnabled()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

https://github.com/symfony/symfony/pull/15611 broke the usage of Xliff translation files (and so all Symfony projects as they are used in core) because it stores SimpleXmlElement instances in the MessageCatalogue, which breaks when loading the cache:

```
PHP Fatal error:  Call to undefined method SimpleXMLElement::__set_state() in .../app/cache/test/translations/catalogue.en.1cd7e874b24ab41081c7781e4161053bf515fc91.php on line 9
```

this is how the cache looks like (truncated a lot of course):

``` php

$catalogue = new MessageCatalogue('en', array (
  'validators' => 
  array (
    'This value should be false.' => 
    SimpleXMLElement::__set_state(array(
       0 => 'This value should be false.',
    )),
  ),
));
```

This is a critical bug in the 2.3 and 2.7 branches
