### PR TITLE
Adding an optional 3rd argument to ContainerBuilder::register()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -775,14 +775,15 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $id    The service identifier
      * @param string $class The service class
+     * @param array  $arguments An array of arguments to pass to the service constructor
      *
      * @return Definition A Definition instance
      *
      * @api
      */
-    public function register($id, $class = null)
+    public function register($id, $class = null, array $arguments = array())
     {
-        return $this->setDefinition($id, new Definition($class));
+        return $this->setDefinition($id, new Definition($class, $arguments));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -773,8 +773,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * This methods allows for simple registration of service definition
      * with a fluid interface.
      *
-     * @param string $id    The service identifier
-     * @param string $class The service class
+     * @param string $id        The service identifier
+     * @param string $class     The service class
      * @param array  $arguments An array of arguments to pass to the service constructor
      *
      * @return Definition A Definition instance

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -69,9 +69,11 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testRegister()
     {
         $builder = new ContainerBuilder();
-        $builder->register('foo', 'Bar\FooClass');
+        $builder->register('foo', 'Bar\FooClass', array('barArg'));
         $this->assertTrue($builder->hasDefinition('foo'), '->register() registers a new service definition');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Definition', $builder->getDefinition('foo'), '->register() returns the newly created Definition instance');
+        $definition = $builder->getDefinition('foo');
+        $this->assertEquals('Bar\FooClass', $definition->getClass());
+        $this->assertEquals(array('barArg'), $definition->getArguments());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -69,6 +69,17 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testRegister()
     {
         $builder = new ContainerBuilder();
+        $builder->register('foo', 'Bar\FooClass');
+        $this->assertTrue($builder->hasDefinition('foo'), '->register() registers a new service definition');
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Definition', $builder->getDefinition('foo'), '->register() returns the newly created Definition instance');
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::register
+     */
+    public function testRegisterWithArguments()
+    {
+        $builder = new ContainerBuilder();
         $builder->register('foo', 'Bar\FooClass', array('barArg'));
         $this->assertTrue($builder->hasDefinition('foo'), '->register() registers a new service definition');
         $definition = $builder->getDefinition('foo');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes (I believe yes) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | none |

This is a really easy PR to make adding service definitions via ContainerBuilder::register() a little bit more fluid. However, is this considered a BC break? Under [Using our Classes](http://symfony.com/doc/current/contributing/code/bc.html#using-our-classes) in the BC promise, you _are_ permitted to "Add an argument to an overridden method" if it has `@api` (which this does). Does that prevent us from adding a new, optional argument? Or is it ok, since a user's implementation of the overridden method will not break (because the argument is optional)?

Thanks!
