### PR TITLE
[Finder] Exclude files based on path before applying the sorting

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/PhpAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/PhpAdapter.php
@@ -68,13 +68,13 @@ class PhpAdapter extends AbstractAdapter
             $iterator = new Iterator\CustomFilterIterator($iterator, $this->filters);
         }
 
+        if ($this->paths || $this->notPaths) {
+            $iterator = new Iterator\PathFilterIterator($iterator, $this->paths, $this->notPaths);
+        }
+
         if ($this->sort) {
             $iteratorAggregate = new Iterator\SortableIterator($iterator, $this->sort);
             $iterator = $iteratorAggregate->getIterator();
-        }
-
-        if ($this->paths || $this->notPaths) {
-            $iterator = new Iterator\PathFilterIterator($iterator, $this->paths, $this->notPaths);
         }
 
         return $iterator;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (perf) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Sorting can be slow, so it is best to applied it after all filtering rules are applied instead of using a bigger list and filtering again after that.

This impacts only people using both the sorting and the name filtering (with `->names()` or `notNames()`)
