### PR TITLE
[Translator][FileDumper] deprecated format method in favor of formatCatalogue.

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.8.0
 -----
 
+ * deprecated FileDumper::format(), overwrite FileDumper::formatCatalogue() instead.
  * deprecated Translator::getMessages(), rely on TranslatorBagInterface::getCatalogue() instead.
  * added option `json_encoding` to JsonFileDumper
  * added options `as_tree`, `inline` to YamlFileDumper

--- a/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
@@ -28,6 +28,16 @@ class CsvFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
+        return $this->formatCatalogue($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
+    {
         $handle = fopen('php://memory', 'rb+');
 
         foreach ($messages->all($domain) as $source => $target) {

--- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
@@ -99,6 +99,8 @@ abstract class FileDumper implements DumperInterface
      */
     protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
     {
+        @trigger_error('The '.__METHOD__.' method will replace the format method in 3.0. You should overwritten it instead of overwriting format instead.', E_USER_DEPRECATED);
+
         return $this->format($messages, $domain);
     }
 
@@ -109,6 +111,8 @@ abstract class FileDumper implements DumperInterface
      * @param string           $domain
      *
      * @return string representation
+     *
+     * @deprecated since version 2.8, to be removed in 3.0. Overwrite formatCatalogue() instead.
      */
     abstract protected function format(MessageCatalogue $messages, $domain);
 

--- a/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
@@ -30,6 +30,16 @@ class IcuResFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
+        return $this->formatCatalogue($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
+    {
         $data = $indexes = $resources = '';
 
         foreach ($messages->all($domain) as $source => $target) {

--- a/src/Symfony/Component/Translation/Dumper/IniFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IniFileDumper.php
@@ -25,6 +25,16 @@ class IniFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
+        return $this->formatCatalogue($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
+    {
         $output = '';
 
         foreach ($messages->all($domain) as $source => $target) {

--- a/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
@@ -25,6 +25,8 @@ class JsonFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
         return $this->formatCatalogue($messages, $domain);
     }
 

--- a/src/Symfony/Component/Translation/Dumper/MoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/MoFileDumper.php
@@ -26,6 +26,16 @@ class MoFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
+        return $this->formatCatalogue($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
+    {
         $output = $sources = $targets = $sourceOffsets = $targetOffsets = '';
         $offsets = array();
         $size = 0;

--- a/src/Symfony/Component/Translation/Dumper/PhpFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PhpFileDumper.php
@@ -25,6 +25,16 @@ class PhpFileDumper extends FileDumper
      */
     protected function format(MessageCatalogue $messages, $domain)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
+        return $this->formatCatalogue($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
+    {
         $output = "<?php\n\nreturn ".var_export($messages->all($domain), true).";\n";
 
         return $output;

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -25,6 +25,16 @@ class PoFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain = 'messages')
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
+        return $this->formatCatalogue($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
+    {
         $output = 'msgid ""'."\n";
         $output .= 'msgstr ""'."\n";
         $output .= '"Content-Type: text/plain; charset=UTF-8\n"'."\n";

--- a/src/Symfony/Component/Translation/Dumper/QtFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/QtFileDumper.php
@@ -25,6 +25,16 @@ class QtFileDumper extends FileDumper
      */
     public function format(MessageCatalogue $messages, $domain)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
+        return $this->formatCatalogue($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
+    {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = true;
         $ts = $dom->appendChild($dom->createElement('TS'));

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -51,6 +51,8 @@ class XliffFileDumper extends FileDumper
      */
     protected function format(MessageCatalogue $messages, $domain)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
         return $this->formatCatalogue($messages, $domain);
     }
 

--- a/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
@@ -49,6 +49,8 @@ class YamlFileDumper extends FileDumper
      */
     protected function format(MessageCatalogue $messages, $domain)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use the formatCatalogue() method instead.', E_USER_DEPRECATED);
+
         return $this->formatCatalogue($messages, $domain);
     }
 

--- a/src/Symfony/Component/Translation/Tests/Dumper/FileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/FileDumperTest.php
@@ -58,9 +58,14 @@ class FileDumperTest extends \PHPUnit_Framework_TestCase
 
 class ConcreteFileDumper extends FileDumper
 {
-    protected function format(MessageCatalogue $messages, $domain)
+    protected function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
     {
         return '';
+    }
+
+    protected function format(MessageCatalogue $messages, $domain)
+    {
+        return $this->formatCatalogue($messages, $domain);
     }
 
     protected function getExtension()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Fixed tickets | ~ |
| Tests pass? | yes |
| License | MIT |

We introduced `formatCatalogue` to allow using options passed to the dump method.
