### PR TITLE
[Yaml] Fix improper comments removal

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -337,16 +337,8 @@ class Parser
 
         $isItUnindentedCollection = $this->isStringUnIndentedCollectionItem($this->currentLine);
 
-        // Comments must not be removed inside a string block (ie. after a line ending with "|")
-        $removeCommentsPattern = '~'.self::FOLDED_SCALAR_PATTERN.'$~';
-        $removeComments = !preg_match($removeCommentsPattern, $this->currentLine);
-
         while ($this->moveToNextLine()) {
             $indent = $this->getCurrentLineIndentation();
-
-            if ($indent === $newIndent) {
-                $removeComments = !preg_match($removeCommentsPattern, $this->currentLine);
-            }
 
             if ($isItUnindentedCollection && !$this->isStringUnIndentedCollectionItem($this->currentLine) && $newIndent === $indent) {
                 $this->moveToPreviousLine();
@@ -355,10 +347,6 @@ class Parser
 
             if ($this->isCurrentLineBlank()) {
                 $data[] = substr($this->currentLine, $newIndent);
-                continue;
-            }
-
-            if ($removeComments && $this->isCurrentLineComment()) {
                 continue;
             }
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -617,6 +617,43 @@ EOF
         ));
     }
 
+    public function testSecondLevelFoldedStringBlockWithComments()
+    {
+        $this->assertEquals(array(
+            'pages' => array(
+                array(
+                    'title' => 'some title',
+                    'content' => <<<EOT
+# comment 1
+header
+
+    # comment 2
+    <body>
+        <h1>title</h1>
+    </body>
+
+footer # comment3
+EOT
+                ),
+            ),
+        ), Yaml::parse(<<<EOF
+pages:
+    -
+        title: some title
+        content: |
+            # comment 1
+            header
+
+                # comment 2
+                <body>
+                    <h1>title</h1>
+                </body>
+
+            footer # comment3
+EOF
+        ));
+    }
+
     public function testNestedFoldedStringBlockWithComments()
     {
         $this->assertEquals(array(array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15857 |
| License | MIT |
| Doc PR | - |

This tries to fix #15857 .

Honestly, I don't have any idea of the regressions it might introduce. Tests are passing, so if this code had any reason to exist, tests covering it are certainly missing :/

Any hint ?
