### PR TITLE
Allow serializer 3.0 in the PropertyInfo component

### DIFF
--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -26,8 +26,8 @@
         "php": ">=5.3.9"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "~2.7",
-        "symfony/serializer": "~2.7",
+        "symfony/phpunit-bridge": "~2.7|~3.0.0",
+        "symfony/serializer": "~2.7|~3.0.0",
         "phpdocumentor/reflection": "^1.0.7",
         "doctrine/annotations": "~1.0"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This makes the component consistent with other components.
