### PR TITLE
[Console] Add clock mock to fix transient test on HHVM

### DIFF
--- a/src/Symfony/Component/Console/Tests/ClockMock.php
+++ b/src/Symfony/Component/Console/Tests/ClockMock.php
@@ -9,14 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\HttpFoundation;
+namespace Symfony\Component\Console\Helper;
+
+use Symfony\Component\Console\Tests;
 
 function time()
 {
     return Tests\time();
 }
 
-namespace Symfony\Component\HttpFoundation\Tests;
+namespace Symfony\Component\Console\Tests;
 
 function with_clock_mock($enable = null)
 {

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
@@ -13,9 +13,22 @@ namespace Symfony\Component\Console\Tests\Helper;
 
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tests;
+
+require_once __DIR__.'/../ClockMock.php';
 
 class ProgressHelperTest extends \PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        Tests\with_clock_mock(true);
+    }
+
+    protected function tearDown()
+    {
+        Tests\with_clock_mock(false);
+    }
+
     public function testAdvance()
     {
         $progress = new ProgressHelper();

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -23,16 +23,14 @@ require_once __DIR__.'/ClockMock.php';
  */
 class CookieTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         with_clock_mock(true);
-        parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         with_clock_mock(false);
-        parent::tearDown();
     }
 
     public function invalidNames()

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -18,16 +18,14 @@ require_once __DIR__.'/ClockMock.php';
 
 class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         with_clock_mock(true);
-        parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         with_clock_mock(false);
-        parent::tearDown();
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -24,16 +24,14 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
 {
     const DELTA = 37;
 
-    public function setUp()
+    protected function setUp()
     {
         with_clock_mock(true);
-        parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         with_clock_mock(false);
-        parent::tearDown();
     }
 
     public function testGetOrigin()

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -24,16 +24,14 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 {
     const DELTA = 20;
 
-    public function setUp()
+    protected function setUp()
     {
         with_clock_mock(true);
-        parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         with_clock_mock(false);
-        parent::tearDown();
     }
 
     public function testStart()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This should fix the most frequent transient test on HHVM (ProgressBarTest::testAnsiColorsAndEmojis)
