### PR TITLE
Improve the structure of the Finder testsuite

### DIFF
--- a/src/Symfony/Component/Finder/Tests/BsdFinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/BsdFinderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests;
+
+use Symfony\Component\Finder\Adapter\BsdFindAdapter;
+
+class BsdFinderTest extends FinderTest
+{
+    protected function getAdapter()
+    {
+        $adapter = new BsdFindAdapter();
+
+        if (!$adapter->isSupported()) {
+            $this->markTestSkipped(get_class($adapter).' is not supported.');
+        }
+
+        return $adapter;
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Finder\Tests;
 
+use Symfony\Component\Finder\Adapter\AdapterInterface;
+use Symfony\Component\Finder\Adapter\GnuFindAdapter;
+use Symfony\Component\Finder\Adapter\PhpAdapter;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\Adapter;
 
 class FinderTest extends Iterator\RealIteratorTestCase
 {
@@ -21,109 +23,94 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertInstanceOf('Symfony\Component\Finder\Finder', Finder::create());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testDirectories($adapter)
+    public function testDirectories()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->directories());
         $this->assertIterator($this->toAbsolute(array('foo', 'toto')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->directories();
         $finder->files();
         $finder->directories();
         $this->assertIterator($this->toAbsolute(array('foo', 'toto')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testFiles($adapter)
+    public function testFiles()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->files());
         $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php', 'test.py', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->files();
         $finder->directories();
         $finder->files();
         $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php', 'test.py', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testDepth($adapter)
+    public function testDepth()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->depth('< 1'));
         $this->assertIterator($this->toAbsolute(array('foo', 'test.php', 'test.py', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->depth('<= 0'));
         $this->assertIterator($this->toAbsolute(array('foo', 'test.php', 'test.py', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->depth('>= 1'));
         $this->assertIterator($this->toAbsolute(array('foo/bar.tmp')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->depth('< 1')->depth('>= 1');
         $this->assertIterator(array(), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testName($adapter)
+    public function testName()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->name('*.php'));
         $this->assertIterator($this->toAbsolute(array('test.php')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->name('test.ph*');
         $finder->name('test.py');
         $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->name('~^test~i');
         $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->name('~\\.php$~i');
         $this->assertIterator($this->toAbsolute(array('test.php')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->name('test.p{hp,y}');
         $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testNotName($adapter)
+    public function testNotName()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->notName('*.php'));
         $this->assertIterator($this->toAbsolute(array('foo', 'foo/bar.tmp', 'test.py', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->notName('*.php');
         $finder->notName('*.py');
         $this->assertIterator($this->toAbsolute(array('foo', 'foo/bar.tmp', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->name('test.ph*');
         $finder->name('test.py');
         $finder->notName('*.php');
         $finder->notName('*.py');
         $this->assertIterator(array(), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->name('test.ph*');
         $finder->name('test.py');
         $finder->notName('*.p{hp,y}');
@@ -133,217 +120,177 @@ class FinderTest extends Iterator\RealIteratorTestCase
     /**
      * @dataProvider getRegexNameTestData
      */
-    public function testRegexName($adapter, $regex)
+    public function testRegexName($regex)
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->name($regex);
         $this->assertIterator($this->toAbsolute(array('test.py', 'test.php')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testSize($adapter)
+    public function testSize()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->files()->size('< 1K')->size('> 500'));
         $this->assertIterator($this->toAbsolute(array('test.php')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testDate($adapter)
+    public function testDate()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->files()->date('until last month'));
         $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testExclude($adapter)
+    public function testExclude()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->exclude('foo'));
         $this->assertIterator($this->toAbsolute(array('test.php', 'test.py', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testIgnoreVCS($adapter)
+    public function testIgnoreVCS()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->ignoreVCS(false)->ignoreDotFiles(false));
         $this->assertIterator($this->toAbsolute(array('.git', 'foo', 'foo/bar.tmp', 'test.php', 'test.py', 'toto', '.bar', '.foo', '.foo/.bar', '.foo/bar', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->ignoreVCS(false)->ignoreVCS(false)->ignoreDotFiles(false);
         $this->assertIterator($this->toAbsolute(array('.git', 'foo', 'foo/bar.tmp', 'test.php', 'test.py', 'toto', '.bar', '.foo', '.foo/.bar', '.foo/bar', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->ignoreVCS(true)->ignoreDotFiles(false));
         $this->assertIterator($this->toAbsolute(array('foo', 'foo/bar.tmp', 'test.php', 'test.py', 'toto', '.bar', '.foo', '.foo/.bar', '.foo/bar', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testIgnoreDotFiles($adapter)
+    public function testIgnoreDotFiles()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->ignoreDotFiles(false)->ignoreVCS(false));
         $this->assertIterator($this->toAbsolute(array('.git', '.bar', '.foo', '.foo/.bar', '.foo/bar', 'foo', 'foo/bar.tmp', 'test.php', 'test.py', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->ignoreDotFiles(false)->ignoreDotFiles(false)->ignoreVCS(false);
         $this->assertIterator($this->toAbsolute(array('.git', '.bar', '.foo', '.foo/.bar', '.foo/bar', 'foo', 'foo/bar.tmp', 'test.php', 'test.py', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->ignoreDotFiles(true)->ignoreVCS(false));
         $this->assertIterator($this->toAbsolute(array('foo', 'foo/bar.tmp', 'test.php', 'test.py', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testSortByName($adapter)
+    public function testSortByName()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sortByName());
         $this->assertIterator($this->toAbsolute(array('foo', 'foo bar', 'foo/bar.tmp', 'test.php', 'test.py', 'toto')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testSortByType($adapter)
+    public function testSortByType()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sortByType());
         $this->assertIterator($this->toAbsolute(array('foo', 'foo bar', 'toto', 'foo/bar.tmp', 'test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testSortByAccessedTime($adapter)
+    public function testSortByAccessedTime()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sortByAccessedTime());
         $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php', 'toto', 'test.py', 'foo', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testSortByChangedTime($adapter)
+    public function testSortByChangedTime()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sortByChangedTime());
         $this->assertIterator($this->toAbsolute(array('toto', 'test.py', 'test.php', 'foo/bar.tmp', 'foo', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testSortByModifiedTime($adapter)
+    public function testSortByModifiedTime()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sortByModifiedTime());
         $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php', 'toto', 'test.py', 'foo', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testSort($adapter)
+    public function testSort()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sort(function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealPath(), $b->getRealPath()); }));
         $this->assertIterator($this->toAbsolute(array('foo', 'foo bar', 'foo/bar.tmp', 'test.php', 'test.py', 'toto')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testFilter($adapter)
+    public function testFilter()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->filter(function (\SplFileInfo $f) { return false !== strpos($f, 'test'); }));
         $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testFollowLinks($adapter)
+    public function testFollowLinks()
     {
         if ('\\' == DIRECTORY_SEPARATOR) {
-            return;
+            $this->markTestSkipped('symlinks are not supported on Windows');
         }
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->followLinks());
         $this->assertIterator($this->toAbsolute(array('foo', 'foo/bar.tmp', 'test.php', 'test.py', 'toto', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testIn($adapter)
+    public function testIn()
     {
-        $finder = $this->buildFinder($adapter);
-        try {
-            $finder->in('foobar');
-            $this->fail('->in() throws a \InvalidArgumentException if the directory does not exist');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('InvalidArgumentException', $e, '->in() throws a \InvalidArgumentException if the directory does not exist');
-        }
-
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $iterator = $finder->files()->name('*.php')->depth('< 1')->in(array(self::$tmpDir, __DIR__))->getIterator();
 
-        $this->assertIterator(array(self::$tmpDir.DIRECTORY_SEPARATOR.'test.php', __DIR__.DIRECTORY_SEPARATOR.'FinderTest.php'), $iterator);
+        $expected = array(
+            self::$tmpDir.DIRECTORY_SEPARATOR.'test.php',
+            __DIR__.DIRECTORY_SEPARATOR.'BsdFinderTest.php',
+            __DIR__.DIRECTORY_SEPARATOR.'FinderTest.php',
+            __DIR__.DIRECTORY_SEPARATOR.'GnuFinderTest.php',
+        );
+
+        $this->assertIterator($expected, $iterator);
     }
 
     /**
-     * @dataProvider getAdaptersTestData
+     * @expectedException \InvalidArgumentException
      */
-    public function testInWithGlob($adapter)
+    public function testInWithNonExistentDirectory()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = new Finder();
+        $finder->in('foobar');
+    }
+
+    public function testInWithGlob()
+    {
+        $finder = $this->buildFinder();
         $finder->in(array(__DIR__.'/Fixtures/*/B/C', __DIR__.'/Fixtures/*/*/B/C'))->getIterator();
 
         $this->assertIterator($this->toAbsoluteFixtures(array('A/B/C/abc.dat', 'copy/A/B/C/abc.dat.copy')), $finder);
     }
 
     /**
-     * @dataProvider getAdaptersTestData
      * @expectedException \InvalidArgumentException
      */
-    public function testInWithNonDirectoryGlob($adapter)
+    public function testInWithNonDirectoryGlob()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = new Finder();
         $finder->in(__DIR__.'/Fixtures/A/a*');
     }
 
     /**
-     * @dataProvider getAdaptersTestData
+     * @expectedException \LogicException
      */
-    public function testGetIterator($adapter)
+    public function testGetIteratorWithoutIn()
     {
-        $finder = $this->buildFinder($adapter);
-        try {
-            $finder->getIterator();
-            $this->fail('->getIterator() throws a \LogicException if the in() method has not been called');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('LogicException', $e, '->getIterator() throws a \LogicException if the in() method has not been called');
-        }
+        $finder = Finder::create();
+        $finder->getIterator();
+    }
 
-        $finder = $this->buildFinder($adapter);
+    public function testGetIterator()
+    {
+        $finder = $this->buildFinder();
         $dirs = array();
         foreach ($finder->directories()->in(self::$tmpDir) as $dir) {
             $dirs[] = (string) $dir;
@@ -356,22 +303,19 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         $this->assertEquals($expected, $dirs, 'implements the \IteratorAggregate interface');
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $this->assertEquals(2, iterator_count($finder->directories()->in(self::$tmpDir)), 'implements the \IteratorAggregate interface');
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $a = iterator_to_array($finder->directories()->in(self::$tmpDir));
         $a = array_values(array_map(function ($a) { return (string) $a; }, $a));
         sort($a);
         $this->assertEquals($expected, $a, 'implements the \IteratorAggregate interface');
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testRelativePath($adapter)
+    public function testRelativePath()
     {
-        $finder = $this->buildFinder($adapter)->in(self::$tmpDir);
+        $finder = $this->buildFinder()->in(self::$tmpDir);
 
         $paths = array();
 
@@ -387,12 +331,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertEquals($ref, $paths);
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testRelativePathname($adapter)
+    public function testRelativePathname()
     {
-        $finder = $this->buildFinder($adapter)->in(self::$tmpDir)->sortByName();
+        $finder = $this->buildFinder()->in(self::$tmpDir)->sortByName();
 
         $paths = array();
 
@@ -408,15 +349,12 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertEquals($ref, $paths);
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testAppendWithAFinder($adapter)
+    public function testAppendWithAFinder()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->files()->in(self::$tmpDir.DIRECTORY_SEPARATOR.'foo');
 
-        $finder1 = $this->buildFinder($adapter);
+        $finder1 = $this->buildFinder();
         $finder1->directories()->in(self::$tmpDir);
 
         $finder = $finder->append($finder1);
@@ -424,12 +362,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsolute(array('foo', 'foo/bar.tmp', 'toto')), $finder->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testAppendWithAnArray($adapter)
+    public function testAppendWithAnArray()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->files()->in(self::$tmpDir.DIRECTORY_SEPARATOR.'foo');
 
         $finder->append($this->toAbsolute(array('foo', 'toto')));
@@ -437,20 +372,14 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsolute(array('foo', 'foo/bar.tmp', 'toto')), $finder->getIterator());
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testAppendReturnsAFinder($adapter)
+    public function testAppendReturnsAFinder()
     {
-        $this->assertInstanceOf('Symfony\\Component\\Finder\\Finder', $this->buildFinder($adapter)->append(array()));
+        $this->assertInstanceOf('Symfony\\Component\\Finder\\Finder', Finder::create()->append(array()));
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testAppendDoesNotRequireIn($adapter)
+    public function testAppendDoesNotRequireIn()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->in(self::$tmpDir.DIRECTORY_SEPARATOR.'foo');
 
         $finder1 = Finder::create()->append($finder);
@@ -494,9 +423,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
     /**
      * @dataProvider getContainsTestData
      */
-    public function testContains($adapter, $matchPatterns, $noMatchPatterns, $expected)
+    public function testContains($matchPatterns, $noMatchPatterns, $expected)
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures')
             ->name('*.txt')->sortByName()
             ->contains($matchPatterns)
@@ -505,12 +434,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testContainsOnDirectory(Adapter\AdapterInterface $adapter)
+    public function testContainsOnDirectory()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->in(__DIR__)
             ->directories()
             ->name('Fixtures')
@@ -518,12 +444,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator(array(), $finder);
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testNotContainsOnDirectory(Adapter\AdapterInterface $adapter)
+    public function testNotContainsOnDirectory()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->in(__DIR__)
             ->directories()
             ->name('Fixtures')
@@ -536,10 +459,8 @@ class FinderTest extends Iterator\RealIteratorTestCase
      * with inner FilesystemIterator in an invalid state.
      *
      * @see https://bugs.php.net/bug.php?id=49104
-     *
-     * @dataProvider getAdaptersTestData
      */
-    public function testMultipleLocations(Adapter\AdapterInterface $adapter)
+    public function testMultipleLocations()
     {
         $locations = array(
             self::$tmpDir.'/',
@@ -547,36 +468,57 @@ class FinderTest extends Iterator\RealIteratorTestCase
         );
 
         // it is expected that there are test.py test.php in the tmpDir
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->in($locations)->depth('< 1')->name('test.php');
 
         $this->assertCount(1, $finder);
     }
 
     /**
-     * Iterator keys must be the file pathname.
+     * Searching in multiple locations with sub directories involves
+     * AppendIterator which does an unnecessary rewind which leaves
+     * FilterIterator with inner FilesystemIterator in an invalid state.
      *
-     * @dataProvider getAdaptersTestData
+     * @see https://bugs.php.net/bug.php?id=49104
      */
-    public function testIteratorKeys(Adapter\AdapterInterface $adapter)
+    public function testMultipleLocationsWithSubDirectories()
     {
-        $finder = $this->buildFinder($adapter)->in(self::$tmpDir);
+        $locations = array(
+            __DIR__.'/Fixtures/one',
+            self::$tmpDir.DIRECTORY_SEPARATOR.'toto',
+        );
+
+        $finder = $this->buildFinder();
+        $finder->in($locations)->depth('< 10')->name('*.neon');
+
+        $expected = array(
+            __DIR__.'/Fixtures/one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'c.neon',
+            __DIR__.'/Fixtures/one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'d.neon',
+        );
+
+        $this->assertIterator($expected, $finder);
+        $this->assertIteratorInForeach($expected, $finder);
+    }
+
+    /**
+     * Iterator keys must be the file pathname.
+     */
+    public function testIteratorKeys()
+    {
+        $finder = $this->buildFinder()->in(self::$tmpDir);
         foreach ($finder as $key => $file) {
             $this->assertEquals($file->getPathname(), $key);
         }
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testRegexSpecialCharsLocationWithPathRestrictionContainingStartFlag(Adapter\AdapterInterface $adapter)
+    public function testRegexSpecialCharsLocationWithPathRestrictionContainingStartFlag()
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.gex[c]a(r)s')
             ->path('/^dir/');
 
         $expected = array('r+e.gex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir',
-                          'r+e.gex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
+            'r+e.gex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat',);
         $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
     }
 
@@ -592,7 +534,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         $this->assertEquals(
             array('c', 'e', 'a', 'd', 'b'),
-            array_map(function (Adapter\AdapterInterface $adapter) {
+            array_map(function (AdapterInterface $adapter) {
                 return $adapter->getName();
             }, $finder->getAdapters())
         );
@@ -615,17 +557,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($filenames, $finder->in(sys_get_temp_dir())->getIterator());
     }
 
-    public function getAdaptersTestData()
-    {
-        return array_map(
-            function ($adapter) { return array($adapter); },
-            $this->getValidAdapters()
-        );
-    }
-
     public function getContainsTestData()
     {
-        $tests = array(
+        return array(
             array('', '', array()),
             array('foo', 'bar', array()),
             array('', 'foobar', array('dolor.txt', 'ipsum.txt', 'lorem.txt')),
@@ -637,26 +571,22 @@ class FinderTest extends Iterator\RealIteratorTestCase
             array('', 'lorem', array('dolor.txt', 'ipsum.txt')),
             array('ipsum dolor sit amet', '/^IPSUM/m', array('lorem.txt')),
         );
-
-        return $this->buildTestData($tests);
     }
 
     public function getRegexNameTestData()
     {
-        $tests = array(
+        return array(
             array('~.+\\.p.+~i'),
             array('~t.*s~i'),
         );
-
-        return $this->buildTestData($tests);
     }
 
     /**
      * @dataProvider getTestPathData
      */
-    public function testPath(Adapter\AdapterInterface $adapter, $matchPatterns, $noMatchPatterns, array $expected)
+    public function testPath($matchPatterns, $noMatchPatterns, array $expected)
     {
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures')
             ->path($matchPatterns)
             ->notPath($noMatchPatterns);
@@ -668,20 +598,20 @@ class FinderTest extends Iterator\RealIteratorTestCase
     {
         // test that by default, PhpAdapter is selected
         $adapters = Finder::create()->getAdapters();
-        $this->assertTrue($adapters[0] instanceof Adapter\PhpAdapter);
+        $this->assertTrue($adapters[0] instanceof PhpAdapter);
 
         // test another adapter selection
         $adapters = Finder::create()->setAdapter('gnu_find')->getAdapters();
-        $this->assertTrue($adapters[0] instanceof Adapter\GnuFindAdapter);
+        $this->assertTrue($adapters[0] instanceof GnuFindAdapter);
 
         // test that useBestAdapter method removes selection
         $adapters = Finder::create()->useBestAdapter()->getAdapters();
-        $this->assertFalse($adapters[0] instanceof Adapter\PhpAdapter);
+        $this->assertFalse($adapters[0] instanceof PhpAdapter);
     }
 
     public function getTestPathData()
     {
-        $tests = array(
+        return array(
             array('', '', array()),
             array('/^A\/B\/C/', '/C$/',
                 array('A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat'),
@@ -722,20 +652,15 @@ class FinderTest extends Iterator\RealIteratorTestCase
                 ),
             ),
         );
-
-        return $this->buildTestData($tests);
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testAccessDeniedException(Adapter\AdapterInterface $adapter)
+    public function testAccessDeniedException()
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('chmod is not supported on Windows');
         }
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->files()->in(self::$tmpDir);
 
         // make 'foo' directory non-readable
@@ -765,16 +690,13 @@ class FinderTest extends Iterator\RealIteratorTestCase
         }
     }
 
-    /**
-     * @dataProvider getAdaptersTestData
-     */
-    public function testIgnoredAccessDeniedException(Adapter\AdapterInterface $adapter)
+    public function testIgnoredAccessDeniedException()
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('chmod is not supported on Windows');
         }
 
-        $finder = $this->buildFinder($adapter);
+        $finder = $this->buildFinder();
         $finder->files()->ignoreUnreadableDirs()->in(self::$tmpDir);
 
         // make 'foo' directory non-readable
@@ -794,62 +716,18 @@ class FinderTest extends Iterator\RealIteratorTestCase
         }
     }
 
-    private function buildTestData(array $tests)
+    /**
+     * @return AdapterInterface
+     */
+    protected function getAdapter()
     {
-        $data = array();
-        foreach ($this->getValidAdapters() as $adapter) {
-            foreach ($tests as $test) {
-                $data[] = array_merge(array($adapter), $test);
-            }
-        }
-
-        return $data;
+        return new PhpAdapter();
     }
 
-    private function buildFinder(Adapter\AdapterInterface $adapter)
+    private function buildFinder()
     {
         return Finder::create()
             ->removeAdapters()
-            ->addAdapter($adapter);
-    }
-
-    private function getValidAdapters()
-    {
-        return array_filter(
-            array(
-                new Adapter\BsdFindAdapter(),
-                new Adapter\GnuFindAdapter(),
-                new Adapter\PhpAdapter(),
-            ),
-            function (Adapter\AdapterInterface $adapter) {
-                return $adapter->isSupported();
-            }
-        );
-    }
-
-    /**
-     * Searching in multiple locations with sub directories involves
-     * AppendIterator which does an unnecessary rewind which leaves
-     * FilterIterator with inner FilesystemIterator in an invalid state.
-     *
-     * @see https://bugs.php.net/bug.php?id=49104
-     */
-    public function testMultipleLocationsWithSubDirectories()
-    {
-        $locations = array(
-            __DIR__.'/Fixtures/one',
-            self::$tmpDir.DIRECTORY_SEPARATOR.'toto',
-        );
-
-        $finder = new Finder();
-        $finder->in($locations)->depth('< 10')->name('*.neon');
-
-        $expected = array(
-            __DIR__.'/Fixtures/one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'c.neon',
-            __DIR__.'/Fixtures/one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'d.neon',
-        );
-
-        $this->assertIterator($expected, $finder);
-        $this->assertIteratorInForeach($expected, $finder);
+            ->addAdapter($this->getAdapter());
     }
 }

--- a/src/Symfony/Component/Finder/Tests/GnuFinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/GnuFinderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests;
+
+use Symfony\Component\Finder\Adapter\GnuFindAdapter;
+
+class GnuFinderTest extends FinderTest
+{
+    protected function getAdapter()
+    {
+        $adapter = new GnuFindAdapter();
+
+        if (!$adapter->isSupported()) {
+            $this->markTestSkipped(get_class($adapter).' is not supported.');
+        }
+
+        return $adapter;
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/Iterator/IteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/IteratorTestCase.php
@@ -16,7 +16,7 @@ abstract class IteratorTestCase extends \PHPUnit_Framework_TestCase
     protected function assertIterator($expected, \Traversable $iterator)
     {
         // set iterator_to_array $use_key to false to avoid values merge
-        // this made FinderTest::testAppendWithAnArray() failed with GnuFinderAdapter
+        // this made FinderTest::testAppendWithAnArray() fail with GnuFinderAdapter
         $values = array_map(function (\SplFileInfo $fileinfo) { return str_replace('/', DIRECTORY_SEPARATOR, $fileinfo->getPathname()); }, iterator_to_array($iterator, false));
 
         $expected = array_map(function ($path) { return str_replace('/', DIRECTORY_SEPARATOR, $path); }, $expected);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Testing against different adapters is now handled by multiple subclasses of a common test case rather than using data providers. This allows tests to be marked as skipped for unsupported adapters instead of making them disappear from the testsuite.
This will also make it much easier to mark tests for the find-based adapters as legacy ones when deprecating them.
This correspond to changes done by @nicolas-grekas in https://github.com/symfony/symfony/pull/15805, backported to 2.3 and with the data providers removed (his PR was keeping data providers for the adapter but making it return a single adapter all the time, hence the much bigger diff in my PR).
All tests in AbstractFinderTest are just moved from the FinderTest (they are all the tests running against multiple adapters). FinderTest itself runs the PhpAdapter (as this is the logic we want to keep in the finder in 3.0). I also tried to have a PhpFinderTest and keeping FinderTest only with the extra tests, but this would make things harder to merge branches between 2.8 and 3.0 in the future (once we remove other adapter tests) as we could simply keep the AbstractFinderTest in 3.0 for now to ease merging PRs adding new tests for bug fixes.
