### PR TITLE
Revert "feature #13756 [3.0][Console] Added type hint (francisbesset)"

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -88,10 +88,6 @@ UPGRADE FROM 2.x to 3.0
    $table->render();
    ```
 
-* Parameters of `renderException()` method of the
-  `Symfony\Component\Console\Application` are type hinted.
-  You must add the type hint to your implementations.
-
 ### DependencyInjection
 
  * The method `remove` was added to `Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface`.

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -616,7 +616,7 @@ class Application
      * @param \Exception      $e      An exception instance
      * @param OutputInterface $output An OutputInterface instance
      */
-    public function renderException(\Exception $e, OutputInterface $output)
+    public function renderException($e, $output)
     {
         do {
             $title = sprintf('  [%s]  ', get_class($e));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This reverts commit ad1888b982be694e9ae2c4a6b8604a0df9d14098, reversing
changes made to fffcc243262f5cb7532ac8bc88ba4ce4713ba989.

The rationale behind this change is that type hinting against Exception is not compatible with PHP7.
The second level rational is that this creates a BC break that can easilly be prevented.

This PR will be seconded by an other one on 2.3 that will allow catching then rendering throwables, and add an `instanceof` type check for $output.

Merging this one first will prevent merge conflicts.
