### PR TITLE
Use random_bytes function if it is available for random number generation

### DIFF
--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -39,7 +39,8 @@
         "symfony/validator": "",
         "symfony/routing": "",
         "doctrine/dbal": "to use the built-in ACL implementation",
-        "ircmaxell/password-compat": ""
+        "ircmaxell/password-compat": "",
+        "paragonie/random_compat": ""
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Security\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15239 |
| License | MIT |
| Doc PR |  |

This is an attempt to use the random_bytes function when generating secure random numbers. This function is included in PHP 7 or through the "paragonie/random_compat" library.

This PR only adds support to use the function if it is available. Changes that can be added is to add a hard dependency on the paragonie/random_compat library, so all current functionality can be deprecated.
