### PR TITLE
[2.8][Security][Guard] GuardTokenInterface vs. TokenInterface in phpDoc

### DIFF
--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
@@ -96,7 +96,7 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      * @param UserInterface $user
      * @param string        $providerKey The provider (i.e. firewall) key
      *
-     * @return GuardTokenInterface
+     * @return TokenInterface|GuardTokenInterface
      */
     public function createAuthenticatedToken(UserInterface $user, $providerKey);
 

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Guard\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Guard\GuardAuthenticatorInterface;
 use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
@@ -56,9 +55,9 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
     /**
      * Finds the correct authenticator for the token and calls it.
      *
-     * @param GuardTokenInterface $token
+     * @param TokenInterface|GuardTokenInterface $token
      *
-     * @return TokenInterface
+     * @return TokenInterface|GuardTokenInterface
      */
     public function authenticate(TokenInterface $token)
     {
@@ -101,6 +100,12 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         // instances that will be checked if you have multiple firewalls.
     }
 
+    /**
+     * @param GuardAuthenticatorInterface $guardAuthenticator
+     * @param PreAuthenticationGuardToken $token
+     *
+     * @return TokenInterface|GuardTokenInterface
+     */
     private function authenticateViaGuard(GuardAuthenticatorInterface $guardAuthenticator, PreAuthenticationGuardToken $token)
     {
         // get the user from the GuardAuthenticator
@@ -138,6 +143,9 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         return $authenticatedToken;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function supports(TokenInterface $token)
     {
         return $token instanceof GuardTokenInterface;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

The new `GuardTokenInterface` is used as a marker to annotate a security token that is compatible with the new Guard component. I noticed that whenever `GuardTokenInterface` is annotated, the code expects the object to also implement `TokenInterface`. This asummption is correct, but we should make it explicit. Especially when looking at `GuardAuthenticationProvider::authenticate` method, I find it confusing that the doc block is incompatible with the type hint.

With this tiny PR, I changed the annotations to `TokenInterface|GuardTokenInterface` where I found it helpful to do this. By doing this, I also found an unused import.

An alternative approach could be declaring `GuardTokenInterface` as an interface that extends `TokenInterface`.

/ping @weaverryan
