### PR TITLE
Adding a MicroKernel that holds service configuration

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/ContainerBuilderAwareLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContainerBuilderAwareLoader.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Configuration loader that holds the ContainerBuilder inside.
+ *
+ * It can be useful to pass this to KernelInterface::registerContainerConfiguration()
+ * instead of a normal Loader if that method will need the ContainerBuilder.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class ContainerBuilderAwareLoader implements LoaderInterface
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $containerBuilder;
+
+    /**
+     * @var LoaderInterface
+     */
+    private $resourceLoader;
+
+    public function __construct(ContainerBuilder $builder, LoaderInterface $resourceLoader)
+    {
+        $this->containerBuilder = $builder;
+        $this->resourceLoader = $resourceLoader;
+    }
+
+    /**
+     * @return ContainerBuilder
+     */
+    public function getContainerBuilder()
+    {
+        return $this->containerBuilder;
+    }
+
+    /**
+     * @return LoaderInterface
+     */
+    public function getResourceLoader()
+    {
+        return $this->resourceLoader;
+    }
+
+    /**
+     * @see {@inheritdoc}
+     */
+    public function load($resource, $type = null)
+    {
+        return $this->resourceLoader->load($resource, $type);
+    }
+
+    /**
+     * @see {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return $this->resourceLoader->supports($resource, $type);
+    }
+
+    /**
+     * @see {@inheritdoc}
+     */
+    public function getResolver()
+    {
+        return $this->resourceLoader->getResolver();
+    }
+
+    /**
+     * @see {@inheritdoc}
+     */
+    public function setResolver(LoaderResolverInterface $resolver)
+    {
+        return $this->resourceLoader->setResolver($resolver);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/MicroKernel.php
+++ b/src/Symfony/Component/HttpKernel/MicroKernel.php
@@ -25,26 +25,6 @@ use Symfony\Component\DependencyInjection\Loader\ContainerBuilderAwareLoader;
 abstract class MicroKernel extends Kernel
 {
     /**
-     * Configure dependency injection extensions that have been added to the container.
-     *
-     * $c->loadFromExtension('framework', array(
-     *     'secret' => '%secret%'
-     * ));
-     *
-     * @param ContainerBuilder $c
-     * @param LoaderInterface  $loader
-     */
-    abstract protected function configureExtensions(ContainerBuilder $c, LoaderInterface $loader);
-
-    /**
-     * Add any service definitions to your container.
-     *
-     * @param ContainerBuilder $c
-     * @param LoaderInterface  $loader
-     */
-    abstract protected function configureServices(ContainerBuilder $c, LoaderInterface $loader);
-
-    /**
      * Applies the bundle configuration and calls configureServices() for continued building.
      *
      * @param LoaderInterface $loader
@@ -57,6 +37,30 @@ abstract class MicroKernel extends Kernel
 
         $this->configureExtensions($loader->getContainerBuilder(), $loader->getResourceLoader());
         $this->configureServices($loader->getContainerBuilder(), $loader->getResourceLoader());
+    }
+
+    /**
+     * Configure dependency injection extensions that have been added to the container.
+     *
+     * $c->loadFromExtension('framework', array(
+     *     'secret' => '%secret%'
+     * ));
+     *
+     * @param ContainerBuilder $c
+     * @param LoaderInterface  $loader
+     */
+    protected function configureExtensions(ContainerBuilder $c, LoaderInterface $loader)
+    {
+    }
+
+    /**
+     * Add any service definitions to your container.
+     *
+     * @param ContainerBuilder $c
+     * @param LoaderInterface  $loader
+     */
+    protected function configureServices(ContainerBuilder $c, LoaderInterface $loader)
+    {
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/MicroKernel.php
+++ b/src/Symfony/Component/HttpKernel/MicroKernel.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel;
+
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Loader\ContainerBuilderAwareLoader;
+
+/**
+ * A Kernel that allows you to configure services.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+abstract class MicroKernel extends Kernel
+{
+    /**
+     * Configure dependency injection extensions that have been added to the container.
+     *
+     * $c->loadFromExtension('framework', array(
+     *     'secret' => '%secret%'
+     * ));
+     *
+     * @param ContainerBuilder $c
+     * @param LoaderInterface  $loader
+     */
+    abstract protected function configureExtensions(ContainerBuilder $c, LoaderInterface $loader);
+
+    /**
+     * Add any service definitions to your container.
+     *
+     * @param ContainerBuilder $c
+     * @param LoaderInterface  $loader
+     */
+    abstract protected function configureServices(ContainerBuilder $c, LoaderInterface $loader);
+
+    /**
+     * Applies the bundle configuration and calls configureServices() for continued building.
+     *
+     * @param LoaderInterface $loader
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        if (!$loader instanceof ContainerBuilderAwareLoader) {
+            throw new \LogicException('registerContainerConfiguration requires the LoaderInterface to be a ContainerBuilderAwareLoader.');
+        }
+
+        $this->configureExtensions($loader->getContainerBuilder(), $loader->getResourceLoader());
+        $this->configureServices($loader->getContainerBuilder(), $loader->getResourceLoader());
+    }
+
+    /**
+     * Returns a loader with the ContainerBuilder embedded inside of it.
+     *
+     * @param ContainerInterface $container
+     *
+     * @return ContainerBuilderAwareLoader
+     */
+    protected function getContainerLoader(ContainerInterface $container)
+    {
+        if (!$container instanceof ContainerBuilder) {
+            throw new \LogicException('Only ContainerBuilder instances are supported.');
+        }
+
+        $loader = parent::getContainerLoader($container);
+
+        return new ContainerBuilderAwareLoader($container, $loader);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/MicroKernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/MicroKernelForTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpKernel\MicroKernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class MicroKernelForTest extends MicroKernel
+{
+    private $configureServicesCalled = false;
+
+    private $configureExtensionsCalled = false;
+
+    private $configureServicesArgs = array();
+
+    public function registerBundles()
+    {
+        return array();
+    }
+
+    public function getContainerLoaderExternally(ContainerInterface $container)
+    {
+        return $this->getContainerLoader($container);
+    }
+
+    protected function configureExtensions(ContainerBuilder $c, LoaderInterface $loader)
+    {
+        $this->configureExtensionsCalled = true;
+    }
+
+    protected function configureServices(ContainerBuilder $c, LoaderInterface $loader)
+    {
+        $this->configureServicesArgs = array($c, $loader);
+
+        $this->configureServicesCalled = true;
+    }
+
+    public function wasConfigureServicesCalled()
+    {
+        return $this->configureServicesCalled;
+    }
+
+    public function wasConfigureExtensionsCalled()
+    {
+        return $this->configureExtensionsCalled;
+    }
+
+    public function getConfigureServicesArguments()
+    {
+        return $this->configureServicesArgs;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/MicroKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/MicroKernelTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests;
+
+use Symfony\Component\DependencyInjection\Loader\ContainerBuilderAwareLoader;
+use Symfony\Component\HttpKernel\Tests\Fixtures\MicroKernelForTest;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Container;
+
+class MicroKernelTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetContainerLoader()
+    {
+        $containerBuilder = new ContainerBuilder();
+        $kernel = new MicroKernelForTest('test', false);
+
+        $loader = $kernel->getContainerLoaderExternally($containerBuilder);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Loader\ContainerBuilderAwareLoader', $loader);
+        $this->assertSame($containerBuilder, $loader->getContainerBuilder());
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testGetContainerLoaderFailsUnlessBuilder()
+    {
+        $containerBuilder = new Container();
+        $kernel = new MicroKernelForTest('test', false);
+
+        $kernel->getContainerLoaderExternally($containerBuilder);
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testRegisterContainerConfigurationOnlyAcceptsContainerAwareBuilderLoader()
+    {
+        $loader = $this->getMock('Symfony\Component\Config\Loader\LoaderInterface');
+        $kernel = new MicroKernelForTest('test', false);
+        $kernel->registerContainerConfiguration($loader);
+    }
+
+    public function testRegisterContainerConfiguration()
+    {
+        $loader = $this->getContainerBuilderAwareLoader();
+        $kernel = new MicroKernelForTest('test', false);
+        $kernel->registerContainerConfiguration($loader);
+
+        $this->assertTrue($kernel->wasConfigureServicesCalled());
+        $configureServicesArgs = $kernel->getConfigureServicesArguments();
+        $this->assertSame($loader->getResourceLoader(), $configureServicesArgs[1], 'The original loader is sent to configureServices');
+    }
+
+    private function getContainerBuilderAwareLoader()
+    {
+        $loader = $this->getMock('Symfony\Component\Config\Loader\LoaderInterface');
+        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        return new ContainerBuilderAwareLoader($builder, $loader);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | not yet |

Hi guys!

This introduces a new kernel whose goal is to be able to build an application without any external files (and to make loading external files easier, since conditional logic can be in PHP).

This allows you to register services and configure DI extensions right in the kernel. With #15742, this (or a sub-class) would be updated to also allow routes to be configured inside the kernel as well.

There is really only one goal of this PR:

1) Allow services/extensions to be configured in the kernel.

Thanks!
