### PR TITLE
[travis] Remove PHP 7 from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,7 @@ matrix:
         - php: 5.6
           env: deps=high
         - php: 7
-        - php: 5.6
           env: deps=low
-    allow_failures:
-        - php: 7
     fast_finish: true
 
 services: mongodb

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/common": "~2.3",
+        "doctrine/common": "~2.4",
         "twig/twig": "~1.20|~2.0",
         "psr/log": "~1.0"
     },
@@ -63,8 +63,8 @@
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7",
         "doctrine/data-fixtures": "1.0.*",
-        "doctrine/dbal": "~2.2",
-        "doctrine/orm": "~2.2,>=2.2.3",
+        "doctrine/dbal": "~2.4",
+        "doctrine/orm": "~2.4,>=2.4.5",
         "monolog/monolog": "~1.3",
         "propel/propel1": "~1.6",
         "ircmaxell/password-compat": "~1.0",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/common": "~2.3"
+        "doctrine/common": "~2.4"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7",
@@ -30,8 +30,8 @@
         "symfony/validator": "~2.3.0,>=2.3.20",
         "symfony/translation": "~2.0,>=2.0.5",
         "doctrine/data-fixtures": "1.0.*",
-        "doctrine/dbal": "~2.2",
-        "doctrine/orm": "~2.2,>=2.2.3"
+        "doctrine/dbal": "~2.4",
+        "doctrine/orm": "~2.4,>=2.4.5"
     },
     "suggest": {
         "symfony/form": "",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Looking at the latests PRs, PHP 7 does not segfault anymore with our test suite.
