### PR TITLE
Fix the phpdoc in the CssSelector TranslatorInterface

### DIFF
--- a/src/Symfony/Component/CssSelector/XPath/TranslatorInterface.php
+++ b/src/Symfony/Component/CssSelector/XPath/TranslatorInterface.php
@@ -29,7 +29,7 @@ interface TranslatorInterface
      * @param string $cssExpr
      * @param string $prefix
      *
-     * @return XPathExpr
+     * @return string
      */
     public function cssToXPath($cssExpr, $prefix = 'descendant-or-self::');
 
@@ -39,7 +39,7 @@ interface TranslatorInterface
      * @param SelectorNode $selector
      * @param string       $prefix
      *
-     * @return XPathExpr
+     * @return string
      */
     public function selectorToXPath(SelectorNode $selector, $prefix = 'descendant-or-self::');
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The phpdoc of the interface does not match the behavior of the implementation. And the return type documented by the interface is impossible to return because the interface asks to apply a string prefix, and the only way is to cast the `XPathExpr` used internally to a string (which is what the implementation does).

This interface is an internal interface anyway.
