### PR TITLE
[Finder] Handle filtering of recursive iterators and use it to skip looping over excluded directories

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/PhpAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/PhpAdapter.php
@@ -31,10 +31,13 @@ class PhpAdapter extends AbstractAdapter
             $flags |= \RecursiveDirectoryIterator::FOLLOW_SYMLINKS;
         }
 
-        $iterator = new \RecursiveIteratorIterator(
-            new Iterator\RecursiveDirectoryIterator($dir, $flags, $this->ignoreUnreadableDirs),
-            \RecursiveIteratorIterator::SELF_FIRST
-        );
+        $iterator = new Iterator\RecursiveDirectoryIterator($dir, $flags, $this->ignoreUnreadableDirs);
+
+        if ($this->exclude) {
+            $iterator = new Iterator\ExcludeDirectoryFilterIterator($iterator, $this->exclude);
+        }
+
+        $iterator = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::SELF_FIRST);
 
         if ($this->minDepth > 0 || $this->maxDepth < PHP_INT_MAX) {
             $iterator = new Iterator\DepthRangeFilterIterator($iterator, $this->minDepth, $this->maxDepth);
@@ -42,10 +45,6 @@ class PhpAdapter extends AbstractAdapter
 
         if ($this->mode) {
             $iterator = new Iterator\FileTypeFilterIterator($iterator, $this->mode);
-        }
-
-        if ($this->exclude) {
-            $iterator = new Iterator\ExcludeDirectoryFilterIterator($iterator, $this->exclude);
         }
 
         if ($this->names || $this->notNames) {

--- a/src/Symfony/Component/Finder/Iterator/FilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilterIterator.php
@@ -18,8 +18,18 @@ namespace Symfony\Component\Finder\Iterator;
  *
  * @author Alex Bogomazov
  */
-abstract class FilterIterator extends \FilterIterator
+abstract class FilterIterator extends \FilterIterator implements \RecursiveIterator
 {
+    public function hasChildren()
+    {
+        return $this->getInnerIterator() instanceof \RecursiveIterator && $this->getInnerIterator()->hasChildren();
+    }
+
+    public function getChildren()
+    {
+        return $this->getInnerIterator()->getChildren();
+    }
+
     /**
      * This is a workaround for the problem with \FilterIterator leaving inner \FilesystemIterator in wrong state after
      * rewind in some cases.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5951, #8685 |
| License | MIT |
| Doc PR | - |

By implementing RecursiveIterator in FilterIterator, we can make it able to skip children of excluded branches of recursive inner iterators.
We use it immediately for our main target: skip over children of excluded directories in the Finder.
This is a significant performance boost when iterating over big directories, thus the "bugfix" status.
