### PR TITLE
Forbid serializing a Crawler

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -311,6 +311,17 @@ class Crawler extends \SplObjectStorage
         }
     }
 
+    // Serializing and unserializing a crawler creates DOM objects in a corrupted state. DOM elements are not properly serializable.
+    public function unserialize($serialized)
+    {
+        throw new \BadMethodCallException('A Crawler cannot be serialized.');
+    }
+
+    public function serialize()
+    {
+        throw new \BadMethodCallException('A Crawler cannot be serialized.');
+    }
+
     /**
      * Returns a node given its position in the node list.
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Unserializing a Crawler instance creates DOM elements in an invalid state, making the Crawler unusable.
While working on #15849, I figured out that DomCrawler actually inherits `Serializable` from its `SplObjectStorage` parent, and so I tried to serialize and unserialize one. The answer is that it does not work. This is what happens when trying to call `parents` on it for instance:

```
Symfony\Component\DomCrawler\Crawler::parents(): Invalid State Error
```
