### PR TITLE
[Finder] Optimize the hot-path

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -18,8 +18,10 @@ namespace Symfony\Component\Finder\Iterator;
  */
 class ExcludeDirectoryFilterIterator extends FilterIterator implements \RecursiveIterator
 {
+    private $iterator;
     private $isRecursive;
-    private $patterns;
+    private $excludedDirs = array();
+    private $excludedPattern;
 
     /**
      * Constructor.
@@ -29,10 +31,18 @@ class ExcludeDirectoryFilterIterator extends FilterIterator implements \Recursiv
      */
     public function __construct(\Iterator $iterator, array $directories)
     {
+        $this->iterator = $iterator;
         $this->isRecursive = $iterator instanceof \RecursiveIterator;
-        $this->patterns = array();
+        $patterns = array();
         foreach ($directories as $directory) {
-            $this->patterns[] = '#(^|/)'.preg_quote($directory, '#').'(/|$)#';
+            if (!$this->isRecursive || false !== strpos($directory, '/')) {
+                $patterns[] = preg_quote($directory, '#');
+            } else {
+                $this->excludedDirs[$directory] = true;
+            }
+        }
+        if ($patterns) {
+            $this->excludedPattern = '#(?:^|/)(?:'.implode('|', $patterns).')(?:/|$)#';
         }
 
         parent::__construct($iterator);
@@ -45,12 +55,15 @@ class ExcludeDirectoryFilterIterator extends FilterIterator implements \Recursiv
      */
     public function accept()
     {
-        $path = $this->isDir() ? $this->current()->getRelativePathname() : $this->current()->getRelativePath();
-        $path = str_replace('\\', '/', $path);
-        foreach ($this->patterns as $pattern) {
-            if (preg_match($pattern, $path)) {
-                return false;
-            }
+        if ($this->isRecursive && isset($this->excludedDirs[$this->getFilename()]) && $this->isDir()) {
+            return false;
+        }
+
+        if ($this->excludedPattern) {
+            $path = $this->isDir() ? $this->current()->getRelativePathname() : $this->current()->getRelativePath();
+            $path = str_replace('\\', '/', $path);
+
+            return !preg_match($this->excludedPattern, $path);
         }
 
         return true;
@@ -58,13 +71,14 @@ class ExcludeDirectoryFilterIterator extends FilterIterator implements \Recursiv
 
     public function hasChildren()
     {
-        return $this->isRecursive && $this->getInnerIterator()->hasChildren();
+        return $this->isRecursive && $this->iterator->hasChildren();
     }
 
     public function getChildren()
     {
-        $children = new self($this->getInnerIterator()->getChildren(), array());
-        $children->patterns = $this->patterns;
+        $children = new self($this->iterator->getChildren(), array());
+        $children->excludedDirs = $this->excludedDirs;
+        $children->excludedPattern = $this->excludedPattern;
 
         return $children;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15824 |
| License | MIT |
| Doc PR | - |

A significant part of the perf gain in #15802 was related to filters not being applied recursively...
#15824 fixing this, performance dropped again.

This PR optimizes the hot path by replacing a regexp test by a simple `isset` when possible.
Blackfire diff after #15824 is the following:
https://blackfire.io/profiles/compare/9e489018-998d-4acb-92a0-46011828e83b/graph

`preg_match` is not called anymore, and  `Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator::current()` is also cut by two.

When this `isset` optimization is disabled and replaced by a concatenation of all the regexps patterns in a single bigger one, the gain is still significant but lower:
https://blackfire.io/profiles/compare/db86b80e-b63e-4fc9-9ff3-9ed32baeb948/graph

This makes me think that an other and last round of optimization is possible by merging all regexps in one in MultiplePcreFilterIterator filters. If someone wants to work on this, please do it :)
