### PR TITLE
[Validator] Fixed group sequence using explicit group for cascaded pr…

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -94,7 +94,7 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
             }
 
             foreach ($groups as $group) {
-                $this->accept($visitor, $value, $group, $propertyPath, Constraint::DEFAULT_GROUP);
+                $this->accept($visitor, $value, $group, $propertyPath, ($this->defaultGroup === $group) ? Constraint::DEFAULT_GROUP : null);
 
                 if (count($visitor->getViolations()) > 0) {
                     break;


### PR DESCRIPTION
…operties

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

In a group sequence, all properties (and cascaded ones) hosted on class A and belonging to the Default group implicitly belong to the group A. However even if we explicitly set a group for cascaded properties, the Default group is always propagated making it impossible to validate our cascaded properties.
For explicit groups the Default group must not be propagated.

Here is an example of use case https://gist.github.com/rpg600/abb765ad2d4446d52e0b that will be fixed.
