### PR TITLE
[Form] Added exception when setAutoInitialize() is called when locked

### DIFF
--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -854,6 +854,10 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public function setAutoInitialize($initialize)
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         $this->autoInitialize = (bool) $initialize;
 
         return $this;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It seems that this method was missing a "locked" check, since it changes state and a locked instance should be immutable. However, because `setAutoInitialize()` is useful during the building of a form, it doesn't really matter a lot whether or not it is changed. But for consistency, it would be nicer if this method too was checked.
