### PR TITLE
Don't trigger deprecation on interfaces

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/EsiResponseCacheStrategyInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/EsiResponseCacheStrategyInterface.php
@@ -15,8 +15,6 @@
 
 namespace Symfony\Component\HttpKernel\HttpCache;
 
-@trigger_error('The '.__NAMESPACE__.'\EsiResponseCacheStrategyInterface class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\HttpCache\ResponseCacheStrategyInterface class instead.', E_USER_DEPRECATED);
-
 /**
  * ResponseCacheStrategyInterface implementations know how to compute the
  * Response cache HTTP header based on the different response cache headers.

--- a/src/Symfony/Component/Security/Core/SecurityContextInterface.php
+++ b/src/Symfony/Component/Security/Core/SecurityContextInterface.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Security\Core;
 
-@trigger_error('The '.__NAMESPACE__.'\SecurityContextInterface interface is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
-
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 

--- a/src/Symfony/Component/Templating/Asset/PackageInterface.php
+++ b/src/Symfony/Component/Templating/Asset/PackageInterface.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Templating\Asset;
 
-@trigger_error('The Symfony\Component\Templating\Asset\PackageInterface is deprecated since version 2.7 and will be removed in 3.0. Use the Asset component instead.', E_USER_DEPRECATED);
-
 /**
  * Asset package interface.
  *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This can trigger false positives when implementing the interface is required for bc reasons. The DebugClassLoader is able to trigger on demand at runtime when required.
