### PR TITLE
[Kernel] Integer version constants

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -61,10 +61,10 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $loadClassCache;
 
     const VERSION = '2.3.33-DEV';
-    const VERSION_ID = '20333';
-    const MAJOR_VERSION = '2';
-    const MINOR_VERSION = '3';
-    const RELEASE_VERSION = '33';
+    const VERSION_ID = 20333;
+    const MAJOR_VERSION = 2;
+    const MINOR_VERSION = 3;
+    const RELEASE_VERSION = 33;
     const EXTRA_VERSION = 'DEV';
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The idea of these constants is that they can be compared without using version_compare. But we want them to be compared as integers not as strings (it worked before as well because of php type juggling). They are integers semantically.
