### PR TITLE
Abstract voter tweaks

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AbstractVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AbstractVoterTest.php
@@ -19,17 +19,10 @@ use Symfony\Component\Security\Core\Authorization\Voter\AbstractVoter;
  */
 class AbstractVoterTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var AbstractVoter
-     */
-    private $voter;
-
     private $token;
 
     protected function setUp()
     {
-        $this->voter = new VoterFixture();
-
         $tokenMock = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $tokenMock
             ->expects($this->any())
@@ -44,7 +37,9 @@ class AbstractVoterTest extends \PHPUnit_Framework_TestCase
      */
     public function testVote($expectedVote, $object, $attributes, $message)
     {
-        $this->assertEquals($expectedVote, $this->voter->vote($this->token, $object, $attributes), $message);
+        $voter = new VoterFixture();
+
+        $this->assertEquals($expectedVote, $voter->vote($this->token, $object, $attributes), $message);
     }
 
     /**
@@ -56,6 +51,16 @@ class AbstractVoterTest extends \PHPUnit_Framework_TestCase
         $voter = new DeprecatedVoterFixture();
 
         $this->assertEquals($expectedVote, $voter->vote($this->token, $object, $attributes), $message);
+    }
+
+    /**
+     * @group legacy
+     * @expectedException \BadMethodCallException
+     */
+    public function testNoOverriddenMethodsThrowsException()
+    {
+        $voter = new DeprecatedVoterNothingImplementedFixture();
+        $voter->vote($this->token, new ObjectFixture(), array('foo'));
     }
 
     public function getData()
@@ -111,6 +116,23 @@ class DeprecatedVoterFixture extends AbstractVoter
     {
         return $attribute === 'foo';
     }
+}
+
+class DeprecatedVoterNothingImplementedFixture extends AbstractVoter
+{
+    protected function getSupportedClasses()
+    {
+        return array(
+            'Symfony\Component\Security\Core\Tests\Authorization\Voter\ObjectFixture',
+        );
+    }
+
+    protected function getSupportedAttributes()
+    {
+        return array('foo', 'bar', 'baz');
+    }
+
+    // this is a bad voter that hasn't overridden isGranted or voteOnAttribute
 }
 
 class ObjectFixture


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (a little) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Based on suggestions from stof in #15870, this simplifies the BC and deprecation throwing code. This also adds a BadMethodCallException in case the user doesn't override `isGranted` _or_ `voteOnAttribute`, because that's just plain wrong (as is calling `isGranted()` on the parent class directly, since that was formerly abstract).
