### PR TITLE
[HttpKernel] Move required RequestStack args as first arguments

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -43,7 +43,7 @@ class HttpKernelExtensionTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        $renderer = new FragmentHandler(array(), false, $context);
+        $renderer = new FragmentHandler($context);
 
         $this->setExpectedException('InvalidArgumentException', 'The "inline" renderer does not exist.');
         $renderer->render('/foo');
@@ -62,7 +62,7 @@ class HttpKernelExtensionTest extends \PHPUnit_Framework_TestCase
 
         $context->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
 
-        $renderer = new FragmentHandler(array($strategy), false, $context);
+        $renderer = new FragmentHandler($context, array($strategy), false);
 
         return $renderer;
     }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -24,7 +24,7 @@
         "symfony/asset": "~2.7|~3.0.0",
         "symfony/finder": "~2.3|~3.0.0",
         "symfony/form": "~2.8",
-        "symfony/http-kernel": "~2.3|~3.0.0",
+        "symfony/http-kernel": "~2.8|~3.0.0",
         "symfony/intl": "~2.3|~3.0.0",
         "symfony/routing": "~2.2|~3.0.0",
         "symfony/templating": "~2.1|~3.0.0",

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -16,8 +16,8 @@
     <services>
         <service id="fragment.handler" class="%fragment.handler.class%">
             <argument type="service" id="service_container" />
-            <argument>%kernel.debug%</argument>
             <argument type="service" id="request_stack" />
+            <argument>%kernel.debug%</argument>
         </service>
 
         <service id="fragment.renderer.inline" class="%fragment.renderer.inline.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -97,9 +97,9 @@
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="router" />
+            <argument type="service" id="request_stack" />
             <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
-            <argument type="service" id="request_stack" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -36,9 +36,9 @@
 
         <service id="locale_listener" class="%locale_listener.class%">
             <tag name="kernel.event_subscriber" />
+            <argument type="service" id="request_stack" />
             <argument>%kernel.default_locale%</argument>
             <argument type="service" id="router" on-invalid="ignore" />
-            <argument type="service" id="request_stack" />
         </service>
 
         <service id="translator_listener" class="Symfony\Component\HttpKernel\EventListener\TranslatorListener">

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/config": "~2.4",
         "symfony/event-dispatcher": "~2.8|~3.0.0",
         "symfony/http-foundation": "~2.4.9|~2.5,>=2.5.4|~3.0.0",
-        "symfony/http-kernel": "~2.7",
+        "symfony/http-kernel": "~2.8",
         "symfony/filesystem": "~2.3|~3.0.0",
         "symfony/routing": "~2.8|~3.0.0",
         "symfony/security-core": "~2.6|~3.0.0",

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/LazyLoadingFragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/LazyLoadingFragmentHandler.php
@@ -25,11 +25,30 @@ class LazyLoadingFragmentHandler extends FragmentHandler
     private $container;
     private $rendererIds = array();
 
-    public function __construct(ContainerInterface $container, $debug = false, RequestStack $requestStack = null)
+    /**
+     * Constructor.
+     *
+     * RequestStack will become required in 3.0.
+     *
+     * @param ContainerInterface $container    A container
+     * @param RequestStack       $requestStack The Request stack that controls the lifecycle of requests
+     * @param bool               $debug        Whether the debug mode is enabled or not
+     */
+    public function __construct(ContainerInterface $container, $requestStack = null, $debug = false)
     {
         $this->container = $container;
 
-        parent::__construct(array(), $debug, $requestStack);
+        if ((null !== $requestStack && !$requestStack instanceof RequestStack) || $debug instanceof RequestStack) {
+            $tmp = $debug;
+            $debug = $requestStack;
+            $requestStack = $tmp;
+
+            @trigger_error('The '.__METHOD__.' method now requires a RequestStack to be given as second argument as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+        } elseif (!$requestStack instanceof RequestStack) {
+            @trigger_error('The '.__METHOD__.' method now requires a RequestStack instance as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+        }
+
+        parent::__construct($requestStack, array(), $debug);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -36,10 +36,36 @@ class LocaleListener implements EventSubscriberInterface
     private $requestStack;
 
     /**
+     * Constructor.
+     *
      * RequestStack will become required in 3.0.
+     *
+     * @param RequestStack                      $requestStack  A RequestStack instance
+     * @param string                            $defaultLocale The default locale
+     * @param RequestContextAwareInterface|null $router        The router
+     *
+     * @throws \InvalidArgumentException
      */
-    public function __construct($defaultLocale = 'en', RequestContextAwareInterface $router = null, RequestStack $requestStack = null)
+    public function __construct($requestStack = null, $defaultLocale = 'en', $router = null)
     {
+        if (is_string($requestStack) || $defaultLocale instanceof RequestContextAwareInterface || $router instanceof RequestStack) {
+            $tmp = $router;
+            $router = $defaultLocale;
+            $defaultLocale = $requestStack;
+            $requestStack = $tmp;
+
+            @trigger_error('The '.__METHOD__.' method now requires a RequestStack to be given as first argument as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+        } elseif (!$requestStack instanceof RequestStack) {
+            @trigger_error('The '.__METHOD__.' method now requires a RequestStack instance as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $requestStack && !$requestStack instanceof RequestStack) {
+            throw new \InvalidArgumentException('RequestStack instance expected.');
+        }
+        if (null !== $router && !$router instanceof RequestContextAwareInterface) {
+            throw new \InvalidArgumentException('Router must implement RequestContextAwareInterface.');
+        }
+
         $this->defaultLocale = $defaultLocale;
         $this->requestStack = $requestStack;
         $this->router = $router;

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -51,24 +51,41 @@ class RouterListener implements EventSubscriberInterface
      * RequestStack will become required in 3.0.
      *
      * @param UrlMatcherInterface|RequestMatcherInterface $matcher      The Url or Request matcher
+     * @param RequestStack                                $requestStack A RequestStack instance
      * @param RequestContext|null                         $context      The RequestContext (can be null when $matcher implements RequestContextAwareInterface)
      * @param LoggerInterface|null                        $logger       The logger
-     * @param RequestStack|null                           $requestStack A RequestStack instance
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($matcher, RequestContext $context = null, LoggerInterface $logger = null, RequestStack $requestStack = null)
+    public function __construct($matcher, $requestStack = null, $context = null, $logger = null)
     {
+        if ($requestStack instanceof RequestContext || $context instanceof LoggerInterface || $logger instanceof RequestStack) {
+            $tmp = $requestStack;
+            $requestStack = $logger;
+            $logger = $context;
+            $context = $tmp;
+
+            @trigger_error('The '.__METHOD__.' method now requires a RequestStack to be given as second argument as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+        } elseif (!$requestStack instanceof RequestStack) {
+            @trigger_error('The '.__METHOD__.' method now requires a RequestStack instance as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $requestStack && !$requestStack instanceof RequestStack) {
+            throw new \InvalidArgumentException('RequestStack instance expected.');
+        }
+        if (null !== $context && !$context instanceof RequestContext) {
+            throw new \InvalidArgumentException('RequestContext instance expected.');
+        }
+        if (null !== $logger && !$logger instanceof LoggerInterface) {
+            throw new \InvalidArgumentException('Logger must implement LoggerInterface.');
+        }
+
         if (!$matcher instanceof UrlMatcherInterface && !$matcher instanceof RequestMatcherInterface) {
             throw new \InvalidArgumentException('Matcher must either implement UrlMatcherInterface or RequestMatcherInterface.');
         }
 
         if (null === $context && !$matcher instanceof RequestContextAwareInterface) {
             throw new \InvalidArgumentException('You must either pass a RequestContext or the matcher must implement RequestContextAwareInterface.');
-        }
-
-        if (!$requestStack instanceof RequestStack) {
-            @trigger_error('The '.__METHOD__.' method now requires a RequestStack instance as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
         }
 
         $this->matcher = $matcher;

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
@@ -44,12 +44,30 @@ class FragmentHandler
      *
      * RequestStack will become required in 3.0.
      *
+     * @param RequestStack                $requestStack The Request stack that controls the lifecycle of requests
      * @param FragmentRendererInterface[] $renderers    An array of FragmentRendererInterface instances
      * @param bool                        $debug        Whether the debug mode is enabled or not
-     * @param RequestStack|null           $requestStack The Request stack that controls the lifecycle of requests
      */
-    public function __construct(array $renderers = array(), $debug = false, RequestStack $requestStack = null)
+    public function __construct($requestStack = null, $renderers = array(), $debug = false)
     {
+        if (is_array($requestStack)) {
+            $tmp = $debug;
+            $debug = $renderers;
+            $renderers = $requestStack;
+            $requestStack = $tmp;
+
+            @trigger_error('The '.__METHOD__.' method now requires a RequestStack to be given as first argument as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+        } elseif (!$requestStack instanceof RequestStack) {
+            @trigger_error('The '.__METHOD__.' method now requires a RequestStack instance as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $requestStack && !$requestStack instanceof RequestStack) {
+            throw new \InvalidArgumentException('RequestStack instance expected.');
+        }
+        if (!is_array($renderers)) {
+            throw new \InvalidArgumentException('Renderers must be an array.');
+        }
+
         $this->requestStack = $requestStack;
         foreach ($renderers as $renderer) {
             $this->addRenderer($renderer);

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
@@ -29,7 +29,7 @@ class LazyLoadingFragmentHandlerTest extends \PHPUnit_Framework_TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())->method('get')->will($this->returnValue($renderer));
 
-        $handler = new LazyLoadingFragmentHandler($container, false, $requestStack);
+        $handler = new LazyLoadingFragmentHandler($container, $requestStack, false);
         $handler->addRendererService('foo', 'foo');
 
         $handler->render('/foo', 'foo');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -28,7 +28,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultLocaleWithoutSession()
     {
-        $listener = new LocaleListener('fr', null, $this->requestStack);
+        $listener = new LocaleListener($this->requestStack, 'fr');
         $event = $this->getEvent($request = Request::create('/'));
 
         $listener->onKernelRequest($event);
@@ -42,7 +42,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $request->cookies->set('foo', 'value');
 
         $request->attributes->set('_locale', 'es');
-        $listener = new LocaleListener('fr', null, $this->requestStack);
+        $listener = new LocaleListener($this->requestStack, 'fr');
         $event = $this->getEvent($request);
 
         $listener->onKernelRequest($event);
@@ -61,7 +61,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/');
 
         $request->attributes->set('_locale', 'es');
-        $listener = new LocaleListener('fr', $router, $this->requestStack);
+        $listener = new LocaleListener($this->requestStack, 'fr', $router);
         $listener->onKernelRequest($this->getEvent($request));
     }
 
@@ -81,7 +81,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
         $event = $this->getMock('Symfony\Component\HttpKernel\Event\FinishRequestEvent', array(), array(), '', false);
 
-        $listener = new LocaleListener('fr', $router, $this->requestStack);
+        $listener = new LocaleListener($this->requestStack, 'fr', $router);
         $listener->onKernelFinishRequest($event);
     }
 
@@ -89,7 +89,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
     {
         $request = Request::create('/');
         $request->setLocale('de');
-        $listener = new LocaleListener('fr', null, $this->requestStack);
+        $listener = new LocaleListener($this->requestStack, 'fr');
         $event = $this->getEvent($request);
 
         $listener->onKernelRequest($event);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -42,7 +42,7 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
                      ->method('getContext')
                      ->will($this->returnValue($context));
 
-        $listener = new RouterListener($urlMatcher, null, null, $this->requestStack);
+        $listener = new RouterListener($urlMatcher, $this->requestStack);
         $event = $this->createGetResponseEventForUri($uri);
         $listener->onKernelRequest($event);
 
@@ -80,7 +80,7 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMatcher()
     {
-        new RouterListener(new \stdClass(), null, null, $this->requestStack);
+        new RouterListener(new \stdClass(), $this->requestStack);
     }
 
     public function testRequestMatcher()
@@ -95,7 +95,7 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
                        ->with($this->isInstanceOf('Symfony\Component\HttpFoundation\Request'))
                        ->will($this->returnValue(array()));
 
-        $listener = new RouterListener($requestMatcher, new RequestContext(), null, $this->requestStack);
+        $listener = new RouterListener($requestMatcher, $this->requestStack, new RequestContext());
         $listener->onKernelRequest($event);
     }
 
@@ -116,7 +116,7 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
                        ->method('getContext')
                        ->will($this->returnValue($context));
 
-        $listener = new RouterListener($requestMatcher, new RequestContext(), null, $this->requestStack);
+        $listener = new RouterListener($requestMatcher, $this->requestStack, new RequestContext());
         $listener->onKernelRequest($event);
 
         // sub-request with another HTTP method
@@ -147,7 +147,7 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
         $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
         $request = Request::create('http://localhost/');
 
-        $listener = new RouterListener($requestMatcher, new RequestContext(), $logger, $this->requestStack);
+        $listener = new RouterListener($requestMatcher, $this->requestStack, new RequestContext(), $logger);
         $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -37,7 +37,7 @@ class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testRenderWhenRendererDoesNotExist()
     {
-        $handler = new FragmentHandler(array(), null, $this->requestStack);
+        $handler = new FragmentHandler($this->requestStack);
         $handler->render('/', 'foo');
     }
 
@@ -87,7 +87,7 @@ class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
             call_user_func_array(array($e, 'with'), $arguments);
         }
 
-        $handler = new FragmentHandler(array(), null, $this->requestStack);
+        $handler = new FragmentHandler($this->requestStack);
         $handler->addRenderer($renderer);
 
         return $handler;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Since we planned to make RequestStack required, we have to move it as first arguments.
