### PR TITLE
Convert Output::write's type to an options arg where verbosity can be passed in as well

### DIFF
--- a/src/Symfony/Component/Console/Output/NullOutput.php
+++ b/src/Symfony/Component/Console/Output/NullOutput.php
@@ -98,7 +98,7 @@ class NullOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function writeln($messages, $type = self::OUTPUT_NORMAL)
+    public function writeln($messages, $options = self::OUTPUT_NORMAL)
     {
         // do nothing
     }
@@ -106,7 +106,7 @@ class NullOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function write($messages, $newline = false, $type = self::OUTPUT_NORMAL)
+    public function write($messages, $newline = false, $options = self::OUTPUT_NORMAL)
     {
         // do nothing
     }

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -121,21 +121,27 @@ abstract class Output implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function writeln($messages, $type = self::OUTPUT_NORMAL)
+    public function writeln($messages, $options = self::OUTPUT_NORMAL)
     {
-        $this->write($messages, true, $type);
+        $this->write($messages, true, $options);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function write($messages, $newline = false, $type = self::OUTPUT_NORMAL)
+    public function write($messages, $newline = false, $options = self::OUTPUT_NORMAL)
     {
-        if (self::VERBOSITY_QUIET === $this->verbosity) {
+        $messages = (array) $messages;
+
+        $types = self::OUTPUT_NORMAL | self::OUTPUT_RAW | self::OUTPUT_PLAIN;
+        $type = $types & $options ?: self::OUTPUT_NORMAL;
+
+        $verbosities = self::VERBOSITY_QUIET | self::VERBOSITY_NORMAL | self::VERBOSITY_VERBOSE | self::VERBOSITY_VERY_VERBOSE | self::VERBOSITY_DEBUG;
+        $verbosity = $verbosities & $options ?: self::VERBOSITY_NORMAL;
+
+        if ($verbosity > $this->getVerbosity()) {
             return;
         }
-
-        $messages = (array) $messages;
 
         foreach ($messages as $message) {
             switch ($type) {
@@ -147,8 +153,6 @@ abstract class Output implements OutputInterface
                 case OutputInterface::OUTPUT_PLAIN:
                     $message = strip_tags($this->formatter->format($message));
                     break;
-                default:
-                    throw new \InvalidArgumentException(sprintf('Unknown output type given (%s)', $type));
             }
 
             $this->doWrite($message, $newline);

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -22,40 +22,36 @@ use Symfony\Component\Console\Formatter\OutputFormatterInterface;
  */
 interface OutputInterface
 {
-    const VERBOSITY_QUIET = 0;
-    const VERBOSITY_NORMAL = 1;
-    const VERBOSITY_VERBOSE = 2;
-    const VERBOSITY_VERY_VERBOSE = 3;
-    const VERBOSITY_DEBUG = 4;
+    const VERBOSITY_QUIET = 16;
+    const VERBOSITY_NORMAL = 32;
+    const VERBOSITY_VERBOSE = 64;
+    const VERBOSITY_VERY_VERBOSE = 128;
+    const VERBOSITY_DEBUG = 256;
 
-    const OUTPUT_NORMAL = 0;
-    const OUTPUT_RAW = 1;
-    const OUTPUT_PLAIN = 2;
+    const OUTPUT_NORMAL = 1;
+    const OUTPUT_RAW = 2;
+    const OUTPUT_PLAIN = 4;
 
     /**
      * Writes a message to the output.
      *
      * @param string|array $messages The message as an array of lines or a single string
      * @param bool         $newline  Whether to add a newline
-     * @param int          $type     The type of output (one of the OUTPUT constants)
-     *
-     * @throws \InvalidArgumentException When unknown output type is given
+     * @param int          $options  A bitmask of options (one of the OUTPUT or VERBOSITY constants), 0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
      *
      * @api
      */
-    public function write($messages, $newline = false, $type = self::OUTPUT_NORMAL);
+    public function write($messages, $newline = false, $options = 0);
 
     /**
      * Writes a message to the output and adds a newline at the end.
      *
      * @param string|array $messages The message as an array of lines of a single string
-     * @param int          $type     The type of output (one of the OUTPUT constants)
-     *
-     * @throws \InvalidArgumentException When unknown output type is given
+     * @param int          $options  A bitmask of options (one of the OUTPUT or VERBOSITY constants), 0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
      *
      * @api
      */
-    public function writeln($messages, $type = self::OUTPUT_NORMAL);
+    public function writeln($messages, $options = 0);
 
     /**
      * Sets the verbosity of the output.

--- a/src/Symfony/Component/Console/Tests/Output/OutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/OutputTest.php
@@ -116,16 +116,6 @@ class OutputTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("\033[33;41;5mfoo\033[39;49;25m\n", $output->output, '->writeln() decorates the output');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage Unknown output type given (24)
-     */
-    public function testWriteWithInvalidOutputType()
-    {
-        $output = new TestOutput();
-        $output->writeln('<foo>foo</foo>', 24);
-    }
-
     public function testWriteWithInvalidStyle()
     {
         $output = new TestOutput();
@@ -137,6 +127,35 @@ class OutputTest extends \PHPUnit_Framework_TestCase
         $output->clear();
         $output->writeln('<bar>foo</bar>');
         $this->assertEquals("<bar>foo</bar>\n", $output->output, '->writeln() do nothing when a style does not exist');
+    }
+
+    /**
+     * @dataProvider verbosityProvider
+     */
+    public function testWriteWithVerbosityOption($verbosity, $expected, $msg)
+    {
+        $output = new TestOutput();
+
+        $output->setVerbosity($verbosity);
+        $output->clear();
+        $output->write('1', false);
+        $output->write('2', false, Output::VERBOSITY_QUIET);
+        $output->write('3', false, Output::VERBOSITY_NORMAL);
+        $output->write('4', false, Output::VERBOSITY_VERBOSE);
+        $output->write('5', false, Output::VERBOSITY_VERY_VERBOSE);
+        $output->write('6', false, Output::VERBOSITY_DEBUG);
+        $this->assertEquals($expected, $output->output, $msg);
+    }
+
+    public function verbosityProvider()
+    {
+        return array(
+            array(Output::VERBOSITY_QUIET, '2', '->write() in QUIET mode only outputs when an explicit QUIET verbosity is passed'),
+            array(Output::VERBOSITY_NORMAL, '123', '->write() in NORMAL mode outputs anything below an explicit VERBOSE verbosity'),
+            array(Output::VERBOSITY_VERBOSE, '1234', '->write() in VERBOSE mode outputs anything below an explicit VERY_VERBOSE verbosity'),
+            array(Output::VERBOSITY_VERY_VERBOSE, '12345', '->write() in VERY_VERBOSE mode outputs anything below an explicit DEBUG verbosity'),
+            array(Output::VERBOSITY_DEBUG, '123456', '->write() in DEBUG mode outputs everything'),
+        );
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15680 |
| License | MIT |
| Doc PR |  |
