### PR TITLE
[HttpKernel] Allow variadic controller parameters to be resolved.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -123,9 +123,14 @@ class ControllerResolver implements ControllerResolverInterface
     {
         $attributes = $request->attributes->all();
         $arguments = array();
+        $variadicAvailable = method_exists('\ReflectionMethod', 'isVariadic');
         foreach ($parameters as $param) {
             if (array_key_exists($param->name, $attributes)) {
-                $arguments[] = $attributes[$param->name];
+                if ($variadicAvailable && $param->isVariadic() && is_array($attributes[$param->name])) {
+                    $arguments = array_merge($arguments, array_values($attributes[$param->name]));
+                } else {
+                    $arguments[] = $attributes[$param->name];
+                }
             } elseif ($param->getClass() && $param->getClass()->isInstance($request)) {
                 $arguments[] = $request;
             } elseif ($param->isDefaultValueAvailable()) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Controller;
 
 use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\VariadicController;
 use Symfony\Component\HttpFoundation\Request;
 
 class ControllerResolverTest extends \PHPUnit_Framework_TestCase
@@ -194,6 +195,22 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $controller = array(new self(), 'controllerMethod5');
         $this->assertEquals(array($request), $resolver->getArguments($request, $controller), '->getArguments() injects the request');
+    }
+
+    /**
+     * @requires PHP 5.6
+     */
+    public function testGetVariadicArguments()
+    {
+        $resolver = new ControllerResolver();
+
+        $request = Request::create('/');
+        $param1 = new \stdClass();
+        $param2 = new \stdClass();
+        $request->attributes->set('foo', 'foo');
+        $request->attributes->set('bar', array($param1, $param2));
+        $controller = array(new VariadicController(), 'action');
+        $this->assertEquals(array('foo', $param1, $param2), $resolver->getArguments($request, $controller));
     }
 
     public function testCreateControllerCanReturnAnyCallable()

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/VariadicController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/VariadicController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
+
+class VariadicController
+{
+    public function action($foo,...$bar)
+    {
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Variadic parameters in controller signature were not handled correctly by the `ControllerResolver`.
