### PR TITLE
Avoid XML error page to crash

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -60,7 +60,6 @@ class Store implements StoreInterface
             // send a 503
             header('HTTP/1.0 503 Service Unavailable');
             header('Retry-After: 10');
-            echo '503 Service Unavailable';
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7572 |
| License | MIT |
| Doc PR |  |

Related to issue:
Allow Flexible Fatal Error Pages #7572. 

When having an action in a Controller whose response content type is XML, if any error happens, the deleted `echo '503 Service Unavailable'` line breaks the XML format of the `error.xml.twig` template.

In Firefox we see something like:

``` xml
503 Service Unavailable<?xml version="1.0" encoding="UTF-8" ?>
^
```

While in Chrome:

```
This page contains the following errors:

error on line 1 at column 1: Document is empty
Below is a rendering of the page up to the first error.
```

And no more text.

While wihout the `echo '503 Service Unavailable'` line, the response would look like:

``` xml
<error code="500" message="Internal Server Error"/>
```
