### PR TITLE
[PropertyAccess]: Allow custom singularify class (WIP)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -499,6 +499,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('magic_call')->defaultFalse()->end()
                         ->booleanNode('throw_exception_on_invalid_index')->defaultFalse()->end()
+                        ->scalarNode('property_singularify')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -857,6 +857,7 @@ class FrameworkExtension extends Extension
             ->getDefinition('property_accessor')
             ->replaceArgument(0, $config['magic_call'])
             ->replaceArgument(1, $config['throw_exception_on_invalid_index'])
+            ->replaceArgument(2, $config['property_singularify'])
         ;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.xml
@@ -8,6 +8,7 @@
         <service id="property_accessor" class="Symfony\Component\PropertyAccess\PropertyAccessor" >
             <argument /> <!-- magicCall, set by the extension -->
             <argument /> <!-- throwExceptionOnInvalidIndex, set by the extension -->
+            <argument /> <!-- propertySingularify, set by the extension -->
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -171,6 +171,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'property_access' => array(
                 'magic_call' => false,
                 'throw_exception_on_invalid_index' => false,
+                'property_singularify' => null,
             ),
         );
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
@@ -4,5 +4,6 @@ $container->loadFromExtension('framework', array(
     'property_access' => array(
         'magic_call' => true,
         'throw_exception_on_invalid_index' => true,
+        'property_singularify' => '\Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularifyClass',
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
@@ -2,3 +2,4 @@ framework:
     property_access:
         magic_call: true
         throw_exception_on_invalid_index: true
+        property_singularify: \Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularifyClass

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -37,13 +37,19 @@ class PropertyAccessor implements PropertyAccessorInterface
     private $ignoreInvalidIndices;
 
     /**
+     * @var StringSingularifyInterface
+     */
+    private $propertySingularify = null;
+
+    /**
      * Should not be used by application code. Use
      * {@link PropertyAccess::createPropertyAccessor()} instead.
      */
-    public function __construct($magicCall = false, $throwExceptionOnInvalidIndex = false)
+    public function __construct($magicCall = false, $throwExceptionOnInvalidIndex = false, $propertySingularify = null)
     {
         $this->magicCall = $magicCall;
         $this->ignoreInvalidIndices = !$throwExceptionOnInvalidIndex;
+        $this->propertySingularify = $propertySingularify ?: new StringSingularifyEnglish();
     }
 
     /**
@@ -389,7 +395,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         $reflClass = new \ReflectionClass($object);
         $camelized = $this->camelize($property);
-        $singulars = (array) StringUtil::singularify($camelized);
+        $singulars = (array) $this->propertySingularify->singularify($camelized);
 
         if (is_array($value) || $value instanceof \Traversable) {
             $methods = $this->findAdderAndRemover($reflClass, $singulars);
@@ -517,7 +523,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             return true;
         }
 
-        $singulars = (array) StringUtil::singularify($camelized);
+        $singulars = (array) $this->propertySingularify->singularify($camelized);
 
         // Any of the two methods is required, but not yet known
         if (null !== $this->findAdderAndRemover($reflClass, $singulars)) {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
@@ -29,6 +29,11 @@ class PropertyAccessorBuilder
     private $throwExceptionOnInvalidIndex = false;
 
     /**
+     * @var StringSingularifyInterface
+     */
+    private $propertySingularify = null;
+
+    /**
      * Enables the use of "__call" by the PropertyAccessor.
      *
      * @return PropertyAccessorBuilder The builder object
@@ -98,12 +103,38 @@ class PropertyAccessorBuilder
     }
 
     /**
+     * Set the singularify class associated to the PropertyAccessor.
+     *
+     * @return PropertyAccessorBuilder The builder object
+     */
+    public function setPropertySingularify(StringSingularifyInterface $propertySingularify)
+    {
+        $this->propertySingularify = $propertySingularify;
+
+        return $this;
+    }
+
+    /**
+     * Get the singularify class associated to the PropertyAccessor.
+     *
+     * @return StringSingularifyInterface The singularify class
+     */
+    public function getPropertySingularify()
+    {
+        if (null === $this->propertySingularify) {
+            $this->propertySingularify = new StringSingularifyEnglish();
+        }
+
+        return $this->propertySingularify;
+    }
+
+    /**
      * Builds and returns a new PropertyAccessor object.
      *
      * @return PropertyAccessorInterface The built PropertyAccessor
      */
     public function getPropertyAccessor()
     {
-        return new PropertyAccessor($this->magicCall, $this->throwExceptionOnInvalidIndex);
+        return new PropertyAccessor($this->magicCall, $this->throwExceptionOnInvalidIndex, $this->propertySingularify);
     }
 }

--- a/src/Symfony/Component/PropertyAccess/StringSingularifyEnglish.php
+++ b/src/Symfony/Component/PropertyAccess/StringSingularifyEnglish.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess;
+
+/**
+ * Creates singulars from plurals.
+ *
+ * @author Luis-Ramón López <lrlopez@gmail.com>
+ */
+class StringSingularifyEnglish implements StringSingularifyInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function singularify($plural)
+    {
+        return StringUtil::singularify($plural);
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/StringSingularifyInterface.php
+++ b/src/Symfony/Component/PropertyAccess/StringSingularifyInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess;
+
+/**
+ * Creates singulars from plurals.
+ *
+ * @author Luis-Ramón López <lrlopez@gmail.com>
+ */
+interface StringSingularifyInterface
+{
+    /**
+     * Returns the singular form of a word.
+     *
+     * If the method can't determine the form with certainty, an array of the
+     * possible singulars is returned.
+     *
+     * @param string $plural A word in plural form
+     *
+     * @return string|array The singular form or an array of possible singular
+     *                      forms
+     */
+    public function singularify($plural);
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestSingularifyClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestSingularifyClass.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+use Symfony\Component\PropertyAccess\StringSingularifyInterface;
+
+class TestSingularifyClass implements StringSingularifyInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function singularify($plural)
+    {
+        return array($plural.'1', $plural.'2');
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyAccess\Tests;
 
 use Symfony\Component\PropertyAccess\PropertyAccessorBuilder;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularifyClass;
 
 class PropertyAccessorBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -51,5 +52,10 @@ class PropertyAccessorBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('Symfony\Component\PropertyAccess\PropertyAccessor', $this->builder->getPropertyAccessor());
         $this->assertInstanceOf('Symfony\Component\PropertyAccess\PropertyAccessor', $this->builder->enableMagicCall()->getPropertyAccessor());
+    }
+
+    public function testPropertySingularify()
+    {
+        $this->assertInstanceOf('Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularifyClass', $this->builder->setPropertySingularify(new TestSingularifyClass())->getPropertySingularify());
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionCustomSingularifyTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionCustomSingularifyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests;
+
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularifyClass;
+
+class PropertyAccessorCollectionTestCustomSingularify_Car
+{
+    private $axes;
+
+    public function __construct($axes = null)
+    {
+        $this->axes = $axes;
+    }
+
+    // In the test, use a name which is returned by our custom singularify class
+    public function addAxes2($axis)
+    {
+        $this->axes[] = $axis;
+    }
+
+    public function removeAxes2($axis)
+    {
+        foreach ($this->axes as $key => $value) {
+            if ($value === $axis) {
+                unset($this->axes[$key]);
+
+                return;
+            }
+        }
+    }
+
+    public function getAxes()
+    {
+        return $this->axes;
+    }
+}
+
+class PropertyAccessorCollectionCustomSingularifyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PropertyAccessor
+     */
+    protected $propertyAccessor;
+
+    protected function setUp()
+    {
+        $this->propertyAccessor = new PropertyAccessor(false, false, new TestSingularifyClass());
+    }
+
+    public function testSetValueCallsAdderForCollectionsWithCustomSingularify()
+    {
+        $axesBefore = array(1 => 'second', 3 => 'fourth', 4 => 'fifth');
+        $axesMerged = array(1 => 'first', 2 => 'second', 3 => 'third');
+        $axesAfter = array(1 => 'second', 5 => 'first', 6 => 'third');
+
+        // Don't use a mock in order to test whether the collections are
+        // modified while iterating them
+        $car = new PropertyAccessorCollectionTestCustomSingularify_Car($axesBefore);
+
+        $this->propertyAccessor->setValue($car, 'axes', $axesMerged);
+
+        $this->assertEquals($axesAfter, $car->getAxes());
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13721, #13723 |
| License | MIT |
| Doc PR | WIP |
- [ ] Write docs about the new feature

I'm going to teach Symfony to some Spanish students. We are using models created in other subjects into our test projects, and so we have to keep the original entities names and properties, which are in Spanish.

When implementing Doctrine X-to-many relationships, Symfony calls `StringUtils::singularify()` for property access. As the method only works for English nouns, awkward methods names (for a native speaker) have to be created for the app to work.

I know this has been discussed multiple times, but I'm proposing a different approach to the problem. What about allowing to override the default behaviour by using custom singularify classes? It would be backward compatible while allowing to plug-in different languages, should it be needed. The PR implements a new configuration parameter inside `property_access` called `property_singularify` that now can point to an alternative class that implements `StringSingularifyInterface`. The interface only defines a `singularify()` method. I still have to run some benchmarks using Blackfire.io to see if there is any noticeable performance degradation, although I don't expect much.

This is my first Symfony contribution so this PR could be (well, it will be) wrong at many levels, so all comments are welcome. Maybe just the idea is bogus, but I want to give it a try.

I'd rather like to see it accepted for the 2.8/3.0 release, I hope is not too late for it.

Thanks guys!
