### PR TITLE
Autoescape prevents viewing debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -37,7 +37,11 @@
                     {% if templates is defined %}
                         <ul id="menu-profiler">
                             {% for name, template in templates %}
-                                {% set menu %}{{ template.renderBlock('menu', { 'collector': profile.getcollector(name)}) }}{% endset %}
+                                {% set menu %}
+                                {% autoescape false %}
+                                {{ template.renderBlock('menu', { 'collector': profile.getcollector(name)}) }}
+                                {% endautoescape %}
+                                {% endset %}
                                 {% if menu != '' %}
                                     <li class="{{ name }}{% if name == panel %} selected{% endif %}">
                                         <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">{{ menu|raw }}</a>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -26,6 +26,7 @@
 
 <div id="sfToolbarMainContent-{{ token }}" class="sf-toolbarreset clear-fix" data-no-turbolink>
     {% for name, template in templates %}
+        {% autoescape false %}
         {{ template.renderblock('toolbar', {
             'collector': profile.getcollector(name),
             'profiler_url': profiler_url,
@@ -34,6 +35,7 @@
             'profiler_markup_version': profiler_markup_version
           })
         }}
+        {% endautoescape %}
     {% endfor %}
 
     {% if 'normal' != position %}


### PR DESCRIPTION
After i upgraded to 2.8 debug toolbar was showing only in pure html

[WebProfilerBundle] added autoescapes 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
