### PR TITLE
Ensure the ClockMock is loaded before using it in the testsuite

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tests;
 
+require_once __DIR__.'/../ClockMock.php';
+
 class ProgressBarTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The `ProgressBarTest` is passing in 2.7 and 2.8 on Travis only because the `LegacyProgressHelperTest` is running first, and so the clock mock is loaded. It would not pass when running it standalone. And the testsuite is currently broken in the master branch because LegacyProgressHelperTest is gone there, and so the clock mock was not loaded before the test.
