### PR TITLE
[ci] Run minimal versions on appveyor only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
 matrix:
     include:
         - php: hhvm
-        - php: 5.3.3
         - php: 5.3
         - php: 5.4
         - php: 5.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,15 +21,17 @@ init:
 install:
     - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
     - cd c:\php
-    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.4.43-nts-Win32-VC9-x86.zip
-    - IF %PHP%==1 7z x php-5.4.43-nts-Win32-VC9-x86.zip -y > 7z.log
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.3.3-nts-Win32-VC9-x86.zip
+    - IF %PHP%==1 7z x php-5.3.3-nts-Win32-VC9-x86.zip -y > 7z.log
     - IF %PHP%==1 appveyor DownloadFile http://nebm.ist.utl.pt/~glopes/misc/intl_win/ICU-51.2-dlls.zip
     - IF %PHP%==1 7z x ICU-51.2-dlls.zip -y > 7z.log
     - IF %PHP%==1 cd ext
-    - IF %PHP%==1 appveyor DownloadFile http://nebm.ist.utl.pt/~glopes/misc/intl_win/php_intl-3.0.0-5.4-nts-vc9-x86.zip
-    - IF %PHP%==1 7z x php_intl-3.0.0-5.4-nts-vc9-x86.zip -y > 7z.log
-    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/apc/3.1.13/php_apc-3.1.13-5.4-nts-vc9-x86.zip
-    - IF %PHP%==1 7z x php_apc-3.1.13-5.4-nts-vc9-x86.zip -y > 7z.log
+    - IF %PHP%==1 appveyor DownloadFile http://nebm.ist.utl.pt/~glopes/misc/intl_win/php_intl-3.0.0-5.3-nts-vc9-x86.zip
+    - IF %PHP%==1 7z x php_intl-3.0.0-5.3-nts-vc9-x86.zip -y > 7z.log
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/apc/3.1.13/php_apc-3.1.13-5.3-nts-vc9-x86.zip
+    - IF %PHP%==1 7z x php_apc-3.1.13-5.3-nts-vc9-x86.zip -y > 7z.log
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/memcache/3.0.8/php_memcache-3.0.8-5.3-nts-vc9-x86.zip
+    - IF %PHP%==1 7z x php_memcache-3.0.8-5.3-nts-vc9-x86.zip -y > 7z.log
     - IF %PHP%==1 cd ..
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - appveyor DownloadFile https://getcomposer.org/composer.phar

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -37,7 +37,8 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         if ('\\' === DIRECTORY_SEPARATOR && null === self::$symlinkOnWindows) {
             $target = tempnam(sys_get_temp_dir(), 'sl');
             $link = sys_get_temp_dir().'/sl'.microtime(true).mt_rand();
-            if (self::$symlinkOnWindows = @symlink($target, $link)) {
+            if (@symlink($target, $link)) {
+                self::$symlinkOnWindows = @is_link($link);
                 unlink($link);
             }
             unlink($target);

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -210,13 +210,15 @@ class IntlDateFormatter
         // behave like the intl extension
         $argumentError = null;
         if (!is_int($timestamp)) {
-            if (PHP_VERSION_ID < 50304) {
-                $argumentError = 'datefmt_format: takes either an array  or an integer timestamp value ';
-            } elseif (!$timestamp instanceof \DateTime) {
-                $argumentError = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object';
+            if (!$timestamp instanceof \DateTime) {
                 if (PHP_VERSION_ID >= 50500 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
                     $argumentError = sprintf('datefmt_format: string \'%s\' is not numeric, which would be required for it to be a valid date', $timestamp);
+                } elseif (PHP_VERSION_ID >= 50304) {
+                    $argumentError = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object';
                 }
+            }
+            if (PHP_VERSION_ID < 50304 && null === $argumentError) {
+                $argumentError = 'datefmt_format: takes either an array  or an integer timestamp value ';
             }
         }
 

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -824,7 +824,7 @@ class NumberFormatter
             // The negative PHP_INT_MAX was being converted to float
             if (
                 $value == self::$int32Range['negative'] &&
-                ((PHP_VERSION_ID < 50400 && PHP_VERSION_ID >= 50314) || PHP_VERSION_ID >= 50404)
+                ((PHP_VERSION_ID < 50400 && PHP_VERSION_ID >= 50314) || PHP_VERSION_ID >= 50404 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone')))
             ) {
                 return (int) $value;
             }
@@ -837,7 +837,8 @@ class NumberFormatter
             // A 32 bit integer was being generated instead of a 64 bit integer
             if (
                   ($value > self::$int32Range['positive'] || $value < self::$int32Range['negative']) &&
-                  (PHP_VERSION_ID < 50314 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404))
+                  (PHP_VERSION_ID < 50314 || (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50404)) &&
+                  !(extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))
             ) {
                 $value = (-2147483648 - ($value % -2147483648)) * ($value / abs($value));
             }

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -590,7 +590,7 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
 
         // Bug #59597 was fixed on PHP 5.3.14 and 5.4.4
         // The negative PHP_INT_MAX was being converted to float
-        if ((PHP_VERSION_ID < 50400 && PHP_VERSION_ID >= 50314) || PHP_VERSION_ID >= 50404) {
+        if ((PHP_VERSION_ID < 50400 && PHP_VERSION_ID >= 50314) || PHP_VERSION_ID >= 50404 || (extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
             $this->assertInternalType('int', $parsedValue);
         } else {
             $this->assertInternalType('float', $parsedValue);

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -79,6 +79,10 @@ abstract class AbstractComparisonValidatorTestCase extends AbstractConstraintVal
         // Make sure we have the correct version loaded
         if ($dirtyValue instanceof \DateTime) {
             IntlTestHelper::requireIntl($this);
+
+            if (PHP_VERSION_ID < 50304 && !(extension_loaded('intl') && method_exists('IntlDateFormatter', 'setTimeZone'))) {
+                $this->markTestSkipped('Intl supports formatting DateTime objects since 5.3.4');
+            }
         }
 
         $constraint = $this->createConstraint(array('value' => $comparedValue));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Hopefully the last round of ci optimizations: what do you think about running the minimal supported version on appveyor only? This removes one matrix line on travis, and gives more flexibility in choosing the minimal version because, where travis only supports a limited list of minimal versions, windows.php.net provides a binary for each and every php ever released.
