### PR TITLE
[Yaml] Fix the parsing of float keys

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -133,6 +133,11 @@ class Parser
                     throw $e;
                 }
 
+                // Convert float keys to strings, to avoid being converted to integers by PHP
+                if (is_float($key)) {
+                    $key = (string) $key;
+                }
+
                 if ('<<' === $key) {
                     if (isset($values['value']) && 0 === strpos($values['value'], '*')) {
                         $isInPlace = substr($values['value'], 1);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -685,6 +685,24 @@ bar: 2
 EOF;
         $this->assertEquals(array('foo' => 1, 'bar' => 2), $this->parser->parse($yaml));
     }
+
+    public function testFloatKeys()
+    {
+        $yaml = <<<EOF
+foo:
+    1.2: "bar"
+    1.3: "baz"
+EOF;
+
+        $expected = array(
+            'foo' => array(
+                '1.2' => 'bar',
+                '1.3' => 'baz',
+            ),
+        );
+
+        $this->assertEquals($expected, $this->parser->parse($yaml));
+    }
 }
 
 class B


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15667 |
| License | MIT |
| Doc PR |  |

Before this fix, the parser was trying to set a float as an array key, and according to the [PHP documentation](http://php.net/manual/en/language.types.array.php) _"The key can either be an integer or a string"_. Therefore, PHP was internally casting the key to an integer.

My first approach was to always cast to string, by changing this line:

```
$key = Inline::parseScalar($values['key']);
```

to

```
$key = (string) Inline::parseScalar($values['key']);
```

But that broke some tests, for instance, the parser is expected to transform the key `false` to `0`, but casting `false` to string results in an empty string, rather than `0`.
