### PR TITLE
[Config] Prototypes info

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -84,13 +84,17 @@ class XmlReferenceDumper
 
             // render prototyped nodes
             if ($node instanceof PrototypedArrayNode) {
-                array_unshift($rootComments, 'prototype');
+                $prototype = $node->getPrototype();
+
+                $info = 'prototype';
+                if (null !== $prototype->getInfo()) {
+                    $info .= ': '.$prototype->getInfo();
+                }
+                array_unshift($rootComments, $info);
 
                 if ($key = $node->getKeyAttribute()) {
                     $rootAttributes[$key] = str_replace('-', ' ', $rootName).' '.$key;
                 }
-
-                $prototype = $node->getPrototype();
 
                 if ($prototype instanceof ArrayNode) {
                     $children = $prototype->getChildren();

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -69,7 +69,12 @@ class YamlReferenceDumper
                 if ($key = $node->getKeyAttribute()) {
                     $keyNodeClass = 'Symfony\Component\Config\Definition\\'.($prototype instanceof ArrayNode ? 'ArrayNode' : 'ScalarNode');
                     $keyNode = new $keyNodeClass($key, $node);
-                    $keyNode->setInfo('Prototype');
+
+                    $info = 'Prototype';
+                    if (null !== $prototype->getInfo()) {
+                        $info .= ': '.$prototype->getInfo();
+                    }
+                    $keyNode->setInfo($info);
 
                     // add children
                     foreach ($children as $childNode) {

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
@@ -64,7 +64,7 @@ class XmlReferenceDumperTest extends \PHPUnit_Framework_TestCase
         child3=""
     />
 
-    <!-- prototype -->
+    <!-- prototype: Parameter name -->
     <parameter name="parameter name">scalar value</parameter>
 
     <!-- prototype -->

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -56,7 +56,7 @@ acme_root:
         child3:               ~ # Example: example setting
     parameters:
 
-        # Prototype
+        # Prototype: Parameter name
         name:                 ~
     connections:
         # Prototype

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
@@ -53,7 +53,7 @@ class ExampleConfiguration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('parameters')
                     ->useAttributeAsKey('name')
-                    ->prototype('scalar')->end()
+                    ->prototype('scalar')->info('Parameter name')->end()
                 ->end()
                 ->arrayNode('connections')
                     ->prototype('array')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no ? |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Prototypes info is currently ignored by dumpers. It might be useful to add extra informations to the `# Prototype` comment in the `config:dump-reference` output.
