### PR TITLE
[SecurityBundle] allow more versions of the ACL package

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/security": "~2.8|~3.0.0",
-        "symfony/security-acl": "~2.8|~3.0.0",
+        "symfony/security-acl": "~2.7|~3.0.0",
         "symfony/http-kernel": "~2.2|~3.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This actually is the version that is required when using the Symfony SE
(`symfony/symfony` requires `symfony/security-acl` in version `~2.7`).
