### PR TITLE
fixed DumpDataCollector to be compatible with Twig 2.0

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -92,7 +92,9 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                     } elseif (isset($trace[$i]['object']) && $trace[$i]['object'] instanceof \Twig_Template) {
                         $info = $trace[$i]['object'];
                         $name = $info->getTemplateName();
-                        $src = $info->getEnvironment()->getLoader()->getSource($name);
+                        $r = new \ReflectionProperty($info, 'env');
+                        $r->setAccessible(true);
+                        $src = $r->getValue($info)->getLoader()->getSource($name);
                         $info = $info->getDebugInfo();
                         if (isset($info[$trace[$i-1]['line']])) {
                             $file = false;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This is a quick fix, but the whole logic is already very fragile as it depends a lot on Twig's implementation.
