### PR TITLE
[FrameworkBundle] Fix templating.helper.code.file_link_format when defined by ini setting

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -364,7 +364,7 @@ class FrameworkExtension extends Extension
                 'sublime' => 'subl://open?url=file://%%f&line=%%l',
             );
 
-            $container->setParameter('templating.helper.code.file_link_format', ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format') ?: (isset($links[$ide]) ? $links[$ide] : $ide));
+            $container->setParameter('templating.helper.code.file_link_format', str_replace('%', '%%', ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')) ?: (isset($links[$ide]) ? $links[$ide] : $ide));
         }
         $container->setParameter('templating.helper.form.resources', $config['form']['resources']);
         $container->setParameter('fragment.renderer.hinclude.global_template', $config['hinclude_default_template']);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Not  bug fix because the fix it fixes has not yet been released in any taggued version, but still a fix.
