### PR TITLE
Remove whitespaces between <input> and <label>

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -211,10 +211,10 @@
     {% if label is not same as(false) -%}
         {% if not compound -%}
             {% set label_attr = label_attr|merge({'for': id}) %}
-        {%- endif %}
+        {%- endif -%}
         {% if required -%}
             {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
-        {%- endif %}
+        {%- endif -%}
         {% if label is empty -%}
             {%- if label_format is not empty -%}
                 {% set label = label_format|replace({


### PR DESCRIPTION
Reason: With the whitespaces, there would be a "gap" between <input> and <label> which is clickable, but doesn't activate the <input>.

It's easy to _add_ some margin with CSS, whereas it's impossible to _remove_ whitespaces with CSS.
