### PR TITLE
Fix legacy security tests

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/LegacySecurityContextTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/LegacySecurityContextTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Tests;
 
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
-use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * @group legacy


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

when merging legacy test classes together in #15893, use statements where not copied, making the tests fail.
