### PR TITLE
Remove duplication of the handling of regex filters in the Finder

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
@@ -41,25 +41,7 @@ class FilecontentFilterIterator extends MultiplePcreFilterIterator
             return false;
         }
 
-        // should at least not match one rule to exclude
-        foreach ($this->noMatchRegexps as $regex) {
-            if (preg_match($regex, $content)) {
-                return false;
-            }
-        }
-
-        // should at least match one rule
-        $match = true;
-        if ($this->matchRegexps) {
-            $match = false;
-            foreach ($this->matchRegexps as $regex) {
-                if (preg_match($regex, $content)) {
-                    return true;
-                }
-            }
-        }
-
-        return $match;
+        return $this->isAccepted($content);
     }
 
     /**

--- a/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
@@ -27,27 +27,7 @@ class FilenameFilterIterator extends MultiplePcreFilterIterator
      */
     public function accept()
     {
-        $filename = $this->current()->getFilename();
-
-        // should at least not match one rule to exclude
-        foreach ($this->noMatchRegexps as $regex) {
-            if (preg_match($regex, $filename)) {
-                return false;
-            }
-        }
-
-        // should at least match one rule
-        $match = true;
-        if ($this->matchRegexps) {
-            $match = false;
-            foreach ($this->matchRegexps as $regex) {
-                if (preg_match($regex, $filename)) {
-                    return true;
-                }
-            }
-        }
-
-        return $match;
+        return $this->isAccepted($this->current()->getFilename());
     }
 
     /**

--- a/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
@@ -44,6 +44,41 @@ abstract class MultiplePcreFilterIterator extends FilterIterator
     }
 
     /**
+     * Checks whether the string is accepted by the regex filters.
+     *
+     * If there is no regexps defined in the class, this method will accept the string.
+     * Such case can be handled by child classes before calling the method if they want to
+     * apply a different behavior.
+     *
+     * @param string $string The string to be matched against filters
+     *
+     * @return bool
+     */
+    protected function isAccepted($string)
+    {
+        // should at least not match one rule to exclude
+        foreach ($this->noMatchRegexps as $regex) {
+            if (preg_match($regex, $string)) {
+                return false;
+            }
+        }
+
+        // should at least match one rule
+        if ($this->matchRegexps) {
+            foreach ($this->matchRegexps as $regex) {
+                if (preg_match($regex, $string)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // If there is no match rules, the file is accepted
+        return true;
+    }
+
+    /**
      * Checks whether the string is a regex.
      *
      * @param string $str

--- a/src/Symfony/Component/Finder/Iterator/PathFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/PathFilterIterator.php
@@ -32,25 +32,7 @@ class PathFilterIterator extends MultiplePcreFilterIterator
             $filename = str_replace('\\', '/', $filename);
         }
 
-        // should at least not match one rule to exclude
-        foreach ($this->noMatchRegexps as $regex) {
-            if (preg_match($regex, $filename)) {
-                return false;
-            }
-        }
-
-        // should at least match one rule
-        $match = true;
-        if ($this->matchRegexps) {
-            $match = false;
-            foreach ($this->matchRegexps as $regex) {
-                if (preg_match($regex, $filename)) {
-                    return true;
-                }
-            }
-        }
-
-        return $match;
+        return $this->isAccepted($filename);
     }
 
     /**


### PR DESCRIPTION
The logic to handle the multiple regexs in MultiplePcreFilterIterator children is the same each time (and will always be the same given it is related to the meaning of properties in MultiplePcreFilterIterator itself).
This extracts this logic in MultiplePcreFilterIterator itself rather than duplicating it in all child classes.
