### PR TITLE
[VarDumper] Fix HtmlDumper constructor calling CliDumper's

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -50,7 +50,7 @@ class HtmlDumper extends CliDumper
      */
     public function __construct($output = null, $charset = null)
     {
-        parent::__construct($output, $charset);
+        AbstractDumper::__construct($output, $charset);
         $this->dumpId = 'sf-dump-'.mt_rand();
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/var-dumper/pull/2#issuecomment-140338205 |
| License | MIT |
| Doc PR | - |
