### PR TITLE
[#13672] Re-adding default assets to FrameworkBundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -43,6 +43,20 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('framework');
 
         $rootNode
+            ->validate()
+                ->ifTrue(function ($v) { return !isset($v['assets']); })
+                ->then(function ($v) {
+                    $v['assets'] = array(
+                        'version' => null,
+                        'version_format' => '%%s?%%s',
+                        'base_path' => '',
+                        'base_urls' => array(),
+                        'packages' => array(),
+                    );
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->scalarNode('secret')->end()
                 ->scalarNode('http_method_override')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | n/a |

In #13672, a default `assets` configuration was added to `framework`. Without this, if you don't have `assets` set, there are some consequences (like the `AssetExtension` not being loaded as a twig extension).

This was removed at some point on the master branch. There's discussion on enabling less things in FrameworkBundle in general, but as this (so far) hasn't been marked as deprecated in 2.8, it shouldn't be removed in 3.0. Said differently, an alternative would be to deprecate relying on this default configuration in 2.8.

Thanks!
