### PR TITLE
[Yaml] Allow comments after tab

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -209,7 +209,8 @@ class Inline
                 $i += strlen($output);
 
                 // remove comments
-                if (false !== $strpos = strpos($output, ' #')) {
+                if ((false !== $strpos = strpos($output, '#')) && 
+                    ($output[$strpos-1] == ' ' || $output[$strpos-1] == "\t")) {
                     $output = rtrim(substr($output, 0, $strpos));
                 }
             } elseif (preg_match('/^(.+?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -209,8 +209,7 @@ class Inline
                 $i += strlen($output);
 
                 // remove comments
-                if ((false !== $strpos = strpos($output, '#')) && 
-                    ($output[$strpos-1] == ' ' || $output[$strpos-1] == "\t")) {
+                if ((false !== $strpos = strpos($output, '#')) && ($output[$strpos - 1] == ' ' || $output[$strpos - 1] == "\t")) {
                     $output = rtrim(substr($output, 0, $strpos));
                 }
             } elseif (preg_match('/^(.+?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -209,7 +209,7 @@ class Inline
                 $i += strlen($output);
 
                 // remove comments
-                if ((false !== $strpos = strpos($output, '#')) && ($output[$strpos - 1] == ' ' || $output[$strpos - 1] == "\t")) {
+                if ((false !== $strpos = strpos($output, '#')) && (' ' === $output[$strpos - 1] || "\t" === $output[$strpos - 1])) {
                     $output = rtrim(substr($output, 0, $strpos));
                 }
             } elseif (preg_match('/^(.+?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -209,8 +209,7 @@ class Inline
                 $i += strlen($output);
 
                 // remove comments
-                if ((false !== $strpos = strpos($output, '#')) && 
-                    ($output[$strpos - 1] == ' ' || $output[$strpos - 1] == "\t")) {
+                if ((false !== $strpos = strpos($output, '#')) && ($output[$strpos - 1] == ' ' || $output[$strpos - 1] == "\t")) {
                     $output = rtrim(substr($output, 0, $strpos));
                 }
             } elseif (preg_match('/^(.+?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
@@ -7,8 +7,9 @@ yaml: |
     ex2: "foo # bar" # comment
     ex3: 'foo # bar' # comment
     ex4: foo # comment
+    ex5: foo	#	comment with tab before    
 php: |
-    array('ex1' => 'foo # bar', 'ex2' => 'foo # bar', 'ex3' => 'foo # bar', 'ex4' => 'foo')
+    array('ex1' => 'foo # bar', 'ex2' => 'foo # bar', 'ex3' => 'foo # bar', 'ex4' => 'foo', 'ex5' => 'foo')
 ---
 test: Comments in the middle
 brief: >


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

If a yml file has a tab character before a line ending comment the comment will be included in the parsed value. Yaml spec allows tab or space as whitespace characters so we need to check for tab as well. See included test.
Recently caused an odd and hard to find bug in our project. 
