### PR TITLE
[Doc] Use new repo location (Goutte & Silex) in some readme.md

### DIFF
--- a/src/Symfony/Component/BrowserKit/README.md
+++ b/src/Symfony/Component/BrowserKit/README.md
@@ -10,7 +10,7 @@ Resources
 ---------
 
 For a simple implementation of a browser based on an HTTP layer, have a look
-at [Goutte](https://github.com/fabpot/Goutte).
+at [Goutte](https://github.com/FriendsOfPHP/Goutte).
 
 For an implementation based on HttpKernelInterface, have a look at the
 [Client](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Client.php)

--- a/src/Symfony/Component/Form/README.md
+++ b/src/Symfony/Component/Form/README.md
@@ -10,7 +10,7 @@ Resources
 
 Silex integration:
 
-https://github.com/fabpot/Silex/blob/master/src/Silex/Provider/FormServiceProvider.php
+https://github.com/silexphp/Silex/blob/master/src/Silex/Provider/FormServiceProvider.php
 
 Documentation:
 

--- a/src/Symfony/Component/Translation/README.md
+++ b/src/Symfony/Component/Translation/README.md
@@ -24,7 +24,7 @@ Resources
 
 Silex integration:
 
-https://github.com/fabpot/Silex/blob/master/src/Silex/Provider/TranslationServiceProvider.php
+https://github.com/silexphp/Silex/blob/master/src/Silex/Provider/TranslationServiceProvider.php
 
 Documentation:
 

--- a/src/Symfony/Component/Validator/README.md
+++ b/src/Symfony/Component/Validator/README.md
@@ -109,7 +109,7 @@ Resources
 
 Silex integration:
 
-https://github.com/fabpot/Silex/blob/master/src/Silex/Provider/ValidatorServiceProvider.php
+https://github.com/silexphp/Silex/blob/master/src/Silex/Provider/ValidatorServiceProvider.php
 
 Documentation:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Correct links to silex and goutte repos to the new organizations, respectively FriendsOfPHP and silexphp.
Not a bug fix, github.com redirects correctly, just typo.
