### PR TITLE
[Console] Ensure the console output is only detected as decorated when both stderr and stdout support colors

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -48,7 +48,12 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
     {
         parent::__construct($this->openOutputStream(), $verbosity, $decorated, $formatter);
 
+        $actualDecorated = $this->isDecorated();
         $this->stderr = new StreamOutput($this->openErrorStream(), $verbosity, $decorated, $this->getFormatter());
+
+        if (null === $decorated) {
+            $this->setDecorated($actualDecorated && $this->stderr->isDecorated());
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10592 #13449 |
| License | MIT |
| Doc PR |  |

This is a simplified version of #13661 which does not create any issues with having two decorators but merely ensures that if either STDERR **or** STDOUT has colors disabled, then both will have decoration disabled. It's not a perfect solution but it's better than having both enabled as this breaks things. And I don't think we can come to a better solution without api changes.
