### PR TITLE
[2.8][Form] Fix php warning on invalid FormFactory::createBuilder() argument

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -76,9 +76,11 @@ class FormFactory implements FormFactoryInterface
         } elseif ($type instanceof FormTypeInterface) {
             // BC
             $typeName = $type->getName();
-        } else {
+        } elseif (is_string($type)) {
             // BC
             $typeName = $type;
+        } else {
+            throw new UnexpectedTypeException($type, 'string, Symfony\Component\Form\ResolvedFormTypeInterface or Symfony\Component\Form\FormTypeInterface');
         }
 
         if (null === $name) {

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -293,6 +293,15 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->factory->createNamedBuilder('name', new \stdClass());
     }
 
+    /**
+     * @expectedException        \Symfony\Component\Form\Exception\UnexpectedTypeException
+     * @expectedExceptionMessage Expected argument of type "string, Symfony\Component\Form\ResolvedFormTypeInterface or Symfony\Component\Form\FormTypeInterface", "stdClass" given
+     */
+    public function testCreateThrowsUnderstandableException()
+    {
+        $this->factory->create(new \stdClass());
+    }
+
     public function testCreateUsesTypeNameIfTypeGivenAsString()
     {
         $options = array('a' => '1', 'b' => '2');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Without this check it comes to a `strpos() expects parameter 1 to be string, object given` warning, when passing an invalid argument to `FormFactory::createBuilder()` (e.g. when calling `$this->createForm(new AnEntity());` instead of `$this->createForm(new AnEntityType());` in a controller).
