### PR TITLE
[validator] Disable Explicit Class Name Group

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -15,6 +15,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
+use Symfony\Component\Validator\Exception\GroupDefinitionException;
 
 /**
  * Contains the properties of a constraint definition.
@@ -55,13 +56,15 @@ abstract class Constraint
     const PROPERTY_CONSTRAINT = 'property';
 
     /**
-     * Maps error codes to the names of their constants
+     * Maps error codes to the names of their constants.
+     *
      * @var array
      */
     protected static $errorNames = array();
 
     /**
-     * Domain-specific data attached to a constraint
+     * Domain-specific data attached to a constraint.
+     *
      * @var mixed
      */
     public $payload;
@@ -229,10 +232,16 @@ abstract class Constraint
      * @param string $group
      *
      * @api
+     *
+     * @throws GroupDefinitionException If the implicit group has been explicitly configured in current constraint.
      */
     public function addImplicitGroupName($group)
     {
-        if (in_array(self::DEFAULT_GROUP, $this->groups) && !in_array($group, $this->groups)) {
+        if (in_array($group, $this->groups)) {
+            throw new GroupDefinitionException(sprintf('The implicit group "%s" has already been explicitly configured in constraint %s', $group, get_class($this)));
+        }
+
+        if (in_array(self::DEFAULT_GROUP, $this->groups)) {
             $this->groups[] = $group;
         }
     }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -215,7 +215,24 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Adds a class constraint.
+     *
+     * If the constraint {@link Traverse} is added, depending on the
+     * property $traverse of that constraint, the traversal strategy
+     * will be set to one of the following:
+     *
+     *  - {@link TraversalStrategy::TRAVERSE} if $traverse is enabled
+     *  - {@link TraversalStrategy::NONE} if $traverse is disabled
+     *
+     * @param Constraint $constraint The class constraint to add
+     *
+     * @return ClassMetadata This object
+     *
+     * @throws ConstraintDefinitionException When trying to add the
+     *                                       {@link Valid} constraint
+     * @throws GroupDefinitionException      When the "class name" group has
+     *                                       been explicity configured in
+     *                                       the given constraint
      */
     public function addConstraint(Constraint $constraint)
     {
@@ -260,6 +277,10 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
      * @param Constraint $constraint The constraint
      *
      * @return ClassMetadata This object
+     *
+     * @throws GroupDefinitionException When the "class name" group has
+     *                                  been explicity configured in
+     *                                  the given constraint
      */
     public function addPropertyConstraint($property, Constraint $constraint)
     {
@@ -301,6 +322,10 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
      * @param Constraint $constraint The constraint
      *
      * @return ClassMetadata This object
+     *
+     * @throws GroupDefinitionException When the "class name" group has
+     *                                  been explicity configured in
+     *                                  the given constraint
      */
     public function addGetterConstraint($property, Constraint $constraint)
     {
@@ -336,6 +361,10 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
      * Merges the constraints of the given metadata into this object.
      *
      * @param ClassMetadata $source The source metadata
+     *
+     * @throws GroupDefinitionException When the "class name" group has
+     *                                  been explicity configured in
+     *                                  the given constraint
      */
     public function mergeConstraints(ClassMetadata $source)
     {

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -277,4 +277,71 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertCount(0, $this->metadata->getPropertyMetadata('foo'), '->getPropertyMetadata() returns an empty collection if no metadata is configured for the given property');
     }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
+     */
+    public function testAddConstraintFailsIfClassNameGroupIsSet()
+    {
+        $metadata = new ClassMetadata(self::CLASSNAME);
+        $constraint = new ConstraintA(array('groups' => array('Entity')));
+        $metadata->addConstraint($constraint);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
+     */
+    public function testAddPropertyConstraintFailsIfClassNameGroupIsSet()
+    {
+        $metadata = new ClassMetadata(self::CLASSNAME);
+        $constraint = new ConstraintA(array('groups' => array('Entity')));
+        $metadata->addPropertyConstraint('firstName', $constraint);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
+     */
+    public function testAddGetterConstraintFailsIfClassNameGroupIsSet()
+    {
+        $metadata = new ClassMetadata(self::CLASSNAME);
+        $constraint = new ConstraintA(array('groups' => array('Entity')));
+        $metadata->addGetterConstraint('lastName', $constraint);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
+     */
+    public function testMergeConstraintsFailsIfClassNameGroupIsSetInClassConstraint()
+    {
+        $metadata = new ClassMetadata(self::CLASSNAME);
+        $parent = new ClassMetadata(self::PARENTCLASS);
+        $constraint = new ConstraintA(array('groups' => array('Entity')));
+        $parent->addConstraint($constraint);
+        $metadata->mergeConstraints($parent);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
+     */
+    public function testMergeConstraintsFailsIfClassNameGroupIsSetInPropertyConstraint()
+    {
+        $metadata = new ClassMetadata(self::CLASSNAME);
+        $parent = new ClassMetadata(self::PARENTCLASS);
+        $constraint = new ConstraintA(array('groups' => array('Entity')));
+        $parent->addPropertyConstraint('firstName', $constraint);
+        $metadata->mergeConstraints($parent);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
+     */
+    public function testMergeConstraintsFailsIfClassNameGroupIsSetInGetterConstraint()
+    {
+        $metadata = new ClassMetadata(self::CLASSNAME);
+        $parent = new ClassMetadata(self::PARENTCLASS);
+        $constraint = new ConstraintA(array('groups' => array('Entity')));
+        $parent->addGetterConstraint('data', $constraint);
+        $metadata->mergeConstraints($parent);
+    }
+
 }


### PR DESCRIPTION
## Issue:

If "class name" group is **explicity** configured in a constraint, the
constraint will not be added to "Default" group.

The following example reproduces this issue:

``` php
class Foo
{
    /**
     * @Assert\NotNull(
     *     groups = {"Foo"}
     * )
     */
    public $nameInFooGroup;

    /**
     * @Assert\NotNull
     */
    public $nameWithoutGroup;

    /**
     * @Assert\NotNull(
     *     groups = {"Default"}
     * )
     */
    public $nameInDefaultGroup;

}
```

Constraints in "Foo" Group:
1.  NotNull constraint on nameWithoutGroup property
2.  NotNull constraint on nameInDefaultGroup property
3.  NotNull constraint on nameInFooGroup property

Constraints in "Default" Group:
1.  NotNull constraint on nameWithoutGroup property
2.  NotNull constraint on nameInDefaultGroup property

The NotNull constraint on nameInFooGroup property is not added to "Default" group.
This is incorrect because "Default" group and "class name" group should be identical
if neither "group sequence" nor "embed object" is used.
## Cause of the Issue:

The implementation of "class name" group didn't follow the JSR-303 spec.
### JSR-303 Spec:

For class X, group X can not be explicitly defined, because all explicit groups
are implemented as inner interfaces of class X and none of the interfaces can use X
as its name, because `class X is already defined`.
This explains why, in the formal group definition, group X does not include constraints
explicitly assigned to group X, because that's impossible in java.

> The group X contains the following constraints:
> - all Default constraints hosted on X
> - all Default constraints hosted on interfaces of X
> - ...
### Symfony Implementation:

This is the official documentation for "Default" group.

> Constraints in the Default group of a class are the constraints that have either no
> explicit group configured or that are **configured to a group equal to the class name** or
> the string Default.

It does not clarify the meaning of "**configured to a group equal to the class name**":
does it mean "implicitly configured" or "explicitly configured"?

If the class name group is not explicitly defined, then everything is fine. Unfortunately,
in Symfony, it's also possible to explicitly configure the "class name" group for constraints:

``` php
...
class User
{
    /**
     * @Assert\NotNull(
     *      groups = {"User"}
     * )
    */
    public $name;
    ...
}
```

In this case, the "NotNull" constraint on name property won't be added to Default group
and that's the issue I am trying to fix.
## Solution:

Follow the JSR-303 spec to forbid the configuration of explicit "class name" group and
when an explicit class name group is found, a GroupDefinitionException exception shall be thrown.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
