### PR TITLE
Dispatch console.terminate *after* console.exception

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -899,13 +899,15 @@ class Application
         try {
             $exitCode = $command->run($input, $output);
         } catch (\Exception $e) {
+            $event = new ConsoleExceptionEvent($command, $input, $output, $e, $e->getCode());
+            $this->dispatcher->dispatch(ConsoleEvents::EXCEPTION, $event);
+
+            $e = $event->getException();
+
             $event = new ConsoleTerminateEvent($command, $input, $output, $e->getCode());
             $this->dispatcher->dispatch(ConsoleEvents::TERMINATE, $event);
 
-            $event = new ConsoleExceptionEvent($command, $input, $output, $e, $event->getExitCode());
-            $this->dispatcher->dispatch(ConsoleEvents::EXCEPTION, $event);
-
-            throw $event->getException();
+            throw $e;
         }
 
         $event = new ConsoleTerminateEvent($command, $input, $output, $exitCode);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -799,7 +799,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(array('command' => 'foo'));
-        $this->assertEquals('before.foo.after.', $tester->getDisplay());
+        $this->assertEquals('before.foo.after.'.PHP_EOL, $tester->getDisplay());
     }
 
     /**
@@ -835,7 +835,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(array('command' => 'foo'));
-        $this->assertContains('before.foo.after.caught.', $tester->getDisplay());
+        $this->assertContains('before.foo.caught.after.', $tester->getDisplay());
     }
 
     protected function getDispatcher()
@@ -845,12 +845,12 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             $event->getOutput()->write('before.');
         });
         $dispatcher->addListener('console.terminate', function (ConsoleTerminateEvent $event) {
-            $event->getOutput()->write('after.');
+            $event->getOutput()->writeln('after.');
 
             $event->setExitCode(128);
         });
         $dispatcher->addListener('console.exception', function (ConsoleExceptionEvent $event) {
-            $event->getOutput()->writeln('caught.');
+            $event->getOutput()->write('caught.');
 
             $event->setException(new \LogicException('caught.', $event->getExitCode(), $event->getException()));
         });


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | - |

The problem is when using the ConsoleHandler from MonologBridge, TERMINATE closes it and removes the output, so when EXCEPTION fires if you want to log the exception it's too late and you don't get any output. See https://github.com/symfony/symfony/blob/ed4fb549014ed628200905c9e10cc0bb522f3168/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php#L115-L145

It is my understanding that TERMINATE is always supposed to come last anyway, so it is a bug in any case, but this particular use case is what prompted the discovery.
