### PR TITLE
Use ObjectManager interface instead of EntityManager

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\Doctrine\Form\ChoiceList;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\Common\Persistence\ObjectManager;
 
 /**
  * Getting Entities through the ORM QueryBuilder.
@@ -35,7 +35,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
      * Construct an ORM Query Builder Loader.
      *
      * @param QueryBuilder|\Closure $queryBuilder
-     * @param EntityManager         $manager
+     * @param ObjectManager         $manager
      * @param string                $class
      *
      * @throws UnexpectedTypeException
@@ -49,8 +49,8 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
         }
 
         if ($queryBuilder instanceof \Closure) {
-            if (!$manager instanceof EntityManager) {
-                throw new UnexpectedTypeException($manager, 'Doctrine\ORM\EntityManager');
+            if (!$manager instanceof ObjectManager) {
+                throw new UnexpectedTypeException($manager, 'Doctrine\Common\Persistence\ObjectManager');
             }
 
             $queryBuilder = $queryBuilder($manager->getRepository($class));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

If you use the EntityManager Decorator pattern that doctrine provides
then simply specifying a query_builder closure where your decorated
em is used fails as it isn't an instance of Doctrine\ORM\EntityManager.
Testing against the ObjectManager interface fixes the issue.
