### PR TITLE
Add tests to the recently added exceptions thrown from YamlFileLoaders

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -290,7 +290,7 @@ class YamlFileLoader extends FileLoader
         try {
             $configuration = $this->yamlParser->parse(file_get_contents($file));
         } catch (ParseException $e) {
-            throw new \InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML.', $file), 0, $e);
+            throw new InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML.', $file), 0, $e);
         }
 
         return $this->validate($configuration, $file);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_format.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_format.yml
@@ -1,0 +1,2 @@
+parameters:
+	FOO: bar

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -87,6 +87,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
             array('bad_services'),
             array('bad_service'),
             array('bad_calls'),
+            array('bad_format'),
         );
     }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/bad_format.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/bad_format.yml
@@ -1,0 +1,3 @@
+blog_show:
+	path:     /blog/{slug}
+	defaults: { _controller: "MyBundle:Blog:show" }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -51,7 +51,15 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function getPathsToInvalidFiles()
     {
-        return array(array('nonvalid.yml'), array('nonvalid2.yml'), array('incomplete.yml'), array('nonvalidkeys.yml'), array('nonesense_resource_plus_path.yml'), array('nonesense_type_without_resource.yml'));
+        return array(
+            array('nonvalid.yml'),
+            array('nonvalid2.yml'),
+            array('incomplete.yml'),
+            array('nonvalidkeys.yml'),
+            array('nonesense_resource_plus_path.yml'),
+            array('nonesense_type_without_resource.yml'),
+            array('bad_format.yml'),
+        );
     }
 
     public function testLoadSpecialRouteName()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -31,13 +31,24 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($loader->loadClassMetadata($metadata));
     }
 
-    public function testLoadClassMetadataThrowsExceptionIfNotAnArray()
+    /**
+     * @dataProvider provideInvalidYamlFiles
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidYamlFiles($path)
     {
-        $loader = new YamlFileLoader(__DIR__.'/nonvalid-mapping.yml');
+        $loader = new YamlFileLoader(__DIR__.'/'.$path);
         $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
 
-        $this->setExpectedException('\InvalidArgumentException');
         $loader->loadClassMetadata($metadata);
+    }
+
+    public function provideInvalidYamlFiles()
+    {
+        return array(
+            array('nonvalid-mapping.yml'),
+            array('bad-format.yml'),
+        );
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/bad-format.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/bad-format.yml
@@ -1,0 +1,9 @@
+namespaces:
+	custom: Symfony\Component\Validator\Tests\Fixtures\
+
+Symfony\Component\Validator\Tests\Fixtures\Entity:
+	constraints:
+		# Custom constraint
+		- Symfony\Component\Validator\Tests\Fixtures\ConstraintA: ~
+		# Custom constraint with namespaces prefix
+		- "custom:ConstraintB": ~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15702 #15731 |
| License | MIT |
| Doc PR | - |
- use the `Symfony\Component\DependencyInjection\Exception\InvalidArgumentException` in the DI component
- add tests
