### PR TITLE
WIP: fix ClockMock.php affects on another tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/ClockMock.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ClockMock.php
@@ -20,23 +20,19 @@ namespace Symfony\Component\HttpFoundation\Tests;
 
 function enable_clock_mock()
 {
-    global $clockMockEnabled;
-    $clockMockEnabled = true;
+    $GLOBALS['http_foundation_enable_clock_mock'] = true;
 }
 
 function disable_clock_mock()
 {
-    global $clockMockEnabled;
-    $clockMockEnabled = 0;
+    $GLOBALS['http_foundation_enable_clock_mock'] = false;
 }
 
 function time()
 {
-    global $clockMockEnabled;
-
-    if ($clockMockEnabled) {
-        return $_SERVER['REQUEST_TIME'];
-    } else {
+    if (!$GLOBALS['http_foundation_enable_clock_mock']) {
         return \time();
     }
+
+    return $_SERVER['REQUEST_TIME'];
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ClockMock.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ClockMock.php
@@ -18,7 +18,25 @@ function time($asFloat = false)
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
+function enable_clock_mock()
+{
+    global $clockMockEnabled;
+    $clockMockEnabled = true;
+}
+
+function disable_clock_mock()
+{
+    global $clockMockEnabled;
+    $clockMockEnabled = 0;
+}
+
 function time()
 {
-    return $_SERVER['REQUEST_TIME'];
+    global $clockMockEnabled;
+
+    if ($clockMockEnabled) {
+        return $_SERVER['REQUEST_TIME'];
+    } else {
+        return \time();
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -23,6 +23,18 @@ require_once __DIR__.'/ClockMock.php';
  */
 class CookieTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        \Symfony\Component\HttpFoundation\Tests\enable_clock_mock();
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        \Symfony\Component\HttpFoundation\Tests\disable_clock_mock();
+        parent::tearDown();
+    }
+
     public function invalidNames()
     {
         return array(

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -18,6 +18,18 @@ require_once __DIR__.'/ClockMock.php';
 
 class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        \Symfony\Component\HttpFoundation\Tests\enable_clock_mock();
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        \Symfony\Component\HttpFoundation\Tests\disable_clock_mock();
+        parent::tearDown();
+    }
+
     /**
      * @covers Symfony\Component\HttpFoundation\ResponseHeaderBag::allPreserveCase
      * @dataProvider provideAllPreserveCase

--- a/src/Symfony/Component/Stopwatch/Tests/ClockMock.php
+++ b/src/Symfony/Component/Stopwatch/Tests/ClockMock.php
@@ -34,6 +34,7 @@ function usleep($us)
 
     if (!$GLOBALS['stopwatch_enable_clock_mock']) {
         \usleep($us);
+
         return;
     }
 

--- a/src/Symfony/Component/Stopwatch/Tests/ClockMock.php
+++ b/src/Symfony/Component/Stopwatch/Tests/ClockMock.php
@@ -18,9 +18,24 @@ function microtime($asFloat = false)
 
 namespace Symfony\Component\Stopwatch\Tests;
 
+function enable_clock_mock()
+{
+    $GLOBALS['stopwatch_enable_clock_mock'] = true;
+}
+
+function disable_clock_mock()
+{
+    $GLOBALS['stopwatch_enable_clock_mock'] = false;
+}
+
 function usleep($us)
 {
     static $now;
+
+    if (!$GLOBALS['stopwatch_enable_clock_mock']) {
+        \usleep($us);
+        return;
+    }
 
     if (null === $now) {
         $now = \microtime(true);
@@ -31,6 +46,10 @@ function usleep($us)
 
 function microtime($asFloat = false)
 {
+    if (!$GLOBALS['stopwatch_enable_clock_mock']) {
+        return \microtime($asFloat);
+    }
+
     if (!$asFloat) {
         return \microtime(false);
     }

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -24,6 +24,18 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
 {
     const DELTA = 37;
 
+    public function setUp()
+    {
+        \Symfony\Component\HttpFoundation\Tests\enable_clock_mock();
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        \Symfony\Component\HttpFoundation\Tests\disable_clock_mock();
+        parent::tearDown();
+    }
+
     public function testGetOrigin()
     {
         $event = new StopwatchEvent(12);

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -24,6 +24,18 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 {
     const DELTA = 20;
 
+    public function setUp()
+    {
+        \Symfony\Component\HttpFoundation\Tests\enable_clock_mock();
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        \Symfony\Component\HttpFoundation\Tests\disable_clock_mock();
+        parent::tearDown();
+    }
+
     public function testStart()
     {
         $stopwatch = new Stopwatch();

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -26,13 +26,13 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        \Symfony\Component\HttpFoundation\Tests\enable_clock_mock();
+        enable_clock_mock();
         parent::setUp();
     }
 
     public function tearDown()
     {
-        \Symfony\Component\HttpFoundation\Tests\disable_clock_mock();
+        disable_clock_mock();
         parent::tearDown();
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

On my local computer tests for HttpCacheTest not passed, because ClockMock make side effects on another tests (it takes time from _SERVER['REQUEST_TIME'] and for my computer difference with real one time and this time was more than expected by HttpCacheTest, one part of code take time from mock, anothers - from native time function). This PR remove this side effects.
