### PR TITLE
Updating behavior to not continue after an authenticator has set the response

### DIFF
--- a/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
@@ -66,7 +66,7 @@ class GuardAuthenticationListener implements ListenerInterface
     public function handle(GetResponseEvent $event)
     {
         if (null !== $this->logger) {
-            $this->logger->info('Checking for guard authentication credentials.', array('firewall_key' => $this->providerKey, 'authenticators' => count($this->guardAuthenticators)));
+            $this->logger->debug('Checking for guard authentication credentials.', array('firewall_key' => $this->providerKey, 'authenticators' => count($this->guardAuthenticators)));
         }
 
         foreach ($this->guardAuthenticators as $key => $guardAuthenticator) {
@@ -77,7 +77,7 @@ class GuardAuthenticationListener implements ListenerInterface
             $this->executeGuardAuthenticator($uniqueGuardKey, $guardAuthenticator, $event);
 
             if ($event->hasResponse()) {
-                $this->logger->info(sprintf('The "%s" authenticator set the response. Any later authenticator will not be called', get_class($guardAuthenticator)));
+                $this->logger->debug(sprintf('The "%s" authenticator set the response. Any later authenticator will not be called', get_class($guardAuthenticator)));
 
                 break;
             }
@@ -89,7 +89,7 @@ class GuardAuthenticationListener implements ListenerInterface
         $request = $event->getRequest();
         try {
             if (null !== $this->logger) {
-                $this->logger->info('Calling getCredentials on guard configurator.', array('firewall_key' => $this->providerKey, 'authenticator' => get_class($guardAuthenticator)));
+                $this->logger->debug('Calling getCredentials() on guard configurator.', array('firewall_key' => $this->providerKey, 'authenticator' => get_class($guardAuthenticator)));
             }
 
             // allow the authenticator to fetch authentication info from the request
@@ -104,7 +104,7 @@ class GuardAuthenticationListener implements ListenerInterface
             $token = new PreAuthenticationGuardToken($credentials, $uniqueGuardKey);
 
             if (null !== $this->logger) {
-                $this->logger->info('Passing guard token information to the GuardAuthenticationProvider', array('firewall_key' => $this->providerKey, 'authenticator' => get_class($guardAuthenticator)));
+                $this->logger->debug('Passing guard token information to the GuardAuthenticationProvider', array('firewall_key' => $this->providerKey, 'authenticator' => get_class($guardAuthenticator)));
             }
             // pass the token into the AuthenticationManager system
             // this indirectly calls GuardAuthenticationProvider::authenticate()
@@ -136,13 +136,13 @@ class GuardAuthenticationListener implements ListenerInterface
         $response = $this->guardHandler->handleAuthenticationSuccess($token, $request, $guardAuthenticator, $this->providerKey);
         if ($response instanceof Response) {
             if (null !== $this->logger) {
-                $this->logger->info('Guard authenticator set success response.', array('response' => $response, 'authenticator' => get_class($guardAuthenticator)));
+                $this->logger->debug('Guard authenticator set success response.', array('response' => $response, 'authenticator' => get_class($guardAuthenticator)));
             }
 
             $event->setResponse($response);
         } else {
             if (null !== $this->logger) {
-                $this->logger->info('Guard authenticator set no success response: request continues.', array('authenticator' => get_class($guardAuthenticator)));
+                $this->logger->debug('Guard authenticator set no success response: request continues.', array('authenticator' => get_class($guardAuthenticator)));
             }
         }
 
@@ -173,7 +173,7 @@ class GuardAuthenticationListener implements ListenerInterface
     {
         if (null === $this->rememberMeServices) {
             if (null !== $this->logger) {
-                $this->logger->info('Remember me skipped: it is not configured for the firewall.', array('authenticator' => get_class($guardAuthenticator)));
+                $this->logger->debug('Remember me skipped: it is not configured for the firewall.', array('authenticator' => get_class($guardAuthenticator)));
             }
 
             return;
@@ -181,7 +181,7 @@ class GuardAuthenticationListener implements ListenerInterface
 
         if (!$guardAuthenticator->supportsRememberMe()) {
             if (null !== $this->logger) {
-                $this->logger->info('Remember me skipped: your authenticator does not support it.', array('authenticator' => get_class($guardAuthenticator)));
+                $this->logger->debug('Remember me skipped: your authenticator does not support it.', array('authenticator' => get_class($guardAuthenticator)));
             }
 
             return;

--- a/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
@@ -75,6 +75,12 @@ class GuardAuthenticationListener implements ListenerInterface
             $uniqueGuardKey = $this->providerKey.'_'.$key;
 
             $this->executeGuardAuthenticator($uniqueGuardKey, $guardAuthenticator, $event);
+
+            if ($event->hasResponse()) {
+                $this->logger->info(sprintf('The "%s" authenticator set the response. Any later authenticator will not be called', get_class($guardAuthenticator)));
+
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/14673/files#r40492765 |
| License | MIT |
| Doc PR | n/a |

This mirrors the behavior in core: _if_ a listener sets a response (on success or failure),
then the other listeners are not called. But if a response is _not_ set
(which is sometimes the case for success, like in BasicAuthenticationListener),
then the other listeners are called, and can even fail.

It's all a bit of an edge-case, as only one authenticator (like authentication listener) would normally be doing any work on a request, but I think matching the other listeners (since I'm not aware of anyone having issues with its behavior) is best.
