### PR TITLE
[Translation] Clean whitespaces and EOL in xliff-core-2.0.xsd

### DIFF
--- a/src/Symfony/Component/Translation/Loader/schema/dic/xliff-core/xliff-core-2.0.xsd
+++ b/src/Symfony/Component/Translation/Loader/schema/dic/xliff-core/xliff-core-2.0.xsd
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-	XLIFF Version 2.0
-	OASIS Standard
-	05 August 2014
-	Copyright (c) OASIS Open 2014. All rights reserved.
-	Source: http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/schemas/
+    XLIFF Version 2.0
+    OASIS Standard
+    05 August 2014
+    Copyright (c) OASIS Open 2014. All rights reserved.
+    Source: http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/schemas/
      -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

See https://github.com/symfony/symfony/pull/15833/files?w=1
