### PR TITLE
[Yaml] Allow tabs before comments at the end of a line

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -209,8 +209,8 @@ class Inline
                 $i += strlen($output);
 
                 // remove comments
-                if (false !== $strpos = strpos($output, ' #')) {
-                    $output = rtrim(substr($output, 0, $strpos));
+                if (preg_match('/[ \t]+#/', $output, $match, PREG_OFFSET_CAPTURE)) {
+                    $output = substr($output, 0, $match[0][1]);
                 }
             } elseif (preg_match('/^(.+?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {
                 $output = $match[1];

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
@@ -7,8 +7,11 @@ yaml: |
     ex2: "foo # bar" # comment
     ex3: 'foo # bar' # comment
     ex4: foo # comment
+    ex5: foo	#	comment with tab before  
+    ex6: foo#foo # comment here
+    ex7: foo 	# ignore me # and me
 php: |
-    array('ex1' => 'foo # bar', 'ex2' => 'foo # bar', 'ex3' => 'foo # bar', 'ex4' => 'foo')
+    array('ex1' => 'foo # bar', 'ex2' => 'foo # bar', 'ex3' => 'foo # bar', 'ex4' => 'foo', 'ex5' => 'foo', 'ex6' => 'foo#foo', 'ex7' => 'foo')
 ---
 test: Comments in the middle
 brief: >


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

If a yml file has a tab character before a line ending comment the comment will be included in the parsed value. Yaml spec allows tab or space as whitespace characters so we need to check for tab as well. See included test.
Recently caused an odd and hard to find bug in our project. 

See spec:
http://www.yaml.org/spec/1.2/spec.html#s-b-comment
http://www.yaml.org/spec/1.2/spec.html#s-separate-in-line 
http://www.yaml.org/spec/1.2/spec.html#s-white

This is a new PR replacing https://github.com/symfony/symfony/pull/15747 

@fabpot 
