### PR TITLE
Fix that two DirectoryResources with different patterns would be deduplicated

### DIFF
--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -38,7 +38,7 @@ class DirectoryResource implements ResourceInterface, \Serializable
      */
     public function __toString()
     {
-        return (string) $this->resource;
+        return md5(serialize(array($this->resource, $this->pattern)));
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -54,7 +54,6 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
     {
         $resource = new DirectoryResource($this->directory);
         $this->assertSame($this->directory, $resource->getResource(), '->getResource() returns the path to the resource');
-        $this->assertSame($this->directory, (string) $resource, '->__toString() returns the path to the resource');
     }
 
     public function testGetPattern()
@@ -85,6 +84,13 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
         $resource = new DirectoryResource($this->directory);
         touch($this->directory.'/new.xml', time() + 20);
         $this->assertFalse($resource->isFresh(time() + 10), '->isFresh() returns false if a new file is added');
+    }
+
+    public function testIsFreshNewFileWithDifferentPattern()
+    {
+        $resource = new DirectoryResource($this->directory, '/.xml$/');
+        touch($this->directory.'/new.yaml', time() + 20);
+        $this->assertTrue($resource->isFresh(time() + 10), '->isFresh() returns true if a new file with a non-matching pattern is added');
     }
 
     public function testIsFreshDeleteFile()
@@ -148,5 +154,13 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($this->directory, $resource->getResource());
         $this->assertSame('/\.(foo|xml)$/', $resource->getPattern());
+    }
+
+    public function testResourcesWithDifferentPatternsAreDifferent()
+    {
+        $resourceA = new DirectoryResource($this->directory, '/.xml$/');
+        $resourceB = new DirectoryResource($this->directory, '/.yaml$/');
+
+        $this->assertEquals(2, count(array_unique(array($resourceA, $resourceB))));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

ResourceInterface::__toString is mainly important because in various places, array_uniqe() is called to perform a de-duplication of resources and will use the string representation for objects.

Thus, we need to take care that if DirectoryResources apply different patterns they must be kept after array_unique calls.
