### PR TITLE
Introduction of syntax/shortcut aware Definition

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -782,7 +782,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function register($id, $class = null)
     {
-        return $this->setDefinition($id, new Definition($class));
+        return $this->setDefinition($id, $this->createDefinition($class));
     }
 
     /**
@@ -1118,6 +1118,17 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         return $services;
+    }
+
+    /**
+     * Creates a new Definition used by register().
+     *
+     * @param string $class
+     * @return Definition
+     */
+    protected function createDefinition($class)
+    {
+        return new Definition($class);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/SyntaxAware/SyntaxAwareContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/SyntaxAware/SyntaxAwareContainerBuilder.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\SyntaxAware;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * A ContainerBuilder that facilitates using the shortcut (e.g. @service_name) syntax.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class SyntaxAwareContainerBuilder extends ContainerBuilder
+{
+    public function __construct(ParameterBagInterface $parameterBag = null)
+    {
+        parent::__construct($parameterBag);
+
+        $this->parameterBag = new SyntaxAwareParameterBag($this->parameterBag);
+    }
+
+    protected function createDefinition($class)
+    {
+        return new SyntaxAwareDefinition($class);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/SyntaxAware/SyntaxAwareDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/SyntaxAware/SyntaxAwareDefinition.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\SyntaxAware;
+
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A definition class that is aware of shortcut syntaxes referring to services and expressions.
+ *
+ * There are two main shortcuts that are available whenever it makes sense:
+ *
+ *  A) Shortcut for referencing services:
+ *      - @logger becomes a Reference to logger
+ *      - @?logger becomes an optional Reference to logger
+ *
+ *  B) Shortcut for creating Expressions:
+ *      - @=service("foo") becomes an Expression('service("foo")')
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class SyntaxAwareDefinition extends Definition
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($class = null, array $arguments = array())
+    {
+        $arguments = $this->resolveServices($arguments);
+
+        parent::__construct($class, $arguments);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setArguments(array $arguments)
+    {
+        $arguments = $this->resolveServices($arguments);
+
+        return parent::setArguments($arguments);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addArgument($argument)
+    {
+        $argument = $this->resolveServices($argument);
+
+        return parent::addArgument($argument);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function replaceArgument($index, $argument)
+    {
+        $argument = $this->resolveServices($argument);
+
+        return parent::replaceArgument($index, $argument);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProperties(array $properties)
+    {
+        $properties = $this->resolveServices($properties);
+
+        return parent::setProperties($properties);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProperty($name, $value)
+    {
+        $value = $this->resolveServices($value);
+
+        return parent::setProperty($name, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFactory($factory)
+    {
+        if (is_string($factory)) {
+            if (strpos($factory, ':') !== false && strpos($factory, '::') === false) {
+                $parts = explode(':', $factory);
+                $factory = array($this->resolveServices('@'.$parts[0]), $parts[1]);
+            }
+        } else {
+            $factory = array($this->resolveServices($factory[0]), $factory[1]);
+        }
+
+        return parent::setFactory($factory);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfigurator($callable)
+    {
+        if (is_array($callable)) {
+            $callable = array($this->resolveServices($callable[0]), $callable[1]);
+        }
+
+        return parent::setConfigurator($callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addMethodCall($method, array $arguments = array())
+    {
+        $arguments = $this->resolveServices($arguments);
+
+        return parent::addMethodCall($method, $arguments);
+    }
+
+    /**
+     * Resolves services.
+     *
+     * @param string|array $value
+     *
+     * @return array|string|Reference
+     */
+    private function resolveServices($value)
+    {
+        if (is_array($value)) {
+            $value = array_map(array('self', 'resolveServices'), $value);
+        } elseif (is_string($value) &&  0 === strpos($value, '@=')) {
+            return new Expression(substr($value, 2));
+        } elseif (is_string($value) &&  0 === strpos($value, '@')) {
+            if (0 === strpos($value, '@@')) {
+                $value = substr($value, 1);
+                $invalidBehavior = null;
+            } elseif (0 === strpos($value, '@?')) {
+                $value = substr($value, 2);
+                $invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
+            } else {
+                $value = substr($value, 1);
+                $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+            }
+
+            if ('=' === substr($value, -1)) {
+                $value = substr($value, 0, -1);
+                $strict = false;
+            } else {
+                $strict = true;
+            }
+
+            if (null !== $invalidBehavior) {
+                $value = new Reference($value, $invalidBehavior, $strict);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/SyntaxAware/SyntaxAwareParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/SyntaxAware/SyntaxAwareParameterBag.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\SyntaxAware;
+
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+/**
+ * A decorator that makes parameters able to use the @= syntax for parameters.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class SyntaxAwareParameterBag implements ParameterBagInterface
+{
+    /**
+     * @var ParameterBagInterface
+     */
+    private $parameterBag;
+
+    public function __construct(ParameterBagInterface $parameterBag)
+    {
+        $this->parameterBag = $parameterBag;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        $this->parameterBag->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(array $parameters)
+    {
+        $parameters = $this->resolveExpressions($parameters);
+
+        $this->parameterBag->add($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all()
+    {
+        return $this->parameterBag->all();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($name)
+    {
+        return $this->parameterBag->get($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($name, $value)
+    {
+        $value = $this->resolveExpressions($value);
+
+        $this->parameterBag->set($name, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($name)
+    {
+        return $this->parameterBag->has($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve()
+    {
+        $this->parameterBag->resolve();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveValue($value)
+    {
+        return $this->parameterBag->resolveValue($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function escapeValue($value)
+    {
+        return $this->parameterBag->escapeValue($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unescapeValue($value)
+    {
+        return $this->parameterBag->unescapeValue($value);
+    }
+
+    /**
+     * @return ParameterBagInterface
+     */
+    public function getParameterBag()
+    {
+        return $this->parameterBag;
+    }
+
+    private function resolveExpressions($value)
+    {
+        if (is_array($value)) {
+            $value = array_map(array('self', 'resolveExpressions'), $value);
+        } elseif (is_string($value) &&  0 === strpos($value, '@=')) {
+            return new Expression(substr($value, 2));
+        }
+
+        return $value;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/SyntaxAware/SyntaxAwareContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/SyntaxAware/SyntaxAwareContainerBuilderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\SyntaxAware\Tests;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\SyntaxAware\SyntaxAwareContainerBuilder;
+
+class SyntaxAwareContainerBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructWrapsParameterBag()
+    {
+        $container = new SyntaxAwareContainerBuilder();
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\SyntaxAware\SyntaxAwareParameterBag', $container->getParameterBag());
+        $outerParamBag = $container->getParameterBag();
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\ParameterBag\ParameterBag', $outerParamBag->getParameterBag());
+
+        $innerBag = new ParameterBag(array('foo' => 'bar'));
+        $container = new SyntaxAwareContainerBuilder($innerBag);
+        $outerParamBag = $container->getParameterBag();
+        $this->assertSame($innerBag, $outerParamBag->getParameterBag());
+    }
+
+    public function testRegisterReturnsAwareDefinition()
+    {
+        $container = new SyntaxAwareContainerBuilder();
+        $actualDefn = $container->register('foo', 'Acme\Foo');
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\SyntaxAware\SyntaxAwareDefinition', $actualDefn);
+        $this->assertEquals('Acme\Foo', $actualDefn->getClass());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/SyntaxAware/SyntaxAwareDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/SyntaxAware/SyntaxAwareDefinitionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\SyntaxAware\Tests;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\SyntaxAware\SyntaxAwareDefinition;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+class SyntaxAwareDefinitionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideServiceSyntaxes
+     */
+    public function testResolveServices($expression, $expectedValue)
+    {
+        $definition = new SyntaxAwareDefinition();
+        $definition->addArgument($expression);
+        $actualArgument = $definition->getArgument(0);
+
+        $this->assertEquals($expectedValue, $actualArgument);
+    }
+
+    public function provideServiceSyntaxes()
+    {
+        $tests = array();
+        $tests[] = array('foo', 'foo');
+
+        $tests[] = array('@foo', new Reference('foo', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE));
+        $tests[] = array('@?foo', new Reference('foo', ContainerInterface::IGNORE_ON_INVALID_REFERENCE));
+
+        $tests[] = array('@foo=', new Reference('foo', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
+        $tests[] = array('@?foo=', new Reference('foo', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, false));
+
+        // the escaped string version
+        $tests[] = array('@@foo', '@foo');
+
+        $tests[] = array(array('foo', '@bar'), array('foo', new Reference('bar')));
+
+        $tests[] = array('@=service("bar")', new Expression('service("bar")'));
+
+        return $tests;
+    }
+
+    public function testConstruct()
+    {
+        $definition = new SyntaxAwareDefinition('Acme\Foo', array('bar', '@pizza_chef'));
+        $arguments = $definition->getArguments();
+
+        $this->assertEquals(array('bar', new Reference('pizza_chef')), $arguments);
+    }
+
+    public function testSetArguments()
+    {
+        $definition = new SyntaxAwareDefinition();
+        $definition->setArguments(array('bar', '@pizza_chef'));
+        $arguments = $definition->getArguments();
+
+        $this->assertEquals(array('bar', new Reference('pizza_chef')), $arguments);
+    }
+
+    public function testAddArgument()
+    {
+        $definition = new SyntaxAwareDefinition();
+        $definition->addArgument('bar');
+        $definition->addArgument('@pizza_chef');
+        $arguments = $definition->getArguments();
+
+        $this->assertEquals(array('bar', new Reference('pizza_chef')), $arguments);
+    }
+
+    public function testReplaceArgument()
+    {
+        $definition = new SyntaxAwareDefinition();
+        $definition->addArgument('bar');
+        $definition->replaceArgument(0, '@pizza_chef');
+        $arguments = $definition->getArguments();
+
+        $this->assertEquals(array(new Reference('pizza_chef')), $arguments);
+    }
+
+    public function testSetProperties()
+    {
+        $definition = new SyntaxAwareDefinition();
+        $definition->setProperties(array('ingredients' => 'anchovies', 'chef' => '@pizza_chef'));
+        $properties = $definition->getProperties();
+
+        $this->assertEquals(array('ingredients' => 'anchovies', 'chef' => new Reference('pizza_chef')), $properties);
+    }
+
+    public function testSetProperty()
+    {
+        $definition = new SyntaxAwareDefinition();
+        $definition->setProperty('ingredients', 'anchovies');
+        $definition->setProperty('chef', '@pizza_chef');
+        $properties = $definition->getProperties();
+
+        $this->assertEquals(array('ingredients' => 'anchovies', 'chef' => new Reference('pizza_chef')), $properties);
+    }
+
+    public function testSetFactory()
+    {
+        $definition = new SyntaxAwareDefinition();
+        $definition->setFactory('CulinarySchool::createChef');
+        $this->assertEquals(array('CulinarySchool', 'createChef'), $definition->getFactory(), 'Class::method are not affected');
+
+        $definition->setFactory('culinary_school:createChef');
+        $this->assertEquals(array(new Reference('culinary_school'), 'createChef'), $definition->getFactory(), 'service:method is transformed into a Reference');
+
+        $definition->setFactory(array('CulinarySchool', 'createChef'));
+        $this->assertEquals(array('CulinarySchool', 'createChef'), $definition->getFactory(), 'An array without the @ is not changed');
+
+        $definition->setFactory(array('@culinary_school', 'createChef'));
+        $this->assertEquals(array(new Reference('culinary_school'), 'createChef'), $definition->getFactory(), 'An array with @ before the "object" is turned into a Reference');
+    }
+
+    public function testConfigurator()
+    {
+        $definition = new SyntaxAwareDefinition();
+
+        $definition->setConfigurator('gordon_ramsay');
+        $this->assertEquals('gordon_ramsay', $definition->getConfigurator(), 'Non-arrays are not transformed');
+
+        $definition->setConfigurator(array('GordonRamsay', 'configureChefs'));
+        $this->assertEquals(array('GordonRamsay', 'configureChefs'), $definition->getConfigurator(), 'An array without @ is not transformed');
+
+        $definition->setConfigurator(array('@gordon_ramsay', 'configureChefs'));
+        $this->assertEquals(array(new Reference('gordon_ramsay'), 'configureChefs'), $definition->getConfigurator(), 'An array with @ is transformed to a Reference');
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/SyntaxAware/SyntaxAwareParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/SyntaxAware/SyntaxAwareParameterBagTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\SyntaxAware;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\SyntaxAware\SyntaxAwareParameterBag;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+class SyntaxAwareParameterBagTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetParameterBag()
+    {
+        $innerBag = new ParameterBag();
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $this->assertSame($innerBag, $bag->getParameterBag());
+    }
+
+    public function testAdd()
+    {
+        $innerBag = new ParameterBag();
+        $bag = new SyntaxAwareParameterBag($innerBag);
+
+        $bag->add(array('should_cook' => true, 'food' => '@=parameter("kernel.debug") ? "debug_pizza" : "pizza"'));
+        $actual = $bag->all();
+        $this->assertEquals(array('should_cook' => true, 'food' => new Expression('parameter("kernel.debug") ? "debug_pizza" : "pizza"')), $actual);
+    }
+
+    public function testSet()
+    {
+        $innerBag = new ParameterBag();
+        $bag = new SyntaxAwareParameterBag($innerBag);
+
+        $bag->set('should_cook', true);
+        $bag->set('food', '@=parameter("kernel.debug") ? "debug_pizza" : "pizza"');
+        $actual = $bag->all();
+        $this->assertEquals(array('should_cook' => true, 'food' => new Expression('parameter("kernel.debug") ? "debug_pizza" : "pizza"')), $actual);
+    }
+
+    public function testClear()
+    {
+        $innerBag = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $innerBag->expects($this->once())
+            ->method('clear');
+
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $bag->clear();
+    }
+
+    public function testAll()
+    {
+        $innerBag = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $innerBag->expects($this->once())
+            ->method('all')
+            ->will($this->returnValue(array('foo' => 'bar')));
+
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $actual = $bag->all();
+        $this->assertEquals(array('foo' => 'bar'), $actual);
+    }
+
+    public function testGet()
+    {
+        $innerBag = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $innerBag->expects($this->once())
+            ->method('get')
+            ->with('foo')
+            ->will($this->returnValue('bar'));
+
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $actual = $bag->get('foo');
+        $this->assertEquals('bar', $actual);
+    }
+
+    public function testHas()
+    {
+        $innerBag = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $innerBag->expects($this->once())
+            ->method('has')
+            ->with('foo')
+            ->will($this->returnValue(true));
+
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $actual = $bag->has('foo');
+        $this->assertEquals(true, $actual);
+    }
+
+    public function testResolve()
+    {
+        $innerBag = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $innerBag->expects($this->once())
+            ->method('resolve');
+
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $bag->resolve();
+    }
+
+    public function testResolveValue()
+    {
+        $innerBag = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $innerBag->expects($this->once())
+            ->method('resolveValue')
+            ->with('%foo%')
+            ->will($this->returnValue('foo_resolved'));
+
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $actual = $bag->resolveValue('%foo%');
+        $this->assertEquals('foo_resolved', $actual);
+    }
+
+    public function testEscapeValue()
+    {
+        $innerBag = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $innerBag->expects($this->once())
+            ->method('escapeValue')
+            ->with('%foo%')
+            ->will($this->returnValue('%%foo%%'));
+
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $actual = $bag->escapeValue('%foo%');
+        $this->assertEquals('%%foo%%', $actual);
+    }
+
+    public function testUnescapeValue()
+    {
+        $innerBag = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $innerBag->expects($this->once())
+            ->method('unescapeValue')
+            ->with('%%foo%%')
+            ->will($this->returnValue('%foo%'));
+
+        $bag = new SyntaxAwareParameterBag($innerBag);
+        $actual = $bag->unescapeValue('%%foo%%');
+        $this->assertEquals('%foo%', $actual);
+    }
+}


### PR DESCRIPTION
Hi guys!

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | not yet... |

Similar to what #15778 does for routes, this aims to make creating Definitions in PHP easier. This is already quite easy, but this PR has 2 additional **goals**:

1) Allow the YAML `@service_name` syntax to be used with Definitions. Subjectively, this makes building services in PHP much more appearling:

``` php
// currently
$container->register('pizza_chef', 'Acme\PizzaChef')
    ->addArgument(new Reference('fire_oven'))
    ->addMethodCall('setRecipeFactory', [new Reference('recipe_factory')]);

// after
$container->register('pizza_chef', 'Acme\PizzaChef')
    ->addArgument('@fire_oven')
    ->addMethodCall('setRecipeFactory', ['@recipe_factory']);
```

Also, this makes the PHP syntax very very close to the YAML syntax, make it easy to learn/teach if this were done more often, e.g in some micro/RAD edition.

2) Accomplish (1) while still having the fluid `ContainerBuilder::register()` interface.

Thanks!
