### PR TITLE
Require actual version of ACL component until ACL/2.8 branch released

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/common": "~2.3",
         "twig/twig": "~1.20|~2.0",
         "psr/log": "~1.0",
-        "symfony/security-acl": "self.version"
+        "symfony/security-acl": "~2.7"
     },
     "replace": {
         "symfony/asset": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/common": "~2.3",
         "twig/twig": "~1.20|~2.0",
         "psr/log": "~1.0",
-        "symfony/security-acl": "~2.8"
+        "symfony/security-acl": "self.version"
     },
     "replace": {
         "symfony/asset": "self.version",


### PR DESCRIPTION
symfony/2.8@stable is not released, so version reference is incorrect.

This will allow require 2.8.x-dev version alongside with symfony/symfony:2.8.x-dev

Fix #15648 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | BC fix |
| Deprecations? | no |
| Tests pass? | [not sure](https://travis-ci.org/scaytrase/symfony/builds/77840665) |
| Fixed tickets | 15648 |
| License | MIT |
| Doc PR | none |
