### PR TITLE
[Cache][Console] - fixed cache:clear command with session pointing to cache directory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -153,6 +153,7 @@ EOF
         }
 
         // remove temp kernel file after cache warmed up
+        $tempKernel->getContainer()->get('session')->save();
         @unlink($tempKernelFile);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #15839 |
| License | MIT |

When running the cache:clear command and have session storage files configured for app/cache/sessions directory an issue arises that prevents renaming of the warmup cache directory on windows system.
There is a precondition that the session needs to be stared during the during CLI / kernel boot.

More info here: 
#15839

[#3071#issuecomment-141682129](https://github.com/Sylius/Sylius/issues/3071#issuecomment-141682129)

default configuration will place session inside cache directory

```
framework:
    session: ~
```

This PR closes the session files opened during the tempKerner boot, so there would be no problem renaming cache directories with open file handlers on windows machines.
