### PR TITLE
Remove minimum width for web profiler content view

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -357,7 +357,6 @@ tr.status-warning td {
 {# Layout
    ========================================================================= #}
 .container {
-    min-width: 960px;
     max-width: 1300px;
     padding-right: 15px;
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This removes the min-width on the Web Profiler's content view, to allow for narrower browser windows to render all content without a horizontal scroll bar. I've checked all of the profiler pages, and none of them seem adversely affected by this. (In some cases, certain content winds up being taller because there's less horizontal space, but that's entirely expected and reasonable).
