### PR TITLE
Use stderr by default when a specific output is not injected

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -120,7 +120,12 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     public function onCommand(ConsoleCommandEvent $event)
     {
-        $this->setOutput($event->getOutput());
+        $output = $event->getOutput();
+        if ($output instanceof ConsoleOutputInterface) {
+            $output = $output->getErrorOutput();
+        }
+
+        $this->setOutput($output);
     }
 
     /**
@@ -149,11 +154,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     protected function write(array $record)
     {
-        if ($record['level'] >= Logger::ERROR && $this->output instanceof ConsoleOutputInterface) {
-            $this->output->getErrorOutput()->write((string) $record['formatted']);
-        } else {
-            $this->output->write((string) $record['formatted']);
-        }
+        $this->output->write((string) $record['formatted']);
     }
 
     /**

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -110,7 +110,7 @@ class ConsoleHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testWritingAndFormatting()
     {
-        $output = $this->getMock('Symfony\Component\Console\Output\ConsoleOutputInterface');
+        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
         $output
             ->expects($this->any())
             ->method('getVerbosity')
@@ -120,19 +120,6 @@ class ConsoleHandlerTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('write')
             ->with('<info>[2013-05-29 16:21:54] app.INFO:</info> My info message  '."\n")
-        ;
-
-        $errorOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $errorOutput
-            ->expects($this->once())
-            ->method('write')
-            ->with('<error>[2013-05-29 16:21:54] app.ERROR:</error> My error message  '."\n")
-        ;
-
-        $output
-            ->expects($this->any())
-            ->method('getErrorOutput')
-            ->will($this->returnValue($errorOutput))
         ;
 
         $handler = new ConsoleHandler(null, false);
@@ -149,18 +136,6 @@ class ConsoleHandlerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertTrue($handler->handle($infoRecord), 'The handler finished handling the log as bubble is false.');
-
-        $errorRecord = array(
-            'message' => 'My error message',
-            'context' => array(),
-            'level' => Logger::ERROR,
-            'level_name' => Logger::getLevelName(Logger::ERROR),
-            'channel' => 'app',
-            'datetime' => new \DateTime('2013-05-29 16:21:54'),
-            'extra' => array(),
-        );
-
-        $this->assertTrue($handler->handle($errorRecord), 'The handler finished handling the log as bubble is false.');
     }
 
     public function testLogsFromListeners()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

stderr is really the best place to put logs by default, so unless someone explicitly passes something else we should use it, and especially not depend on the log level to decide where to output.
