### PR TITLE
Fix missing compiled field while serializing Route

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -110,6 +110,7 @@ class Route implements \Serializable
             'schemes'      => $this->schemes,
             'methods'      => $this->methods,
             'condition'    => $this->condition,
+            'compiled'     => $this->compiled,
         ));
     }
 
@@ -124,6 +125,7 @@ class Route implements \Serializable
         $this->schemes = $data['schemes'];
         $this->methods = $data['methods'];
         $this->condition = $data['condition'];
+        $this->compiled = $data['compiled'];
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -229,4 +229,16 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($route, $unserialized);
         $this->assertNotSame($route, $unserialized);
     }
+
+    public function testSerializeHasCompiledField()
+    {
+        $route = new Route('/{foo}', array('foo' => 'default'), array('foo' => '\d+'));
+        $route->compile();
+
+        $serialized = serialize($route);
+        $unSerialized = unserialize($serialized);
+
+        $this->assertEquals($route, $unSerialized);
+        $this->assertNotSame($route, $unSerialized);
+    }
 }


### PR DESCRIPTION
[Routing][2.4] Fix missing compiled field while serializing Route

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15645 |
| License | MIT |
| Doc PR | none |
