### PR TITLE
Remove wrong deprecation triggers for forms in the DI extension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -33,20 +33,14 @@ class FormPass implements CompilerPassInterface
         // Builds an array with service IDs as keys and tag aliases as values
         $types = array();
 
-        // Remember which names will not be supported in Symfony 3.0 to trigger
-        // deprecation errors
-        $legacyNames = array();
-
         foreach ($container->findTaggedServiceIds('form.type') as $serviceId => $tag) {
             // The following if-else block is deprecated and will be removed
             // in Symfony 3.0
-            // Deprecation errors are triggered in DependencyInjectionExtension
+            // Deprecation errors are triggered in the form registry
             if (isset($tag[0]['alias'])) {
                 $types[$tag[0]['alias']] = $serviceId;
-                $legacyNames[$tag[0]['alias']] = true;
             } else {
                 $types[$serviceId] = $serviceId;
-                $legacyNames[$serviceId] = true;
             }
 
             // Support type access by FQCN
@@ -55,7 +49,6 @@ class FormPass implements CompilerPassInterface
         }
 
         $definition->replaceArgument(1, $types);
-        $definition->replaceArgument(4, $legacyNames);
 
         $typeExtensions = array();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -46,8 +46,6 @@
             <argument type="collection" />
             <!-- All services with tag "form.type_guesser" are inserted here by FormPass -->
             <argument type="collection" />
-            <!-- The deprecated type names are inserted here by FormPass -->
-            <argument type="collection" />
         </service>
 
         <!-- ValidatorTypeGuesser -->
@@ -157,7 +155,7 @@
         <!-- FormTypeHttpFoundationExtension -->
         <service id="form.type_extension.form.http_foundation" class="Symfony\Component\Form\Extension\HttpFoundation\Type\FormTypeHttpFoundationExtension">
             <argument type="service" id="form.type_extension.form.request_handler" />
-            <tag name="form.type_extension" alias="form" />
+            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
 
         <!-- HttpFoundationRequestHandler -->
@@ -171,14 +169,14 @@
 
         <!-- FormTypeValidatorExtension -->
         <service id="form.type_extension.form.validator" class="Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension">
-            <tag name="form.type_extension" alias="form" />
+            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="validator" />
         </service>
         <service id="form.type_extension.repeated.validator" class="Symfony\Component\Form\Extension\Validator\Type\RepeatedTypeValidatorExtension">
-            <tag name="form.type_extension" alias="repeated" />
+            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\RepeatedType" />
         </service>
         <service id="form.type_extension.submit.validator" class="Symfony\Component\Form\Extension\Validator\Type\SubmitTypeValidatorExtension">
-            <tag name="form.type_extension" alias="submit" />
+            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\SubmitType" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -10,7 +10,7 @@
         </service>
 
         <service id="form.type_extension.csrf" class="Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension">
-            <tag name="form.type_extension" alias="form" />
+            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="security.csrf.token_manager" />
             <argument>%form.type_extension.csrf.enabled%</argument>
             <argument>%form.type_extension.csrf.field_name%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
@@ -21,7 +21,7 @@
 
         <!-- DataCollectorTypeExtension -->
         <service id="form.type_extension.form.data_collector" class="%form.type_extension.form.data_collector.class%">
-            <tag name="form.type_extension" alias="form" />
+            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="data_collector.form" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -43,7 +43,6 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
             array(),
             array(),
             array(),
-            array(),
         ));
 
         $definition1 = new Definition(__CLASS__.'_Type1');
@@ -80,7 +79,6 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
             array(),
             array(),
             array(),
-            array(),
         ));
 
         $definition1 = new Definition(__CLASS__.'_Type1');
@@ -104,41 +102,6 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
         ), $extDefinition->getArgument(1));
     }
 
-    public function testPassLegacyNames()
-    {
-        $container = new ContainerBuilder();
-        $container->addCompilerPass(new FormPass());
-
-        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
-        $extDefinition->setArguments(array(
-            new Reference('service_container'),
-            array(),
-            array(),
-            array(),
-            array(),
-        ));
-
-        $definition1 = new Definition(__CLASS__.'_Type1');
-        $definition1->addTag('form.type');
-        $definition2 = new Definition(__CLASS__.'_Type2');
-        $definition2->addTag('form.type', array('alias' => 'mytype2'));
-
-        $container->setDefinition('form.extension', $extDefinition);
-        $container->setDefinition('my.type1', $definition1);
-        $container->setDefinition('my.type2', $definition2);
-
-        $container->compile();
-
-        $extDefinition = $container->getDefinition('form.extension');
-
-        $this->assertEquals(array(
-            // Service ID if no alias is set
-            'my.type1' => true,
-            // Alias if set
-            'mytype2' => true,
-        ), $extDefinition->getArgument(4));
-    }
-
     public function testAddTaggedTypeExtensions()
     {
         $container = new ContainerBuilder();
@@ -147,7 +110,6 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
         $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
         $extDefinition->setArguments(array(
             new Reference('service_container'),
-            array(),
             array(),
             array(),
             array(),
@@ -188,7 +150,6 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
         $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
         $extDefinition->setArguments(array(
             new Reference('service_container'),
-            array(),
             array(),
             array(),
             array(),

--- a/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
+++ b/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
@@ -22,19 +22,17 @@ class DependencyInjectionExtension implements FormExtensionInterface
     private $typeServiceIds;
     private $typeExtensionServiceIds;
     private $guesserServiceIds;
-    private $legacyNames;
     private $guesser;
     private $guesserLoaded = false;
 
     public function __construct(ContainerInterface $container,
         array $typeServiceIds, array $typeExtensionServiceIds,
-        array $guesserServiceIds, array $legacyNames = array())
+        array $guesserServiceIds)
     {
         $this->container = $container;
         $this->typeServiceIds = $typeServiceIds;
         $this->typeExtensionServiceIds = $typeExtensionServiceIds;
         $this->guesserServiceIds = $guesserServiceIds;
-        $this->legacyNames = $legacyNames;
     }
 
     public function getType($name)
@@ -43,14 +41,10 @@ class DependencyInjectionExtension implements FormExtensionInterface
             throw new InvalidArgumentException(sprintf('The field type "%s" is not registered with the service container.', $name));
         }
 
-        if (isset($this->legacyNames[$name])) {
-            @trigger_error('Accessing form types by type name/service ID is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
-        }
-
         $type = $this->container->get($this->typeServiceIds[$name]);
 
         // BC: validate result of getName() for legacy names (non-FQCN)
-        if (isset($this->legacyNames[$name]) && $type->getName() !== $name) {
+        if ($name !== get_class($type) && $type->getName() !== $name) {
             throw new InvalidArgumentException(
                 sprintf('The type name specified for the service "%s" does not match the actual name. Expected "%s", given "%s"',
                     $this->typeServiceIds[$name],
@@ -65,23 +59,11 @@ class DependencyInjectionExtension implements FormExtensionInterface
 
     public function hasType($name)
     {
-        if (isset($this->typeServiceIds[$name])) {
-            if (isset($this->legacyNames[$name])) {
-                @trigger_error('Accessing form types by type name/service ID is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
-            }
-
-            return true;
-        }
-
-        return false;
+        return isset($this->typeServiceIds[$name]);
     }
 
     public function getTypeExtensions($name)
     {
-        if (isset($this->legacyNames[$name])) {
-            @trigger_error('Accessing form types by type name/service ID is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
-        }
-
         $extensions = array();
 
         if (isset($this->typeExtensionServiceIds[$name])) {
@@ -95,10 +77,6 @@ class DependencyInjectionExtension implements FormExtensionInterface
 
     public function hasTypeExtensions($name)
     {
-        if (isset($this->legacyNames[$name])) {
-            @trigger_error('Accessing form types by type name/service ID is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead.', E_USER_DEPRECATED);
-        }
-
         return isset($this->typeExtensionServiceIds[$name]);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15490 |
| License | MIT |
| Doc PR | n/a |

When a form type provides a BC layer with old form names (all core types do), the form registry will ask for type extensions registered on the legacy name for BC, and trigger a warning if it finds any.
The DependencyInjectionExtension should not trigger warnings on its own when being asked for such extensions (especially when it has none registered). this means that the extension does not even need to know whether the name is a legacy one or a new one btw.
Core extensions are also registered using the proper extended type rather than legacy names.
