### PR TITLE
[Config] Fix enum default value in Yaml dumper

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -88,7 +88,7 @@ class YamlReferenceDumper
             }
         } elseif ($node instanceof EnumNode) {
             $comments[] = 'One of '.implode('; ', array_map('json_encode', $node->getValues()));
-            $default = '~';
+            $default = $node->hasDefaultValue() ? Inline::dump($node->getDefaultValue()) : '~';
         } else {
             $default = '~';
 

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
@@ -37,6 +37,7 @@ class XmlReferenceDumperTest extends \PHPUnit_Framework_TestCase
         return str_replace("\n", PHP_EOL, <<<EOL
 <!-- Namespace: http://example.org/schema/dic/acme_root -->
 <!-- scalar-required: Required -->
+<!-- enum-with-default: One of "this"; "that" -->
 <!-- enum: One of "this"; "that" -->
 <config
     boolean="true"
@@ -48,6 +49,7 @@ class XmlReferenceDumperTest extends \PHPUnit_Framework_TestCase
     scalar-array-empty=""
     scalar-array-defaults="elem1,elem2"
     scalar-required=""
+    enum-with-default="this"
     enum=""
 >
 

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -43,6 +43,7 @@ acme_root:
         - elem1
         - elem2
     scalar_required:      ~ # Required
+    enum_with_default:    this # One of "this"; "that"
     enum:                 ~ # One of "this"; "that"
 
     # some info

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
@@ -34,6 +34,7 @@ class ExampleConfiguration implements ConfigurationInterface
                 ->scalarNode('scalar_array_empty')->defaultValue(array())->end()
                 ->scalarNode('scalar_array_defaults')->defaultValue(array('elem1', 'elem2'))->end()
                 ->scalarNode('scalar_required')->isRequired()->end()
+                ->enumNode('enum_with_default')->values(array('this', 'that'))->defaultValue('this')->end()
                 ->enumNode('enum')->values(array('this', 'that'))->end()
                 ->arrayNode('array')
                     ->info('some info')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

The default value is not correctly included when dumping an EnumNode in Yaml. This is now fixed
