### PR TITLE
[Validator] mark test as legacy

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -189,6 +189,9 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame($validator, 'validator', $listener);
     }
 
+    /**
+     * @group legacy
+     */
     public function testValidatorInterfaceUntilSymfony24()
     {
         // Mock of ValidatorInterface until apiVersion 2.4
@@ -199,6 +202,7 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group legacy
      * @expectedException \InvalidArgumentException
      */
     public function testInvalidValidatorInterface()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Ref https://github.com/symfony/symfony/pull/15708#discussion_r39246000

Failing test are hhvm binaries: https://travis-ci.org/symfony/symfony/jobs/79951993#L530
